### PR TITLE
Add some underscores, fix warnings

### DIFF
--- a/sdk/core/core/inc/_az_cfg.h
+++ b/sdk/core/core/inc/_az_cfg.h
@@ -39,8 +39,8 @@
 
 #endif
 
-#ifndef AZ_CFG_H
-#define AZ_CFG_H
+#ifndef _az_CFG_H
+#define _az_CFG_H
 
 #ifdef _MSC_VER
 #define AZ_INLINE static __forceinline

--- a/sdk/core/core/inc/az_action.h
+++ b/sdk/core/core/inc/az_action.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_ACTION_H
-#define AZ_ACTION_H
+#ifndef _az_ACTION_H
+#define _az_ACTION_H
 
 #include <az_contract.h>
 #include <az_result.h>

--- a/sdk/core/core/inc/az_base64.h
+++ b/sdk/core/core/inc/az_base64.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_BASE64_H
-#define AZ_BASE64_H
+#ifndef _az_BASE64_H
+#define _az_BASE64_H
 
 #include <az_mut_span.h>
 #include <az_result.h>

--- a/sdk/core/core/inc/az_contract.h
+++ b/sdk/core/core/inc/az_contract.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_CONTRACT_H
-#define AZ_CONTRACT_H
+#ifndef _az_CONTRACT_H
+#define _az_CONTRACT_H
 
 #include <az_result.h>
 

--- a/sdk/core/core/inc/az_curl_adapter.h
+++ b/sdk/core/core/inc/az_curl_adapter.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_CURL_ADAPTER_H
-#define AZ_CURL_ADAPTER_H
+#ifndef _az_CURL_ADAPTER_H
+#define _az_CURL_ADAPTER_H
 
 #include <az_http_request_builder.h>
 #include <az_http_response.h>

--- a/sdk/core/core/inc/az_curl_slist.h
+++ b/sdk/core/core/inc/az_curl_slist.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_CURL_SLIST_H
-#define AZ_CURL_SLIST_H
+#ifndef _az_CURL_SLIST_H
+#define _az_CURL_SLIST_H
 
 #include <az_pair.h>
 #include <az_result.h>

--- a/sdk/core/core/inc/az_hex.h
+++ b/sdk/core/core/inc/az_hex.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_HEX_H
-#define AZ_HEX_H
+#ifndef _az_HEX_H
+#define _az_HEX_H
 
 #include <stdint.h>
 

--- a/sdk/core/core/inc/az_http_client.h
+++ b/sdk/core/core/inc/az_http_client.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_HTTP_CLIENT_H
-#define AZ_HTTP_CLIENT_H
+#ifndef _az_HTTP_CLIENT_H
+#define _az_HTTP_CLIENT_H
 
 #include <az_http_request_builder.h>
 #include <az_http_response.h>

--- a/sdk/core/core/inc/az_http_header.h
+++ b/sdk/core/core/inc/az_http_header.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_HTTP_HEADER_H
-#define AZ_HTTP_HEADER_H
+#ifndef _az_HTTP_HEADER_H
+#define _az_HTTP_HEADER_H
 
 #include <az_action.h>
 #include <az_pair.h>
@@ -14,10 +14,11 @@
 
 static az_span const AZ_HTTP_HEADER_CONTENT_LENGTH = AZ_CONST_STR("Content-Length");
 static az_span const AZ_HTTP_HEADER_CONTENT_TYPE = AZ_CONST_STR("Content-Type");
-static az_span const AZ_HTTP_HEADER_TEXT_PLAIN_CHARSET_UTF_8 = AZ_CONST_STR("text/plain; charset=UTF-8");
 static az_span const AZ_HTTP_HEADER_X_MS_CLIENT_REQUESTID = AZ_CONST_STR("x-ms-client-request-id");
 static az_span const AZ_HTTP_HEADER_X_MS_DATE = AZ_CONST_STR("x-ms-date");
 static az_span const AZ_HTTP_HEADER_X_MS_VERSION = AZ_CONST_STR("x-ms-version");
