### PR TITLE
Adding append_body to http request builder

### DIFF
--- a/sdk/core/core/inc/az_http_request_builder.h
+++ b/sdk/core/core/inc/az_http_request_builder.h
@@ -43,6 +43,7 @@ typedef struct {
   uint16_t retry_headers_start;
   uint16_t headers_end;
   az_span body;
+  bool has_query;
 } az_http_request_builder;
 
 extern az_span const AZ_HTTP_METHOD_VERB_GET;
@@ -122,6 +123,23 @@ AZ_NODISCARD az_result az_http_request_builder_append_header(
     az_http_request_builder * const p_hrb,
     az_span const key,
     az_span const value);
+
+/**
+ * @brief Adds path to url request.
+ * For instance, if url in request is `http://example.net` and this function is called with path
+ * equals to `test`, then request url will be updated to `http://example.net/test`.
+ * Use this function to create a path after url.
+ *
+ * Note: This function will work as long as no query parameter has been added to url. Otherwise
+ * function will return error and url will not be updated. It is not supported appending path after
+ * a query parameter was set.
+ *
+ * @param p_hrb
+ * @param path
+ * @return AZ_NODISCARD az_http_request_builder_append_path
+ */
+AZ_NODISCARD az_result
+az_http_request_builder_append_path(az_http_request_builder * const p_hrb, az_span const path);
 
 /**
  * @brief Mark that the HTTP headers that are gong to be added via

--- a/sdk/core/core/inc/az_http_request_builder.h
+++ b/sdk/core/core/inc/az_http_request_builder.h
@@ -43,7 +43,7 @@ typedef struct {
   uint16_t retry_headers_start;
   uint16_t headers_end;
   az_span body;
-  bool has_query;
+  uint16_t query_start;
 } az_http_request_builder;
 
 extern az_span const AZ_HTTP_METHOD_VERB_GET;
@@ -126,13 +126,9 @@ AZ_NODISCARD az_result az_http_request_builder_append_header(
 
 /**
  * @brief Adds path to url request.
- * For instance, if url in request is `http://example.net` and this function is called with path
- * equals to `test`, then request url will be updated to `http://example.net/test`.
- * Use this function to create a path after url.
+ * For instance, if url in request is `http://example.net?qp=1` and this function is called with
+ * path equals to `test`, then request url will be updated to `http://example.net/test?qp=1`.
  *
- * Note: This function will work as long as no query parameter has been added to url. Otherwise
- * function will return error and url will not be updated. It is not supported appending path after
- * a query parameter was set.
  *
  * @param p_hrb
  * @param path

--- a/sdk/core/core/src/az_http_request_builder.c
+++ b/sdk/core/core/src/az_http_request_builder.c
@@ -79,7 +79,7 @@ AZ_NODISCARD az_result az_http_request_builder_init(
     .retry_headers_start = max_headers,
     .headers_end = 0,
     .body = body,
-    .has_query = false,
+    .query_start = 0,
   };
 
   return AZ_OK;
@@ -124,7 +124,11 @@ AZ_NODISCARD az_result az_http_request_builder_set_query_parameter(
   }
 
   // Append either '?' or '&'
-  p_hrb->url.begin[p_hrb->url.size] = p_hrb->has_query ? '&' : '?';
+  p_hrb->url.begin[p_hrb->url.size] = p_hrb->query_start ? '&' : '?';
+  // update QPs starting position when it's 0
+  if (!p_hrb->query_start) {
+    p_hrb->query_start = p_hrb->url.size;
+  }
   p_hrb->url.size += 1;
 
   // Append parameter name
@@ -139,9 +143,6 @@ AZ_NODISCARD az_result az_http_request_builder_set_query_parameter(
   p_hrb->url.size += value.size;
 
   assert(p_hrb->url.size == new_url_size);
-
-  // Update status request as having query
-  p_hrb->has_query = true;
 
   return AZ_OK;
 }
@@ -175,26 +176,40 @@ az_http_request_builder_append_path(az_http_request_builder * const p_hrb, az_sp
   AZ_CONTRACT_ARG_NOT_NULL(&path);
 
   // check if there is enough space yet
-  if (p_hrb->url.size + path.size >= p_hrb->max_url_size) {
+  uint16_t url_after_path_size = p_hrb->url.size + path.size + 1 /* separator '/' to be added */;
+  uint16_t query_len
+      = p_hrb->query_start ? p_hrb->url.size - p_hrb->query_start : p_hrb->query_start;
+  if (url_after_path_size >= p_hrb->max_url_size) {
     return AZ_ERROR_BUFFER_OVERFLOW;
   }
 
