### PR TITLE
Re-add mac into matrix

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -7,7 +7,7 @@ jobs:
 - job: Validate
   strategy:
     matrix:
-      Build with no dependencies at all (No samples)
+      # Build with no dependencies at all (No samples)
       Linux_x64:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: ''

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -140,6 +140,7 @@ jobs:
 
         git clone https://github.com/Microsoft/vcpkg.git
         cd vcpkg
+        git checkout $(VcpkgCommit)
         git rev-parse --verify HEAD
         git status
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -8,105 +8,113 @@ jobs:
   strategy:
     matrix:
       # Build with no dependencies at all (No samples)
-      Linux_x64:
-        vm.image: 'ubuntu-18.04'
-        vcpkg.deps: ''
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      Win_x86:
-        vm.image: 'windows-2019'
-        vcpkg.deps: ''
-        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: Win32
-      Win_x64:
-        vm.image: 'windows-2019'
-        vcpkg.deps: ''
-        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: x64
+      # Linux_x64:
+      #   vm.image: 'ubuntu-18.04'
+      #   vcpkg.deps: ''
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      # Win_x86:
+      #   vm.image: 'windows-2019'
+      #   vcpkg.deps: ''
+      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: Win32
+      # Win_x64:
+      #   vm.image: 'windows-2019'
+      #   vcpkg.deps: ''
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: x64
+
+      # Expect consistent success
       MacOS_x64:
        vm.image: 'macOS-10.14'
        vcpkg.deps: ''
        VCPKG_DEFAULT_TRIPLET: 'x64-osx'
 
       # Build with sample dependencies [curl for transport]
-      Linux_x64_with_samples:
-        vm.image: 'ubuntu-18.04'
-        vcpkg.deps: 'curl[ssl]'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX'
-      Win_x86_with_samples:
-        vm.image: 'windows-2019'
-        vcpkg.deps: 'curl[winssl]'
-        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32'
-      Win_x64_with_samples:
-        vm.image: 'windows-2019'
-        vcpkg.deps: 'curl[winssl]'
-        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32'
-      #MacOS_x64_with_samples:
-      #  vm.image: 'macOS-10.14'
-      #  vcpkg.deps: 'curl[ssl]'
-      #  VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-      #  build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX'
+      # Linux_x64_with_samples:
+      #   vm.image: 'ubuntu-18.04'
+      #   vcpkg.deps: 'curl[ssl]'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      #   build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX'
+      # Win_x86_with_samples:
+      #   vm.image: 'windows-2019'
+      #   vcpkg.deps: 'curl[winssl]'
+      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: Win32
+      #   build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32'
+      # Win_x64_with_samples:
+      #   vm.image: 'windows-2019'
+      #   vcpkg.deps: 'curl[winssl]'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: x64
+      #   build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32'
+
+      # Expect intermittent failure
+      MacOS_x64_with_samples:
+       vm.image: 'macOS-10.14'
+       vcpkg.deps: 'curl[ssl]'
+       VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+       build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX'
 
       # Build with sample dependencies and unit testing [curl for transport and cmoka]
-      Linux_x64_with_samples_and_unit_test:
-        vm.image: 'ubuntu-18.04'
-        vcpkg.deps: 'curl[ssl] cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
-      Win_x86_with_samples_and_unit_test:
-        vm.image: 'windows-2019'
-        vcpkg.deps: 'curl[winssl] cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
-      Win_x64_with_samples_and_unit_test:
-        vm.image: 'windows-2019'
-        vcpkg.deps: 'curl[winssl] cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
-      #MacOS_x64_with_samples_and_unit_test:
-      #  vm.image: 'macOS-10.14'
-      #  vcpkg.deps: 'curl[ssl] cmocka'
-      #  VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-      #  build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
+      # Linux_x64_with_samples_and_unit_test:
+      #   vm.image: 'ubuntu-18.04'
+      #   vcpkg.deps: 'curl[ssl] cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      #   build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
+      # Win_x86_with_samples_and_unit_test:
+      #   vm.image: 'windows-2019'
+      #   vcpkg.deps: 'curl[winssl] cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: Win32
+      #   build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
+      # Win_x64_with_samples_and_unit_test:
+      #   vm.image: 'windows-2019'
+      #   vcpkg.deps: 'curl[winssl] cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: x64
+      #   build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
+
+      # Expect intermittent failure
+      MacOS_x64_with_samples_and_unit_test:
+       vm.image: 'macOS-10.14'
+       vcpkg.deps: 'curl[ssl] cmocka'
+       VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+       build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
 
       # Build with unit testing only. No samples [cmoka]