+static az_span const AZ_HTTP_HEADER_TEXT_PLAIN_CHARSET_UTF_8
+    = AZ_CONST_STR("text/plain; charset=UTF-8");
 
 /**
  * Emits an HTTP header as a sequence of spans in a format "%{key}: %{value}"

--- a/sdk/core/core/inc/az_http_header.h
+++ b/sdk/core/core/inc/az_http_header.h
@@ -14,11 +14,13 @@
 
 static az_span const AZ_HTTP_HEADER_CONTENT_LENGTH = AZ_CONST_STR("Content-Length");
 static az_span const AZ_HTTP_HEADER_CONTENT_TYPE = AZ_CONST_STR("Content-Type");
+
+static az_span const AZ_HTTP_HEADER_TEXT_PLAIN_CHARSET_UTF_8
+    = AZ_CONST_STR("text/plain; charset=UTF-8");
+
 static az_span const AZ_HTTP_HEADER_X_MS_CLIENT_REQUESTID = AZ_CONST_STR("x-ms-client-request-id");
 static az_span const AZ_HTTP_HEADER_X_MS_DATE = AZ_CONST_STR("x-ms-date");
 static az_span const AZ_HTTP_HEADER_X_MS_VERSION = AZ_CONST_STR("x-ms-version");
-static az_span const AZ_HTTP_HEADER_TEXT_PLAIN_CHARSET_UTF_8
-    = AZ_CONST_STR("text/plain; charset=UTF-8");
 
 /**
  * Emits an HTTP header as a sequence of spans in a format "%{key}: %{value}"

--- a/sdk/core/core/inc/az_http_pipeline.h
+++ b/sdk/core/core/inc/az_http_pipeline.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_HTTP_PIPELINE_H
-#define AZ_HTTP_PIPELINE_H
+#ifndef _az_HTTP_PIPELINE_H
+#define _az_HTTP_PIPELINE_H
 
 #include <az_http_policy.h>
 #include <az_http_request_builder.h>

--- a/sdk/core/core/inc/az_http_policy.h
+++ b/sdk/core/core/inc/az_http_policy.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_HTTP_POLICY_H
-#define AZ_HTTP_POLICY_H
+#ifndef _az_HTTP_POLICY_H
+#define _az_HTTP_POLICY_H
 
 #include <az_http_request_builder.h>
 #include <az_http_response.h>

--- a/sdk/core/core/inc/az_http_query.h
+++ b/sdk/core/core/inc/az_http_query.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_HTTP_QUERY_H
-#define AZ_HTTP_QUERY_H
+#ifndef _az_HTTP_QUERY_H
+#define _az_HTTP_QUERY_H
 
 #include <az_pair.h>
 #include <az_result.h>

--- a/sdk/core/core/inc/az_http_request.h
+++ b/sdk/core/core/inc/az_http_request.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_HTTP_REQUEST_H
-#define AZ_HTTP_REQUEST_H
+#ifndef _az_HTTP_REQUEST_H
+#define _az_HTTP_REQUEST_H
 
 #include <az_pair.h>
 #include <az_span.h>

--- a/sdk/core/core/inc/az_http_request_builder.h
+++ b/sdk/core/core/inc/az_http_request_builder.h
@@ -5,8 +5,8 @@
  * @brief Interface declaration for bulding an HTTP Request.
  */
 
-#ifndef AZ_HTTP_REQUEST_BUILDER_H
-#define AZ_HTTP_REQUEST_BUILDER_H
+#ifndef _az_HTTP_REQUEST_BUILDER_H
+#define _az_HTTP_REQUEST_BUILDER_H
 
 #include <az_mut_span.h>
 #include <az_pair.h>

--- a/sdk/core/core/inc/az_http_response.h
+++ b/sdk/core/core/inc/az_http_response.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_HTTP_RESPONSE_H
-#define AZ_HTTP_RESPONSE_H
+#ifndef _az_HTTP_RESPONSE_H
+#define _az_HTTP_RESPONSE_H
 
 #include <az_result.h>
 #include <az_span_builder.h>

--- a/sdk/core/core/inc/az_http_response_parser.h
+++ b/sdk/core/core/inc/az_http_response_parser.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_HTTP_RESPONSE_PARSER_H
-#define AZ_HTTP_RESPONSE_PARSER_H
+#ifndef _az_HTTP_RESPONSE_PARSER_H
+#define _az_HTTP_RESPONSE_PARSER_H
 
 #include <az_pair.h>
 #include <az_result.h>

