### PR TITLE
update key_vault names to keyvault

### DIFF
--- a/sdk/keyvault/keyvault/inc/az_keyvault.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault.h
@@ -9,7 +9,7 @@
 
 #include <stdlib.h>
 
-#define AZ_KEY_VAULT_KEY_TYPE_NONE_STR ""
+#define AZ_KEYVAULT_KEY_TYPE_NONE_STR ""
 
 #include <_az_cfg_prefix.h>
 
@@ -19,19 +19,19 @@
  * one of this enum values.
  */
 typedef enum {
-  AZ_KEY_VAULT_KEY_TYPE_NONE = 0,
-  AZ_KEY_VAULT_KEY_TYPE_KEY = 1,
-  AZ_KEY_VAULT_KEY_TYPE_SECRET = 2,
-  AZ_KEY_VAULT_KEY_TYPE_CERTIFICATE = 3,
-} az_key_vault_key_type;
+  AZ_KEYVAULT_KEY_TYPE_NONE = 0,
+  AZ_KEYVAULT_KEY_TYPE_KEY = 1,
+  AZ_KEYVAULT_KEY_TYPE_SECRET = 2,
+  AZ_KEYVAULT_KEY_TYPE_CERTIFICATE = 3,
+} az_keyvault_key_type;
 
 typedef enum {
-  AZ_KEY_VAULT_JSON_WEB_KEY_TYPE_NONE = 0,
-  AZ_KEY_VAULT_JSON_WEB_KEY_TYPE_EC = 1,
-  AZ_KEY_VAULT_JSON_WEB_KEY_TYPE_EC_HSM = 2,
-  AZ_KEY_VAULT_JSON_WEB_KEY_TYPE_RSA = 3,
-  AZ_KEY_VAULT_JSON_WEB_KEY_TYPE_RSA_HSM = 4,
-  AZ_KEY_VAULT_JSON_WEB_KEY_TYPE_OCT = 5,
+  AZ_KEYVAULT_JSON_WEB_KEY_TYPE_NONE = 0,
+  AZ_KEYVAULT_JSON_WEB_KEY_TYPE_EC = 1,
+  AZ_KEYVAULT_JSON_WEB_KEY_TYPE_EC_HSM = 2,
+  AZ_KEYVAULT_JSON_WEB_KEY_TYPE_RSA = 3,
+  AZ_KEYVAULT_JSON_WEB_KEY_TYPE_RSA_HSM = 4,
+  AZ_KEYVAULT_JSON_WEB_KEY_TYPE_OCT = 5,
 } az_keyvault_json_web_key_type;
 
 typedef struct {
@@ -109,7 +109,7 @@ AZ_NODISCARD az_result az_keyvault_keys_key_create(
 AZ_NODISCARD az_result az_keyvault_keys_key_get(
     az_keyvault_keys_client * client,
     az_span const key_name,
-    az_key_vault_key_type const key_type,
+    az_keyvault_key_type const key_type,
     az_http_response const * const response);
 
 #include <_az_cfg_suffix.h>

--- a/sdk/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/keyvault/keyvault/src/az_keyvault_client.c
@@ -19,18 +19,18 @@
 enum { MAX_URL_SIZE = 200 };
 enum { MAX_BODY_SIZE = 1024 };
 
-static az_span const AZ_KEY_VAULT_KEY_TYPE_KEY_STR = AZ_CONST_STR("keys");
-static az_span const AZ_KEY_VAULT_KEY_TYPE_SECRET_STR = AZ_CONST_STR("secrets");
-static az_span const AZ_KEY_VAULT_KEY_TYPE_CERTIFICATE_STR = AZ_CONST_STR("certificates");
+static az_span const AZ_KEYVAULT_KEY_TYPE_KEY_STR = AZ_CONST_STR("keys");
+static az_span const AZ_KEYVAULT_KEY_TYPE_SECRET_STR = AZ_CONST_STR("secrets");
+static az_span const AZ_KEYVAULT_KEY_TYPE_CERTIFICATE_STR = AZ_CONST_STR("certificates");
 
-static az_span const AZ_KEY_VAULT_WEB_KEY_TYPE_EC_STR = AZ_CONST_STR("EC");
-static az_span const AZ_KEY_VAULT_WEB_KEY_TYPE_EC_HSM_STR = AZ_CONST_STR("EC-HSM");
-static az_span const AZ_KEY_VAULT_WEB_KEY_TYPE_RSA_STR = AZ_CONST_STR("RSA");
-static az_span const AZ_KEY_VAULT_WEB_KEY_TYPE_RSA_HSM_STR = AZ_CONST_STR("RSA-HSM");
-static az_span const AZ_KEY_VAULT_WEB_KEY_TYPE_OCT_STR = AZ_CONST_STR("oct");
+static az_span const AZ_KEYVAULT_WEB_KEY_TYPE_EC_STR = AZ_CONST_STR("EC");
+static az_span const AZ_KEYVAULT_WEB_KEY_TYPE_EC_HSM_STR = AZ_CONST_STR("EC-HSM");
+static az_span const AZ_KEYVAULT_WEB_KEY_TYPE_RSA_STR = AZ_CONST_STR("RSA");
+static az_span const AZ_KEYVAULT_WEB_KEY_TYPE_RSA_HSM_STR = AZ_CONST_STR("RSA-HSM");
+static az_span const AZ_KEYVAULT_WEB_KEY_TYPE_OCT_STR = AZ_CONST_STR("oct");
 
-static az_span const AZ_KEY_VAULT_CREATE_KEY_URL_KEYS = AZ_CONST_STR("keys");
-static az_span const AZ_KEY_VAULT_CREATE_KEY_URL_CREATE = AZ_CONST_STR("create");
+static az_span const AZ_KEYVAULT_CREATE_KEY_URL_KEYS = AZ_CONST_STR("keys");
+static az_span const AZ_KEYVAULT_CREATE_KEY_URL_CREATE = AZ_CONST_STR("create");
 
 static az_span const AZ_HTTP_REQUEST_BUILDER_HEADER_CONTENT_TYPE_LABEL
     = AZ_CONST_STR("Content-Type");
@@ -44,43 +44,43 @@ az_keyvault_keys_client_options const AZ_KEYVAULT_CLIENT_DEFAULT_OPTIONS
             .delay_in_ms = 30,
         } };
 