-  // validate there are no query parameters in url
-  if (p_hrb->has_query) {
-    return AZ_ERROR_ARG;
+  // check if QPs shift is required
+  if (p_hrb->query_start) {
+    // shift right QPs from right to left
+    uint16_t query_end = p_hrb->query_start + query_len;
+    for (uint16_t offset = 0; offset <= query_len; ++offset) {
+      p_hrb->url.begin[url_after_path_size - offset] = p_hrb->url.begin[query_end - offset];
+    }
   }
 
   // use span builder to write into URL. That way errors are handled by span builder.
   az_span_builder url_builder = az_span_builder_create(p_hrb->url);
   // update builder buffer to the max supported URL
-  url_builder.buffer.size = p_hrb->max_url_size;
+  url_builder.buffer.size = url_after_path_size - query_len;
   // update current builder possition to start at current url size
-  url_builder.size = p_hrb->url.size;
+  url_builder.size = p_hrb->query_start ? p_hrb->query_start : p_hrb->url.size;
 
   // append separator byte
   AZ_RETURN_IF_FAILED(az_span_builder_append_byte(&url_builder, '/'));
   // append path
   AZ_RETURN_IF_FAILED(az_span_builder_append(&url_builder, path));
+
+  // update query start
+  if (p_hrb->query_start) {
+    p_hrb->query_start = url_builder.size;
+    url_builder.size = url_after_path_size;
+    url_builder.buffer.size = url_after_path_size;
+  }
 
   // update request url span
   p_hrb->url = az_span_builder_mut_result(&url_builder);

--- a/sdk/core/core/src/az_http_request_builder.c
+++ b/sdk/core/core/src/az_http_request_builder.c
@@ -127,7 +127,7 @@ AZ_NODISCARD az_result az_http_request_builder_set_query_parameter(
   p_hrb->url.begin[p_hrb->url.size] = p_hrb->query_start ? '&' : '?';
   // update QPs starting position when it's 0
   if (!p_hrb->query_start) {
-    p_hrb->query_start = p_hrb->url.size;
+    p_hrb->query_start = (uint16_t)p_hrb->url.size;
   }
   p_hrb->url.size += 1;
 
@@ -176,9 +176,10 @@ az_http_request_builder_append_path(az_http_request_builder * const p_hrb, az_sp
   AZ_CONTRACT_ARG_NOT_NULL(&path);
 
   // check if there is enough space yet
-  uint16_t url_after_path_size = p_hrb->url.size + path.size + 1 /* separator '/' to be added */;
+  uint16_t url_after_path_size
+      = (uint16_t)p_hrb->url.size + (uint16_t)path.size + 1 /* separator '/' to be added */;
   uint16_t query_len
-      = p_hrb->query_start ? p_hrb->url.size - p_hrb->query_start : p_hrb->query_start;
+      = p_hrb->query_start ? (uint16_t)p_hrb->url.size - p_hrb->query_start : p_hrb->query_start;
   if (url_after_path_size >= p_hrb->max_url_size) {
     return AZ_ERROR_BUFFER_OVERFLOW;
   }
@@ -206,7 +207,7 @@ az_http_request_builder_append_path(az_http_request_builder * const p_hrb, az_sp
 
   // update query start
   if (p_hrb->query_start) {
-    p_hrb->query_start = url_builder.size;
+    p_hrb->query_start = (uint16_t)url_builder.size;
     url_builder.size = url_after_path_size;
     url_builder.buffer.size = url_after_path_size;
   }

--- a/sdk/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/keyvault/keyvault/src/az_keyvault_client.c
@@ -84,21 +84,6 @@ az_keyvault_get_json_web_key_type_span(az_keyvault_json_web_key_type const key_t
   }
 }
 
-AZ_INLINE AZ_NODISCARD az_result az_keyvault_build_url_for_create_key(
-    az_span const uri,
-    az_span const key_name,
-    az_span_builder * const s_builder) {
-  AZ_RETURN_IF_FAILED(az_span_builder_append(s_builder, uri));
-  AZ_RETURN_IF_FAILED(az_span_builder_append_byte(s_builder, '/'));
-  AZ_RETURN_IF_FAILED(az_span_builder_append(s_builder, AZ_KEYVAULT_CREATE_KEY_URL_KEYS));
-  AZ_RETURN_IF_FAILED(az_span_builder_append_byte(s_builder, '/'));
-  AZ_RETURN_IF_FAILED(az_span_builder_append(s_builder, key_name));
-  AZ_RETURN_IF_FAILED(az_span_builder_append_byte(s_builder, '/'));
-  AZ_RETURN_IF_FAILED(az_span_builder_append(s_builder, AZ_KEYVAULT_CREATE_KEY_URL_CREATE));
-
-  return AZ_OK;
-}
-
 /**
  * @brief Action that uses json builder to construct http request body used by create key
  *
@@ -106,7 +91,8 @@ AZ_INLINE AZ_NODISCARD az_result az_keyvault_build_url_for_create_key(
  * @param write
  * @return AZ_NODISCARD build_request_json_body
  */
-AZ_NODISCARD az_result build_request_json_body(az_span const kty, az_span_action const write) {
+AZ_NODISCARD AZ_INLINE az_result
+build_request_json_body(az_span const kty, az_span_action const write) {
   az_json_builder builder = { 0 };
 
   AZ_RETURN_IF_FAILED(az_json_builder_init(&builder, write));
@@ -140,15 +126,6 @@ AZ_NODISCARD az_result az_keyvault_keys_key_create(
   az_span const az_json_web_key_type_span
       = az_keyvault_get_json_web_key_type_span(json_web_key_type);
 
-  // Allocate buffer in stack to create URL like:
-  // {vaultBaseUrl}/keys/{key_name}/create
-  uint8_t url_buffer[MAX_URL_SIZE];
-  az_mut_span const url_buffer_span_temp = AZ_SPAN_FROM_ARRAY(url_buffer);
-  az_span_builder s_builder = az_span_builder_create(url_buffer_span_temp);
-  AZ_RETURN_IF_FAILED(az_keyvault_build_url_for_create_key(client->uri, key_name, &s_builder));
-  // take an span from the created URL since url might be shorter than MAX_URL_SIZE
-  az_span const url_buffer_span = az_span_builder_result(&s_builder);
-
   // Allocate buffer in stack to hold body request
   uint8_t body_buffer[MAX_BODY_SIZE];
   az_span_builder json_builder
@@ -164,8 +141,13 @@ AZ_NODISCARD az_result az_keyvault_keys_key_create(
       request_buffer_span,
       MAX_URL_SIZE,
       AZ_HTTP_METHOD_VERB_POST,
-      url_buffer_span,
+      client->uri,
       created_body));
+
+  // add path to request
+  AZ_RETURN_IF_FAILED(az_http_request_builder_append_path(&hrb, AZ_KEYVAULT_CREATE_KEY_URL_KEYS));
+  AZ_RETURN_IF_FAILED(az_http_request_builder_append_path(&hrb, key_name));
+  AZ_RETURN_IF_FAILED(az_http_request_builder_append_path(&hrb, AZ_KEYVAULT_CREATE_KEY_URL_CREATE));
 
   // add version to request
   AZ_RETURN_IF_FAILED(az_http_request_builder_set_query_parameter(
@@ -179,20 +161,6 @@ AZ_NODISCARD az_result az_keyvault_keys_key_create(
 
   // start pipeline
   return az_http_pipeline_process(&client->pipeline, &hrb, response);
-}
-
-AZ_INLINE AZ_NODISCARD az_result az_keyvault_build_url_for_get_key(
-    az_span const uri,
-    az_span const key_type,
-    az_span const key_name,
-    az_mut_span const out) {
-  az_span_builder s_builder = az_span_builder_create(out);
-  AZ_RETURN_IF_FAILED(az_span_builder_append(&s_builder, uri));
-  AZ_RETURN_IF_FAILED(az_span_builder_append_byte(&s_builder, '/'));
-  AZ_RETURN_IF_FAILED(az_span_builder_append(&s_builder, key_type));
-  AZ_RETURN_IF_FAILED(az_span_builder_append_byte(&s_builder, '/'));
-  AZ_RETURN_IF_FAILED(az_span_builder_append(&s_builder, key_name));
-  return AZ_OK;
 }
 
 /**
@@ -213,35 +181,20 @@ AZ_NODISCARD az_result az_keyvault_keys_key_get(
   uint8_t request_buffer[1024 * 4];
   az_mut_span request_buffer_span = AZ_SPAN_FROM_ARRAY(request_buffer);
 
-  /* ******** build url for request  ******
-   * add key_type, key_name and version to url request
-   */
+  // Get the key type name from key type
   az_span const az_key_type_span = az_keyvault_get_key_type_span(key_type);
-
-  // make sure we can handle url within the MAX_URL_SIZE
-  size_t const url_size_with_path = client->uri.size + 2 /* 2 path separators '\'*/
-      + az_key_type_span.size + key_name.size;
-  AZ_CONTRACT(url_size_with_path <= MAX_URL_SIZE, AZ_ERROR_BUFFER_OVERFLOW);
-
-  // Put a new buffer on the stack to hold a url with the key name and type
-  uint8_t url_buffer[MAX_URL_SIZE];
-  az_mut_span const url_buffer_span
-      = (az_mut_span){ .begin = url_buffer, .size = url_size_with_path };
-  AZ_RETURN_IF_FAILED(
-      az_keyvault_build_url_for_get_key(client->uri, az_key_type_span, key_name, url_buffer_span));
 
   // create request
   // TODO: define max URL size
   az_http_request_builder hrb;
   AZ_RETURN_IF_FAILED(az_http_request_builder_init(
-      &hrb,
-      request_buffer_span,
-      MAX_URL_SIZE,
-      AZ_HTTP_METHOD_VERB_GET,
-      az_mut_span_to_span(url_buffer_span),
-      AZ_SPAN_NULL));
+      &hrb, request_buffer_span, MAX_URL_SIZE, AZ_HTTP_METHOD_VERB_GET, client->uri, AZ_SPAN_NULL));
 
-  // add version to request
+  // Add path to request
+  AZ_RETURN_IF_FAILED(az_http_request_builder_append_path(&hrb, az_key_type_span));
+  AZ_RETURN_IF_FAILED(az_http_request_builder_append_path(&hrb, key_name));
+
+  // add version to request as query parameter
   AZ_RETURN_IF_FAILED(az_http_request_builder_set_query_parameter(
       &hrb, AZ_STR("api-version"), client->retry_options.service_version));
 

--- a/sdk/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/keyvault/keyvault/src/az_keyvault_client.c
@@ -146,12 +146,18 @@ AZ_NODISCARD az_result az_keyvault_keys_key_create(
 
   // add path to request
   AZ_RETURN_IF_FAILED(az_http_request_builder_append_path(&hrb, AZ_KEYVAULT_CREATE_KEY_URL_KEYS));
-  AZ_RETURN_IF_FAILED(az_http_request_builder_append_path(&hrb, key_name));
-  AZ_RETURN_IF_FAILED(az_http_request_builder_append_path(&hrb, AZ_KEYVAULT_CREATE_KEY_URL_CREATE));
 
   // add version to request
   AZ_RETURN_IF_FAILED(az_http_request_builder_set_query_parameter(
       &hrb, AZ_STR("api-version"), client->retry_options.service_version));
+
+  AZ_RETURN_IF_FAILED(az_http_request_builder_append_path(&hrb, key_name));
+
+  // add extra header just for testing append_path after another query
+  AZ_RETURN_IF_FAILED(az_http_request_builder_set_query_parameter(
+      &hrb, AZ_STR("ignore"), client->retry_options.service_version));
+
+  AZ_RETURN_IF_FAILED(az_http_request_builder_append_path(&hrb, AZ_KEYVAULT_CREATE_KEY_URL_CREATE));
 
   // Adding header content-type json
   AZ_RETURN_IF_FAILED(az_http_request_builder_append_header(
@@ -192,11 +198,13 @@ AZ_NODISCARD az_result az_keyvault_keys_key_get(
 
   // Add path to request
   AZ_RETURN_IF_FAILED(az_http_request_builder_append_path(&hrb, az_key_type_span));
-  AZ_RETURN_IF_FAILED(az_http_request_builder_append_path(&hrb, key_name));
 
   // add version to request as query parameter
   AZ_RETURN_IF_FAILED(az_http_request_builder_set_query_parameter(
       &hrb, AZ_STR("api-version"), client->retry_options.service_version));
+
+  // Add path to request after adding query parameter
+  AZ_RETURN_IF_FAILED(az_http_request_builder_append_path(&hrb, key_name));
 
   // start pipeline
   return az_http_pipeline_process(&client->pipeline, &hrb, response);

--- a/sdk/keyvault/keyvault/test/main.c
+++ b/sdk/keyvault/keyvault/test/main.c
@@ -16,17 +16,19 @@ int exit_code = 0;
 
 int main() {
   {
-    az_span const uri = AZ_STR("http://example.net");
-    az_span const key_type = AZ_STR("keys");
-    az_span const key_name = AZ_STR("name");
-    uint8_t out_array[50];
-    az_mut_span const out
-        = (az_mut_span){ .begin = out_array, .size = uri.size + key_name.size + key_type.size + 2 };
+    az_span const kty = AZ_STR("RSA");
+    uint8_t body_buffer[1024];
+    az_mut_span const span_to_buffer = (az_mut_span)AZ_SPAN_FROM_ARRAY(body_buffer);
+    az_span_builder json_builder = az_span_builder_create(span_to_buffer);
 
-    az_span const expected = AZ_STR("http://example.net/keys/name");
+    az_span const expected = AZ_STR("{\"kty\":\"RSA\"}");
 
-    TEST_ASSERT(az_keyvault_build_url_for_get_key(uri, key_type, key_name, out) == AZ_OK);
-    TEST_ASSERT(az_span_eq(az_mut_span_to_span(out), expected));
+    TEST_ASSERT(
+        build_request_json_body(kty, az_span_builder_append_action(&json_builder)) == AZ_OK);
+
+    az_span const result = az_span_builder_result(&json_builder);
+
+    TEST_ASSERT(az_span_eq(result, expected));
   }
   return exit_code;
 }


### PR DESCRIPTION
Removing the need of having a new buffer allocated in stack to build a url + path by adding `append_path` directly into http request buffer

blocking behavior to allow appending path only before adding query parameters.

I also added a new field to http request body as a flag to quickly check if there are query parameters in url or not.
#233 