### PR TITLE
adding support for adding key operations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,10 +28,18 @@
             "preLaunchTask": "build"
         },
         {
-            "name": "KeyVault",
+            "name": "KeyVault IT",
             "type": "gdb",
             "request": "launch",
             "target": "./Debug/sdk/keyvault/keyvault/az_keyvault_test",
+            "cwd": "${workspaceRoot}",
+            "preLaunchTask": "build"
+        },
+        {
+            "name": "KeyVaultPOC",
+            "type": "gdb",
+            "request": "launch",
+            "target": "./Debug/sdk/keyvault/keyvault/az_keyvault_poc",
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "build",
             // Add ids and secrets here to use it when debuging KeyVaultPOC

--- a/sdk/keyvault/keyvault/inc/az_keyvault_create_key_options.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault_create_key_options.h
@@ -56,7 +56,7 @@ AZ_NODISCARD AZ_INLINE bool az_keyvault_create_key_options_is_full(
  */
 AZ_NODISCARD AZ_INLINE az_result
 az_keyvault_create_key_options_clear(az_keyvault_create_key_options * const self) {
-  self->key_operations.size = 0;
+  self->key_operations = (az_keyvault_create_key_options_key_operation){ 0 };
   return AZ_OK;
 }
 

--- a/sdk/keyvault/keyvault/inc/az_keyvault_create_key_options.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault_create_key_options.h
@@ -8,8 +8,23 @@
 
 #include <_az_cfg_prefix.h>
 
+static uint8_t const AZ_KEYVAULT_MAX_KEY_OPERATIONS = 6;
+
+AZ_NODISCARD AZ_INLINE az_span az_keyvault_key_operation_decrypt() { return AZ_STR("decrypt"); }
+AZ_NODISCARD AZ_INLINE az_span az_keyvault_key_operation_encrypt() { return AZ_STR("encrypt"); }
+AZ_NODISCARD AZ_INLINE az_span az_keyvault_key_operation_sign() { return AZ_STR("sign"); }
+AZ_NODISCARD AZ_INLINE az_span az_keyvault_key_operation_unwrapKey() { return AZ_STR("unwrapKey"); }
+AZ_NODISCARD AZ_INLINE az_span az_keyvault_key_operation_verify() { return AZ_STR("verify"); }
+AZ_NODISCARD AZ_INLINE az_span az_keyvault_key_operation_wrapKey() { return AZ_STR("wrapKey"); }
+
+typedef struct {
+  az_span operations[6];
+  uint8_t size;
+} az_keyvault_create_key_options_key_operation;
+
 typedef struct {
   az_optional_bool enabled;
+  az_keyvault_create_key_options_key_operation key_operations;
   /* TODO: adding next options
   Datetime not_before;
   Datetime expires_on
@@ -17,6 +32,82 @@ typedef struct {
   List keyOperations
   */
 } az_keyvault_create_key_options;
+
+/**
+ * @brief check if there is at least one operation
+ *
+ */
+AZ_NODISCARD AZ_INLINE bool az_keyvault_create_key_options_is_empty(
+    az_keyvault_create_key_options const * self) {
+  return self->key_operations.size == 0;
+}
+
+/**
+ * @brief check if operation array is full
+ *
+ */
+AZ_NODISCARD AZ_INLINE bool az_keyvault_create_key_options_is_full(
+    az_keyvault_create_key_options * const self) {
+  return self->key_operations.size >= AZ_KEYVAULT_MAX_KEY_OPERATIONS;
+}
+
+/**
+ * @brief set size of operations to 0 so it can be written again
+ *
+ */
+AZ_NODISCARD AZ_INLINE az_result
+az_keyvault_create_key_options_clear(az_keyvault_create_key_options * const self) {
+  self->key_operations.size = 0;
+  return AZ_OK;
+}
+
+/**
+ * @brief Append an operation to a create key options
+ *
+ */
+AZ_NODISCARD AZ_INLINE az_result az_keyvault_create_key_options_append_operation(
+    az_keyvault_create_key_options * const self,
+    az_span const operation) {
+
+  if (az_keyvault_create_key_options_is_full(self)) {
+    return AZ_ERROR_BUFFER_OVERFLOW;
+  }
+
+  az_keyvault_create_key_options_key_operation * current_operations = &self->key_operations;
+  uint8_t const current_size = current_operations->size;
+
+  current_operations->operations[current_size] = operation;
+  current_operations->size = current_size + 1;
+
+  return AZ_OK;
+}
+
+/**
+ * @brief Append all available operations for key options
+ *
+ */
+AZ_NODISCARD AZ_INLINE az_result
+az_keyvault_create_key_options_append_all_operations(az_keyvault_create_key_options * const self) {
+
+  if (!az_keyvault_create_key_options_is_empty(self)) {
+    // options must be empty to allow appending all operations
+    return AZ_ERROR_BUFFER_OVERFLOW;
+  }
+  AZ_RETURN_IF_FAILED(
+      az_keyvault_create_key_options_append_operation(self, az_keyvault_key_operation_decrypt()));
+  AZ_RETURN_IF_FAILED(
+      az_keyvault_create_key_options_append_operation(self, az_keyvault_key_operation_encrypt()));
+  AZ_RETURN_IF_FAILED(
+      az_keyvault_create_key_options_append_operation(self, az_keyvault_key_operation_sign()));
+  AZ_RETURN_IF_FAILED(
+      az_keyvault_create_key_options_append_operation(self, az_keyvault_key_operation_unwrapKey()));
+  AZ_RETURN_IF_FAILED(
+      az_keyvault_create_key_options_append_operation(self, az_keyvault_key_operation_verify()));
+  AZ_RETURN_IF_FAILED(
+      az_keyvault_create_key_options_append_operation(self, az_keyvault_key_operation_wrapKey()));
+
+  return AZ_OK;
+}
 
 #include <_az_cfg_suffix.h>
 

--- a/sdk/keyvault/keyvault/inc/az_keyvault_create_key_options.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault_create_key_options.h
@@ -29,7 +29,6 @@ typedef struct {
   Datetime not_before;
   Datetime expires_on
   List tags
-  List keyOperations
   */
 } az_keyvault_create_key_options;
 

--- a/sdk/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/keyvault/keyvault/src/az_keyvault_client.c
@@ -70,6 +70,15 @@ static AZ_NODISCARD az_result _az_keyvault_keys_key_create_build_json_body(
             &builder, AZ_STR("enabled"), az_json_value_create_boolean(enabled_field.data)));
         AZ_RETURN_IF_FAILED(az_json_builder_write_object_close(&builder));
       }