-      Linux_x64_with_unit_test:
-        vm.image: 'ubuntu-18.04'
-        vcpkg.deps: 'cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DUNIT_TESTING=ON -DCMAKE_BUILD_TYPE=Debug'
-        AZ_SDK_CODE_COV: 1
-      Win_x86_with_unit_test:
-        vm.image: 'windows-2019'
-        vcpkg.deps: 'cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DUNIT_TESTING=ON'
-      Win_x64_with_unit_test:
-        vm.image: 'windows-2019'
-        vcpkg.deps: 'cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DUNIT_TESTING=ON'
-      #MacOS_x64_with_unit_test:
-      #  vm.image: 'macOS-10.14'
-      #  vcpkg.deps: 'cmocka'
-      #  VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-      #  build.args: ' -DUNIT_TESTING=ON'
+      # Linux_x64_with_unit_test:
+      #   vm.image: 'ubuntu-18.04'
+      #   vcpkg.deps: 'cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      #   build.args: ' -DUNIT_TESTING=ON -DCMAKE_BUILD_TYPE=Debug'
+      #   AZ_SDK_CODE_COV: 1
+      # Win_x86_with_unit_test:
+      #   vm.image: 'windows-2019'
+      #   vcpkg.deps: 'cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: Win32
+      #   build.args: ' -DUNIT_TESTING=ON'
+      # Win_x64_with_unit_test:
+      #   vm.image: 'windows-2019'
+      #   vcpkg.deps: 'cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: x64
+      #   build.args: ' -DUNIT_TESTING=ON'
+
+      # Expect intermittent failure
+      MacOS_x64_with_unit_test:
+       vm.image: 'macOS-10.14'
+       vcpkg.deps: 'cmocka'
+       VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+       build.args: ' -DUNIT_TESTING=ON'
   pool:
     vmImage: $(vm.image)
   variables:
@@ -126,10 +134,15 @@ jobs:
         echo "xcode path:"
         sudo xcode-select --print-path
 
-        # Expect failure:
-        brew install gcc
+        # Install gcc 9
+        brew install gcc@9
+        gcc --version
+
         git clone https://github.com/Microsoft/vcpkg.git
         cd vcpkg
+        git rev-parse --verify HEAD
+        git status
+
         ./bootstrap-vcpkg.sh
 
         # Validate that vcpkg bootstrap succeeded

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -7,52 +7,48 @@ jobs:
 - job: Validate
   strategy:
     matrix:
-      # Build with no dependencies at all (No samples)
-      # Linux_x64:
-      #   vm.image: 'ubuntu-18.04'
-      #   vcpkg.deps: ''
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      # Win_x86:
-      #   vm.image: 'windows-2019'
-      #   vcpkg.deps: ''
-      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: Win32
-      # Win_x64:
-      #   vm.image: 'windows-2019'
-      #   vcpkg.deps: ''
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: x64
-
-      # Expect consistent success
+      Build with no dependencies at all (No samples)
+      Linux_x64:
+        vm.image: 'ubuntu-18.04'
+        vcpkg.deps: ''
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      Win_x86:
+        vm.image: 'windows-2019'
+        vcpkg.deps: ''
+        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: Win32
+      Win_x64:
+        vm.image: 'windows-2019'
+        vcpkg.deps: ''
+        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: x64
       MacOS_x64:
        vm.image: 'macOS-10.14'
        vcpkg.deps: ''
        VCPKG_DEFAULT_TRIPLET: 'x64-osx'
 
       # Build with sample dependencies [curl for transport]