-AZ_NODISCARD AZ_INLINE az_span az_keyvault_get_key_type_span(az_key_vault_key_type const key_type) {
+AZ_NODISCARD AZ_INLINE az_span az_keyvault_get_key_type_span(az_keyvault_key_type const key_type) {
   switch (key_type) {
-    case AZ_KEY_VAULT_KEY_TYPE_KEY: {
-      return AZ_KEY_VAULT_KEY_TYPE_KEY_STR;
+    case AZ_KEYVAULT_KEY_TYPE_KEY: {
+      return AZ_KEYVAULT_KEY_TYPE_KEY_STR;
     }
 
-    case AZ_KEY_VAULT_KEY_TYPE_SECRET: {
-      return AZ_KEY_VAULT_KEY_TYPE_SECRET_STR;
+    case AZ_KEYVAULT_KEY_TYPE_SECRET: {
+      return AZ_KEYVAULT_KEY_TYPE_SECRET_STR;
     }
 
-    case AZ_KEY_VAULT_KEY_TYPE_CERTIFICATE: {
-      return AZ_KEY_VAULT_KEY_TYPE_CERTIFICATE_STR;
+    case AZ_KEYVAULT_KEY_TYPE_CERTIFICATE: {
+      return AZ_KEYVAULT_KEY_TYPE_CERTIFICATE_STR;
     }
 
-    default: { return az_str_to_span(AZ_KEY_VAULT_KEY_TYPE_NONE_STR); }
+    default: { return az_str_to_span(AZ_KEYVAULT_KEY_TYPE_NONE_STR); }
   }
 }
 
 AZ_NODISCARD AZ_INLINE az_span
 az_keyvault_get_json_web_key_type_span(az_keyvault_json_web_key_type const key_type) {
   switch (key_type) {
-    case AZ_KEY_VAULT_JSON_WEB_KEY_TYPE_EC: {
-      return AZ_KEY_VAULT_WEB_KEY_TYPE_EC_STR;
+    case AZ_KEYVAULT_JSON_WEB_KEY_TYPE_EC: {
+      return AZ_KEYVAULT_WEB_KEY_TYPE_EC_STR;
     }
-    case AZ_KEY_VAULT_JSON_WEB_KEY_TYPE_EC_HSM: {
-      return AZ_KEY_VAULT_WEB_KEY_TYPE_EC_HSM_STR;
+    case AZ_KEYVAULT_JSON_WEB_KEY_TYPE_EC_HSM: {
+      return AZ_KEYVAULT_WEB_KEY_TYPE_EC_HSM_STR;
     }
-    case AZ_KEY_VAULT_JSON_WEB_KEY_TYPE_RSA: {
-      return AZ_KEY_VAULT_WEB_KEY_TYPE_RSA_STR;
+    case AZ_KEYVAULT_JSON_WEB_KEY_TYPE_RSA: {
+      return AZ_KEYVAULT_WEB_KEY_TYPE_RSA_STR;
     }
-    case AZ_KEY_VAULT_JSON_WEB_KEY_TYPE_RSA_HSM: {
-      return AZ_KEY_VAULT_WEB_KEY_TYPE_RSA_HSM_STR;
+    case AZ_KEYVAULT_JSON_WEB_KEY_TYPE_RSA_HSM: {
+      return AZ_KEYVAULT_WEB_KEY_TYPE_RSA_HSM_STR;
     }
-    case AZ_KEY_VAULT_JSON_WEB_KEY_TYPE_OCT: {
-      return AZ_KEY_VAULT_WEB_KEY_TYPE_OCT_STR;
+    case AZ_KEYVAULT_JSON_WEB_KEY_TYPE_OCT: {
+      return AZ_KEYVAULT_WEB_KEY_TYPE_OCT_STR;
     }
-    default: { return az_str_to_span(AZ_KEY_VAULT_KEY_TYPE_NONE_STR); }
+    default: { return az_str_to_span(AZ_KEYVAULT_KEY_TYPE_NONE_STR); }
   }
 }
 
@@ -90,11 +90,11 @@ AZ_INLINE AZ_NODISCARD az_result az_keyvault_build_url_for_create_key(
     az_span_builder * const s_builder) {
   AZ_RETURN_IF_FAILED(az_span_builder_append(s_builder, uri));
   AZ_RETURN_IF_FAILED(az_span_builder_append_byte(s_builder, '/'));
-  AZ_RETURN_IF_FAILED(az_span_builder_append(s_builder, AZ_KEY_VAULT_CREATE_KEY_URL_KEYS));
+  AZ_RETURN_IF_FAILED(az_span_builder_append(s_builder, AZ_KEYVAULT_CREATE_KEY_URL_KEYS));
   AZ_RETURN_IF_FAILED(az_span_builder_append_byte(s_builder, '/'));
   AZ_RETURN_IF_FAILED(az_span_builder_append(s_builder, key_name));
   AZ_RETURN_IF_FAILED(az_span_builder_append_byte(s_builder, '/'));
-  AZ_RETURN_IF_FAILED(az_span_builder_append(s_builder, AZ_KEY_VAULT_CREATE_KEY_URL_CREATE));
+  AZ_RETURN_IF_FAILED(az_span_builder_append(s_builder, AZ_KEYVAULT_CREATE_KEY_URL_CREATE));
 
   return AZ_OK;
 }
@@ -207,7 +207,7 @@ AZ_INLINE AZ_NODISCARD az_result az_keyvault_build_url_for_get_key(
 AZ_NODISCARD az_result az_keyvault_keys_key_get(
     az_keyvault_keys_client * client,
     az_span const key_name,
-    az_key_vault_key_type const key_type,
+    az_keyvault_key_type const key_type,
     az_http_response const * const response) {
   // create request buffer TODO: define size for a getKey Request
   uint8_t request_buffer[1024 * 4];

--- a/sdk/keyvault/keyvault/test/client_key_POC.c
+++ b/sdk/keyvault/keyvault/test/client_key_POC.c
@@ -41,7 +41,7 @@ int main() {
       = az_http_response_init(&create_response, (az_mut_span)AZ_SPAN_FROM_ARRAY(key));
 
   az_result create_result = az_keyvault_keys_key_create(
-      &client, AZ_STR("test-new-key"), AZ_KEY_VAULT_JSON_WEB_KEY_TYPE_RSA, NULL, &create_response);
+      &client, AZ_STR("test-new-key"), AZ_KEYVAULT_JSON_WEB_KEY_TYPE_RSA, NULL, &create_response);
 
   printf("Key created:\n %s", key);
 
@@ -68,7 +68,7 @@ int main() {
       = az_http_response_init(&get_create_response, (az_mut_span)AZ_SPAN_FROM_ARRAY(get_key));
 
   az_result get_key_result = az_keyvault_keys_key_get(
-      &get_client, AZ_STR("test-new-key"), AZ_KEY_VAULT_KEY_TYPE_KEY, &get_create_response);
+      &get_client, AZ_STR("test-new-key"), AZ_KEYVAULT_KEY_TYPE_KEY, &get_create_response);
 
   printf("\n\nGet Key Now:\n %s", get_key);
 


### PR DESCRIPTION
Following guidelines, we must use service's full name with no underscores