+      if (!az_keyvault_create_key_options_is_empty(options)) {
+        AZ_RETURN_IF_FAILED(az_json_builder_write_object_member(
+            &builder, AZ_STR("key_ops"), az_json_value_create_array()));
+        for (uint8_t op = 0; op < options->key_operations.size; ++op) {
+          AZ_RETURN_IF_FAILED(az_json_builder_write_array_item(
+              &builder, az_json_value_create_string(options->key_operations.operations[op])));
+        }
+        AZ_RETURN_IF_FAILED(az_json_builder_write_array_close(&builder));
+      }
     }
   }
 

--- a/sdk/keyvault/keyvault/test/az_keyvault_create_key_options_test.c
+++ b/sdk/keyvault/keyvault/test/az_keyvault_create_key_options_test.c
@@ -18,6 +18,10 @@ void az_create_key_options_test() {
     TEST_ASSERT(options.key_operations.size == 1)
     TEST_ASSERT(az_span_eq(options.key_operations.operations[0], az_keyvault_key_operation_sign()))
 
+    // check we can't add all if not empty
+    TEST_ASSERT(
+        az_keyvault_create_key_options_append_all_operations(&options) == AZ_ERROR_BUFFER_OVERFLOW)
+
     // clear
     TEST_ASSERT(az_keyvault_create_key_options_clear(&options) == AZ_OK)
     TEST_ASSERT(options.key_operations.size == 0)

--- a/sdk/keyvault/keyvault/test/az_keyvault_create_key_options_test.c
+++ b/sdk/keyvault/keyvault/test/az_keyvault_create_key_options_test.c
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <az_keyvault_create_key_options.h>
+#include <az_span.h>
+
+#include "./az_test.h"
+
+#include <_az_cfg.h>
+
+void az_create_key_options_test() {
+  {
+    az_keyvault_create_key_options options = { 0 };
+    // Append
+    TEST_ASSERT(
+        az_keyvault_create_key_options_append_operation(&options, az_keyvault_key_operation_sign())
+        == AZ_OK)
+    TEST_ASSERT(options.key_operations.size == 1)
+    TEST_ASSERT(az_span_eq(options.key_operations.operations[0], az_keyvault_key_operation_sign()))
+
+    // clear
+    TEST_ASSERT(az_keyvault_create_key_options_clear(&options) == AZ_OK)
+    TEST_ASSERT(options.key_operations.size == 0)
+
+    // Append all
+    TEST_ASSERT(az_keyvault_create_key_options_append_all_operations(&options) == AZ_OK)
+    TEST_ASSERT(
+        az_span_eq(options.key_operations.operations[0], az_keyvault_key_operation_decrypt()));
+    TEST_ASSERT(
+        az_span_eq(options.key_operations.operations[1], az_keyvault_key_operation_encrypt()));
+    TEST_ASSERT(az_span_eq(options.key_operations.operations[2], az_keyvault_key_operation_sign()));
+    TEST_ASSERT(
+        az_span_eq(options.key_operations.operations[3], az_keyvault_key_operation_unwrapKey()));
+    TEST_ASSERT(
+        az_span_eq(options.key_operations.operations[4], az_keyvault_key_operation_verify()));
+    TEST_ASSERT(
+        az_span_eq(options.key_operations.operations[5], az_keyvault_key_operation_wrapKey()));
+
+    // fail next append, full list
+    TEST_ASSERT(
+        az_keyvault_create_key_options_append_operation(
+            &options, az_keyvault_key_operation_verify())
+        == AZ_ERROR_BUFFER_OVERFLOW)
+
+    // is full check
+    TEST_ASSERT(az_keyvault_create_key_options_is_full(&options))
+    TEST_ASSERT(!az_keyvault_create_key_options_is_empty(&options))
+
+    // clear
+    TEST_ASSERT(az_keyvault_create_key_options_clear(&options) == AZ_OK)
+
+    // is full check
+    TEST_ASSERT(!az_keyvault_create_key_options_is_full(&options))
+    TEST_ASSERT(az_keyvault_create_key_options_is_empty(&options))
+  }
+}

--- a/sdk/keyvault/keyvault/test/client_key_poc.c
+++ b/sdk/keyvault/keyvault/test/client_key_poc.c
@@ -77,6 +77,8 @@ int main() {
 
   // override options values
   key_options.enabled = az_optional_bool_create(false);
+  az_result append_result = az_keyvault_create_key_options_append_operation(
+      &key_options, az_keyvault_key_operation_sign());
 
   az_result create_result = az_keyvault_keys_key_create(
       &client,

--- a/sdk/keyvault/keyvault/test/main.c
+++ b/sdk/keyvault/keyvault/test/main.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "./az_keyvault_create_key_options_test.c"
 #include "./az_test.h"
 
 #include <_az_cfg.h>
@@ -80,5 +81,6 @@ int main() {
       TEST_ASSERT(az_span_eq(result, expected));
     }
   }
+  az_create_key_options_test();
   return exit_code;
 }


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-c/issues/267

Adding key operation with MAX size since this is a fixed list:

"key_ops": [
    "encrypt",
    "decrypt",
    "sign",
    "verify",
    "wrapKey",
    "unwrapKey"
  ],
Adding Support for append operation, append all, clear.

SDK will add operation list to json payload if there is at least one operation added
SDK is exposing in_line functions for each valid operation (avoiding the use of ENUM)
SDK is not validating if user is adding unsupported operation (some random span/string), but it will just return server error response from service directly

