### PR TITLE
Remove dependency on azure-ulib-c

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "sdk/ustorageclient/deps/azure-macro-utils-c"]
 	path = sdk/ustorageclient/deps/azure-macro-utils-c
 	url = https://github.com/Azure/azure-macro-utils-c.git
-[submodule "sdk/ustorageclient/deps/azure-ulib-c"]
-	path = sdk/ustorageclient/deps/azure-ulib-c
-	url = https://github.com/Azure/azure-ulib-c.git
 [submodule "sdk/ustorageclient/deps/azure-c-shared-utility"]
 	path = sdk/ustorageclient/deps/azure-c-shared-utility
 	url = https://github.com/Azure/azure-c-shared-utility.git

--- a/sdk/ustorageclient/CMakeLists.txt
+++ b/sdk/ustorageclient/CMakeLists.txt
@@ -41,10 +41,10 @@ target_include_directories(azure_iot_ustorageclient PRIVATE
     ${PROJECT_SOURCE_DIR}/deps/umock-c/inc
     ${PROJECT_SOURCE_DIR}/deps/azure-macro-utils-c/inc
     ${PROJECT_SOURCE_DIR}/deps/azure-c-shared-utility/inc
-    ${PROJECT_SOURCE_DIR}/deps/azure-ulib-c/inc
-    ${PROJECT_SOURCE_DIR}/deps/azure-ulib-c/config
+    #${PROJECT_SOURCE_DIR}/deps/azure-ulib-c/inc
+    #${PROJECT_SOURCE_DIR}/deps/azure-ulib-c/config
     #ulib pal directory TODO: fix with environment variable from azure-ulib-c cmake
-    ${PROJECT_SOURCE_DIR}/deps/azure-ulib-c/pal/MSBUILD/X86
+    #${PROJECT_SOURCE_DIR}/deps/azure-ulib-c/pal/MSBUILD/X86
 )
 
 set(AZURE_IOT_USTORAGECLIENT_INC_FOLDER ${PROJECT_SOURCE_DIR}/inc CACHE INTERNAL "this is what needs to be included if using sharedLib lib" FORCE)
@@ -56,7 +56,7 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/deps/azure-c-testrunnerswitcher EXCLUDE_F
 #turn on use_built_in_httpapi option for azure-c-shared-utility
 set(use_builtin_httpapi ON CACHE BOOL "enable built-in httpapi_compact")
 add_subdirectory(${PROJECT_SOURCE_DIR}/deps/azure-c-shared-utility EXCLUDE_FROM_ALL)
-add_subdirectory(${PROJECT_SOURCE_DIR}/deps/azure-ulib-c EXCLUDE_FROM_ALL)
+#add_subdirectory(${PROJECT_SOURCE_DIR}/deps/azure-ulib-c EXCLUDE_FROM_ALL)
 
 setTargetBuildProperties(azure_iot_ustorageclient)
 

--- a/sdk/ustorageclient/build_all/configs/ustorageclient_functions.cmake
+++ b/sdk/ustorageclient/build_all/configs/ustorageclient_functions.cmake
@@ -54,7 +54,8 @@ function(azstorage_c_windows_unittests_add_dll what_is_building folder)
 
     #Link necessary libs to dll library
     target_link_libraries(${what_is_building}_dll
-                PRIVATE azure_ulib_c umock_c ctest testrunnerswitcher azure_iot_ustorageclient ${what_is_building}_testsonly_lib
+                #add azure_ulib_c back later
+                PRIVATE umock_c ctest testrunnerswitcher azure_iot_ustorageclient ${what_is_building}_testsonly_lib
     )
 
 endfunction()
@@ -79,7 +80,8 @@ function(azstorage_c_windows_unittests_add_exe what_is_building folder)
     target_compile_definitions(${what_is_building}_exe PUBLIC USE_CTEST)
     target_include_directories(${what_is_building}_exe PUBLIC ${sharedutil_include_directories})
     target_link_libraries(${what_is_building}_exe
-                PRIVATE azure_ulib_c umock_c ctest testrunnerswitcher azure_iot_ustorageclient
+                #add azure_ulib_c back later
+                PRIVATE umock_c ctest testrunnerswitcher azure_iot_ustorageclient
     )
 
     #Add test to ctest list
