### PR TITLE
Rename `json_state` => `json_parser`.

### DIFF
--- a/sdk/core/core/CMakeLists.txt
+++ b/sdk/core/core/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library (
   src/az_http_request_builder.c
   src/az_http_response_action.c
   src/az_http_response_parser.c
-  src/az_json_read.c
+  src/az_json_parser.c
   src/az_mut_span.c
   src/az_pair.c
   src/az_span_builder.c

--- a/sdk/core/core/inc/az_json_parser.h
+++ b/sdk/core/core/inc/az_json_parser.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_JSON_READ_H
-#define AZ_JSON_READ_H
+#ifndef AZ_JSON_PARSER_H
+#define AZ_JSON_PARSER_H
 
 #include <az_result.h>
 #include <az_span_reader.h>
@@ -49,23 +49,23 @@ typedef enum {
 typedef struct {
   az_span_reader reader;
   az_json_stack stack;
-} az_json_state;
+} az_json_parser;
 
-AZ_NODISCARD az_json_state az_json_state_create(az_span const buffer);
+AZ_NODISCARD az_json_parser az_json_parser_create(az_span const buffer);
 
-AZ_NODISCARD az_result az_json_read(az_json_state * const p_state, az_json_value * const out_value);
+AZ_NODISCARD az_result az_json_parser_get(az_json_parser * const self, az_json_value * const out_value);
 
 AZ_NODISCARD az_result
-az_json_read_object_member(
-    az_json_state * const p_state,
+az_json_parser_get_object_member(
+    az_json_parser * const self,
     az_json_member * const out_member);
 
 AZ_NODISCARD az_result
-az_json_read_array_element(
-    az_json_state * const p_state,
+az_json_parser_get_array_element(
+    az_json_parser * const self,
     az_json_value * const out_value);
 
-AZ_NODISCARD az_result az_json_state_done(az_json_state const * const p_state);
+AZ_NODISCARD az_result az_json_parser_done(az_json_parser const * const self);
 
 AZ_NODISCARD az_result az_json_get_object_member_value(
     az_span const json,

--- a/sdk/core/core/inc/az_json_parser.h
+++ b/sdk/core/core/inc/az_json_parser.h
@@ -77,6 +77,7 @@ AZ_NODISCARD AZ_INLINE az_result az_json_get_object_member_string_value(
     az_span const name,
     az_span * const out_value) {
   AZ_CONTRACT_ARG_NOT_NULL(out_value);
+
   az_json_value value;
   AZ_RETURN_IF_FAILED(az_json_get_object_member_value(json, name, &value));
 
@@ -93,6 +94,7 @@ AZ_NODISCARD AZ_INLINE az_result az_json_get_object_member_numeric_value(
     az_span const name,
     double * const out_value) {
   AZ_CONTRACT_ARG_NOT_NULL(out_value);
+
   az_json_value value;
   AZ_RETURN_IF_FAILED(az_json_get_object_member_value(json, name, &value));
 

--- a/sdk/core/core/src/az_json_parser.c
+++ b/sdk/core/core/src/az_json_parser.c
@@ -83,27 +83,6 @@ static void az_span_reader_skip_json_white_space(az_span_reader * const self) {
   }
 }
 
-/*
-AZ_NODISCARD static az_result az_json_parser_read_keyword_rest(
-    az_span_reader * const self,
-    az_span const keyword) {
-  az_span_reader_next(self);
-  az_span_reader k = az_span_reader_create(keyword);
-  while (true) {
-    az_result_byte const ko = az_span_reader_current(&k);
-    if (ko == AZ_ERROR_EOF) {
-      return AZ_OK;
-    }
-    az_result_byte const o = az_span_reader_current(self);
-    if (o != ko) {
-      return az_error_unexpected_char(o);
-    }
-    az_span_reader_next(self);
-    az_span_reader_next(&k);
-  }
-}
-*/
-
 // 18 decimal digits. 10^18 - 1.
 //                        0         1
 //                        012345678901234567

--- a/sdk/core/core/test/curl_easy_perform_poc.c
+++ b/sdk/core/core/test/curl_easy_perform_poc.c
@@ -3,7 +3,7 @@
 
 #include <az_http_client.h>
 #include <az_http_request_builder.h>
-#include <az_json_read.h>
+#include <az_json_parser.h>
 #include <az_pair.h>
 #include <az_span.h>
 #include <az_span_builder.h>


### PR DESCRIPTION
- `*_json_state_*` => `*_json_parser_*`.
- `az_json_read_keyword_rest` has been removed.
- `self` parameter. 