-      # Linux_x64_with_samples:
-      #   vm.image: 'ubuntu-18.04'
-      #   vcpkg.deps: 'curl[ssl]'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      #   build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX'
-      # Win_x86_with_samples:
-      #   vm.image: 'windows-2019'
-      #   vcpkg.deps: 'curl[winssl]'
-      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: Win32
-      #   build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32'
-      # Win_x64_with_samples:
-      #   vm.image: 'windows-2019'
-      #   vcpkg.deps: 'curl[winssl]'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: x64
-      #   build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32'
-
-      # Expect intermittent failure
+      Linux_x64_with_samples:
+        vm.image: 'ubuntu-18.04'
+        vcpkg.deps: 'curl[ssl]'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX'
+      Win_x86_with_samples:
+        vm.image: 'windows-2019'
+        vcpkg.deps: 'curl[winssl]'
+        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: Win32
+        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32'
+      Win_x64_with_samples:
+        vm.image: 'windows-2019'
+        vcpkg.deps: 'curl[winssl]'
+        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: x64
+        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32'
       MacOS_x64_with_samples:
        vm.image: 'macOS-10.14'
        vcpkg.deps: 'curl[ssl]'
@@ -60,27 +56,25 @@ jobs:
        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX'
 
       # Build with sample dependencies and unit testing [curl for transport and cmoka]
-      # Linux_x64_with_samples_and_unit_test:
-      #   vm.image: 'ubuntu-18.04'
-      #   vcpkg.deps: 'curl[ssl] cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      #   build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
-      # Win_x86_with_samples_and_unit_test:
-      #   vm.image: 'windows-2019'
-      #   vcpkg.deps: 'curl[winssl] cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: Win32
-      #   build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
-      # Win_x64_with_samples_and_unit_test:
-      #   vm.image: 'windows-2019'
-      #   vcpkg.deps: 'curl[winssl] cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: x64
-      #   build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
-
-      # Expect intermittent failure
+      Linux_x64_with_samples_and_unit_test:
+        vm.image: 'ubuntu-18.04'
+        vcpkg.deps: 'curl[ssl] cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
+      Win_x86_with_samples_and_unit_test:
+        vm.image: 'windows-2019'
+        vcpkg.deps: 'curl[winssl] cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: Win32
+        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
+      Win_x64_with_samples_and_unit_test:
+        vm.image: 'windows-2019'
+        vcpkg.deps: 'curl[winssl] cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: x64
+        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
       MacOS_x64_with_samples_and_unit_test:
        vm.image: 'macOS-10.14'
        vcpkg.deps: 'curl[ssl] cmocka'
@@ -88,28 +82,26 @@ jobs:
        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
 
       # Build with unit testing only. No samples [cmoka]
-      # Linux_x64_with_unit_test:
-      #   vm.image: 'ubuntu-18.04'
-      #   vcpkg.deps: 'cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      #   build.args: ' -DUNIT_TESTING=ON -DCMAKE_BUILD_TYPE=Debug'
-      #   AZ_SDK_CODE_COV: 1
-      # Win_x86_with_unit_test:
-      #   vm.image: 'windows-2019'
-      #   vcpkg.deps: 'cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: Win32
-      #   build.args: ' -DUNIT_TESTING=ON'
-      # Win_x64_with_unit_test:
-      #   vm.image: 'windows-2019'
-      #   vcpkg.deps: 'cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: x64
-      #   build.args: ' -DUNIT_TESTING=ON'
-
-      # Expect intermittent failure
+      Linux_x64_with_unit_test:
+        vm.image: 'ubuntu-18.04'
+        vcpkg.deps: 'cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        build.args: ' -DUNIT_TESTING=ON -DCMAKE_BUILD_TYPE=Debug'
+        AZ_SDK_CODE_COV: 1
+      Win_x86_with_unit_test:
+        vm.image: 'windows-2019'
+        vcpkg.deps: 'cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: Win32
+        build.args: ' -DUNIT_TESTING=ON'
+      Win_x64_with_unit_test:
+        vm.image: 'windows-2019'
+        vcpkg.deps: 'cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: x64
+        build.args: ' -DUNIT_TESTING=ON'
       MacOS_x64_with_unit_test:
        vm.image: 'macOS-10.14'
        vcpkg.deps: 'cmocka'
