### PR TITLE
update http response with the right size of the response from adapter

### DIFF
--- a/sdk/core/core/inc/az_curl_adapter.h
+++ b/sdk/core/core/inc/az_curl_adapter.h
@@ -42,7 +42,7 @@ AZ_NODISCARD AZ_INLINE az_result az_curl_done(CURL ** const pp) {
 
 AZ_NODISCARD az_result az_http_client_send_request_impl(
     az_http_request_builder * const p_hrb,
-    az_http_response const * const response,
+    az_http_response * const response,
     bool const buildRFC7230);
 
 #include <_az_cfg_suffix.h>

--- a/sdk/core/core/inc/az_http_client.h
+++ b/sdk/core/core/inc/az_http_client.h
@@ -23,7 +23,7 @@
  */
 AZ_NODISCARD AZ_INLINE az_result az_http_client_send_request(
     az_http_request_builder * const p_hrb,
-    az_http_response const * const response) {
+    az_http_response * const response) {
   return az_http_client_send_request_impl(p_hrb, response, true);
 }
 
@@ -37,7 +37,7 @@ AZ_NODISCARD AZ_INLINE az_result az_http_client_send_request(
  */
 AZ_NODISCARD AZ_INLINE az_result az_http_client_send_request_and_get_body(
     az_http_request_builder * const p_hrb,
-    az_http_response const * const response) {
+    az_http_response * const response) {
   return az_http_client_send_request_impl(p_hrb, response, false);
 }
 

--- a/sdk/core/core/inc/az_http_pipeline.h
+++ b/sdk/core/core/inc/az_http_pipeline.h
@@ -19,7 +19,7 @@ typedef struct {
 AZ_NODISCARD az_result az_http_pipeline_process(
     az_http_pipeline * pipeline,
     az_http_request_builder * const hrb,
-    az_http_response const * const response);
+    az_http_response * const response);
 
 #include <_az_cfg_suffix.h>
 #endif

--- a/sdk/core/core/inc/az_http_policy.h
+++ b/sdk/core/core/inc/az_http_policy.h
@@ -45,7 +45,7 @@ typedef AZ_NODISCARD az_result (*az_http_policy_pfnc_process)(
     az_http_policy * policies,
     void * const data,
     az_http_request_builder * hrb,
-    az_http_response const * const response);
+    az_http_response * const response);
 
 struct az_http_policy {
   az_http_policy_pfnc_process pfnc_process;
@@ -56,43 +56,43 @@ AZ_NODISCARD az_result az_http_pipeline_policy_uniquerequestid(
     az_http_policy * const policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response);
+    az_http_response * const response);
 
 AZ_NODISCARD az_result az_http_pipeline_policy_retry(
     az_http_policy * const policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response);
+    az_http_response * const response);
 
 AZ_NODISCARD az_result az_http_pipeline_policy_authentication(
     az_http_policy * const policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response);
+    az_http_response * const response);
 
 AZ_NODISCARD az_result az_http_pipeline_policy_logging(
     az_http_policy * const policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response);
+    az_http_response * const response);
 
 AZ_NODISCARD az_result az_http_pipeline_policy_bufferresponse(
     az_http_policy * const policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response);
+    az_http_response * const response);
 
 AZ_NODISCARD az_result az_http_pipeline_policy_distributedtracing(
     az_http_policy * const policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response);
+    az_http_response * const response);
 
 AZ_NODISCARD az_result az_http_pipeline_policy_transport(
     az_http_policy * const policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response);
+    az_http_response * const response);
 
 #include <_az_cfg_suffix.h>
 

--- a/sdk/core/core/inc/az_http_response.h
+++ b/sdk/core/core/inc/az_http_response.h
@@ -4,17 +4,26 @@
 #ifndef AZ_HTTP_RESPONSE_H
 #define AZ_HTTP_RESPONSE_H
 
