### PR TITLE
adding az_keyvault_keys_client_options_init for getting default options

### DIFF
--- a/sdk/keyvault/keyvault/inc/az_keyvault.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault.h
@@ -43,6 +43,23 @@ typedef struct {
   az_keyvault_keys_client_options options;
 } az_keyvault_keys_client;
 
+extern az_keyvault_keys_client_options const AZ_KEYVAULT_CLIENT_DEFAULT_OPTIONS;
+
+/**
+ * @brief Init a client with default options
+ * This is convinient method to create a client with basic settings
+ * Options can be updated specifally after this for unique customization
+ *
+ * Use this, for instance, when only caring about setting one option by calling this method and then
+ * overriding that specific option
+ */
+AZ_NODISCARD AZ_INLINE az_result
+az_keyvault_keys_client_options_init(az_keyvault_keys_client_options * const options) {
+  AZ_CONTRACT_ARG_NOT_NULL(options);
+  *options = AZ_KEYVAULT_CLIENT_DEFAULT_OPTIONS;
+  return AZ_OK;
+}
+
 AZ_NODISCARD AZ_INLINE az_result az_keyvault_keys_client_init(
     az_keyvault_keys_client * const client,
     az_span const uri,

--- a/sdk/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/keyvault/keyvault/src/az_keyvault_client.c
@@ -21,6 +21,13 @@ static az_span const AZ_KEY_VAULT_KEY_TYPE_KEY_STR = AZ_CONST_STR("keys");
 static az_span const AZ_KEY_VAULT_KEY_TYPE_SECRET_STR = AZ_CONST_STR("secrets");
 static az_span const AZ_KEY_VAULT_KEY_TYPE_CERTIFICATE_STR = AZ_CONST_STR("certificates");
 
+az_keyvault_keys_client_options const AZ_KEYVAULT_CLIENT_DEFAULT_OPTIONS
+    = { .service_version = AZ_CONST_STR("7.0"),
+        .retry = {
+            .max_retry = 3,
+            .delay_in_ms = 30,
+        } };
+
 AZ_NODISCARD AZ_INLINE az_span az_keyvault_get_key_type_span(az_key_vault_key_type const key_type) {
   switch (key_type) {
     case AZ_KEY_VAULT_KEY_TYPE_KEY: {

--- a/sdk/keyvault/keyvault/test/client_key_POC.c
+++ b/sdk/keyvault/keyvault/test/client_key_POC.c
@@ -31,7 +31,6 @@ int main() {
       = { .service_version = AZ_STR("7.0"), .retry = { .max_retry = 3, .delay_in_ms = 10 } };
 
   // Init client
-  // TODO: introduce init and init_with_options so client_options can be optional for user
   az_result operation_result = az_keyvault_keys_client_init(
       &client, az_str_to_span(getenv(URI_ENV)), &credential, &client_options);
 
@@ -42,6 +41,33 @@ int main() {
       = az_keyvault_keys_key_get(&client, AZ_STR("test-key"), AZ_KEY_VAULT_KEY_TYPE_KEY, &key_span);
 
   printf("response: %s", key);
+
+  uint8_t same_key[1024 * 2];
+  const az_mut_span same_key_span = AZ_SPAN_FROM_ARRAY(same_key);
+  // init a new client with default options
+  az_keyvault_keys_client client_default_options;
+  az_keyvault_keys_client_options default_options;
+  operation_result = az_keyvault_keys_client_options_init(&default_options);
+
+  // override one specific value
+  default_options.retry.delay_in_ms = 1000;
+
+  // Creating credential again since we can't currently re-use same credential
+  // https://github.com/Azure/azure-sdk-for-c/issues/211
+  az_client_secret_credential credential2 = { 0 };
+  az_result const creds_retcode2 = az_client_secret_credential_init(
+      &credential2,
+      az_str_to_span(getenv(TENANT_ID_ENV)),
+      az_str_to_span(getenv(CLIENT_ID_ENV)),
+      az_str_to_span(getenv(CLIENT_SECRET_ENV)));
+
+  operation_result = az_keyvault_keys_client_init(
+      &client_default_options, az_str_to_span(getenv(URI_ENV)), &credential2, &default_options);
+
+  get_key_result = az_keyvault_keys_key_get(
+      &client_default_options, AZ_STR("test-key"), AZ_KEY_VAULT_KEY_TYPE_KEY, &same_key_span);
+
+  printf("\n\n same response: %s", same_key);
 
   return exit_code;
 }


### PR DESCRIPTION
as it was mentioned on stand up meeting.
This approach adds an init function for client options witch copies values from a static definition of client options.
Then user can change any specific value

adding example of usage on the keyvault POC