### PR TITLE
Do not refresh token unless it is 3 minutes before expiration

### DIFF
--- a/sdk/core/core/inc/az_token_credential.h
+++ b/sdk/core/core/inc/az_token_credential.h
@@ -7,6 +7,7 @@
 #include <az_credential.h>
 
 #include <stdint.h>
+#include <time.h>
 
 #include <_az_cfg_prefix.h>
 
@@ -20,6 +21,7 @@ typedef struct {
   // TODO: all updates to this must be thread-safe
   uint8_t token_buf[AZ_TOKEN_CREDENTIAL_TOKEN_BUFFER_SIZE];
   az_mut_span token;
+  clock_t expiration;
 } az_token_credential;
 
 AZ_INLINE AZ_NODISCARD az_result

--- a/sdk/core/core/src/az_client_secret_credential.c
+++ b/sdk/core/core/src/az_client_secret_credential.c
@@ -111,6 +111,10 @@ az_token_credential_get_resource_url(az_span const request_url, az_span_builder 
     }
   }
 
+  if (!az_span_eq_ascii_ignore_case(url.scheme, AZ_STR("https"))) {
+    return AZ_ERROR_ARG; // So that we won't send a token over http
+  }
+
   // Add "https://"
   AZ_RETURN_IF_FAILED(az_span_builder_append(p_builder, url.scheme));
   AZ_RETURN_IF_FAILED(az_span_builder_append(p_builder, AZ_STR("://")));


### PR DESCRIPTION
We cache he token, and reuse it if it is within its expiration time. In case clock() is not supported, we request every time. In case we can't get/parse expiration time, we don't error the token request, but will not keep it for the next time either.
What I don't like is that the token is per resource, and we don't (yet) take that into consideration. Example: for key vault, the resource is "https://vault.azure.net", but if you use the same policy for other service, or for a keyvault in different domain (if that's possible), then we're going to reuse the token when we shouldn't. I'm not yet sure what is the best thing to do about this, I'll discuss with the team. Probably it won't be addressed in this PR.
But what I will probably add to this PR is, loooking for 401 more explicitly, and force getting new token if there's a problem authentcating.