### PR TITLE
ANSI colors for Core and Keyvault tests

### DIFF
--- a/sdk/core/core/test/az_test.h
+++ b/sdk/core/core/test/az_test.h
@@ -4,7 +4,7 @@
 #include <assert.h>
 
 #define ANSI_COLOR_RED     "\x1b[31m"
-#define ANSI_COLOR_GREEN   "\x1b[32m"
+#define _az_ANSI_COLOR_GREEN "\x1b[32m"
 #define ANSI_COLOR_RESET   "\x1b[0m"
 
 extern int exit_code;

--- a/sdk/core/core/test/az_test.h
+++ b/sdk/core/core/test/az_test.h
@@ -3,14 +3,18 @@
 
 #include <assert.h>
 
+#define ANSI_COLOR_RED     "\x1b[31m"
+#define ANSI_COLOR_GREEN   "\x1b[32m"
+#define ANSI_COLOR_RESET   "\x1b[0m"
+
 extern int exit_code;
 
 #define TEST_ASSERT(c) \
   do { \
     if (c) { \
-      printf("  - `%s`: succeeded\n", #c); \
+      printf("  - `%s`: " ANSI_COLOR_GREEN "succeeded" ANSI_COLOR_RESET "\n", #c); \
     } else { \
-      fprintf(stderr, "  - `%s`: failed\n", #c); \
+      fprintf(stderr, "  - `%s`: " ANSI_COLOR_RED "failed" ANSI_COLOR_RESET "\n", #c); \
       assert(false); \
       exit_code = 1; \
     } \

--- a/sdk/keyvault/keyvault/test/az_test.h
+++ b/sdk/keyvault/keyvault/test/az_test.h
@@ -3,14 +3,18 @@
 
 #include <assert.h>
 
+#define ANSI_COLOR_RED     "\x1b[31m"
+#define ANSI_COLOR_GREEN   "\x1b[32m"
+#define ANSI_COLOR_RESET   "\x1b[0m"
+
 extern int exit_code;
 
 #define TEST_ASSERT(c) \
   do { \
     if (c) { \
-      printf("  - `%s`: succeeded\n", #c); \
+      printf("  - `%s`: " ANSI_COLOR_GREEN "succeeded" ANSI_COLOR_RESET "\n", #c); \
     } else { \
-      fprintf(stderr, "  - `%s`: failed\n", #c); \
+      fprintf(stderr, "  - `%s`: " ANSI_COLOR_RED "failed" ANSI_COLOR_RESET "\n", #c); \
       assert(false); \
       exit_code = 1; \
     } \


### PR DESCRIPTION
Added ANSI Green for succeed and ANSI Red for failed in the test for core and keyvault