-#include <az_mut_span.h>
+#include <az_span_builder.h>
 
 #include <_az_cfg_prefix.h>
 
 typedef struct {
-  az_mut_span value;
+  az_span_builder builder;
 } az_http_response;
 
 AZ_NODISCARD AZ_INLINE az_result
-az_http_response_init(az_http_response * const self, az_mut_span const value) {
-  self->value = value;
+az_http_response_init(az_http_response * const self, az_span_builder const builder) {
+  self->builder = builder;
+  return AZ_OK;
+}
+
+/**
+ * @brief Sets size of builder to zero so builder's buffer can be written from start
+ *
+ */
+AZ_NODISCARD AZ_INLINE az_result az_http_response_reset(az_http_response * const self) {
+  self->builder.size = 0;
   return AZ_OK;
 }
 

--- a/sdk/core/core/src/az_client_secret_credential.c
+++ b/sdk/core/core/src/az_client_secret_credential.c
@@ -28,7 +28,7 @@ static AZ_NODISCARD az_result no_op_policy(
     az_http_policy * const p_policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response) {
+    az_http_response * const response) {
   (void)data;
   return p_policies[0].pfnc_process(&(p_policies[1]), p_policies[0].data, hrb, response);
 }

--- a/sdk/core/core/src/az_client_secret_credential.c
+++ b/sdk/core/core/src/az_client_secret_credential.c
@@ -38,7 +38,7 @@ AZ_INLINE AZ_NODISCARD az_result az_token_credential_send_get_token_request(
     az_span const resource_url,
     az_mut_span const auth_url_buf,
     az_mut_span const auth_body_buf,
-    az_mut_span const response_buf) {
+    az_http_response * response) {
   az_span auth_url = { 0 };
   {
     az_span_builder builder = az_span_builder_create(auth_url_buf);
@@ -70,7 +70,12 @@ AZ_INLINE AZ_NODISCARD az_result az_token_credential_send_get_token_request(
 
   az_http_request_builder hrb = { 0 };
   AZ_RETURN_IF_FAILED(az_http_request_builder_init(
-      &hrb, response_buf, (uint16_t)auth_url.size, AZ_HTTP_METHOD_VERB_POST, auth_url, auth_body));
+      &hrb,
+      response->builder.buffer, // NOTE: using response buffer as request buffer... is this ok?
+      (uint16_t)auth_url.size,
+      AZ_HTTP_METHOD_VERB_POST,
+      auth_url,
+      auth_body));
 
   static az_http_pipeline pipeline = {
       .policies = {
@@ -85,8 +90,7 @@ AZ_INLINE AZ_NODISCARD az_result az_token_credential_send_get_token_request(
       },
     };
 
-  az_http_response response = { .value = response_buf };
-  AZ_RETURN_IF_FAILED(az_http_pipeline_process(&pipeline, &hrb, &response));
+  AZ_RETURN_IF_FAILED(az_http_pipeline_process(&pipeline, &hrb, response));
 
   return AZ_OK;
 }
@@ -128,7 +132,7 @@ az_token_credential_get_resource_url(az_span const request_url, az_span_builder 
 AZ_INLINE AZ_NODISCARD az_result az_token_credential_update(
     az_client_secret_credential * const credential,
     az_span const request_url,
-    az_mut_span const response_buf) {
+    az_http_response * const response) {
   {
     uint8_t auth_resource_url_buf[AZ_TOKEN_CREDENTIAL_AUTH_RESOURCE_URL_BUF_SIZE] = { 0 };
     az_mut_span const auth_resource_url = AZ_SPAN_FROM_ARRAY(auth_resource_url_buf);
@@ -153,7 +157,7 @@ AZ_INLINE AZ_NODISCARD az_result az_token_credential_update(
     az_mut_span const auth_body = AZ_SPAN_FROM_ARRAY(auth_body_buf);
 
     az_result const token_request_result = az_token_credential_send_get_token_request(
-        credential, resource_url, auth_url, auth_body, response_buf);
+        credential, resource_url, auth_url, auth_body, response);
 
     az_mut_span_memset(auth_body, '#');
     az_mut_span_memset(auth_url, '#');
@@ -163,7 +167,8 @@ AZ_INLINE AZ_NODISCARD az_result az_token_credential_update(
   az_span body = { 0 };
   {
     az_http_response_parser parser = { 0 };
-    AZ_RETURN_IF_FAILED(az_http_response_parser_init(&parser, az_mut_span_to_span(response_buf)));
+    AZ_RETURN_IF_FAILED(
+        az_http_response_parser_init(&parser, az_span_builder_result(&response->builder)));
 
     az_http_response_status_line status_line = { 0 };
     AZ_RETURN_IF_FAILED(az_http_response_parser_read_status_line(&parser, &status_line));
@@ -206,9 +211,11 @@ AZ_INLINE AZ_NODISCARD az_result az_token_credential_get_token(
     az_span const request_url) {
   uint8_t response_buf[AZ_TOKEN_CREDENTIAL_RESPONSE_BUF_SIZE] = { 0 };
   az_mut_span const response = AZ_SPAN_FROM_ARRAY(response_buf);
+  az_http_response http_response;
+  AZ_RETURN_IF_FAILED(az_http_response_init(&http_response, az_span_builder_create(response)));
 
   az_result const credential_update_result
-      = az_token_credential_update(credential, request_url, response);
+      = az_token_credential_update(credential, request_url, &http_response);
 
   az_mut_span_memset(response, '#');
   return credential_update_result;

--- a/sdk/core/core/src/az_curl_adapter.c
+++ b/sdk/core/core/src/az_curl_adapter.c
@@ -261,6 +261,42 @@ AZ_NODISCARD az_result setup_response_redirect(
 }
 
 /**
+ * @brief use this method to group all the actions that we do with CURL so we can clean it after it
+ * no matter is there is an error at any step.
+ *
+ * @param p_curl
+ * @param p_hrb
+ * @param response
+ * @param buildRFC7230
+ * @return
+ */
+AZ_NODISCARD az_result az_http_client_send_request_impl_process(
+    CURL * p_curl,
+    az_http_request_builder * const p_hrb,
+    az_http_response * const response,
+    bool const buildRFC7230) {
+  az_result result = AZ_ERROR_ARG;
+
+  AZ_RETURN_IF_CURL_FAILED(setup_headers(p_curl, p_hrb));
+
+  AZ_RETURN_IF_CURL_FAILED(setup_url(p_curl, p_hrb));
+
+  AZ_RETURN_IF_CURL_FAILED(setup_response_redirect(p_curl, &response->builder, buildRFC7230));
+
+  if (az_span_eq(p_hrb->method_verb, AZ_HTTP_METHOD_VERB_GET)) {
+    result = az_curl_send_get_request(p_curl);
+  } else if (az_span_eq(p_hrb->method_verb, AZ_HTTP_METHOD_VERB_POST)) {
+    result = az_curl_send_post_request(p_curl, p_hrb);
+  }
+
+  // make sure to set the end of the body response as the end of the complete response
+  if (az_succeeded(result)) {
+    AZ_RETURN_IF_FAILED(az_span_builder_append(&response->builder, AZ_STR_ZERO));
+  }
+  return AZ_OK;
+}
+
+/**
  * @brief uses AZ_HTTP_BUILDER to set up CURL request and perform it.
  *
  * @param p_hrb
@@ -275,31 +311,16 @@ AZ_NODISCARD az_result az_http_client_send_request_impl(
   AZ_CONTRACT_ARG_NOT_NULL(response);
 
   CURL * p_curl = NULL;
-  az_result result = AZ_ERROR_ARG;
-  az_span_builder response_builder = az_span_builder_create(response->value);
 
+  // init curl
   AZ_RETURN_IF_FAILED(az_curl_init(&p_curl));
 
-  AZ_RETURN_IF_CURL_FAILED(setup_headers(p_curl, p_hrb));
+  // process request
+  az_result process_result
+      = az_http_client_send_request_impl_process(p_curl, p_hrb, response, buildRFC7230);
 
-  AZ_RETURN_IF_CURL_FAILED(setup_url(p_curl, p_hrb));
-
-  AZ_RETURN_IF_CURL_FAILED(setup_response_redirect(p_curl, &response_builder, buildRFC7230));
-
-  if (az_span_eq(p_hrb->method_verb, AZ_HTTP_METHOD_VERB_GET)) {
-    result = az_curl_send_get_request(p_curl);
-  } else if (az_span_eq(p_hrb->method_verb, AZ_HTTP_METHOD_VERB_POST)) {
-    result = az_curl_send_post_request(p_curl, p_hrb);
-  }
-
-  // make sure to set the end of the body response as the end of the complete response
-  if (az_succeeded(result)) {
-    AZ_RETURN_IF_FAILED(az_span_builder_append(&response_builder, AZ_STR_ZERO));
-  }
-  // update http_response value with the actual response size to avoid garbage
-  // https://github.com/Azure/azure-sdk-for-c/issues/219
-  response->value = az_span_builder_mut_result(&response_builder);
-
+  // no matter if error or not, call curl done before returning to let curl clean everything
   AZ_RETURN_IF_FAILED(az_curl_done(&p_curl));
-  return result;
+
+  return process_result;
 }

--- a/sdk/core/core/src/az_curl_adapter.c
+++ b/sdk/core/core/src/az_curl_adapter.c
@@ -269,7 +269,7 @@ AZ_NODISCARD az_result setup_response_redirect(
  */
 AZ_NODISCARD az_result az_http_client_send_request_impl(
     az_http_request_builder * const p_hrb,
-    az_http_response const * const response,
+    az_http_response * const response,
     bool const buildRFC7230) {
   AZ_CONTRACT_ARG_NOT_NULL(p_hrb);
   AZ_CONTRACT_ARG_NOT_NULL(response);
@@ -296,6 +296,9 @@ AZ_NODISCARD az_result az_http_client_send_request_impl(
   if (az_succeeded(result)) {
     AZ_RETURN_IF_FAILED(az_span_builder_append(&response_builder, AZ_STR_ZERO));
   }
+  // update http_response value with the actual response size to avoid garbage
+  // https://github.com/Azure/azure-sdk-for-c/issues/219
+  response->value = az_span_builder_mut_result(&response_builder);
 
   AZ_RETURN_IF_FAILED(az_curl_done(&p_curl));
   return result;

--- a/sdk/core/core/src/az_http_pipeline.c
+++ b/sdk/core/core/src/az_http_pipeline.c
@@ -9,7 +9,7 @@
 AZ_NODISCARD az_result az_http_pipeline_process(
     az_http_pipeline * pipeline,
     az_http_request_builder * const hrb,
-    az_http_response const * const response) {
+    az_http_response * const response) {
   AZ_CONTRACT_ARG_NOT_NULL(hrb);
   AZ_CONTRACT_ARG_NOT_NULL(response);
   AZ_CONTRACT_ARG_NOT_NULL(pipeline);

--- a/sdk/core/core/src/az_http_policy.c
+++ b/sdk/core/core/src/az_http_policy.c
@@ -17,7 +17,7 @@
 AZ_NODISCARD AZ_INLINE az_result az_http_pipeline_nextpolicy(
     az_http_policy * const p_policies,
     az_http_request_builder * const hrb,
-    az_http_response const * const response) {
+    az_http_response * const response) {
 
   AZ_CONTRACT_ARG_NOT_NULL(p_policies);
   AZ_CONTRACT_ARG_NOT_NULL(hrb);
@@ -38,7 +38,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_uniquerequestid(
     az_http_policy * const p_policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response) {
+    az_http_response * const response) {
   (void)data;
   AZ_CONTRACT_ARG_NOT_NULL(p_policies);
   AZ_CONTRACT_ARG_NOT_NULL(hrb);
@@ -58,7 +58,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_retry(
     az_http_policy * const p_policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response) {
+    az_http_response * const response) {
   (void)data;
   AZ_CONTRACT_ARG_NOT_NULL(p_policies);
   AZ_CONTRACT_ARG_NOT_NULL(hrb);
@@ -71,7 +71,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_authentication(
     az_http_policy * const p_policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response) {
+    az_http_response * const response) {
   AZ_CONTRACT_ARG_NOT_NULL(p_policies);
   AZ_CONTRACT_ARG_NOT_NULL(hrb);
   AZ_CONTRACT_ARG_NOT_NULL(response);
@@ -87,7 +87,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_logging(
     az_http_policy * const p_policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response) {
+    az_http_response * const response) {
   (void)data;
   AZ_CONTRACT_ARG_NOT_NULL(p_policies);
   AZ_CONTRACT_ARG_NOT_NULL(hrb);
@@ -100,7 +100,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_bufferresponse(
     az_http_policy * const p_policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response) {
+    az_http_response * const response) {
   (void)data;
   AZ_CONTRACT_ARG_NOT_NULL(p_policies);
   AZ_CONTRACT_ARG_NOT_NULL(hrb);
@@ -114,7 +114,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_distributedtracing(
     az_http_policy * const p_policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response) {
+    az_http_response * const response) {
   (void)data;
   AZ_CONTRACT_ARG_NOT_NULL(p_policies);
   AZ_CONTRACT_ARG_NOT_NULL(hrb);
@@ -127,7 +127,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_transport(
     az_http_policy * const p_policies,
     void * const data,
     az_http_request_builder * const hrb,
-    az_http_response const * const response) {
+    az_http_response * const response) {
   (void)data;
   AZ_CONTRACT_ARG_NOT_NULL(p_policies);
   AZ_CONTRACT_ARG_NOT_NULL(hrb);

--- a/sdk/core/core/src/az_http_policy.c
+++ b/sdk/core/core/src/az_http_policy.c
@@ -40,9 +40,6 @@ AZ_NODISCARD az_result az_http_pipeline_policy_uniquerequestid(
     az_http_request_builder * const hrb,
     az_http_response * const response) {
   (void)data;
-  AZ_CONTRACT_ARG_NOT_NULL(p_policies);
-  AZ_CONTRACT_ARG_NOT_NULL(hrb);
-  AZ_CONTRACT_ARG_NOT_NULL(response);
 
   // TODO - add a UUID create implementation
   az_span const uniqueid = AZ_CONST_STR("123e4567-e89b-12d3-a456-426655440000");
@@ -60,10 +57,10 @@ AZ_NODISCARD az_result az_http_pipeline_policy_retry(
     az_http_request_builder * const hrb,
     az_http_response * const response) {
   (void)data;
-  AZ_CONTRACT_ARG_NOT_NULL(p_policies);
-  AZ_CONTRACT_ARG_NOT_NULL(hrb);
-  AZ_CONTRACT_ARG_NOT_NULL(response);
-  // Retry logic
+
+  // reset response to be written from the start
+  AZ_RETURN_IF_FAILED(az_http_response_reset(response));
+
   return az_http_pipeline_nextpolicy(p_policies, hrb, response);
 }
 
@@ -72,9 +69,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_authentication(
     void * const data,
     az_http_request_builder * const hrb,
     az_http_response * const response) {
-  AZ_CONTRACT_ARG_NOT_NULL(p_policies);
-  AZ_CONTRACT_ARG_NOT_NULL(hrb);
-  AZ_CONTRACT_ARG_NOT_NULL(response);
+
   AZ_CONTRACT_ARG_NOT_NULL(data);
 
   az_credential * const credential = (az_credential *)(data);
@@ -89,9 +84,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_logging(
     az_http_request_builder * const hrb,
     az_http_response * const response) {
   (void)data;
-  AZ_CONTRACT_ARG_NOT_NULL(p_policies);
-  AZ_CONTRACT_ARG_NOT_NULL(hrb);
-  AZ_CONTRACT_ARG_NOT_NULL(response);
+
   // Authentication logic
   return az_http_pipeline_nextpolicy(p_policies, hrb, response);
 }
@@ -102,9 +95,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_bufferresponse(
     az_http_request_builder * const hrb,
     az_http_response * const response) {
   (void)data;
-  AZ_CONTRACT_ARG_NOT_NULL(p_policies);
-  AZ_CONTRACT_ARG_NOT_NULL(hrb);
-  AZ_CONTRACT_ARG_NOT_NULL(response);
+
   // buffer response logic
   //  this might be uStream
   return az_http_pipeline_nextpolicy(p_policies, hrb, response);
@@ -116,9 +107,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_distributedtracing(
     az_http_request_builder * const hrb,
     az_http_response * const response) {
   (void)data;
-  AZ_CONTRACT_ARG_NOT_NULL(p_policies);
-  AZ_CONTRACT_ARG_NOT_NULL(hrb);
-  AZ_CONTRACT_ARG_NOT_NULL(response);
+
   // Distributed tracing logic
   return az_http_pipeline_nextpolicy(p_policies, hrb, response);
 }
@@ -129,9 +118,6 @@ AZ_NODISCARD az_result az_http_pipeline_policy_transport(
     az_http_request_builder * const hrb,
     az_http_response * const response) {
   (void)data;
-  AZ_CONTRACT_ARG_NOT_NULL(p_policies);
-  AZ_CONTRACT_ARG_NOT_NULL(hrb);
-  AZ_CONTRACT_ARG_NOT_NULL(response);
 
   // Transport policy is the last policy
   //  If a policy exists after the transport policy

--- a/sdk/core/core/test/curl_easy_perform_poc.c
+++ b/sdk/core/core/test/curl_easy_perform_poc.c
@@ -32,7 +32,8 @@ int main() {
 
   // response buffer
   uint8_t buf_response[1024 * 4];
-  az_http_response http_buf_response = { .value = AZ_SPAN_FROM_ARRAY(buf_response) };
+  az_http_response http_buf_response
+      = { .builder = az_span_builder_create((az_mut_span)AZ_SPAN_FROM_ARRAY(buf_response)) };
 
   // create request for keyVault
   az_result build_result = az_http_request_builder_init(
@@ -78,7 +79,7 @@ int main() {
   az_result const get_response = az_http_pipeline_process(&pipeline, &hrb, &http_buf_response);
 
   if (az_succeeded(get_response)) {
-    printf("Response is: \n%s", http_buf_response.value.begin);
+    printf("Response is: \n%s", buf_response);
   } else {
     printf("Error during running test\n");
   }

--- a/sdk/core/core/test/curl_easy_perform_poc.c
+++ b/sdk/core/core/test/curl_easy_perform_poc.c
@@ -32,7 +32,7 @@ int main() {
 
   // response buffer
   uint8_t buf_response[1024 * 4];
-  az_http_response const http_buf_response = { .value = AZ_SPAN_FROM_ARRAY(buf_response) };
+  az_http_response http_buf_response = { .value = AZ_SPAN_FROM_ARRAY(buf_response) };
 
   // create request for keyVault
   az_result build_result = az_http_request_builder_init(

--- a/sdk/keyvault/keyvault/inc/az_keyvault.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault.h
@@ -110,7 +110,7 @@ AZ_NODISCARD az_result az_keyvault_keys_key_get(
     az_keyvault_keys_client * client,
     az_span const key_name,
     az_keyvault_key_type const key_type,
-    az_http_response const * const response);
+    az_http_response * const response);
 
 #include <_az_cfg_suffix.h>
 

--- a/sdk/keyvault/keyvault/inc/az_keyvault.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault.h
@@ -104,13 +104,13 @@ AZ_NODISCARD az_result az_keyvault_keys_key_create(
     az_span const key_name,
     az_keyvault_json_web_key_type const json_web_key_type,
     az_keyvault_keys_keys_options const * const options,
-    az_http_response const * const response);
+    az_http_response * const response);
 
 AZ_NODISCARD az_result az_keyvault_keys_key_get(
     az_keyvault_keys_client * client,
     az_span const key_name,
     az_key_vault_key_type const key_type,
-    az_http_response const * const response);
+    az_http_response * const response);
 
 #include <_az_cfg_suffix.h>
 

--- a/sdk/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/keyvault/keyvault/src/az_keyvault_client.c
@@ -208,7 +208,7 @@ AZ_NODISCARD az_result az_keyvault_keys_key_get(
     az_keyvault_keys_client * client,
     az_span const key_name,
     az_keyvault_key_type const key_type,
-    az_http_response const * const response) {
+    az_http_response * const response) {
   // create request buffer TODO: define size for a getKey Request
   uint8_t request_buffer[1024 * 4];
   az_mut_span request_buffer_span = AZ_SPAN_FROM_ARRAY(request_buffer);

--- a/sdk/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/keyvault/keyvault/src/az_keyvault_client.c
@@ -127,7 +127,7 @@ AZ_NODISCARD az_result az_keyvault_keys_key_create(
     az_span const key_name,
     az_keyvault_json_web_key_type const json_web_key_type,
     az_keyvault_keys_keys_options const * const options,
-    az_http_response const * const response) {
+    az_http_response * const response) {
   (void)options;
 
   // Request buffer
@@ -208,7 +208,7 @@ AZ_NODISCARD az_result az_keyvault_keys_key_get(
     az_keyvault_keys_client * client,
     az_span const key_name,
     az_key_vault_key_type const key_type,
-    az_http_response const * const response) {
+    az_http_response * const response) {
   // create request buffer TODO: define size for a getKey Request
   uint8_t request_buffer[1024 * 4];
   az_mut_span request_buffer_span = AZ_SPAN_FROM_ARRAY(request_buffer);

--- a/sdk/keyvault/keyvault/test/client_key_POC.c
+++ b/sdk/keyvault/keyvault/test/client_key_POC.c
@@ -37,8 +37,8 @@ int main() {
   // Create a buffer for response
   uint8_t key[1024 * 4];
   az_http_response create_response = { 0 };
-  az_result init_http_response_result
-      = az_http_response_init(&create_response, (az_mut_span)AZ_SPAN_FROM_ARRAY(key));
+  az_result init_http_response_result = az_http_response_init(
+      &create_response, az_span_builder_create((az_mut_span)AZ_SPAN_FROM_ARRAY(key)));
 
   az_result create_result = az_keyvault_keys_key_create(
       &client, AZ_STR("test-new-key"), AZ_KEY_VAULT_JSON_WEB_KEY_TYPE_RSA, NULL, &create_response);
@@ -64,8 +64,8 @@ int main() {
   // Create a buffer for response
   uint8_t get_key[1024 * 4];
   az_http_response get_create_response = { 0 };
-  init_http_response_result
-      = az_http_response_init(&get_create_response, (az_mut_span)AZ_SPAN_FROM_ARRAY(get_key));
+  init_http_response_result = az_http_response_init(
+      &get_create_response, az_span_builder_create((az_mut_span)AZ_SPAN_FROM_ARRAY(get_key)));
 
   az_result get_key_result = az_keyvault_keys_key_get(
       &get_client, AZ_STR("test-new-key"), AZ_KEY_VAULT_KEY_TYPE_KEY, &get_create_response);


### PR DESCRIPTION
Updating curl adapter to return http response with one span of the response that was written into buffer response only (right size).

https://github.com/Azure/azure-sdk-for-c/issues/219