### PR TITLE
Victor/curl/adding option to include curl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@
 cmake_minimum_required (VERSION 3.12)
 
 option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
+option(BUILD_CURL_TRANSPORT "Build internal http transport implementation with CURL for HTTP Pipeline" OFF)
 
 if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
@@ -23,12 +24,22 @@ enable_testing ()
 include(eng/cmake/global_compile_options.txt)
 
 add_subdirectory(sdk/core/core)
-add_subdirectory(sdk/transport_policies/curl)
+# Adding trasnport implementation for curl
+# Users can still build Core and SDK client without depending on a HTPP transport implementation
+if(BUILD_CURL_TRANSPORT)
+  add_subdirectory(sdk/transport_policies/curl)
+endif()
+
 add_subdirectory(sdk/keyvault/keyvault)
 add_subdirectory(sdk/storage/blobs)
 
 if(NOT DEFINED ENV{AZ_SDK_C_NO_SAMPLES})
+  # current samples require an HTTP transport implementation.
+  # disable adding samples if building CURL transport is disabled
+  # Remove this condition if implementing another http transport and link that with samples
+  if(BUILD_CURL_TRANSPORT)
     add_subdirectory(sdk/keyvault/keyvault/samples)
     add_subdirectory(sdk/storage/blobs/samples)
+  endif()
 endif()
 # add_subdirectory(sdk/storage/ustorageclient)

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -88,7 +88,7 @@ jobs:
       vcpkg install $(vcpkg.deps)
     displayName: vcpkg install dependencies
     # Execute only if there is at least one dependency to be installed
-    condition: and(succeeded(), not(eq(variables['vcpkg.dep'], '')))
+    condition: and(succeeded(), not(eq(variables['vcpkg.dep'], NULL)))
 
   - task: CMake@1
     inputs:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -6,26 +6,22 @@ jobs:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ''
       Win_x86:
         vm.image: 'windows-2019'
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ''
       Win_x64:
         vm.image: 'windows-2019'
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ''
       MacOS_x64:
         vm.image: 'macOS-10.14'
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        build.args: ''
         
       Linux_x64_with_samples:
         vm.image: 'ubuntu-18.04'
@@ -84,7 +80,7 @@ jobs:
         echo "##vso[task.setvariable variable=VCPKG_INSTALLATION_ROOT;]$(pwd)"
 
     # Execute only for Mac and if there is at least one dependency to be installed
-    condition: and(succeeded(), contains(variables['vm.image'], 'macOS'), not(eq(variables['vcpkg.dep'], '')))
+    condition: and(succeeded(), contains(variables['vm.image'], 'macOS'), not(eq(variables['vcpkg.deps'], '')))
     displayName: vcpkg bootstrap
 
 
@@ -92,7 +88,7 @@ jobs:
       vcpkg install $(vcpkg.deps)
     displayName: vcpkg install dependencies
     # Execute only if there is at least one dependency to be installed
-    condition: and(succeeded(), not(eq(variables['vcpkg.dep'], '')))
+    condition: and(succeeded(), not(eq(variables['vcpkg.deps'], '')))
 
   - task: CMake@1
     inputs:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -83,7 +83,7 @@ jobs:
         echo "##vso[task.prependpath]$(pwd)"
         echo "##vso[task.setvariable variable=VCPKG_INSTALLATION_ROOT;]$(pwd)"
 
-    condition: contains(variables['vm.image'], 'macOS')
+    condition: and(contains(variables['vm.image'], 'macOS'), contains(variables['vcpkg.dep'], 'curl'))
     displayName: vcpkg bootstrap
 
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -6,51 +6,47 @@ jobs:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        buid.args: ''
       Win_x86:
         vm.image: 'windows-2019'
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-        buid.args: ''
       Win_x64:
         vm.image: 'windows-2019'
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-        buid.args: ''
       MacOS_x64:
         vm.image: 'macOS-10.14'
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        buid.args: ''
-      
+        
       Linux_x64_with_samples:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: 'curl[ssl]'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        buid.args: ' -DBUILD_CURL_TRANSPORT=ON'
+        build.args: ' -DBUILD_CURL_TRANSPORT=ON'
       Win_x86_with_samples:
         vm.image: 'windows-2019'
         vcpkg.deps: 'curl[winssl]'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-        buid.args: ' -DBUILD_CURL_TRANSPORT=ON'
+        build.args: ' -DBUILD_CURL_TRANSPORT=ON'
       Win_x64_with_samples:
         vm.image: 'windows-2019'
         vcpkg.deps: 'curl[winssl]'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-        buid.args: ' -DBUILD_CURL_TRANSPORT=ON'
+        build.args: ' -DBUILD_CURL_TRANSPORT=ON'
       MacOS_x64_with_samples:
         vm.image: 'macOS-10.14'
         vcpkg.deps: 'curl[ssl]'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        buid.args: ' -DBUILD_CURL_TRANSPORT=ON'
+        build.args: ' -DBUILD_CURL_TRANSPORT=ON'
   pool:
     vmImage: $(vm.image)
   steps:
@@ -83,14 +79,16 @@ jobs:
         echo "##vso[task.prependpath]$(pwd)"
         echo "##vso[task.setvariable variable=VCPKG_INSTALLATION_ROOT;]$(pwd)"
 
