### PR TITLE
use function to create policy instead of manual creation

### DIFF
--- a/sdk/core/core/inc/az_http_policy.h
+++ b/sdk/core/core/inc/az_http_policy.h
@@ -4,6 +4,7 @@
 #ifndef AZ_HTTP_POLICY_H
 #define AZ_HTTP_POLICY_H
 
+#include <az_client_secret_credential.h>
 #include <az_http_request_builder.h>
 #include <az_mut_span.h>
 #include <az_result.h>
@@ -57,6 +58,16 @@ AZ_NODISCARD az_result az_http_pipeline_policy_authentication(
     void * const data,
     az_http_request_builder * const hrb,
     az_mut_span const * const response);
+
+AZ_INLINE AZ_NODISCARD az_result
+az_http_pipeline_policy_authentication_with_secret_credential_build(
+    az_client_secret_credential * credential,
+    az_http_policy * out) {
+  AZ_CONTRACT_ARG_NOT_NULL(out);
+  *out = (az_http_policy){ .pfnc_process = az_http_pipeline_policy_authentication,
+                           .data = credential };
+  return AZ_OK;
+}
 
 AZ_NODISCARD az_result az_http_pipeline_policy_logging(
     az_http_policy * const policies,

--- a/sdk/core/core/test/curl_easy_perform_poc.c
+++ b/sdk/core/core/test/curl_easy_perform_poc.c
@@ -61,11 +61,18 @@ int main() {
     return creds_retcode;
   }
 
+  az_http_policy authentication_policy = { 0 };
+  // use safe policy creator for specific authentication type.
+  // next function will make sure that the right policy implementation is used for a secret
+  // credential
+  AZ_RETURN_IF_FAILED(az_http_pipeline_policy_authentication_with_secret_credential_build(
+      &credential, &authentication_policy));
+
   az_http_pipeline pipeline = (az_http_pipeline){
     .policies = {
       { .pfnc_process = az_http_pipeline_policy_uniquerequestid, .data = NULL },
       { .pfnc_process = az_http_pipeline_policy_retry, .data = NULL },
-      { .pfnc_process = az_http_pipeline_policy_authentication, .data = &credential },
+      authentication_policy,
       { .pfnc_process = az_http_pipeline_policy_logging,.data = NULL },
       { .pfnc_process = az_http_pipeline_policy_bufferresponse,.data = NULL },
       { .pfnc_process = az_http_pipeline_policy_distributedtracing,.data = NULL },

--- a/sdk/keyvault/keyvault/inc/az_keyvault.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault.h
@@ -51,11 +51,19 @@ AZ_NODISCARD AZ_INLINE az_result az_keyvault_keys_client_init(
 
   client->uri = uri;
   client->version = options->version;
+
+  az_http_policy authentication_policy = { 0 };
+  // use safe policy creator for specific authentication type.
+  // next function will make sure that the right policy implementation is used for a secret
+  // credential
+  AZ_RETURN_IF_FAILED(az_http_pipeline_policy_authentication_with_secret_credential_build(
+      credential, &authentication_policy));
+
   client->pipeline = (az_http_pipeline){
     .policies = {
       { .pfnc_process = az_http_pipeline_policy_uniquerequestid, .data = NULL },
       { .pfnc_process = az_http_pipeline_policy_retry, .data = NULL },
-      { .pfnc_process = az_http_pipeline_policy_authentication, .data = credential },
+      authentication_policy,
       { .pfnc_process = az_http_pipeline_policy_logging,.data = NULL },
       { .pfnc_process = az_http_pipeline_policy_bufferresponse,.data = NULL },
       { .pfnc_process = az_http_pipeline_policy_distributedtracing,.data = NULL },


### PR DESCRIPTION
@sergey-shandar , is this what you were referring to for having policy creators instead of manually mapping policy and data?

Code will look bigger since we have to validate that each policy is successfully created before adding it to pipeline.

Only authentication policy is presented here. But same idea would be added for each policy...

Asking for your comments @antkmsft @gilbertw 