### PR TITLE
add literal null span

### DIFF
--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -55,10 +55,15 @@ AZ_NODISCARD AZ_INLINE int32_t az_span_capacity(az_span span) { return span._int
 /********************************  CONSTRUCTORS */
 
 /**
+ * @brief Creates an empty span literal
+ */
+#define AZ_SPAN_LITERAL_NULL { ._internal = {.ptr = NULL, .length = 0, .capacity = 0} }
+
+/**
  * @brief Creates an empty span
  *
  */
-#define AZ_SPAN_NULL (az_span){ ._internal = {.ptr = NULL, .length = 0, .capacity = 0} }
+#define AZ_SPAN_NULL (az_span) AZ_SPAN_LITERAL_NULL
 
 // A size of the string literal.
 // Details: to make sure that `S` is a `string literal`, we are appending `""`


### PR DESCRIPTION
needed for initialization of other structs. eg:
```
#define TEST_EMPTY_OPTIONS \
  { \
    .module_id = AZ_SPAN_LITERAL_NULL, .user_agent = AZ_SPAN_LITERAL_NULL \
  }
```