### PR TITLE
Adding bulding options for selecting what to build

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
         {
             "label": "build",
             "type": "shell",
-            "command": "cd Debug && rm -rf * && cmake -Duse_default_uuid=ON -DCMAKE_BUILD_TYPE=Debug  .. && make"
+            "command": "cd Debug && rm -rf * && cmake -DBUILD_AZ_KEY_VAULT_CLIENT=ON -DCMAKE_BUILD_TYPE=Debug  .. && make"
         }
     ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,22 @@ endif()
 
 project(az LANGUAGES C)
 enable_testing ()
-add_subdirectory(sdk/core/core)
-add_subdirectory(sdk/keyvault/keyvault)
-# add_subdirectory(sdk/storage/ustorageclient)
+
+# make options for each subdirectoy so it can be selected what to build on CI Pipelines
+option(BUILD_AZ_CORE "Build lib and targets from Azure CORE" ON)
+option(BUILD_AZ_KEY_VAULT_CLIENT "Build lib and targets from Azure KeyVault client" OFF)
+option(BUILD_AZ_USTORAGE_CLIENT "Build targets from u-storage cliente" OFF)
+
+if (BUILD_AZ_CORE)
+  add_subdirectory(sdk/core/core)
+endif()
+if (BUILD_AZ_KEY_VAULT_CLIENT)
+  # adding core only for linking library. No tests or executables will be created
+  if (NOT BUILD_AZ_CORE)
+    add_subdirectory(sdk/core/core)
+  endif()
+  add_subdirectory(sdk/keyvault/keyvault)
+endif()
+if (BUILD_AZ_USTORAGE_CLIENT)
+  add_subdirectory(sdk/storage/ustorageclient)
+endif()

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -39,7 +39,7 @@ jobs:
     displayName: cmake version
   - task: CMake@1
     inputs:
-      cmakeArgs: -Duse_default_uuid=ON ..
+      cmakeArgs: -DBUILD_AZ_KEY_VAULT_CLIENT=ON
     displayName: cmake generate
   - task: CMake@1
     inputs:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -39,7 +39,7 @@ jobs:
     displayName: cmake version
   - task: CMake@1
     inputs:
-      cmakeArgs: -DBUILD_AZ_KEY_VAULT_CLIENT=ON
+      cmakeArgs: -DBUILD_AZ_KEY_VAULT_CLIENT=ON ..
     displayName: cmake generate
   - task: CMake@1
     inputs:

--- a/sdk/core/core/CMakeLists.txt
+++ b/sdk/core/core/CMakeLists.txt
@@ -51,26 +51,28 @@ target_include_directories (az_core PUBLIC inc)
 # make sure that users can consume the project as a library.
 add_library (az::core ALIAS az_core)
 
-add_executable (az_core_test test/main.c)
+# build test and executables only if requested
+if (BUILD_AZ_CORE)
+  add_executable (az_core_test test/main.c)
+  target_link_libraries(az_core_test PRIVATE az_core)
+  target_link_libraries(az_core PRIVATE CURL::libcurl)
 
-target_link_libraries(az_core_test PRIVATE az_core)
+  # curl easy perform POC
+  add_executable (curl_easy_perform_poc test/curl_easy_perform_poc.c)
+  target_link_libraries(curl_easy_perform_poc PRIVATE 
+    az_core 
+    CURL::libcurl)
 
-# curl easy perform POC
-add_executable (curl_easy_perform_poc test/curl_easy_perform_poc.c)
-target_link_libraries(curl_easy_perform_poc PRIVATE 
-  az_core 
-  CURL::libcurl)
+  if (UNIX)
+    target_link_libraries(az_core_test PRIVATE m)
+    target_link_libraries(curl_easy_perform_poc PRIVATE m)
+  endif()
 
-target_link_libraries(az_core PRIVATE CURL::libcurl)
+  add_test(NAME az_core_test COMMAND az_core_test)
+
+endif()
 
 if (MOCK_CURL)
   MESSAGE("Will mock all calls to http client with static responses")
   add_definitions(-DMOCK_CURL="MOCK")
 endif()
-
-if (UNIX)
-  target_link_libraries(az_core_test PRIVATE m)
-  target_link_libraries(curl_easy_perform_poc PRIVATE m)
-endif()
-
-add_test(NAME az_core_test COMMAND az_core_test)

--- a/sdk/keyvault/keyvault/inc/az_keyvault.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault.h
@@ -34,7 +34,7 @@ AZ_NODISCARD az_result az_keyvault_keys_client_init(
     az_keyvault_keys_client * client,
     az_span uri,
     /*Azure Credentials */
-    az_keyvault_keys_client_options * options);
+    az_keyvault_keys_client_options const * options);
 
 AZ_NODISCARD az_result az_keyvault_keys_createKey(
     az_keyvault_keys_client * client,

--- a/sdk/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/keyvault/keyvault/src/az_keyvault_client.c
@@ -11,7 +11,7 @@ AZ_NODISCARD az_result az_keyvault_keys_client_init(
     az_keyvault_keys_client * client,
     az_span uri,
     /*Azure Credentials */
-    az_keyvault_keys_client_options * options) {
+    az_keyvault_keys_client_options const * options) {
   (void)client;
   (void)uri;
   (void)options;


### PR DESCRIPTION
Proposing this simple way of splitting sub-directories (projects) on cmake project

- Default configuration (`cmake ..`) would build:
  - Core lib 
  - Core test and executable
This would be the option for a Core pipeline where we want CORE tests to be run

- KeyVault + Core (`cmake -DBUILD_AZ_CORE=OFF -DBUILD_AZ_KEY_VAULT_CLIENT=ON`) would build:
  - Core lib only
  - KeyVault lib and executable
This would be for the KeyVault client pipeline where we want keyVault tests to be run.

Both cases would depend on building CORE, but second one will not care about if there is an error on CORE test cases.


Adding also an option for ustorage and leaving if OFF..  Wondering if we would just prefer to delete that one for now?

 