### PR TITLE
Fix HTTP request sending in auth code

### DIFF
--- a/sdk/core/core/inc/az_credentials.h
+++ b/sdk/core/core/inc/az_credentials.h
@@ -31,14 +31,15 @@ typedef AZ_NODISCARD az_result (*_az_credential_set_scopes_fn)(void * credential
 
 typedef struct {
   struct {
+    az_http_client_fn * http_client;
     _az_credential_apply_fn apply_credential;
     _az_credential_set_scopes_fn set_scopes; // NULL if this credential doesn't support scopes.
   } _internal;
-} _az_credential_vtbl;
+} _az_credential;
 
 typedef struct {
   struct {
-    _az_credential_vtbl vtbl; // must be the first field in every credential structure
+    _az_credential credential; // must be the first field in every credential structure
     az_span tenant_id;
     az_span client_id;
     az_span client_secret;

--- a/sdk/core/core/inc/az_credentials.h
+++ b/sdk/core/core/inc/az_credentials.h
@@ -31,7 +31,7 @@ typedef AZ_NODISCARD az_result (*_az_credential_set_scopes_fn)(void * credential
 
 typedef struct {
   struct {
-    az_http_client_fn * http_client;
+    az_http_transport_options http_transport_options;
     _az_credential_apply_fn apply_credential;
     _az_credential_set_scopes_fn set_scopes; // NULL if this credential doesn't support scopes.
   } _internal;

--- a/sdk/core/core/inc/az_http.h
+++ b/sdk/core/core/inc/az_http.h
@@ -338,7 +338,13 @@ AZ_NODISCARD AZ_INLINE az_result az_http_response_reset(az_http_response * self)
 }
 
 typedef AZ_NODISCARD az_result (
-    *az_http_client_fn)(az_http_request * p_request, az_http_response * p_response);
+    *az_http_client_send_request_fn)(az_http_request * p_request, az_http_response * p_response);
+
+typedef struct {
+  struct {
+    az_http_client_send_request_fn send_request;
+  } _internal;
+} az_http_transport_options;
 
 #include <_az_cfg_suffix.h>
 

--- a/sdk/core/core/internal/az_credentials_internal.h
+++ b/sdk/core/core/internal/az_credentials_internal.h
@@ -13,7 +13,7 @@
 #include <_az_cfg_prefix.h>
 
 AZ_INLINE AZ_NODISCARD az_result
-_az_credential_set_scopes(_az_credential_vtbl * credential, az_span scopes) {
+_az_credential_set_scopes(_az_credential * credential, az_span scopes) {
   return (credential->_internal.set_scopes == NULL)
       ? AZ_OK
       : (credential->_internal.set_scopes)(credential, scopes);

--- a/sdk/core/core/src/az_aad.c
+++ b/sdk/core/core/src/az_aad.c
@@ -81,11 +81,17 @@ AZ_NODISCARD az_result _az_aad_build_body(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result _az_aad_request_token(az_http_request * ref_request, _az_token * out_token) {
-  AZ_RETURN_IF_FAILED(az_http_request_append_header(
+AZ_NODISCARD az_result _az_aad_request_token(
+    az_http_client_fn * http_client,
+    az_http_request * ref_request,
+    _az_token * out_token) {
+  // FIXME: If you uncomment the line below, we'll start getting HTTP 400 Bad Request instead of 200
+  // OK. I suspect, it is because there's a bug in the code that adds headers. Could be something
+  // else, of course.
+  /*AZ_RETURN_IF_FAILED(az_http_request_append_header(
       ref_request,
       AZ_SPAN_FROM_STR("Content-Type"),
-      AZ_SPAN_FROM_STR("application/x-www-url-form-urlencoded")));
+      AZ_SPAN_FROM_STR("application/x-www-url-form-urlencoded")));*/
 
   uint8_t response_buf[_az_AAD_RESPONSE_BUF_SIZE] = { 0 };
   az_http_response response = { 0 };
@@ -96,7 +102,7 @@ AZ_NODISCARD az_result _az_aad_request_token(az_http_request * ref_request, _az_
       .p_policies = {
         { .process = az_http_pipeline_policy_retry, .p_options = NULL },
         { .process = az_http_pipeline_policy_logging, .p_options = NULL },
-        { .process = az_http_pipeline_policy_transport, .p_options = NULL },
+        { .process = az_http_pipeline_policy_transport, .p_options = http_client },
       },
     };
   AZ_RETURN_IF_FAILED(az_http_pipeline_process(&pipeline, ref_request, &response));

--- a/sdk/core/core/src/az_aad.c
+++ b/sdk/core/core/src/az_aad.c
@@ -7,6 +7,8 @@
 #include <az_pal_clock_internal.h>
 #include <az_time_internal.h>
 
+#include <stddef.h>
+
 #include <_az_cfg.h>
 
 AZ_NODISCARD bool _az_token_expired(_az_token const * token) {
@@ -82,7 +84,7 @@ AZ_NODISCARD az_result _az_aad_build_body(
 }
 
 AZ_NODISCARD az_result _az_aad_request_token(
-    az_http_client_fn * http_client,
+    az_http_transport_options * http_transport_options,
     az_http_request * ref_request,
     _az_token * out_token) {
   // FIXME: If you uncomment the line below, we'll start getting HTTP 400 Bad Request instead of 200
@@ -102,7 +104,7 @@ AZ_NODISCARD az_result _az_aad_request_token(
       .p_policies = {
         { .process = az_http_pipeline_policy_retry, .p_options = NULL },
         { .process = az_http_pipeline_policy_logging, .p_options = NULL },
-        { .process = az_http_pipeline_policy_transport, .p_options = http_client },
+        { .process = az_http_pipeline_policy_transport, .p_options = http_transport_options },
       },
     };
   AZ_RETURN_IF_FAILED(az_http_pipeline_process(&pipeline, ref_request, &response));

--- a/sdk/core/core/src/az_aad_private.h
+++ b/sdk/core/core/src/az_aad_private.h
@@ -30,7 +30,7 @@ AZ_NODISCARD az_result _az_aad_build_body(
     az_span * out_body);
 
 AZ_NODISCARD az_result _az_aad_request_token(
-    az_http_client_fn * http_client,
+    az_http_transport_options * http_transport_options,
     az_http_request * request,
     _az_token * out_token);
 

--- a/sdk/core/core/src/az_aad_private.h
+++ b/sdk/core/core/src/az_aad_private.h
@@ -29,7 +29,10 @@ AZ_NODISCARD az_result _az_aad_build_body(
     az_span client_secret,
     az_span * out_body);
 
-AZ_NODISCARD az_result _az_aad_request_token(az_http_request * request, _az_token * out_token);
+AZ_NODISCARD az_result _az_aad_request_token(
+    az_http_client_fn * http_client,
+    az_http_request * request,
+    _az_token * out_token);
 
 AZ_NODISCARD bool _az_token_expired(_az_token const * token);
 AZ_NODISCARD _az_token _az_token_get(_az_token const * self);

--- a/sdk/core/core/src/az_credentials.c
+++ b/sdk/core/core/src/az_credentials.c
@@ -5,6 +5,8 @@
 #include <az_credentials.h>
 #include <az_http.h>
 
+#include <stddef.h>
+
 #include <_az_cfg.h>
 
 static AZ_NODISCARD az_result
@@ -28,7 +30,7 @@ _az_client_secret_credential_request_token(az_client_secret_credential * credent
       &request, az_http_method_post(), url, AZ_SPAN_FROM_BUFFER(header_buf), body));
 
   return _az_aad_request_token(
-      credential->_internal.credential._internal.http_client,
+      &credential->_internal.credential._internal.http_transport_options,
       &request,
       &credential->_internal.token);
 }
@@ -67,7 +69,7 @@ AZ_NODISCARD az_result az_client_secret_credential_init(
     ._internal = {
       .credential = {
         ._internal = {
-          .http_client = NULL,
+          .http_transport_options = NULL,
           .apply_credential = (_az_credential_apply_fn)_az_client_secret_credential_apply,
           .set_scopes = (_az_credential_set_scopes_fn)_az_client_secret_credential_set_scopes,
           },

--- a/sdk/core/core/src/az_credentials.c
+++ b/sdk/core/core/src/az_credentials.c
@@ -27,7 +27,10 @@ _az_client_secret_credential_request_token(az_client_secret_credential * credent
   AZ_RETURN_IF_FAILED(az_http_request_init(
       &request, az_http_method_post(), url, AZ_SPAN_FROM_BUFFER(header_buf), body));
 
-  return _az_aad_request_token(&request, &credential->_internal.token);
+  return _az_aad_request_token(
+      credential->_internal.credential._internal.http_client,
+      &request,
+      &credential->_internal.token);
 }
 
 // This gets called from the http credential policy
@@ -62,8 +65,9 @@ AZ_NODISCARD az_result az_client_secret_credential_init(
     az_span client_secret) {
   *self = (az_client_secret_credential){
     ._internal = {
-      .vtbl = {
+      .credential = {
         ._internal = {
+          .http_client = NULL,
           .apply_credential = (_az_credential_apply_fn)_az_client_secret_credential_apply,
           .set_scopes = (_az_credential_set_scopes_fn)_az_client_secret_credential_set_scopes,
           },

--- a/sdk/core/core/src/az_http_policy.c
+++ b/sdk/core/core/src/az_http_policy.c
@@ -161,6 +161,8 @@ AZ_NODISCARD az_result az_http_pipeline_policy_transport(
     az_http_response * p_response) {
   (void)p_policies; // this is the last policy in the pipeline, we just void it
 
-  az_http_client_fn client = *(az_http_client_fn *)p_options;
-  return client(p_request, p_response);
+  az_http_client_send_request_fn const send_request
+      = ((az_http_transport_options const *)p_options)->_internal.send_request;
+
+  return send_request(p_request, p_response);
 }

--- a/sdk/core/core/src/az_http_policy.c
+++ b/sdk/core/core/src/az_http_policy.c
@@ -94,7 +94,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_retry(
 }
 
 AZ_INLINE AZ_NODISCARD az_result
-_az_apply_credential(_az_credential_vtbl * credential, az_http_request * ref_request) {
+_az_apply_credential(_az_credential * credential, az_http_request * ref_request) {
   return (credential->_internal.apply_credential)(credential, ref_request);
 }
 
@@ -103,7 +103,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_credential(
     void * options,
     az_http_request * ref_request,
     az_http_response * out_response) {
-  AZ_RETURN_IF_FAILED(_az_apply_credential((_az_credential_vtbl *)options, ref_request));
+  AZ_RETURN_IF_FAILED(_az_apply_credential((_az_credential *)options, ref_request));
   return az_http_pipeline_nextpolicy(policies, ref_request, out_response);
 }
 

--- a/sdk/keyvault/keyvault/inc/az_keyvault.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault.h
@@ -28,7 +28,7 @@ typedef struct {
   struct {
     _az_http_policy_apiversion_options api_version;
     _az_http_policy_telemetry_options _telemetry_options;
-    az_http_client_fn http_client;
+    az_http_transport_options http_transport_options;
   } _internal;
 } az_keyvault_keys_client_options;
 
@@ -41,7 +41,7 @@ typedef struct {
  * overriding that specific option
  */
 AZ_NODISCARD az_keyvault_keys_client_options
-az_keyvault_keys_client_options_default(az_http_client_fn http_client);
+az_keyvault_keys_client_options_default(az_http_transport_options const * http_transport_options);
 
 typedef struct {
   struct {

--- a/sdk/keyvault/keyvault/inc/az_keyvault.h
+++ b/sdk/keyvault/keyvault/inc/az_keyvault.h
@@ -51,7 +51,7 @@ typedef struct {
     az_span uri;
     az_http_pipeline pipeline;
     az_keyvault_keys_client_options options;
-    _az_credential_vtbl * credential;
+    _az_credential * credential;
   } _internal;
 } az_keyvault_keys_client;
 

--- a/sdk/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/keyvault/keyvault/src/az_keyvault_client.c
@@ -7,6 +7,8 @@
 #include <az_keyvault.h>
 #include <az_span.h>
 
+#include <stddef.h>
+
 #include <_az_cfg.h>
 
 /**
@@ -38,11 +40,11 @@ AZ_NODISCARD AZ_INLINE az_span az_keyvault_client_constant_for_application_json(
 }
 
 AZ_NODISCARD az_keyvault_keys_client_options
-az_keyvault_keys_client_options_default(az_http_client_fn http_client) {
+az_keyvault_keys_client_options_default(az_http_transport_options const * http_transport_options) {
 
   az_keyvault_keys_client_options options = (az_keyvault_keys_client_options){
-    ._internal
-    = { .http_client = http_client, .api_version = az_http_policy_apiversion_options_default() },
+    ._internal = { .http_transport_options = *http_transport_options,
+                   .api_version = az_http_policy_apiversion_options_default() },
     .retry = az_http_policy_retry_options_default(),
   };
 
@@ -62,38 +64,55 @@ AZ_NODISCARD az_result az_keyvault_keys_client_init(
   AZ_CONTRACT_ARG_NOT_NULL(options);
 
   _az_credential * const cred = (_az_credential *)credential;
-  cred->_internal.http_client = &self->_internal.options._internal.http_client;
+  cred->_internal.http_transport_options = options->_internal.http_transport_options;
 
-  *self
-      = (az_keyvault_keys_client){ ._internal
-                                   = { .uri = AZ_SPAN_FROM_BUFFER(self->_internal.url_buffer),
-                                       .options = *options,
-                                       .credential = cred,
-                                       .pipeline = (az_http_pipeline){
-                                           .p_policies = {
-                                               { .process = az_http_pipeline_policy_apiversion,
-                                                 .p_options
-                                                 = &self->_internal.options._internal.api_version },
-                                               { .process = az_http_pipeline_policy_uniquerequestid,
-                                                 .p_options = NULL },
-                                               { .process = az_http_pipeline_policy_telemetry,
-                                                 .p_options = &self->_internal.options._internal
-                                                                   ._telemetry_options },
-                                               { .process = az_http_pipeline_policy_retry,
-                                                 .p_options = &(self->_internal.options.retry) },
-                                               { .process = az_http_pipeline_policy_credential,
-                                                 .p_options = cred },
-                                               { .process = az_http_pipeline_policy_logging,
-                                                 .p_options = NULL },
-                                               { .process = az_http_pipeline_policy_bufferresponse,
-                                                 .p_options = NULL },
-                                               { .process
-                                                 = az_http_pipeline_policy_distributedtracing,
-                                                 .p_options = NULL },
-                                               { .process = az_http_pipeline_policy_transport,
-                                                 .p_options
-                                                 = &self->_internal.options._internal.http_client },
-                                           } } } };
+  *self = (az_keyvault_keys_client) {
+    ._internal = {
+      .uri = AZ_SPAN_FROM_BUFFER(self->_internal.url_buffer),
+      .options = *options,
+      .credential = cred,
+      .pipeline = (az_http_pipeline) {
+        .p_policies = {
+          {
+            .process = az_http_pipeline_policy_apiversion,
+            .p_options = &self->_internal.options._internal.api_version,
+          },
+          {
+            .process = az_http_pipeline_policy_uniquerequestid,
+            .p_options = NULL,
+          },
+          {
+            .process = az_http_pipeline_policy_telemetry,
+            .p_options = &self->_internal.options._internal._telemetry_options,
+          },
+          {
+            .process = az_http_pipeline_policy_retry,
+            .p_options = &self->_internal.options.retry,
+          },
+          {
+            .process = az_http_pipeline_policy_credential,
+            .p_options = cred,
+          },
+          {
+            .process = az_http_pipeline_policy_logging,
+            .p_options = NULL,
+          },
+          {
+            .process = az_http_pipeline_policy_bufferresponse,
+            .p_options = NULL,
+          },
+          {
+            .process = az_http_pipeline_policy_distributedtracing,
+            .p_options = NULL,
+          },
+          {
+            .process = az_http_pipeline_policy_transport,
+            .p_options = &self->_internal.options._internal.http_transport_options,
+          },
+        },
+      },
+    },
+  };
 
   // Copy url to client buffer so customer can re-use buffer on his/her side
   AZ_RETURN_IF_FAILED(az_span_copy(self->_internal.uri, uri, &self->_internal.uri));

--- a/sdk/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/keyvault/keyvault/src/az_keyvault_client.c
@@ -61,7 +61,8 @@ AZ_NODISCARD az_result az_keyvault_keys_client_init(
   AZ_CONTRACT_ARG_NOT_NULL(self);
   AZ_CONTRACT_ARG_NOT_NULL(options);
 
-  _az_credential_vtbl * const cred = (_az_credential_vtbl *)credential;
+  _az_credential * const cred = (_az_credential *)credential;
+  cred->_internal.http_client = &self->_internal.options._internal.http_client;
 
   *self
       = (az_keyvault_keys_client){ ._internal

--- a/sdk/keyvault/keyvault/test/client_key_poc.c
+++ b/sdk/keyvault/keyvault/test/client_key_poc.c
@@ -38,9 +38,17 @@ int main() {
     printf("Failed to init credential");
   }
 
+  az_http_transport_options http_transport_options = { 0 };
+  az_result const http_transport_options_init_status
+      = az_http_transport_options_init(&http_transport_options);
+
+  if (az_failed(http_transport_options_init_status)) {
+    printf("Failed to init http transport options");
+  }
+
   // Init client.
   az_keyvault_keys_client_options options
-      = az_keyvault_keys_client_options_default(az_http_client_curl);
+      = az_keyvault_keys_client_options_default(&http_transport_options);
 
   // URL will be copied to client's internal buffer. So we don't need to keep the content of URL
   // buffer immutable  on client's side

--- a/sdk/storage/blobs/inc/az_storage_blobs.h
+++ b/sdk/storage/blobs/inc/az_storage_blobs.h
@@ -11,22 +11,19 @@
 #include <az_result.h>
 #include <az_span.h>
 
-#include <stddef.h>
-
 #include <_az_cfg_prefix.h>
 
 static az_span const AZ_STORAGE_API_VERSION = AZ_SPAN_LITERAL_FROM_STR("2019-02-02");
+
 typedef struct {
   az_http_policy_retry_options retry;
   struct {
-    az_http_client_fn http_client;
+    az_http_transport_options http_transport_options;
     _az_http_policy_apiversion_options api_version;
     _az_http_policy_telemetry_options _telemetry_options;
   } _internal;
 } az_storage_blobs_blob_client_options;
 
-AZ_NODISCARD az_storage_blobs_blob_client_options
-az_storage_blobs_blob_client_options_default(az_http_client_fn http_client);
 typedef struct {
   struct {
     // buffer to copy customer url. Then it stays immutable
@@ -48,6 +45,9 @@ AZ_NODISCARD az_result az_storage_blobs_blob_client_init(
 typedef struct {
   az_span option;
 } az_storage_blobs_blob_upload_options;
+
+AZ_NODISCARD az_storage_blobs_blob_client_options
+az_storage_blobs_blob_client_options_default(az_http_transport_options const * http_transport_options);
 
 AZ_NODISCARD AZ_INLINE az_storage_blobs_blob_upload_options
 az_storage_blobs_blob_upload_options_default() {

--- a/sdk/storage/blobs/inc/az_storage_blobs.h
+++ b/sdk/storage/blobs/inc/az_storage_blobs.h
@@ -35,7 +35,7 @@ typedef struct {
     az_span uri;
     az_http_pipeline pipeline;
     az_storage_blobs_blob_client_options options;
-    _az_credential_vtbl * credential;
+    _az_credential * credential;
   } _internal;
 } az_storage_blobs_blob_client;
 

--- a/sdk/storage/blobs/src/az_storage_blobs_blob_client.c
+++ b/sdk/storage/blobs/src/az_storage_blobs_blob_client.c
@@ -41,7 +41,8 @@ AZ_NODISCARD az_result az_storage_blobs_blob_client_init(
   AZ_CONTRACT_ARG_NOT_NULL(client);
   AZ_CONTRACT_ARG_NOT_NULL(options);
 
-  _az_credential_vtbl * const cred = (_az_credential_vtbl *)credential;
+  _az_credential * const cred = (_az_credential *)credential;
+  cred->_internal.http_client = &client->_internal.options._internal.http_client;
 
   *client = (az_storage_blobs_blob_client){ ._internal = {
     .uri = AZ_SPAN_FROM_BUFFER(client->_internal.url_buffer),

--- a/sdk/transport_policies/curl/inc/az_curl.h
+++ b/sdk/transport_policies/curl/inc/az_curl.h
@@ -9,8 +9,7 @@
 
 #include <_az_cfg_prefix.h>
 
-AZ_NODISCARD az_result
-az_http_client_curl(az_http_request * p_request, az_http_response * p_response);
+AZ_NODISCARD az_result az_http_transport_options_init(az_http_transport_options * out_options);
 
 #include <_az_cfg_suffix.h>
 

--- a/sdk/transport_policies/curl/src/az_curl.c
+++ b/sdk/transport_policies/curl/src/az_curl.c
@@ -22,7 +22,7 @@
 
 #define AZ_CONTRACT_ARG_NOT_NULL(arg) AZ_CONTRACT((arg) != NULL, AZ_ERROR_ARG)
 
-AZ_NODISCARD az_result az_span_malloc(size_t size, az_span * out) {
+static AZ_NODISCARD az_result _az_span_malloc(size_t size, az_span * out) {
   AZ_CONTRACT_ARG_NOT_NULL(out);
 
   uint8_t * const p = (uint8_t *)malloc(size);
@@ -33,7 +33,7 @@ AZ_NODISCARD az_result az_span_malloc(size_t size, az_span * out) {
   return AZ_OK;
 }
 
-void az_span_free(az_span * p) {
+static void _az_span_free(az_span * p) {
   if (p == NULL) {
     return;
   }
@@ -44,19 +44,19 @@ void az_span_free(az_span * p) {
 /**
  * Converts CURLcode to az_result.
  */
-AZ_NODISCARD AZ_INLINE az_result az_curl_code_to_result(CURLcode code) {
+AZ_NODISCARD AZ_INLINE az_result _az_http_client_curl_code_to_result(CURLcode code) {
   return code == CURLE_OK ? AZ_OK : AZ_ERROR_HTTP_PAL;
 }
 
 // returning AZ error on CURL Error
-#define AZ_RETURN_IF_CURL_FAILED(exp) AZ_RETURN_IF_FAILED(az_curl_code_to_result(exp))
+#define AZ_RETURN_IF_CURL_FAILED(exp) AZ_RETURN_IF_FAILED(_az_http_client_curl_code_to_result(exp))
 
-AZ_NODISCARD AZ_INLINE az_result az_curl_init(CURL ** out) {
+AZ_NODISCARD AZ_INLINE az_result _az_http_client_curl_init(CURL ** out) {
   *out = curl_easy_init();
   return AZ_OK;
 }
 
-AZ_NODISCARD AZ_INLINE az_result az_curl_done(CURL ** pp) {
+AZ_NODISCARD AZ_INLINE az_result _az_http_client_curl_done(CURL ** pp) {
   AZ_CONTRACT_ARG_NOT_NULL(pp);
   AZ_CONTRACT_ARG_NOT_NULL(*pp);
 
@@ -65,10 +65,10 @@ AZ_NODISCARD AZ_INLINE az_result az_curl_done(CURL ** pp) {
   return AZ_OK;
 }
 
-uint8_t zerobyte[] = { 0 };
-az_span const AZ_SPAN_ZEROBYTE = AZ_SPAN_LITERAL_FROM_INITIALIZED_BUFFER(zerobyte);
+static uint8_t zerobyte[] = { 0 };
+static az_span const AZ_SPAN_ZEROBYTE = AZ_SPAN_LITERAL_FROM_INITIALIZED_BUFFER(zerobyte);
 
-az_span const AZ_HTTP_REQUEST_BUILDER_HEADER_SEPARATOR = AZ_SPAN_LITERAL_FROM_STR(": ");
+static az_span const AZ_HTTP_REQUEST_BUILDER_HEADER_SEPARATOR = AZ_SPAN_LITERAL_FROM_STR(": ");
 
 /**
  * @brief writes a header key and value to a buffer as a 0-terminated string and using a separator
@@ -79,8 +79,8 @@ az_span const AZ_HTTP_REQUEST_BUILDER_HEADER_SEPARATOR = AZ_SPAN_LITERAL_FROM_ST
  * @param separator symbol to be used between key and value
  * @return az_result
  */
-AZ_NODISCARD az_result
-az_write_to_buffer(az_span writable_buffer, az_pair header, az_span separator) {
+static AZ_NODISCARD az_result
+_az_span_write_to_buffer(az_span writable_buffer, az_pair header, az_span separator) {
 
   AZ_RETURN_IF_FAILED(az_span_append(writable_buffer, header.key, &writable_buffer));
   AZ_RETURN_IF_FAILED(az_span_append(writable_buffer, separator, &writable_buffer));
@@ -89,7 +89,8 @@ az_write_to_buffer(az_span writable_buffer, az_pair header, az_span separator) {
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_curl_slist_append(struct curl_slist ** self, char const * str) {
+static AZ_NODISCARD az_result
+_az_http_client_curl_slist_append(struct curl_slist ** self, char const * str) {
   AZ_CONTRACT_ARG_NOT_NULL(self);
   AZ_CONTRACT_ARG_NOT_NULL(str);
 
@@ -111,8 +112,10 @@ AZ_NODISCARD az_result az_curl_slist_append(struct curl_slist ** self, char cons
  * @param separator a symbol to be used between key and value for a header
  * @return az_result
  */
-AZ_NODISCARD az_result
-az_add_header_to_curl_list(az_pair header, struct curl_slist ** p_list, az_span separator) {
+static AZ_NODISCARD az_result _az_http_client_curl_add_header_to_curl_list(
+    az_pair header,
+    struct curl_slist ** p_list,
+    az_span separator) {
   AZ_CONTRACT_ARG_NOT_NULL(p_list);
 
   // allocate a buffer for header
@@ -121,20 +124,20 @@ az_add_header_to_curl_list(az_pair header, struct curl_slist ** p_list, az_span 
     size_t const buffer_size = (size_t)az_span_length(header.key)
         + (size_t)az_span_length(separator) + (size_t)az_span_length(header.value) + 1;
 
-    AZ_RETURN_IF_FAILED(az_span_malloc(buffer_size, &writable_buffer));
+    AZ_RETURN_IF_FAILED(_az_span_malloc(buffer_size, &writable_buffer));
   }
 
   // write buffer
-  az_result result = az_write_to_buffer(writable_buffer, header, separator);
+  az_result result = _az_span_write_to_buffer(writable_buffer, header, separator);
 
   // attach header only when write was OK
   if (az_succeeded(result)) {
     char const * const buffer = (char const *)az_span_ptr(writable_buffer);
-    result = az_curl_slist_append(p_list, buffer);
+    result = _az_http_client_curl_slist_append(p_list, buffer);
   }
 
   // at any case, error or OK, free the allocated memory
-  az_span_free(&writable_buffer);
+  _az_span_free(&writable_buffer);
   return result;
 }
 
@@ -145,8 +148,9 @@ az_add_header_to_curl_list(az_pair header, struct curl_slist ** p_list, az_span 
  * @param p_headers list of headers in curl specific list
  * @return az_result
  */
-AZ_NODISCARD az_result
-az_build_headers(az_http_request * p_request, struct curl_slist ** p_headers) {
+AZ_NODISCARD az_result static _az_http_client_curl_build_headers(
+    az_http_request * p_request,
+    struct curl_slist ** p_headers) {
   AZ_CONTRACT_ARG_NOT_NULL(p_request);
 
   az_pair header;
@@ -154,8 +158,8 @@ az_build_headers(az_http_request * p_request, struct curl_slist ** p_headers) {
        offset < (int32_t)(az_span_length(p_request->_internal.headers) / sizeof(az_pair));
        ++offset) {
     AZ_RETURN_IF_FAILED(az_http_request_get_header(p_request, offset, &header));
-    AZ_RETURN_IF_FAILED(
-        az_add_header_to_curl_list(header, p_headers, AZ_HTTP_REQUEST_BUILDER_HEADER_SEPARATOR));
+    AZ_RETURN_IF_FAILED(_az_http_client_curl_add_header_to_curl_list(
+        header, p_headers, AZ_HTTP_REQUEST_BUILDER_HEADER_SEPARATOR));
   }
 
   return AZ_OK;
@@ -169,7 +173,8 @@ az_build_headers(az_http_request * p_request, struct curl_slist ** p_headers) {
  * @param url_from_request a url that is not zero terminated
  * @return az_result
  */
-AZ_NODISCARD az_result az_write_url(az_span writable_buffer, az_span url_from_request) {
+static AZ_NODISCARD az_result
+_az_http_client_curl_write_url(az_span writable_buffer, az_span url_from_request) {
 
   AZ_RETURN_IF_FAILED(az_span_append(writable_buffer, url_from_request, &writable_buffer));
   AZ_RETURN_IF_FAILED(az_span_append(writable_buffer, AZ_SPAN_ZEROBYTE, &writable_buffer));
@@ -187,7 +192,11 @@ AZ_NODISCARD az_result az_write_url(az_span writable_buffer, az_span url_from_re
  * @param userp this represent a structure linked to response by us before
  * @return int
  */
-size_t write_to_span(void * contents, size_t size, size_t nmemb, void * userp) {
+static size_t _az_http_client_curl_write_to_span(
+    void * contents,
+    size_t size,
+    size_t nmemb,
+    void * userp) {
   size_t const expected_size = size * nmemb;
   az_span * const user_buffer_builder = (az_span *)userp;
 
@@ -202,7 +211,7 @@ size_t write_to_span(void * contents, size_t size, size_t nmemb, void * userp) {
 /**
  * handles GET request
  */
-AZ_NODISCARD az_result az_curl_send_get_request(CURL * p_curl) {
+static AZ_NODISCARD az_result _az_http_client_curl_send_get_request(CURL * p_curl) {
   AZ_CONTRACT_ARG_NOT_NULL(p_curl);
 
   // send
@@ -214,15 +223,15 @@ AZ_NODISCARD az_result az_curl_send_get_request(CURL * p_curl) {
 /**
  * handles DELETE request
  */
-AZ_NODISCARD az_result
-az_curl_send_delete_request(CURL * p_curl, az_http_request const * p_request) {
+static AZ_NODISCARD az_result
+_az_http_client_curl_send_delete_request(CURL * p_curl, az_http_request const * p_request) {
   AZ_CONTRACT_ARG_NOT_NULL(p_curl);
   AZ_CONTRACT_ARG_NOT_NULL(p_request);
 
-  AZ_RETURN_IF_FAILED(
-      az_curl_code_to_result(curl_easy_setopt(p_curl, CURLOPT_CUSTOMREQUEST, "DELETE")));
+  AZ_RETURN_IF_FAILED(_az_http_client_curl_code_to_result(
+      curl_easy_setopt(p_curl, CURLOPT_CUSTOMREQUEST, "DELETE")));
 
-  AZ_RETURN_IF_FAILED(az_curl_code_to_result(curl_easy_perform(p_curl)));
+  AZ_RETURN_IF_FAILED(_az_http_client_curl_code_to_result(curl_easy_perform(p_curl)));
 
   return AZ_OK;
 }
@@ -230,7 +239,8 @@ az_curl_send_delete_request(CURL * p_curl, az_http_request const * p_request) {
 /**
  * handles POST request. It handles seting up a body for request
  */
-AZ_NODISCARD az_result az_curl_send_post_request(CURL * p_curl, az_http_request const * p_request) {
+static AZ_NODISCARD az_result
+_az_http_client_curl_send_post_request(CURL * p_curl, az_http_request const * p_request) {
   AZ_CONTRACT_ARG_NOT_NULL(p_curl);
   AZ_CONTRACT_ARG_NOT_NULL(p_request);
 
@@ -238,25 +248,29 @@ AZ_NODISCARD az_result az_curl_send_post_request(CURL * p_curl, az_http_request 
   az_span body = { 0 };
   int32_t required_length
       = az_span_length(p_request->_internal.body) + az_span_length(AZ_SPAN_ZEROBYTE);
-  AZ_RETURN_IF_FAILED(az_span_malloc(required_length, &body));
+  AZ_RETURN_IF_FAILED(_az_span_malloc(required_length, &body));
 
   char * b = (char *)az_span_ptr(body);
   az_result res_code = az_span_to_str(b, required_length, p_request->_internal.body);
 
   if (az_succeeded(res_code)) {
-    res_code = az_curl_code_to_result(curl_easy_setopt(p_curl, CURLOPT_POSTFIELDS, b));
+    res_code = _az_http_client_curl_code_to_result(curl_easy_setopt(p_curl, CURLOPT_POSTFIELDS, b));
     if (az_succeeded(res_code)) {
-      res_code = az_curl_code_to_result(curl_easy_perform(p_curl));
+      res_code = _az_http_client_curl_code_to_result(curl_easy_perform(p_curl));
     }
   }
 
-  az_span_free(&body);
+  _az_span_free(&body);
   AZ_RETURN_IF_FAILED(res_code);
 
   return AZ_OK;
 }
 
-int32_t _az_curl_upload_read_callback(void * ptr, size_t size, size_t nmemb, void * userdata) {
+static int32_t _az_http_client_curl_upload_read_callback(
+    void * ptr,
+    size_t size,
+    size_t nmemb,
+    void * userdata) {
 
   az_span * mut_span = (az_span *)userdata;
 
@@ -277,8 +291,8 @@ int32_t _az_curl_upload_read_callback(void * ptr, size_t size, size_t nmemb, voi
 /**
  * handles POST request. It handles seting up a body for request
  */
-AZ_NODISCARD az_result
-az_curl_send_upload_request(CURL * p_curl, az_http_request const * p_request) {
+static AZ_NODISCARD az_result
+_az_http_client_curl_send_upload_request(CURL * p_curl, az_http_request const * p_request) {
   AZ_CONTRACT_ARG_NOT_NULL(p_curl);
   AZ_CONTRACT_ARG_NOT_NULL(p_request);
 
@@ -286,37 +300,38 @@ az_curl_send_upload_request(CURL * p_curl, az_http_request const * p_request) {
   az_span body = { 0 };
   int32_t required_size
       = az_span_length(p_request->_internal.body) + az_span_length(AZ_SPAN_ZEROBYTE);
-  AZ_RETURN_IF_FAILED(az_span_malloc(required_size, &body));
+  AZ_RETURN_IF_FAILED(_az_span_malloc(required_size, &body));
 
   char * b = (char *)az_span_ptr(body);
   az_result res_code = az_span_to_str(b, required_size, p_request->_internal.body);
 
   if (az_succeeded(res_code)) {
-    res_code = az_curl_code_to_result(curl_easy_setopt(p_curl, CURLOPT_UPLOAD, 1L));
+    res_code = _az_http_client_curl_code_to_result(curl_easy_setopt(p_curl, CURLOPT_UPLOAD, 1L));
     if (az_succeeded(res_code)) {
-      res_code = az_curl_code_to_result(
-          curl_easy_setopt(p_curl, CURLOPT_READFUNCTION, _az_curl_upload_read_callback));
+      res_code = _az_http_client_curl_code_to_result(curl_easy_setopt(
+          p_curl, CURLOPT_READFUNCTION, _az_http_client_curl_upload_read_callback));
       if (az_succeeded(res_code)) {
 
         // Setup the request to pass the body in as the data stream to read
-        res_code = az_curl_code_to_result(curl_easy_setopt(p_curl, CURLOPT_READDATA, body));
+        res_code
+            = _az_http_client_curl_code_to_result(curl_easy_setopt(p_curl, CURLOPT_READDATA, body));
 
         if (az_succeeded(res_code)) {
 
           // Set the size of the upload
-          res_code = az_curl_code_to_result(
+          res_code = _az_http_client_curl_code_to_result(
               curl_easy_setopt(p_curl, CURLOPT_INFILESIZE, (curl_off_t)az_span_length(body)));
 
           // Do the curl work
           if (az_succeeded(res_code)) {
-            res_code = az_curl_code_to_result(curl_easy_perform(p_curl));
+            res_code = _az_http_client_curl_code_to_result(curl_easy_perform(p_curl));
           }
         }
       }
     }
   }
 
-  az_span_free(&body);
+  _az_span_free(&body);
   AZ_RETURN_IF_FAILED(res_code);
 
   return AZ_OK;
@@ -329,7 +344,8 @@ az_curl_send_upload_request(CURL * p_curl, az_http_request const * p_request) {
  * @param p_request an http request builder
  * @return az_result
  */
-AZ_NODISCARD az_result setup_headers(CURL * p_curl, az_http_request * p_request) {
+static AZ_NODISCARD az_result
+_az_http_client_curl_setup_headers(CURL * p_curl, az_http_request * p_request) {
   AZ_CONTRACT_ARG_NOT_NULL(p_curl);
   AZ_CONTRACT_ARG_NOT_NULL(p_request);
 
@@ -341,7 +357,7 @@ AZ_NODISCARD az_result setup_headers(CURL * p_curl, az_http_request * p_request)
   // creates a slist for bulding curl headers
   struct curl_slist * p_list = NULL;
   // build headers into a slist as curl is expecting
-  AZ_RETURN_IF_FAILED(az_build_headers(p_request, &p_list));
+  AZ_RETURN_IF_FAILED(_az_http_client_curl_build_headers(p_request, &p_list));
   // set all headers from slist
   AZ_RETURN_IF_CURL_FAILED(curl_easy_setopt(p_curl, CURLOPT_HTTPHEADER, p_list));
 
@@ -355,7 +371,8 @@ AZ_NODISCARD az_result setup_headers(CURL * p_curl, az_http_request * p_request)
  * @param p_request an az http request builder holding all data to send request
  * @return az_result
  */
-AZ_NODISCARD az_result setup_url(CURL * p_curl, az_http_request const * p_request) {
+static AZ_NODISCARD az_result
+_az_http_client_curl_setup_url(CURL * p_curl, az_http_request const * p_request) {
   AZ_CONTRACT_ARG_NOT_NULL(p_curl);
   AZ_CONTRACT_ARG_NOT_NULL(p_request);
 
@@ -365,20 +382,20 @@ AZ_NODISCARD az_result setup_url(CURL * p_curl, az_http_request const * p_reques
     size_t const extra_space_for_zero = az_span_length(AZ_SPAN_ZEROBYTE);
     size_t const url_final_size = az_span_length(p_request->_internal.url) + extra_space_for_zero;
     // allocate buffer to add \0
-    AZ_RETURN_IF_FAILED(az_span_malloc(url_final_size, &writable_buffer));
+    AZ_RETURN_IF_FAILED(_az_span_malloc(url_final_size, &writable_buffer));
   }
 
   // write url in buffer (will add \0 at the end)
-  az_result result = az_write_url(writable_buffer, p_request->_internal.url);
+  az_result result = _az_http_client_curl_write_url(writable_buffer, p_request->_internal.url);
 
   if (az_succeeded(result)) {
     char * buffer = (char *)az_span_ptr(writable_buffer);
-    result = az_curl_code_to_result(curl_easy_setopt(p_curl, CURLOPT_URL, buffer));
+    result = _az_http_client_curl_code_to_result(curl_easy_setopt(p_curl, CURLOPT_URL, buffer));
   }
 
   // free used buffer before anything else
   memset(az_span_ptr(writable_buffer), 0, az_span_capacity(writable_buffer));
-  az_span_free(&writable_buffer);
+  _az_span_free(&writable_buffer);
 
   return result;
 }
@@ -390,13 +407,18 @@ AZ_NODISCARD az_result setup_url(CURL * p_curl, az_http_request const * p_reques
  * @param response_builder an http request builder holding all http request data
  * @return az_result
  */
-AZ_NODISCARD az_result setup_response_redirect(CURL * p_curl, az_span * response_builder) {
+static AZ_NODISCARD az_result
+_az_http_client_curl_setup_response_redirect(CURL * p_curl, az_span * response_builder) {
   AZ_CONTRACT_ARG_NOT_NULL(p_curl);
 
-  AZ_RETURN_IF_CURL_FAILED(curl_easy_setopt(p_curl, CURLOPT_HEADERFUNCTION, write_to_span));
+  AZ_RETURN_IF_CURL_FAILED(
+      curl_easy_setopt(p_curl, CURLOPT_HEADERFUNCTION, _az_http_client_curl_write_to_span));
+
   AZ_RETURN_IF_CURL_FAILED(curl_easy_setopt(p_curl, CURLOPT_HEADERDATA, (void *)response_builder));
 
-  AZ_RETURN_IF_CURL_FAILED(curl_easy_setopt(p_curl, CURLOPT_WRITEFUNCTION, write_to_span));
+  AZ_RETURN_IF_CURL_FAILED(
+      curl_easy_setopt(p_curl, CURLOPT_WRITEFUNCTION, _az_http_client_curl_write_to_span));
+
   AZ_RETURN_IF_CURL_FAILED(curl_easy_setopt(p_curl, CURLOPT_WRITEDATA, (void *)response_builder));
 
   return AZ_OK;
@@ -412,26 +434,27 @@ AZ_NODISCARD az_result setup_response_redirect(CURL * p_curl, az_span * response
 
  * @return AZ_OK if request was sent and a response was received
  */
-AZ_NODISCARD az_result az_http_client_send_request_impl_process(
+static AZ_NODISCARD az_result _az_http_client_curl_send_request_impl_process(
     CURL * p_curl,
     az_http_request * p_request,
     az_http_response * response) {
   az_result result = AZ_ERROR_ARG;
 
-  AZ_RETURN_IF_CURL_FAILED(setup_headers(p_curl, p_request));
+  AZ_RETURN_IF_FAILED(_az_http_client_curl_setup_headers(p_curl, p_request));
 
-  AZ_RETURN_IF_CURL_FAILED(setup_url(p_curl, p_request));
+  AZ_RETURN_IF_FAILED(_az_http_client_curl_setup_url(p_curl, p_request));
 
-  AZ_RETURN_IF_CURL_FAILED(setup_response_redirect(p_curl, &response->_internal.http_response));
+  AZ_RETURN_IF_FAILED(
+      _az_http_client_curl_setup_response_redirect(p_curl, &response->_internal.http_response));
 
   if (az_span_is_equal(p_request->_internal.method, az_http_method_get())) {
-    result = az_curl_send_get_request(p_curl);
+    result = _az_http_client_curl_send_get_request(p_curl);
   } else if (az_span_is_equal(p_request->_internal.method, az_http_method_post())) {
-    result = az_curl_send_post_request(p_curl, p_request);
+    result = _az_http_client_curl_send_post_request(p_curl, p_request);
   } else if (az_span_is_equal(p_request->_internal.method, az_http_method_delete())) {
-    result = az_curl_send_delete_request(p_curl, p_request);
+    result = _az_http_client_curl_send_delete_request(p_curl, p_request);
   } else if (az_span_is_equal(p_request->_internal.method, az_http_method_put())) {
-    result = az_curl_send_upload_request(p_curl, p_request);
+    result = _az_http_client_curl_send_upload_request(p_curl, p_request);
   } else {
     return AZ_ERROR_HTTP_INVALID_METHOD_VERB;
   }
@@ -459,14 +482,14 @@ az_http_client_curl(az_http_request * p_request, az_http_response * p_response) 
   CURL * p_curl = NULL;
 
   // init curl
-  AZ_RETURN_IF_FAILED(az_curl_init(&p_curl));
+  AZ_RETURN_IF_FAILED(_az_http_client_curl_init(&p_curl));
 
   // process request
   az_result process_result
-      = az_http_client_send_request_impl_process(p_curl, p_request, p_response);
+      = _az_http_client_curl_send_request_impl_process(p_curl, p_request, p_response);
 
   // no matter if error or not, call curl done before returning to let curl clean everything
-  AZ_RETURN_IF_FAILED(az_curl_done(&p_curl));
+  AZ_RETURN_IF_FAILED(_az_http_client_curl_done(&p_curl));
 
   return process_result;
 }

--- a/sdk/transport_policies/curl/src/az_curl.c
+++ b/sdk/transport_policies/curl/src/az_curl.c
@@ -148,7 +148,7 @@ static AZ_NODISCARD az_result _az_http_client_curl_add_header_to_curl_list(
  * @param p_headers list of headers in curl specific list
  * @return az_result
  */
-AZ_NODISCARD az_result static _az_http_client_curl_build_headers(
+static AZ_NODISCARD az_result _az_http_client_curl_build_headers(
     az_http_request * p_request,
     struct curl_slist ** p_headers) {
   AZ_CONTRACT_ARG_NOT_NULL(p_request);


### PR DESCRIPTION
@JeffreyRichter, _az_credential now needs the http_client_fn to send requests, this PR adds that.

@vhvb1989, there was a bug in our CURL code - when we used AZ_RETURN_IF_CURL_FAILED against az_result (i.e. instead of AZ_RETURN_IF_FAILED). I've made naming changes as well, and also marked all the local non-AZ_INLINE functions as static, so these internal function are never visible to linker outside of that C file (but that is not critical for the bugfix).

[ATTENTION: Make sure you see the changes to the az_curl.c (at the very end of this PR) - Github hides the change claiming it is "large" to show by default, so you need to click to expand]

For some reason, I am getting HTTP 400 (Bad Request), when I include Content-Type header for token request. But everything works fine if I don't add any header. But it works in Postman, so I think it is highly likely that there's a bug is in the code that handles HTTP headers - either CURL http client implementation, or in http_request.

With Content-Type commented out, this actually fixes auth token retrieval, although I would like to be able to include it for auth requests. Plus, if I am right, you won't be able to send any HTTP request anyways, if there's all-affecting http header bug in our code. If so, let's fix it tomorrow. 

Also, do we use pointer to pointer to http_client client intentionally? We use it in all client options, plus http policy expects not the pointer to http client, but a pointer to pointer. Therefore, I also wrote credential_policy to stick tho that format. Is this intentional to allow switching http clients in run time? (i.e. you update keyvault client's http client after it was initialized, and it starts sending all further http requests via another client)