### PR TITLE
Update linux agent to 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ To get started with a specific library, see the **README.md** file located in th
 service libraries in the `/sdk` directory.
 
 ### Prerequisites
-- CMake version 3.12 is required to use these libraries.
+- CMake version 3.12 or higher is required to use these libraries.
 - Vcpkg is required to download project dependencies.
-- On Linux, development headers for OpenSSL 1.1.1 and UUID are required to build the project.
+- On Linux/macOS, development headers for OpenSSL 1.1 are required to build the project.
 
 ### Building the SDK
 Follow the instructions in the [contributing guide](CONTRIBUTING.md) to build the SDK. The same instructions apply

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -3,7 +3,7 @@ jobs:
   strategy:
     matrix:
       Linux:
-        vm.image: 'ubuntu-16.04'
+        vm.image: 'ubuntu-18.04'
         vcpkg.deps: 'curl[ssl]'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
       Win:


### PR DESCRIPTION
Verified that both the 16.04 and 18.04 agents use the same version of CMake (3.12).