### PR TITLE
Victor/adding bash build for linux

### DIFF
--- a/.build.sh
+++ b/.build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Get path from where we are 
+LOCATION="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+BUILD_DIR="${LOCATION}/build"
+
+# run cmake and build
+cmake -s $LOCATION -B $BUILD_DIR
+cmake --build $BUILD_DIR

--- a/.build.sh
+++ b/.build.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Get path from where we are 
-LOCATION="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-BUILD_DIR="${LOCATION}/build"
-
-# run cmake and build
-cmake -s $LOCATION -B $BUILD_DIR
-cmake --build $BUILD_DIR

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ To get started with a specific library, see the **README.md** file located in th
 ### Prerequisites
 CMake version 3.12 is required to use these libraries.
 
+### Development Environment
+Project contains files to work on Windows or Linux based OS.
+
+#### Windows
+Use PowerShell to run {projectDir}/build.ps1
+
+#### Linux
+Use bash to run {projectDir}/build-tools/build.sh
+
+Output libraries are created in /build folder
+
 ## Need help?
 * File an issue via [Github Issues](https://github.com/Azure/azure-sdk-for-c/issues/new/choose).
 * Check [previous questions](https://stackoverflow.com/questions/tagged/azure+c) or ask new ones on StackOverflow using `azure` and `c` tags.

--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Get path from where we are 
+LOCATION="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
+BUILD_DIR="${LOCATION}/build"
+
+# run cmake and build
+cmake -s $LOCATION -B $BUILD_DIR
+cmake --build $BUILD_DIR


### PR DESCRIPTION
This is basically breaking dependency on powerShell only for running build.ps1
There´s a way to have powerShell installed in Ubuntu but I think we don't want to depend or ask clients to install PowerShell in order to be able to use this build script