### PR TITLE
Fix implicit fallthrough warning on GCC

### DIFF
--- a/sdk/core/core/CMakeLists.txt
+++ b/sdk/core/core/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library (az_core src/az_json_read.c src/az_http_request.c src/az_pair.c)
 if(MSVC)
   target_compile_options(az_core PRIVATE /W4 /WX)
 else()
-  target_compile_options(az_core PRIVATE -Wall -Wextra -pedantic -Werror -Wimplicit-fallthrough=2)
+  target_compile_options(az_core PRIVATE -Wall -Wextra -pedantic -Werror -Wno-error=unknown-warning -Wunknown-warning-option -Wimplicit-fallthrough=2)
 endif()
 
 target_include_directories (az_core PUBLIC inc)

--- a/sdk/core/core/CMakeLists.txt
+++ b/sdk/core/core/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library (az_core src/az_json_read.c src/az_http_request.c src/az_pair.c)
 if(MSVC)
   target_compile_options(az_core PRIVATE /W4 /WX)
 else()
-  target_compile_options(az_core PRIVATE -Wall -Wextra -pedantic -W)
+  target_compile_options(az_core PRIVATE -Wall -Wextra -pedantic -Werror -Wimplicit-fallthrough=2)
 endif()
 
 target_include_directories (az_core PUBLIC inc)

--- a/sdk/core/core/src/az_json_read.c
+++ b/sdk/core/core/src/az_json_read.c
@@ -206,6 +206,7 @@ static az_result az_json_read_number_digit_rest(
     switch (c) {
       case '-':
         e_sign = -1;
+        /*[[fallthrough]]*/
       case '+':
         az_span_reader_next(p_reader);
         c = az_span_reader_current(p_reader);


### PR DESCRIPTION
More info: https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/
The comment is inspired by C++17's [[fallthrough]] attribute (https://en.cppreference.com/w/cpp/language/attributes/fallthrough).