### PR TITLE
remove -Wdocumentation-unknown-command

### DIFF
--- a/eng/cmake/global_compile_options.txt
+++ b/eng/cmake/global_compile_options.txt
@@ -9,7 +9,7 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")
   endif()
 
-  add_compile_options(-Xclang -Wall -Wextra -pedantic  ${WARNINGS_AS_ERRORS_FLAG} -Wdocumentation -Wdocumentation-unknown-command -Wcast-qual)
+  add_compile_options(-Xclang -Wall -Wextra -pedantic  ${WARNINGS_AS_ERRORS_FLAG} -Wdocumentation -Wdocumentation-unknown-command -fcomment-block-commands=retval -Wcast-qual)
 else()
   if(WARNINGS_AS_ERRORS)
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")

--- a/sdk/core/core/CMakeLists.txt
+++ b/sdk/core/core/CMakeLists.txt
@@ -36,7 +36,7 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")
   endif()
 
-  target_compile_options(az_core PRIVATE -Xclang -Wall -Wextra -pedantic ${WARNINGS_AS_ERRORS_FLAG} -Wdocumentation -Wdocumentation-unknown-command -Wcast-qual)
+  target_compile_options(az_core PRIVATE -Xclang -Wall -Wextra -pedantic ${WARNINGS_AS_ERRORS_FLAG} -Wdocumentation -Wdocumentation-unknown-command -fcomment-block-commands=retval -Wcast-qual)
 else()
   if(WARNINGS_AS_ERRORS)
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")

--- a/sdk/platform/http_client/curl/CMakeLists.txt
+++ b/sdk/platform/http_client/curl/CMakeLists.txt
@@ -29,7 +29,7 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")
   endif()
 
-  target_compile_options(az_curl PRIVATE -Xclang -Wall -Wextra -pedantic  ${WARNINGS_AS_ERRORS_FLAG} -Wdocumentation -Wdocumentation-unknown-command -Wcast-qual)
+  target_compile_options(az_curl PRIVATE -Xclang -Wall -Wextra -pedantic  ${WARNINGS_AS_ERRORS_FLAG} -Wdocumentation -Wdocumentation-unknown-command -fcomment-block-commands=retval -Wcast-qual)
 else()
   if(WARNINGS_AS_ERRORS)
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")

--- a/sdk/platform/http_client/nohttp/CMakeLists.txt
+++ b/sdk/platform/http_client/nohttp/CMakeLists.txt
@@ -21,7 +21,7 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")
   endif()
 
-  target_compile_options(az_nohttp PRIVATE -Xclang -Wall -Wextra -pedantic  ${WARNINGS_AS_ERRORS_FLAG} -Wdocumentation -Wdocumentation-unknown-command -Wcast-qual)
+  target_compile_options(az_nohttp PRIVATE -Xclang -Wall -Wextra -pedantic  ${WARNINGS_AS_ERRORS_FLAG} -Wdocumentation -Wdocumentation-unknown-command -fcomment-block-commands=retval -Wcast-qual)
 else()
   if(WARNINGS_AS_ERRORS)
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")


### PR DESCRIPTION
`-Wdocumentation-unknown-command` flags the doxygen tag `@retval` as an invalid command when it is indeed a valid tag that we should be using in our documentation. We should remove it to unblock good docs.