--- a/sdk/core/core/inc/az_json_builder.h
+++ b/sdk/core/core/inc/az_json_builder.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_JSON_BUILDER_H
-#define AZ_JSON_BUILDER_H
+#ifndef _az_JSON_BUILDER_H
+#define _az_JSON_BUILDER_H
 
 #include <az_json_token.h>
 #include <az_result.h>
@@ -41,4 +41,4 @@ AZ_NODISCARD az_result az_json_builder_write_array_close(az_json_builder * const
 
 #include <_az_cfg_suffix.h>
 
-#endif // !AZ_JSON_BUILDER_H
+#endif

--- a/sdk/core/core/inc/az_json_get.h
+++ b/sdk/core/core/inc/az_json_get.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_JSON_GET_H
-#define AZ_JSON_GET_H
+#ifndef _az_JSON_GET_H
+#define _az_JSON_GET_H
 
 #include <az_json_token.h>
 #include <az_result.h>

--- a/sdk/core/core/inc/az_json_parser.h
+++ b/sdk/core/core/inc/az_json_parser.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_JSON_PARSER_H
-#define AZ_JSON_PARSER_H
+#ifndef _az_JSON_PARSER_H
+#define _az_JSON_PARSER_H
 
 #include <az_json_token.h>
 #include <az_result.h>

--- a/sdk/core/core/inc/az_json_pointer.h
+++ b/sdk/core/core/inc/az_json_pointer.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_JSON_POINTER_H
-#define AZ_JSON_POINTER_H
+#ifndef _az_JSON_POINTER_H
+#define _az_JSON_POINTER_H
 
 #include <az_result.h>
 #include <az_span.h>

--- a/sdk/core/core/inc/az_json_string.h
+++ b/sdk/core/core/inc/az_json_string.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_JSON_STRING_H
-#define AZ_JSON_STRING_H
+#ifndef _az_JSON_STRING_H
+#define _az_JSON_STRING_H
 
 #include <az_result.h>
 #include <az_span.h>

--- a/sdk/core/core/inc/az_json_token.h
+++ b/sdk/core/core/inc/az_json_token.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_JSON_TOKEN_H
-#define AZ_JSON_TOKEN_H
+#ifndef _az_JSON_TOKEN_H
+#define _az_JSON_TOKEN_H
 
 #include <az_span.h>
 
@@ -77,24 +77,21 @@ AZ_NODISCARD AZ_INLINE az_json_token az_json_token_span(az_span const span) {
  *
  * If the JSON value is not a boolean then the function returns an error.
  */
-AZ_NODISCARD az_result
-az_json_token_get_boolean(az_json_token const self, bool * const out);
+AZ_NODISCARD az_result az_json_token_get_boolean(az_json_token const self, bool * const out);
 
 /**
  * Copies a string span to @var out from the given JSON value.
  *
  * If the JSON value is not a string then the function returns an error.
  */
-AZ_NODISCARD az_result
-az_json_token_get_string(az_json_token const self, az_span * const out);
+AZ_NODISCARD az_result az_json_token_get_string(az_json_token const self, az_span * const out);
 
 /**
  * Copies a number to @var out from the given JSON value.
  *
  * If the JSON value is not a number then the function returns an error.
  */
-AZ_NODISCARD az_result
-az_json_token_get_number(az_json_token const self, double * const out);
+AZ_NODISCARD az_result az_json_token_get_number(az_json_token const self, double * const out);
 
 typedef struct {
   az_span name;

--- a/sdk/core/core/inc/az_mock_curl.h
+++ b/sdk/core/core/inc/az_mock_curl.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_MOCK_CURL_H
-#define AZ_MOCK_CURL_H
+#ifndef _az_MOCK_CURL_H
+#define _az_MOCK_CURL_H
 
 #include <az_http_request.h>
 #include <az_http_response.h>

--- a/sdk/core/core/inc/az_mut_span.h
+++ b/sdk/core/core/inc/az_mut_span.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_MUT_SPAN_H
-#define AZ_MUT_SPAN_H
+#ifndef _az_MUT_SPAN_H
+#define _az_MUT_SPAN_H
 
 #include <az_action.h>
 #include <az_contract.h>

--- a/sdk/core/core/inc/az_optional_bool.h
+++ b/sdk/core/core/inc/az_optional_bool.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_OPTIONAL_BOOL_H
-#define AZ_OPTIONAL_BOOL_H
+#ifndef _az_OPTIONAL_BOOL_H
+#define _az_OPTIONAL_BOOL_H
 
 #include <stdbool.h>
 

--- a/sdk/core/core/inc/az_pair.h
+++ b/sdk/core/core/inc/az_pair.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_PAIR_H
-#define AZ_PAIR_H
+#ifndef _az_PAIR_H
+#define _az_PAIR_H
 
 #include <az_action.h>
 #include <az_result.h>

--- a/sdk/core/core/inc/az_result.h
+++ b/sdk/core/core/inc/az_result.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_RESULT_H
-#define AZ_RESULT_H
+#ifndef _az_RESULT_H
+#define _az_RESULT_H
 
 #include <az_static_assert.h>
 

--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_SPAN_H
-#define AZ_SPAN_H
+#ifndef _az_SPAN_H
+#define _az_SPAN_H
 
 #include <az_action.h>
 #include <az_result.h>

--- a/sdk/core/core/inc/az_span_builder.h
+++ b/sdk/core/core/inc/az_span_builder.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_SPAN_BUILDER_H
-#define AZ_SPAN_BUILDER_H
+#ifndef _az_SPAN_BUILDER_H
+#define _az_SPAN_BUILDER_H
 
 #include <az_action.h>
 #include <az_mut_span.h>

--- a/sdk/core/core/inc/az_span_malloc.h
+++ b/sdk/core/core/inc/az_span_malloc.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_SPAN_MALLOC_H
-#define AZ_SPAN_MALLOC_H
+#ifndef _az_SPAN_MALLOC_H
+#define _az_SPAN_MALLOC_H
 
 #include <az_mut_span.h>
 #include <az_result.h>

--- a/sdk/core/core/inc/az_span_reader.h
+++ b/sdk/core/core/inc/az_span_reader.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_SPAN_READER_H
-#define AZ_SPAN_READER_H
+#ifndef _az_SPAN_READER_H
+#define _az_SPAN_READER_H
 
 #include <az_contract.h>
 #include <az_result.h>

--- a/sdk/core/core/inc/az_span_span.h
+++ b/sdk/core/core/inc/az_span_span.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_SPAN_SPAN_H
-#define AZ_SPAN_SPAN_H
+#ifndef _az_SPAN_SPAN_H
+#define _az_SPAN_SPAN_H
 
 #include <az_result.h>
 #include <az_span.h>

--- a/sdk/core/core/inc/az_span_writer.h
+++ b/sdk/core/core/inc/az_span_writer.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_SPAN_WRITER_H
-#define AZ_SPAN_WRITER_H
+#ifndef _az_SPAN_WRITER_H
+#define _az_SPAN_WRITER_H
 
 #include <az_action.h>
 #include <az_result.h>

--- a/sdk/core/core/inc/az_static_assert.h
+++ b/sdk/core/core/inc/az_static_assert.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_STATIC_ASSERT_H
-#define AZ_STATIC_ASSERT_H
+#ifndef _az_STATIC_ASSERT_H
+#define _az_STATIC_ASSERT_H
 
 #include <stdbool.h>
 

--- a/sdk/core/core/inc/az_str.h
+++ b/sdk/core/core/inc/az_str.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_STR_H
-#define AZ_STR_H
+#ifndef _az_STR_H
+#define _az_STR_H
 
 #include <az_action.h>
 #include <az_span.h>

--- a/sdk/core/core/inc/az_uri.h
+++ b/sdk/core/core/inc/az_uri.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_URI_H
-#define AZ_URI_H
+#ifndef _az_URI_H
+#define _az_URI_H
 
 #include <az_result.h>
 #include <az_span.h>

--- a/sdk/core/core/inc/az_url.h
+++ b/sdk/core/core/inc/az_url.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_URL_H
-#define AZ_URL_H
+#ifndef _az_URL_H
+#define _az_URL_H
 
 #include <az_result.h>
 #include <az_span.h>

--- a/sdk/identity/identity/inc/az_identity_access_token.h
+++ b/sdk/identity/identity/inc/az_identity_access_token.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_IDENTITY_ACCESS_TOKEN_H
-#define AZ_IDENTITY_ACCESS_TOKEN_H
+#ifndef _az_IDENTITY_ACCESS_TOKEN_H
+#define _az_IDENTITY_ACCESS_TOKEN_H
 
 #include <az_contract.h>
 #include <az_result.h>
@@ -14,13 +14,16 @@
 #include <_az_cfg_prefix.h>
 
 enum {
-  _az_IDENTITY_ACCESS_TOKEN_TOKEN_BUF_SIZE = 3 * (1024 / 2),
+  _az_IDENTITY_ACCESS_TOKEN_TOKEN_BUF_SIZE
+  = 3 * (1024 / 2), // 1.5 KiB; Typical base64-encoded token is slightly bigger than 1 KiB.
 };
 
 typedef struct {
-  size_t _token_size;
-  clock_t _token_expiration;
-  uint8_t _token_buf[_az_IDENTITY_ACCESS_TOKEN_TOKEN_BUF_SIZE];
+  struct {
+    size_t token_size;
+    clock_t token_expiration;
+    uint8_t token_buf[_az_IDENTITY_ACCESS_TOKEN_TOKEN_BUF_SIZE];
+  } _internal;
 } az_identity_access_token;
 
 AZ_INLINE AZ_NODISCARD az_result

--- a/sdk/identity/identity/inc/az_identity_access_token_context.h
+++ b/sdk/identity/identity/inc/az_identity_access_token_context.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_IDENTITY_ACCESS_TOKEN_CONTEXT_H
-#define AZ_IDENTITY_ACCESS_TOKEN_CONTEXT_H
+#ifndef _az_IDENTITY_ACCESS_TOKEN_CONTEXT_H
+#define _az_IDENTITY_ACCESS_TOKEN_CONTEXT_H
 
 #include <az_contract.h>
 #include <az_identity_access_token.h>
@@ -13,10 +13,12 @@
 #include <_az_cfg_prefix.h>
 
 typedef struct {
-  az_identity_credential_func _credential_func;
-  void const * _credential;
-  az_identity_access_token * _token;
-  az_span _scope;
+  struct {
+    az_identity_credential_func credential_func;
+    void const * credential;
+    az_identity_access_token * token;
+    az_span scope;
+  } _internal;
 } az_identity_access_token_context;
 
 AZ_INLINE AZ_NODISCARD az_result az_identity_access_token_context_init(
@@ -26,15 +28,17 @@ AZ_INLINE AZ_NODISCARD az_result az_identity_access_token_context_init(
     az_span const scope) {
   AZ_CONTRACT_ARG_NOT_NULL(self);
   AZ_CONTRACT_ARG_NOT_NULL(credential);
-  AZ_CONTRACT_ARG_NOT_NULL(((az_identity_credential const *)credential)->_func);
+  AZ_CONTRACT_ARG_NOT_NULL(((az_identity_credential const *)credential)->_internal.func);
   AZ_CONTRACT_ARG_NOT_NULL(token);
   AZ_CONTRACT_ARG_VALID_SPAN(scope);
 
   *self = (az_identity_access_token_context){
-    ._credential_func = ((az_identity_credential const *)credential)->_func,
-    ._credential = credential,
-    ._token = token,
-    ._scope = scope,
+    ._internal = {
+      .credential_func = ((az_identity_credential const *)credential)->_internal.func,
+      .credential = credential,
+      .token = token,
+      .scope = scope,
+    },
   };
 
   return AZ_OK;

--- a/sdk/identity/identity/inc/az_identity_client_secret_credential.h
+++ b/sdk/identity/identity/inc/az_identity_client_secret_credential.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_IDENTITY_CLIENT_SECRET_CREDENTIAL_H
-#define AZ_IDENTITY_CLIENT_SECRET_CREDENTIAL_H
+#ifndef _az_IDENTITY_CLIENT_SECRET_CREDENTIAL_H
+#define _az_IDENTITY_CLIENT_SECRET_CREDENTIAL_H
 
 #include <az_identity_credential.h>
 #include <az_result.h>
@@ -11,7 +11,9 @@
 #include <_az_cfg_prefix.h>
 
 typedef struct {
-  az_identity_credential _credential;
+  struct {
+    az_identity_credential credential;
+  } _internal;
   az_span tenant_id;
   az_span client_id;
   az_span client_secret;

--- a/sdk/identity/identity/inc/az_identity_credential.h
+++ b/sdk/identity/identity/inc/az_identity_credential.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_IDENTITY_CREDENTIAL_H
-#define AZ_IDENTITY_CREDENTIAL_H
+#ifndef _az_IDENTITY_CREDENTIAL_H
+#define _az_IDENTITY_CREDENTIAL_H
 
 #include <az_contract.h>
 #include <az_http_request_builder.h>
@@ -14,7 +14,9 @@ typedef AZ_NODISCARD az_result (
     *az_identity_credential_func)(void * const data, az_http_request_builder * const hrb);
 
 typedef struct {
-  az_identity_credential_func _func; // must be the first field in every credential structure
+  struct {
+    az_identity_credential_func func; // must be the first field in every credential structure
+  } _internal;
 } az_identity_credential;
 
 AZ_INLINE AZ_NODISCARD az_result _az_identity_credential_init(
@@ -23,7 +25,9 @@ AZ_INLINE AZ_NODISCARD az_result _az_identity_credential_init(
   AZ_CONTRACT_ARG_NOT_NULL(self);
   AZ_CONTRACT_ARG_NOT_NULL(credential_func);
 
-  *self = (az_identity_credential){ ._func = credential_func };
+  *self = (az_identity_credential){
+    ._internal = { .func = credential_func, },
+  };
 
   return AZ_OK;
 }

--- a/sdk/identity/identity/src/az_identity_client_secret_credential.c
+++ b/sdk/identity/identity/src/az_identity_client_secret_credential.c
@@ -46,9 +46,9 @@ _az_identity_client_secret_credential_ms_oauth2_send_get_token_request(
     az_mut_span const hrb_buf,
     az_http_response * response,
     clock_t * const requested_at) {
-  AZ_CONTRACT_ARG_NOT_NULL(token_context->_credential);
+  AZ_CONTRACT_ARG_NOT_NULL(token_context->_internal.credential);
   az_identity_client_secret_credential const * const credential
-      = (az_identity_client_secret_credential const *)(token_context->_credential);
+      = (az_identity_client_secret_credential const *)(token_context->_internal.credential);
 
   az_span auth_url = { 0 };
   {
@@ -75,7 +75,7 @@ _az_identity_client_secret_credential_ms_oauth2_send_get_token_request(
     AZ_RETURN_IF_FAILED(az_uri_encode(credential->client_secret, &builder));
 
     AZ_RETURN_IF_FAILED(az_span_builder_append(&builder, AZ_STR("&scope=")));
-    AZ_RETURN_IF_FAILED(az_uri_encode(token_context->_scope, &builder));
+    AZ_RETURN_IF_FAILED(az_uri_encode(token_context->_internal.scope, &builder));
 
     auth_body = az_span_builder_result(&builder);
   }
@@ -160,7 +160,9 @@ AZ_INLINE AZ_NODISCARD az_result _az_identity_client_secret_credential_ms_oauth2
     AZ_RETURN_IF_FAILED(az_json_get_object_member(body, AZ_STR("access_token"), &value));
     AZ_RETURN_IF_FAILED(az_json_token_get_string(value, &token_str));
 
-    az_mut_span const token_buf = AZ_SPAN_FROM_ARRAY(token_context->_token->_token_buf);
+    az_mut_span const token_buf
+        = AZ_SPAN_FROM_ARRAY(token_context->_internal.token->_internal.token_buf);
+
     az_span_builder builder = az_span_builder_create(token_buf);
     az_mut_span_fill(token_buf, 0);
 
@@ -168,11 +170,11 @@ AZ_INLINE AZ_NODISCARD az_result _az_identity_client_secret_credential_ms_oauth2
     az_result const token_append_result = az_span_builder_append(&builder, token_str);
 
     if (az_succeeded(token_append_result)) {
-      token_context->_token->_token_size = az_span_builder_result(&builder).size;
+      token_context->_internal.token->_internal.token_size = az_span_builder_result(&builder).size;
 
       clock_t const expiration = requested_at + expiration_clock;
       if (expiration > 0) {
-        token_context->_token->_token_expiration = expiration;
+        token_context->_internal.token->_internal.token_expiration = expiration;
       }
     } else {
       az_mut_span_fill(token_buf, 'X');
@@ -200,7 +202,7 @@ AZ_INLINE AZ_NODISCARD az_result _az_identity_client_secret_credential_renew_tok
 
 AZ_INLINE AZ_NODISCARD az_result _az_identity_client_secret_credential_ensure_token_credential(
     az_identity_access_token_context const * const token_context) {
-  clock_t const expiration = token_context->_token->_token_expiration;
+  clock_t const expiration = token_context->_internal.token->_internal.token_expiration;
   if (expiration > 0) {
     clock_t const clk = clock();
     if (clk > 0 && clk < expiration) {
@@ -215,7 +217,7 @@ static AZ_NODISCARD az_result _az_identity_client_secret_credential_credential_f
     az_identity_access_token_context const * const token_context,
     az_http_request_builder * const hrb) {
   AZ_CONTRACT_ARG_NOT_NULL(token_context);
-  AZ_CONTRACT_ARG_NOT_NULL(token_context->_token);
+  AZ_CONTRACT_ARG_NOT_NULL(token_context->_internal.token);
   AZ_CONTRACT_ARG_NOT_NULL(hrb);
 
   {
@@ -235,8 +237,8 @@ static AZ_NODISCARD az_result _az_identity_client_secret_credential_credential_f
       hrb,
       AZ_STR("authorization"),
       (az_span){
-          .begin = token_context->_token->_token_buf,
-          .size = token_context->_token->_token_size,
+          .begin = token_context->_internal.token->_internal.token_buf,
+          .size = token_context->_internal.token->_internal.token_size,
       });
 }
 
@@ -251,13 +253,15 @@ AZ_NODISCARD az_result az_identity_client_secret_credential_init(
   AZ_CONTRACT_ARG_VALID_SPAN(client_secret);
 
   *self = (az_identity_client_secret_credential){
-    ._credential = { 0 },
+    ._internal = {
+      .credential = { 0 },
+    },
     .tenant_id = tenant_id,
     .client_id = client_id,
     .client_secret = client_secret,
   };
 
   return _az_identity_credential_init(
-      &(self->_credential),
+      &(self->_internal.credential),
       (az_identity_credential_func)_az_identity_client_secret_credential_credential_func);
 }

--- a/sdk/keyvault/keyvault/inc/az_keyvault.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_KEYVAULT_H
-#define AZ_KEYVAULT_H
+#ifndef _az_KEYVAULT_H
+#define _az_KEYVAULT_H
 
 #include <az_contract.h>
 #include <az_http_pipeline.h>

--- a/sdk/keyvault/keyvault/inc/az_keyvault_create_key_options.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault_create_key_options.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_KEYVAULT_CREATE_KEY_OPTIONS_H
-#define AZ_KEYVAULT_CREATE_KEY_OPTIONS_H
+#ifndef _az_KEYVAULT_CREATE_KEY_OPTIONS_H
+#define _az_KEYVAULT_CREATE_KEY_OPTIONS_H
 
 #include <az_optional_bool.h>
 #include <az_pair.h>

--- a/sdk/storage/blobs/inc/az_storage_blobs.h
+++ b/sdk/storage/blobs/inc/az_storage_blobs.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef AZ_STORAGE_BLOBS_H
-#define AZ_STORAGE_BLOBS_H
+#ifndef _az_STORAGE_BLOBS_H
+#define _az_STORAGE_BLOBS_H
 
 #include <az_contract.h>
 #include <az_http_pipeline.h>
@@ -116,7 +116,7 @@ AZ_NODISCARD AZ_INLINE az_result az_storage_blobs_blob_client_init(
  */
 AZ_NODISCARD az_result az_storage_blobs_blob_upload(
     az_storage_blobs_blob_client * client,
-    az_span content, /* Buffer of content*/
+    az_span const content, /* Buffer of content*/
     az_storage_blobs_blob_upload_options * const options,
     az_http_response * const response);
 

--- a/sdk/storage/blobs/test/storage_blobs_poc.c
+++ b/sdk/storage/blobs/test/storage_blobs_poc.c
@@ -6,6 +6,8 @@
 #include <az_json_get.h>
 #include <az_storage_blobs.h>
 
+#include <stdlib.h>
+
 #include <_az_cfg.h>
 
 #define TENANT_ID_ENV "tenant_id"


### PR DESCRIPTION
1. Identity: move stuff to _internal struct, as we discussed.
2. Add _az_ prefix for all include guards.
3. Fix storage warnings (the getenv/stdlib.h one could actually have lead to runtime errors BTW)