-    condition: and(contains(variables['vm.image'], 'macOS'), contains(variables['vcpkg.dep'], 'curl'))
+    # Execute only for Mac and if there is at least one dependency to be installed
+    condition: and(succeeded(), contains(variables['vm.image']), 'macOS', not(eq(variables['vcpkg.dep'], '')))
     displayName: vcpkg bootstrap
 
 
   - script: |
       vcpkg install $(vcpkg.deps)
     displayName: vcpkg install dependencies
-    condition: contains(variables['vcpkg.dep'], 'curl')
+    # Execute only if there is at least one dependency to be installed
+    condition: and(succeeded(), not(eq(variables['vcpkg.dep'], '')))
 
   - task: CMake@1
     inputs:
@@ -98,7 +96,7 @@ jobs:
     displayName: cmake version
   - task: CMake@1
     inputs:
-      cmakeArgs: $(vcpkg.deps) ..
+      cmakeArgs: $(build.args) ..
     displayName: cmake generate
   - task: CMake@1
     inputs:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -80,7 +80,7 @@ jobs:
         echo "##vso[task.setvariable variable=VCPKG_INSTALLATION_ROOT;]$(pwd)"
 
     # Execute only for Mac and if there is at least one dependency to be installed
-    condition: and(succeeded(), contains(variables['vm.image']), 'macOS', not(eq(variables['vcpkg.dep'], '')))
+    condition: and(succeeded(), contains(variables['vm.image']), 'macOS'), not(eq(variables['vcpkg.dep'], '')))
     displayName: vcpkg bootstrap
 
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -90,6 +90,7 @@ jobs:
   - script: |
       vcpkg install $(vcpkg.deps)
     displayName: vcpkg install dependencies
+    condition: contains(variables['vcpkg.dep'], 'curl')
 
   - task: CMake@1
     inputs:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -4,24 +4,53 @@ jobs:
     matrix:
       Linux_x64:
         vm.image: 'ubuntu-18.04'
+        vcpkg.deps: ''
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        buid.args: ''
+      Win_x86:
+        vm.image: 'windows-2019'
+        vcpkg.deps: ''
+        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: Win32
+        buid.args: ''
+      Win_x64:
+        vm.image: 'windows-2019'
+        vcpkg.deps: ''
+        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: x64
+        buid.args: ''
+      MacOS_x64:
+        vm.image: 'macOS-10.14'
+        vcpkg.deps: ''
+        VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+        buid.args: ''
+      
+      Linux_x64_with_samples:
+        vm.image: 'ubuntu-18.04'
         vcpkg.deps: 'curl[ssl]'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      Win_x86:
+        buid.args: ' -DBUILD_CURL_TRANSPORT=ON'
+      Win_x86_with_samples:
         vm.image: 'windows-2019'
         vcpkg.deps: 'curl[winssl]'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-      Win_x64:
+        buid.args: ' -DBUILD_CURL_TRANSPORT=ON'
+      Win_x64_with_samples:
         vm.image: 'windows-2019'
         vcpkg.deps: 'curl[winssl]'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-      MacOS_x64:
+        buid.args: ' -DBUILD_CURL_TRANSPORT=ON'
+      MacOS_x64_with_samples:
         vm.image: 'macOS-10.14'
         vcpkg.deps: 'curl[ssl]'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+        buid.args: ' -DBUILD_CURL_TRANSPORT=ON'
   pool:
     vmImage: $(vm.image)
   steps:
@@ -68,7 +97,7 @@ jobs:
     displayName: cmake version
   - task: CMake@1
     inputs:
-      cmakeArgs: -Duse_default_uuid=ON ..
+      cmakeArgs: $(vcpkg.deps) ..
     displayName: cmake generate
   - task: CMake@1
     inputs:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -80,7 +80,7 @@ jobs:
         echo "##vso[task.setvariable variable=VCPKG_INSTALLATION_ROOT;]$(pwd)"
 
     # Execute only for Mac and if there is at least one dependency to be installed
-    condition: and(succeeded(), contains(variables['vm.image']), 'macOS'), not(eq(variables['vcpkg.dep'], '')))
+    condition: and(succeeded(), contains(variables['vm.image'], 'macOS'), not(eq(variables['vcpkg.dep'], '')))
     displayName: vcpkg bootstrap
 
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -6,22 +6,26 @@ jobs:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        build.args: ''
       Win_x86:
         vm.image: 'windows-2019'
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
+        build.args: ''
       Win_x64:
         vm.image: 'windows-2019'
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
+        build.args: ''
       MacOS_x64:
         vm.image: 'macOS-10.14'
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+        build.args: ''
         
       Linux_x64_with_samples:
         vm.image: 'ubuntu-18.04'
@@ -88,7 +92,7 @@ jobs:
       vcpkg install $(vcpkg.deps)
     displayName: vcpkg install dependencies
     # Execute only if there is at least one dependency to be installed
-    condition: and(succeeded(), not(eq(variables['vcpkg.dep'], NULL)))
+    condition: and(succeeded(), not(eq(variables['vcpkg.dep'], '')))
 
   - task: CMake@1
     inputs:


### PR DESCRIPTION
Adding compilation option to build az http transport curl with default OFF

This way for building default, we won't require libcurl to be installed.
We need to disable building samples if http transport curl is disabled because we don't have any other implementation.

Default build will only include az_core, az_keyvault and az_storage libs