@@ -107,7 +109,8 @@ function(azstorage_c_linux_unittests_add_exe what_is_building folder)
     target_compile_definitions(${what_is_building}_exe PUBLIC USE_CTEST)
     target_include_directories(${what_is_building}_exe PUBLIC ${sharedutil_include_directories})
     target_link_libraries(${what_is_building}_exe
-                PRIVATE azure_ulib_c umock_c ctest testrunnerswitcher azure_iot_ustorageclient
+                #add azure_ulib_c back later
+                PRIVATE umock_c ctest testrunnerswitcher azure_iot_ustorageclient
     )
 
     #Add test to ctest list
@@ -133,7 +136,8 @@ function(azstorage_build_c_test_target what_is_building folder)
     include_directories(${PROJECT_SOURCE_DIR}/config)
 
     #Set shared utility include directories
-    set(ustorageclient_test_framework_includes ${sharedutil_include_directories} ${AZURE_ULIB_C_INC_FOLDER} ${MACRO_UTILS_INC_FOLDER} ${UMOCK_C_INC_FOLDER} ${TESTRUNNERSWITCHER_INC_FOLDER} ${CTEST_INC_FOLDER})
+    #add ${AZURE_ULIB_C_INC_FOLDER} back later
+    set(ustorageclient_test_framework_includes ${sharedutil_include_directories} ${MACRO_UTILS_INC_FOLDER} ${UMOCK_C_INC_FOLDER} ${TESTRUNNERSWITCHER_INC_FOLDER} ${CTEST_INC_FOLDER})
     include_directories(${ustorageclient_test_framework_includes})
 
     #Create Windows/Linux test executables
@@ -170,7 +174,7 @@ function(azstorage_build_c_sample_target what_is_building folder)
     )
     target_link_libraries(${what_is_building}_exe
                 PRIVATE azure_iot_ustorageclient
-                PRIVATE azure_ulib_c
+                #PRIVATE azure_ulib_c
                 PRIVATE aziotsharedutil
     )
 

--- a/sdk/ustorageclient/config/azstorage_storage_config.h
+++ b/sdk/ustorageclient/config/azstorage_storage_config.h
@@ -13,7 +13,8 @@
  * call stack and will be hard to interpret.
  * Only comment this out if you have already tested your function arguments.
  */
-#define AZSTORAGE_BLOB_VALIDATE_ARGUMENTS
+// TODO: once azure-ulib-c is public this can be enabled
+// #define AZSTORAGE_BLOB_VALIDATE_ARGUMENTS
 
 /**
  * @brief bytes allocated to storing a whole blob in an array

--- a/sdk/ustorageclient/src/azstorage_blob.c
+++ b/sdk/ustorageclient/src/azstorage_blob.c
@@ -10,7 +10,8 @@
 #include "azure_c_shared_utility/platform.h"
 #include "azure_c_shared_utility/xlogging.h"
 #include "azure_c_shared_utility/strings.h"
-#include "ucontract.h"
+// TODO: once azure-ulib-c is public this can be enabled
+//#include "ucontract.h"
 
 #include "azstorage_storage_config.h"
 
@@ -140,6 +141,11 @@ AZSTORAGE_RESULT azstorage_blob_storage_client_create(AZSTORAGE_BLOB_HANDLE blob
         /*[azstorage_blob_service_client_create_service_uri_NULL_FAIL]*/
         UCONTRACT_REQUIRE_NOT_NULL(service_uri, AZSTORAGE_ILLEGAL_ARGUMENT_ERROR)
     );
+    #else
+        if (blob_storage_client == NULL || service_uri == NULL)
+        {
+            return AZSTORAGE_ILLEGAL_ARGUMENT_ERROR;
+        }
     #endif
 
     AZSTORAGE_RESULT result;
@@ -170,6 +176,11 @@ void azstorage_blob_storage_client_destroy(AZSTORAGE_BLOB_HANDLE blob_storage_cl
         /*[azstorage_blob_storage_client_destroy_blob_storage_client_NULL_FAIL]*/
         UCONTRACT_REQUIRE_NOT_NULL(blob_storage_client,);
     );
+    #else
+        if (blob_storage_client == NULL)
+        {
+            return;
+        }
     #endif
 
     AZSTORAGE_BLOB_STORAGE_CLIENT* cb = (AZSTORAGE_BLOB_STORAGE_CLIENT*)blob_storage_client;
