### PR TITLE
copyng keyvault options inside client structure

### DIFF
--- a/sdk/core/core/inc/az_http_policy.h
+++ b/sdk/core/core/inc/az_http_policy.h
@@ -30,12 +30,12 @@ typedef struct az_http_policy az_http_policy;
 /**
  * @brief options for retry policy
  * max_retry = maximun number of retry intents before returning error
- * delay = waiting time before retrying in miliseconds
+ * delay_in_ms = waiting time before retrying in miliseconds
  *
  */
 typedef struct {
-  size_t max_retry;
-  size_t delay;
+  uint16_t max_retry;
+  uint16_t delay_in_ms;
 } az_keyvault_keys_client_options_retry;
 
 // PipelinePolicies must implement the process function

--- a/sdk/core/core/inc/az_http_policy.h
+++ b/sdk/core/core/inc/az_http_policy.h
@@ -27,6 +27,17 @@
 
 typedef struct az_http_policy az_http_policy;
 
+/**
+ * @brief options for retry policy
+ * max_retry = maximun number of retry intents before returning error
+ * delay = waiting time before retrying in miliseconds
+ *
+ */
+typedef struct {
+  size_t max_retry;
+  size_t delay;
+} az_keyvault_keys_client_options_retry;
+
 // PipelinePolicies must implement the process function
 //
 typedef AZ_NODISCARD az_result (*az_http_policy_pfnc_process)(

--- a/sdk/keyvault/keyvault/inc/az_keyvault.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault.h
@@ -26,7 +26,7 @@ typedef enum {
 } az_key_vault_key_type;
 
 typedef struct {
-  az_span version;
+  az_span service_version;
   az_keyvault_keys_client_options_retry retry;
 } az_keyvault_keys_client_options;
 

--- a/sdk/keyvault/keyvault/inc/az_keyvault.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault.h
@@ -26,7 +26,8 @@ typedef enum {
 } az_key_vault_key_type;
 
 typedef struct {
-  az_span const version;
+  az_span version;
+  az_keyvault_keys_client_options_retry retry;
 } az_keyvault_keys_client_options;
 
 typedef struct {
@@ -39,7 +40,7 @@ typedef struct {
 typedef struct {
   az_span uri;
   az_http_pipeline pipeline;
-  az_span version;
+  az_keyvault_keys_client_options options;
 } az_keyvault_keys_client;
 
 AZ_NODISCARD AZ_INLINE az_result az_keyvault_keys_client_init(
@@ -50,11 +51,12 @@ AZ_NODISCARD AZ_INLINE az_result az_keyvault_keys_client_init(
   AZ_CONTRACT_ARG_NOT_NULL(client);
 
   client->uri = uri;
-  client->version = options->version;
+  // Copy all client options so user can dispose options but client will keep it
+  client->options = *options;
   client->pipeline = (az_http_pipeline){
     .policies = {
       { .pfnc_process = az_http_pipeline_policy_uniquerequestid, .data = NULL },
-      { .pfnc_process = az_http_pipeline_policy_retry, .data = NULL },
+      { .pfnc_process = az_http_pipeline_policy_retry, .data = &client->options.retry },
       { .pfnc_process = az_http_pipeline_policy_authentication, .data = credential },
       { .pfnc_process = az_http_pipeline_policy_logging,.data = NULL },
       { .pfnc_process = az_http_pipeline_policy_bufferresponse,.data = NULL },

--- a/sdk/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/keyvault/keyvault/src/az_keyvault_client.c
@@ -107,8 +107,8 @@ AZ_NODISCARD az_result az_keyvault_keys_key_get(
       az_mut_span_to_span(url_buffer_span)));
 
   // add version to request
-  AZ_RETURN_IF_FAILED(
-      az_http_request_builder_set_query_parameter(&hrb, AZ_STR("api-version"), client->version));
+  AZ_RETURN_IF_FAILED(az_http_request_builder_set_query_parameter(
+      &hrb, AZ_STR("api-version"), client->options.version));
 
   // start pipeline
   return az_http_pipeline_process(&hrb, out, &client->pipeline);

--- a/sdk/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/keyvault/keyvault/src/az_keyvault_client.c
@@ -108,7 +108,7 @@ AZ_NODISCARD az_result az_keyvault_keys_key_get(
 
   // add version to request
   AZ_RETURN_IF_FAILED(az_http_request_builder_set_query_parameter(
-      &hrb, AZ_STR("api-version"), client->options.version));
+      &hrb, AZ_STR("api-version"), client->options.service_version));
 
   // start pipeline
   return az_http_pipeline_process(&hrb, out, &client->pipeline);

--- a/sdk/keyvault/keyvault/test/client_key_POC.c
+++ b/sdk/keyvault/keyvault/test/client_key_POC.c
@@ -28,7 +28,7 @@ int main() {
 
   // Create client options
   az_keyvault_keys_client_options client_options
-      = { .version = AZ_STR("7.0"), .retry = { .max_retry = 3, .delay = 10 } };
+      = { .service_version = AZ_STR("7.0"), .retry = { .max_retry = 3, .delay_in_ms = 10 } };
 
   // Init client
   // TODO: introduce init and init_with_options so client_options can be optional for user

--- a/sdk/keyvault/keyvault/test/client_key_POC.c
+++ b/sdk/keyvault/keyvault/test/client_key_POC.c
@@ -27,12 +27,13 @@ int main() {
       az_str_to_span(getenv(CLIENT_SECRET_ENV)));
 
   // Create client options
-  az_keyvault_keys_client_options options = { .version = AZ_STR("7.0") };
+  az_keyvault_keys_client_options client_options
+      = { .version = AZ_STR("7.0"), .retry = { .max_retry = 3, .delay = 10 } };
 
   // Init client
-  // TODO: introduce init and init_with_options so options can be optional for user
+  // TODO: introduce init and init_with_options so client_options can be optional for user
   az_result operation_result = az_keyvault_keys_client_init(
-      &client, az_str_to_span(getenv(URI_ENV)), &credential, &options);
+      &client, az_str_to_span(getenv(URI_ENV)), &credential, &client_options);
 
   // Use client to get a key
   uint8_t key[1024 * 2];


### PR DESCRIPTION
This is after @JeffreyRichter 's suggestion.  
Simple change to move version and any other client option inside client_options and copy entire structure so user can dispose settings structure after client is init.