### PR TITLE
change pointer alignment and braces

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,7 @@ TabWidth: 2
 IndentWidth: 2
 IncludeBlocks: Preserve
 NamespaceIndentation: None
-PointerAlignment: Middle
+PointerAlignment: Left
 AlignAfterOpenBracket: AlwaysBreak
 AlignEscapedNewlines: DontAlign
 AllowAllParametersOfDeclarationOnNextLine: false
@@ -15,6 +15,7 @@ BinPackParameters: false
 IndentCaseLabels: true
 BreakBeforeTernaryOperators: true
 BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Allman
 Cpp11BracedListStyle: false
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false


### PR DESCRIPTION
Seems like we are aligned on the pointer alignment. I also have added the break on brace option as was mentioned in the issued bug. The IoT client team prefers it and seems some others in that discussion do as well so if anyone else has any objections to that addition please feel free to voice concerns.