@@ -140,7 +132,6 @@ jobs:
 
         git clone https://github.com/Microsoft/vcpkg.git
         cd vcpkg
-        git checkout $(VcpkgCommit)
         git rev-parse --verify HEAD
         git status
 


### PR DESCRIPTION
Mac builds are now consistently passing. I ran a few builds winding vcpkg back through its commit history yesterday. All builds passed.

I still suspect this was a problem with the agent image and that that the problem was cleared up. However if we run into this issue again I've added logging to point out what commit vcpkg was checked out at so we can try to reproduce the issue. We're already pinning and logging the versions of gcc and the xcode toolchain. 

Test builds showing that vcpkg bootstrap passes at all of the commit SHAs from yesterday: 
* https://dev.azure.com/azure-sdk/internal/_build/results?buildId=282424&view=logs&j=dc3052a9-e5af-54f8-ab6d-5ce88a3ff2ba&t=c6caa277-780d-5cd8-986c-6635e5625c03
* https://dev.azure.com/azure-sdk/internal/_build/results?buildId=282425&view=logs&j=dc3052a9-e5af-54f8-ab6d-5ce88a3ff2ba&t=c6caa277-780d-5cd8-986c-6635e5625c03
* https://dev.azure.com/azure-sdk/internal/_build/results?buildId=282425&view=logs&j=dc3052a9-e5af-54f8-ab6d-5ce88a3ff2ba&t=c6caa277-780d-5cd8-986c-6635e5625c03
* https://dev.azure.com/azure-sdk/internal/_build/results?buildId=282427&view=logs&j=dc3052a9-e5af-54f8-ab6d-5ce88a3ff2ba&t=c6caa277-780d-5cd8-986c-6635e5625c03
* https://dev.azure.com/azure-sdk/internal/_build/results?buildId=282429&view=logs&j=dc3052a9-e5af-54f8-ab6d-5ce88a3ff2ba&t=c6caa277-780d-5cd8-986c-6635e5625c03
* https://dev.azure.com/azure-sdk/internal/_build/results?buildId=282430&view=logs&j=dc3052a9-e5af-54f8-ab6d-5ce88a3ff2ba&t=c6caa277-780d-5cd8-986c-6635e5625c03
* https://dev.azure.com/azure-sdk/internal/_build/results?buildId=282433&view=logs&j=dc3052a9-e5af-54f8-ab6d-5ce88a3ff2ba&t=c6caa277-780d-5cd8-986c-6635e5625c03
* https://dev.azure.com/azure-sdk/internal/_build/results?buildId=282434&view=logs&j=dc3052a9-e5af-54f8-ab6d-5ce88a3ff2ba&t=c6caa277-780d-5cd8-986c-6635e5625c03

Test builds for vcpkg SHAs from today (also passing): 
* https://dev.azure.com/azure-sdk/internal/_build/results?buildid=282518&view=results
* https://dev.azure.com/azure-sdk/internal/_build/results?buildid=282519&view=results

For those who see the "Fix MacOS build" in the vcpkg commit list (these are related to a specific port, not the vcpkg bootstrapping process which was the part that was failing for us) I went ahead and ran these passing builds to show that the commit before and the commit containing the "Fix MacOS build" were passing: 
* "Fix macOS builds" commit -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=282503&view=logs&j=dc3052a9-e5af-54f8-ab6d-5ce88a3ff2ba&t=c6caa277-780d-5cd8-986c-6635e5625c03
* commit before the "Fix macOS builds" commit -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=282504&view=logs&j=dc3052a9-e5af-54f8-ab6d-5ce88a3ff2ba&t=c6caa277-780d-5cd8-986c-6635e5625c03