### PR TITLE
adding first steps of json deserializer for keyvault JsonWebKey with tags only

### DIFF
--- a/sdk/core/core/inc/az_json_data.h
+++ b/sdk/core/core/inc/az_json_data.h
@@ -7,13 +7,44 @@
 #include <az_json_token.h>
 #include <az_mut_span.h>
 #include <az_span.h>
+#include <az_span_builder.h>
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #include <_az_cfg_prefix.h>
 
 typedef struct az_json_data az_json_data;
+
+/**
+ * Creates @_az_type from the given type/variable.
+ */
+#define _AZ_TYPE(DATA_TYPE) \
+  ((az_type){ \
+      .size = sizeof(DATA_TYPE), \
+      .align = AZ_ALIGNOF(DATA_TYPE), \
+  })
+
+/**
+ * Creates @az_data from the given variable.
+ */
+#define _AZ_DATA(DATA) ((az_data){ .p = &DATA, .type = _AZ_TYPE(DATA) })
+
+/**
+ * Run-time type properties.
+ */
+typedef struct {
+  size_t size;
+  size_t align;
+} az_type;
+
+/**
+ * Run-time data properties.
+ */
+typedef struct {
+  void const * p;
+  az_type type;
+} az_data;
 
 typedef struct {
   struct {
@@ -33,7 +64,9 @@ typedef struct {
   } _internal;
 } az_json_object;
 
-AZ_NODISCARD AZ_INLINE size_t az_json_object_size(az_json_object const a) { return a._internal.size; }
+AZ_NODISCARD AZ_INLINE size_t az_json_object_size(az_json_object const a) {
+  return a._internal.size;
+}
 
 typedef enum {
   AZ_JSON_DATA_NULL = 0,
@@ -110,6 +143,26 @@ az_json_object_get(az_json_object const o, size_t const i) {
 
 AZ_NODISCARD az_result
 az_json_to_data(az_span const json, az_mut_span const buffer, az_json_data const ** const out);
+
+AZ_NODISCARD az_result az_span_builder_write_json_string(
+    az_span_builder * const builder,
+    az_span const json_string,
+    az_span * const out);
+
+AZ_NODISCARD az_result
+az_span_builder_top_aligned_append(az_span_builder * const builder, az_data const data);
+
+AZ_NODISCARD az_result az_span_builder_top_array_revert(
+    az_span_builder * const builder,
+    az_type const item_type,
+    size_t const new_size,
+    void const ** const out_array_begin,
+    size_t * const out_array_size);
+
+AZ_NODISCARD az_result az_span_builder_aligned_append(
+    az_span_builder * const builder,
+    az_data const data,
+    void const ** const out);
 
 #include <_az_cfg_suffix.h>
 

--- a/sdk/keyvault/keyvault/CMakeLists.txt
+++ b/sdk/keyvault/keyvault/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_C_STANDARD 99)
 add_library (
   az_keyvault
   src/az_keyvault_client.c
+  src/az_keyvault_key_bundle.c
   )
 
 if(MSVC)

--- a/sdk/keyvault/keyvault/inc/az_keyvault_key_bundle.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault_key_bundle.h
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#ifndef _az_KEYVAULT_KEY_BUNDLE_H
+#define _az_KEYVAULT_KEY_BUNDLE_H
+
+#include <az_mut_span.h>
+#include <az_optional_bool.h>
+#include <az_pair.h>
+#include <az_result.h>
+#include <az_span.h>
+#include <az_span_span.h>
+#include <az_str.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <_az_cfg_prefix.h>
+
+typedef struct {
+  bool is_present;
+  az_span data;
+} az_span_optional;
+
+typedef struct {
+  az_span_optional key;
+} az_keyvault_json_web_key;
+
+typedef struct {
+  bool is_present;
+  az_keyvault_json_web_key data;
+} az_keyvault_json_web_key_optional;
+
+typedef struct {
+  az_span recoveryLevel;
+} az_keyvault_key_attributes;
+
+typedef struct {
+  bool is_present;
+  az_keyvault_key_attributes data;
+} az_keyvault_key_attributes_optional;
+
+typedef struct {
+  bool is_present;
+  az_pair_span data;
+} az_pair_span_optional;
+
+typedef struct {
+  az_keyvault_json_web_key_optional key;
+  az_keyvault_key_attributes_optional attributes;
+  az_pair_span_optional tags;
+} az_keyvault_key_bundle;
+
+AZ_NODISCARD az_result az_keyvault_json_to_key_bundle(
+    az_span const json,
+    az_mut_span const buffer,
+    az_keyvault_key_bundle const ** const out);
+
+#include <_az_cfg_suffix.h>
+
+#endif

--- a/sdk/keyvault/keyvault/src/az_keyvault_key_bundle.c
+++ b/sdk/keyvault/keyvault/src/az_keyvault_key_bundle.c
@@ -1,0 +1,116 @@
+#include <az_json_data.h>
+#include <az_json_parser.h>
+#include <az_json_token.h>
+#include <az_keyvault_key_bundle.h>
+#include <az_optional_bool.h>
+#include <az_pair.h>
+#include <az_result.h>
+#include <az_span.h>
+#include <az_span_builder.h>
+#include <az_span_span.h>
+#include <az_str.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <_az_cfg.h>
+
+AZ_NODISCARD az_result _az_span_builder_write_pair_span(
+    az_span_builder * const builder,
+    az_json_parser * const parser,
+    az_json_token const token,
+    az_pair_span * const out) {
+  switch (token.kind) {
+    case AZ_JSON_TOKEN_OBJECT: {
+      size_t const buffer_size = builder->buffer.size;
+      while (true) {
+        az_json_token_member token_member = { 0 };
+        az_result const result = az_json_parser_read_object_member(parser, &token_member);
+        if (result == AZ_ERROR_ITEM_NOT_FOUND) {
+          break;
+        }
+        AZ_RETURN_IF_FAILED(result);
+        az_pair data_member = { 0 };
+        AZ_RETURN_IF_FAILED(
+            az_span_builder_write_json_string(builder, token_member.name, &data_member.key));
+        // check that only string is expected here. First json level
+
+        if (token_member.value.kind != AZ_JSON_TOKEN_STRING) {
+          return AZ_ERROR_JSON_INVALID_STATE;
+        }
+
+        AZ_RETURN_IF_FAILED(az_span_builder_write_json_string(
+            builder, token_member.value.data.string, &data_member.value));
+
+        AZ_RETURN_IF_FAILED(az_span_builder_top_aligned_append(builder, _AZ_DATA(data_member)));
+      }
+      void const * p = { 0 };
+      size_t i = 0;
+      AZ_RETURN_IF_FAILED(
+          az_span_builder_top_array_revert(builder, _AZ_TYPE(az_pair), buffer_size, &p, &i));
+      *out = (az_pair_span){ .begin = p, .size = i };
+      break;
+    }
+    default: { return AZ_ERROR_JSON_INVALID_STATE; }
+  }
+  return AZ_OK;
+}
+
+AZ_NODISCARD az_result _az_span_builder_write_key_bundle(
+    az_span_builder * const builder,
+    az_json_parser * const parser,
+    az_json_token const token,
+    az_keyvault_key_bundle * const out) {
+  switch (token.kind) {
+    case AZ_JSON_TOKEN_OBJECT: {
+      size_t const buffer_size = builder->buffer.size;
+      while (true) {
+        az_json_token_member token_member = { 0 };
+        az_result const result = az_json_parser_read_object_member(parser, &token_member);
+        if (result == AZ_ERROR_ITEM_NOT_FOUND) {
+          break;
+        }
+        AZ_RETURN_IF_FAILED(result);
+
+        // TODO: Compare as json str and not as span
+        if (az_span_is_equal(token_member.name, AZ_STR("tags"))) {
+          out->tags.is_present = true;
+          AZ_RETURN_IF_FAILED(_az_span_builder_write_pair_span(
+              builder, parser, token_member.value, &out->tags.data));
+        } else {
+          return AZ_ERROR_JSON_INVALID_STATE;
+        }
+      }
+      break;
+    }
+    default: { return AZ_ERROR_JSON_INVALID_STATE; }
+  }
+  return AZ_OK;
+}
+
+AZ_INLINE AZ_NODISCARD az_result _az_span_builder_append_key_bundle(
+    az_span_builder * const builder,
+    az_keyvault_key_bundle const data,
+    az_keyvault_key_bundle const ** const out) {
+  void const * p = { 0 };
+  AZ_RETURN_IF_FAILED(az_span_builder_aligned_append(builder, _AZ_DATA(data), &p));
+  *out = (az_keyvault_key_bundle const *)p;
+  return AZ_OK;
+}
+
+AZ_NODISCARD az_result az_keyvault_json_to_key_bundle(
+    az_span const json,
+    az_mut_span const buffer,
+    az_keyvault_key_bundle const ** const out) {
+
+  az_json_parser parser = az_json_parser_create(json);
+  az_span_builder builder = az_span_builder_create(buffer);
+  az_json_token token = { 0 };
+
+  AZ_RETURN_IF_FAILED(az_json_parser_read(&parser, &token));
+
+  az_keyvault_key_bundle data = { 0 };
+  AZ_RETURN_IF_FAILED(_az_span_builder_write_key_bundle(&builder, &parser, token, &data));
+  return _az_span_builder_append_key_bundle(&builder, data, out);
+}

--- a/sdk/keyvault/keyvault/test/az_json_parse.c
+++ b/sdk/keyvault/keyvault/test/az_json_parse.c
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <az_json_data.h>
+#include <az_keyvault_key_bundle.h>
+#include <az_pair.h>
+#include <az_span.h>
+
+#include "./az_test.h"
+
+#include <_az_cfg.h>
+
+void az_tags_test() {
+  {
+    uint8_t buffer[200] = { 0 };
+    az_keyvault_key_bundle const * data = { 0 };
+    az_span const json = AZ_STR("{\"tags\":{\"key\":\"value\", \"key2\":\"value2\"}}");
+
+    az_result parse_result
+        = az_keyvault_json_to_key_bundle(json, (az_mut_span)AZ_SPAN_FROM_ARRAY(buffer), &data);
+
+    TEST_ASSERT(parse_result == AZ_OK);
+    az_pair * pair = (az_pair *)data->tags.data.begin;
+
+    TEST_ASSERT(data->tags.is_present == true);
+    TEST_ASSERT(data->tags.data.size == 2);
+
+    TEST_ASSERT(az_span_is_equal(pair->key, AZ_STR("key")));
+    TEST_ASSERT(az_span_is_equal(pair->value, AZ_STR("value")));
+
+    pair += 1;
+    TEST_ASSERT(az_span_is_equal(pair->key, AZ_STR("key2")));
+    TEST_ASSERT(az_span_is_equal(pair->value, AZ_STR("value2")));
+  }
+  {
+    uint8_t buffer[200] = { 0 };
+    az_keyvault_key_bundle const * data = { 0 };
+    az_span const json = AZ_STR("{\"nOtags\":{\"key\":\"value\", \"key2\":\"value2\"}}");
+
+    az_result parse_result
+        = az_keyvault_json_to_key_bundle(json, (az_mut_span)AZ_SPAN_FROM_ARRAY(buffer), &data);
+
+    TEST_ASSERT(parse_result == AZ_ERROR_JSON_INVALID_STATE);
+  }
+}

--- a/sdk/keyvault/keyvault/test/main.c
+++ b/sdk/keyvault/keyvault/test/main.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "./az_json_parse.c"
 #include "./az_keyvault_create_key_options_test.c"
 #include "./az_test.h"
 
@@ -82,5 +83,6 @@ int main() {
     }
   }
   az_create_key_options_test();
+  az_tags_test();
   return exit_code;
 }


### PR DESCRIPTION
This is an example about how to use json de-serializer from a json with only tags (see unit tests for the example)

Next steps would be to add the other fields from JsonWebKey. But feedback can be start now here