### PR TITLE
Update .gitignore to exclude vscode related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,7 +332,9 @@ ASALocalRun/
 # CMake
 build/
 /cmake-build-debug
-.vscode/settings.json
 
 #Doxygen
 [Dd]ocs/
+
+# VS Code Files
+.vscode


### PR DESCRIPTION
We should decide what to do with the checked-in `launch.json` and `tasks.json` files.

cc @vhvb1989, @gilbertw 