### PR TITLE
add win32 to the build/test matrix

### DIFF
--- a/eng/pipelines/client.yml
+++ b/eng/pipelines/client.yml
@@ -21,5 +21,8 @@ pr:
       - sdk/
       - eng/
 
+variables:
+  skipComponentGovernanceDetection: true
+
 jobs:
   - template: ./templates/jobs/archetype-sdk-client.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -2,15 +2,23 @@ jobs:
 - job: BuildTest
   strategy:
     matrix:
-      Linux:
+      Linux_x64:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: 'curl[ssl]'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      Win:
+      Win_x86:
+        vm.image: 'windows-2019'
+        vcpkg.deps: 'curl[winssl]'
+        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: Win32
+      Win_x64:
         vm.image: 'windows-2019'
         vcpkg.deps: 'curl[winssl]'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-      MacOS:
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: x64
+      MacOS_x64:
         vm.image: 'macOS-10.14'
         vcpkg.deps: 'curl[ssl]'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'


### PR DESCRIPTION
This brings the test matrix to

- Linux 64 bit, gcc (Ubuntu 18.04)
- Win 32 bit, msvc (Windows 2019)
- Win 64 bit, msvc (Windows 2019)
- MacOS 64 bit, clang (MacOS 10.14)