@@ -207,6 +218,12 @@ AZSTORAGE_RESULT azstorage_blob_put(AZSTORAGE_BLOB_HANDLE blob_storage_client, A
             AZSTORAGE_ILLEGAL_ARGUMENT_ERROR,
             "If buffer is NULL, buffer_len shall be 0.\nIf buffer is NOT NULL, buffer_len shall be greater than 0.\n")
     );
+    #else
+        if (blob_storage_client == NULL || blob_path == NULL || blob_type > AZSTORAGE_BLOB_TYPE_APPEND_BLOB ||
+            ((buffer != NULL && buffer_len == 0) || (buffer_len > 0 && buffer == NULL )))
+        {
+            return AZSTORAGE_ILLEGAL_ARGUMENT_ERROR;
+        }
     #endif
 
     AZSTORAGE_RESULT result;
@@ -280,6 +297,11 @@ AZSTORAGE_RESULT azstorage_blob_append_block(AZSTORAGE_BLOB_HANDLE blob_storage_
         UCONTRACT_REQUIRE_NOT_NULL(buffer, AZSTORAGE_ILLEGAL_ARGUMENT_ERROR),
         UCONTRACT_REQUIRE_NOT_EQUALS(buffer_len, 0, AZSTORAGE_ILLEGAL_ARGUMENT_ERROR)
     );
+    #else
+        if (blob_storage_client == NULL || blob_path == NULL || buffer == NULL || buffer_len == 0)
+        {
+            return AZSTORAGE_ILLEGAL_ARGUMENT_ERROR;
+        }
     #endif
 
     AZSTORAGE_RESULT result;
@@ -347,6 +369,11 @@ AZSTORAGE_RESULT azstorage_blob_get_metadata(AZSTORAGE_BLOB_HANDLE blob_storage_
         /*[azstorage_blob_get_metadata_response_header_NULL_FAIL]*/
         UCONTRACT_REQUIRE_NOT_NULL(response_headers, AZSTORAGE_ILLEGAL_ARGUMENT_ERROR)
     );
+    #else
+        if (blob_storage_client == NULL || blob_path == NULL || response_headers == NULL)
+        {
+            return AZSTORAGE_ILLEGAL_ARGUMENT_ERROR;
+        }
     #endif
 
     AZSTORAGE_RESULT result;
@@ -394,6 +421,11 @@ AZSTORAGE_RESULT azstorage_blob_get_bytes(AZSTORAGE_BLOB_HANDLE blob_storage_cli
         /*[azstorage_blob_get_bytes_buffer_len_zero_FAIL]*/
         UCONTRACT_REQUIRE_NOT_EQUALS(buffer_len, 0, AZSTORAGE_ILLEGAL_ARGUMENT_ERROR)
     );
+    #else
+        if (blob_storage_client == NULL || blob_path == NULL || buffer == NULL || buffer_len == 0)
+        {
+            return AZSTORAGE_ILLEGAL_ARGUMENT_ERROR;
+        }
     #endif
 
     AZSTORAGE_RESULT result;

--- a/sdk/ustorageclient/tests/azstorage_blob_ut/CMakeLists.txt
+++ b/sdk/ustorageclient/tests/azstorage_blob_ut/CMakeLists.txt
@@ -25,10 +25,10 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/deps/umock-c/inc
     ${PROJECT_SOURCE_DIR}/deps/azure-macro-utils-c/inc
     ${PROJECT_SOURCE_DIR}/deps/azure-c-shared-utility/inc
-    ${PROJECT_SOURCE_DIR}/deps/azure-ulib-c/inc
-    ${PROJECT_SOURCE_DIR}/deps/azure-ulib-c/config
+    #${PROJECT_SOURCE_DIR}/deps/azure-ulib-c/inc
+    #${PROJECT_SOURCE_DIR}/deps/azure-ulib-c/config
     #ulib pal directory TODO: fix with environment variable from azure-ulib-c cmake
-    ${PROJECT_SOURCE_DIR}/deps/azure-ulib-c/pal/MSBUILD/X86
+    #${PROJECT_SOURCE_DIR}/deps/azure-ulib-c/pal/MSBUILD/X86
 )
 
 add_definitions(-DNO_LOGGING)


### PR DESCRIPTION
This is a private repo.  Once it's made public it can be added back.
Since it provides code contracts facilities the contracts had to be
implemented manually.  All tests pass.