### PR TITLE
Add IoT Hub Client Functionality

### DIFF
--- a/sdk/iot/core/README.md
+++ b/sdk/iot/core/README.md
@@ -17,7 +17,22 @@ TBD
 To use IoT Hub connectivity, the first action by a developer should be to initialize the
 client with the `az_iot_hub_client_init()` API. Once that is initialized, you may use the
 `az_iot_hub_client_user_name_get()` and `az_iot_hub_client_client_id_get()` to get the
-user name and client id to establish a connection with IoT Hub. An example use case is below.
+user name and client id to establish a connection with IoT Hub. 
+
+The user name will be of the following form:
+```C
+//[Format without module id] {iothubhostname}/{device_id}/?api-version=2018-06-30
+//[Format with module id] {iothubhostname}/{device_id}/{module_id}/?api-version=2018-06-30
+```
+
+The client id will be of the following form:
+```C
+//[Format without module id] {device_id}
+//[Format with module id] {device_id}/{module_id}
+```
+
+
+An example use case is below.
 
 ```C
 //FOR SIMPLICITY THIS DOES NOT HAVE ERROR CHECKING. IN PRODUCTION ENSURE PROPER ERROR CHECKING.

--- a/sdk/iot/core/README.md
+++ b/sdk/iot/core/README.md
@@ -12,11 +12,54 @@ TBD
 
 ## Examples
 
+### IoT Hub Client
+
+To use IoT Hub connectivity, the first action by a developer should be to initialize the
+client with the `az_iot_hub_client_init()` API. Once that is initialized, you may use the
+`az_iot_hub_client_user_name_get()` and `az_iot_hub_client_client_id_get()` to get the
+user name and client id to establish a connection with IoT Hub. An example use case is below.
+
+```C
+//FOR SIMPLICITY THIS DOES NOT HAVE ERROR CHECKING. IN PRODUCTION ENSURE PROPER ERROR CHECKING.
+
+az_iot_hub_client my_client;
+static az_span my_iothub_hostname = AZ_SPAN_LITERAL_FROM_STR("constoso.azure-devices.net");
+static az_span my_device_id = AZ_SPAN_LITERAL_FROM_STR("contoso_device");
+
+//Make sure to size the buffer to fit the user name (100 is an example)
+static uint8_t my_mqtt_user_name_buffer[100];
+static az_span my_mqtt_user_name = AZ_SPAN_LITERAL_FROM_BUFFER(my_mqtt_user_name_buffer);
+
+//Make sure to size the buffer to fit the client id (16 is an example)
+static uint8_t my_mqtt_client_id_buffer[16];
+static az_span my_mqtt_client_id = AZ_SPAN_LITERAL_FROM_BUFFER(my_mqtt_client_id_buffer);
+
+int main()
+{
+  //Get the default IoT Hub options
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+
+  //Initialize the client with hostname, device id, and options
+  az_iot_hub_client_init(&my_client, my_iothub_hostname, my_device_id, &options);
+
+  //Get the MQTT user name to connect
+  az_iot_hub_client_user_name_get(&my_client, my_mqtt_user_name, &my_mqtt_user_name)
+
+  //Get the MQTT client id to connect
+  az_iot_hub_client_client_id_get(&my_client, my_mqtt_client_id, &my_mqtt_client_id);
+
+  //At this point you are free to use my_mqtt_client_id and my_mqtt_user_name to connect using
+  //your MQTT client.
+}
+```
+
 ### Telemetry
 
 Telemetry functionality can be achieved by sending a user payload to a specific topic. In order to get the appropriate topic to which to send, use the `az_iot_hub_client_telemetry_publish_topic_get()` API. An example use case is below.
 
 ```C
+//FOR SIMPLICITY THIS DOES NOT HAVE ERROR CHECKING. IN PRODUCTION ENSURE PROPER ERROR CHECKING.
+
 static az_iot_hub_client my_client;
 static az_span my_iothub_hostname = AZ_SPAN_LITERAL_FROM_STR("constoso.azure-devices.net");
 static az_span my_device_id = AZ_SPAN_LITERAL_FROM_STR("contoso_device");
@@ -30,7 +73,8 @@ void my_telemetry_func()
   //Optionally, the size can include space for a null terminator.
   //Here, the buffer is zero initialized to null terminate the topic.
   uint8_t telemetry_topic_buffer[64] = { 0 };
-  az_span topic_span = AZ_SPAN_FROM_BUFFER(telemetry_topic_buffer);
+  az_span topic_span = az_span_init(telemetry_topic_buffer, 0,
+                sizeof(telemetry_topic_buffer) / sizeof(telemetry_topic_buffer[0]));
 
   //Get the NULL terminated topic and put in topic_span to send the telemetry
   az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, topic_span, &topic_span);

--- a/sdk/iot/core/README.md
+++ b/sdk/iot/core/README.md
@@ -26,8 +26,10 @@ void my_telemetry_func()
   //Initialize the client to then pass to the telemetry API
   az_iot_hub_client_init(&my_client, my_iothub_hostname, my_device_id, NULL);
 
-  //Allocate a span to put the telemetry topic
-  uint8_t telemetry_topic_buffer[64];
+  //Allocate a span with capacity large enough to put the telemetry topic.
+  //Optionally, the size can include space for a null terminator.
+  //Here, the buffer is zero initialized to null terminate the topic.
+  uint8_t telemetry_topic_buffer[64] = { 0 };
   az_span topic_span = AZ_SPAN_FROM_BUFFER(telemetry_topic_buffer);
 
   //Get the NULL terminated topic and put in topic_span to send the telemetry

--- a/sdk/iot/core/README.md
+++ b/sdk/iot/core/README.md
@@ -19,19 +19,6 @@ client with the `az_iot_hub_client_init()` API. Once that is initialized, you ma
 `az_iot_hub_client_user_name_get()` and `az_iot_hub_client_client_id_get()` to get the
 user name and client id to establish a connection with IoT Hub. 
 
-The user name will be of the following form:
-```C
-//[Format without module id] {iothubhostname}/{device_id}/?api-version=2018-06-30
-//[Format with module id] {iothubhostname}/{device_id}/{module_id}/?api-version=2018-06-30
-```
-
-The client id will be of the following form:
-```C
-//[Format without module id] {device_id}
-//[Format with module id] {device_id}/{module_id}
-```
-
-
 An example use case is below.
 
 ```C

--- a/sdk/iot/core/README.md
+++ b/sdk/iot/core/README.md
@@ -92,7 +92,7 @@ void my_telemetry_func()
                 sizeof(telemetry_topic_buffer) / sizeof(telemetry_topic_buffer[0]));
 
   //Get the NULL terminated topic and put in topic_span to send the telemetry
-  az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, topic_span, &topic_span);
+  az_iot_hub_client_telemetry_publish_topic_get(&my_client, NULL, topic_span, &topic_span);
 }
 ```
 

--- a/sdk/iot/core/inc/az_iot_hub_client.h
+++ b/sdk/iot/core/inc/az_iot_hub_client.h
@@ -69,6 +69,10 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
 
 /**
  * @brief Gets the MQTT user name.
+ * 
+ * The user name will be of the following format:
+ * [Format without module id] {iothubhostname}/{device_id}/?api-version=2018-06-30
+ * [Format with module id] {iothubhostname}/{device_id}/{module_id}/?api-version=2018-06-30
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] mqtt_user_name An empty #az_span with sufficient capacity to hold the MQTT user name.
@@ -82,6 +86,10 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
 
 /**
  * @brief Gets the MQTT client id.
+ * 
+ * The client id will be of the following format:
+ * [Format without module id] {device_id}
+ * [Format with module id] {device_id}/{module_id}
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] mqtt_client_id An empty #az_span with sufficient capacity to hold the MQTT client id.

--- a/sdk/iot/core/inc/az_iot_hub_client.h
+++ b/sdk/iot/core/inc/az_iot_hub_client.h
@@ -71,8 +71,8 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
  * @brief Gets the MQTT user name.
  * 
  * The user name will be of the following format:
- * [Format without module id] {iothubhostname}/{device_id}/?api-version=2018-06-30
- * [Format with module id] {iothubhostname}/{device_id}/{module_id}/?api-version=2018-06-30
+ * [Format without module id] {iothubhostname}/{device_id}/?api-version=2018-06-30&{user_agent}
+ * [Format with module id] {iothubhostname}/{device_id}/{module_id}/?api-version=2018-06-30&{user_agent}
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] mqtt_user_name An empty #az_span with sufficient capacity to hold the MQTT user name.

--- a/sdk/iot/core/inc/az_iot_hub_client.h
+++ b/sdk/iot/core/inc/az_iot_hub_client.h
@@ -222,6 +222,10 @@ az_iot_hub_client_properties_next(az_iot_hub_client_properties* properties, az_p
 /**
  * @brief Gets the MQTT topic that must be used for device to cloud telemetry messages.
  * @note Telemetry MQTT Publish messages must have QoS At Least Once (1).
+ * 
+ * Should the user want a null terminated topic string, they may allocate a buffer large enough
+ * to fit the topic plus a null terminator. They must set the last byte themselves or zero initialize
+ * the buffer.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] properties An optional #az_iot_hub_client_properties object (can be NULL).

--- a/sdk/iot/core/src/az_iot_hub_client.c
+++ b/sdk/iot/core/src/az_iot_hub_client.c
@@ -1,12 +1,128 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
+#include <stdint.h>
+
 #include "az_iot_hub_client.h"
+#include <az_precondition.h>
+#include <az_result.h>
 #include <az_span.h>
 
 #include <_az_cfg.h>
 
+static const uint8_t hub_client_forward_slash = '/';
+static const uint8_t hub_client_param_separator = '&';
+static const uint8_t hub_client_null_terminate = '\0';
+
+static const az_span hub_client_api_version = AZ_SPAN_LITERAL_FROM_STR("?api-version=2018-06-30");
+
 AZ_NODISCARD az_iot_hub_client_options az_iot_hub_client_options_default()
 {
   return (az_iot_hub_client_options){ .module_id = AZ_SPAN_NULL, .user_agent = AZ_SPAN_NULL };
+}
+
+AZ_NODISCARD az_result az_iot_hub_client_init(
+    az_iot_hub_client* client,
+    az_span iot_hub_hostname,
+    az_span device_id,
+    az_iot_hub_client_options const* options)
+{
+  AZ_PRECONDITION_NOT_NULL(client);
+  AZ_PRECONDITION_VALID_SPAN(iot_hub_hostname, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(device_id, 1, false);
+  AZ_PRECONDITION_NOT_NULL(options);
+
+  client->_internal.iot_hub_hostname = iot_hub_hostname;
+  client->_internal.device_id = device_id;
+  client->_internal.options.module_id = options->module_id;
+  client->_internal.options.user_agent = options->user_agent;
+
+  return AZ_OK;
+}
+
+AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
+    az_iot_hub_client const* client,
+    az_span mqtt_user_name,
+    az_span* out_mqtt_user_name)
+{
+  AZ_PRECONDITION_NOT_NULL(client);
+  AZ_PRECONDITION_VALID_SPAN(mqtt_user_name, 0, false);
+  AZ_PRECONDITION_NOT_NULL(out_mqtt_user_name);
+
+  const az_span* module_id = &(client->_internal.options.module_id);
+  const az_span* user_agent = &(client->_internal.options.user_agent);
+
+  if (az_span_capacity(mqtt_user_name)
+      < (int32_t)(
+            az_span_length(client->_internal.iot_hub_hostname) + sizeof(hub_client_forward_slash)
+            + az_span_length(client->_internal.device_id) + sizeof(hub_client_forward_slash)
+            + az_span_length(*module_id)
+            + (az_span_length(*module_id) != 0 ? sizeof(hub_client_forward_slash) : 0)
+            + az_span_length(*user_agent)
+            + (az_span_length(*user_agent) != 0 ? sizeof(hub_client_param_separator) : 0)
+            + az_span_length(hub_client_api_version) + sizeof(hub_client_null_terminate)))
+  {
+    return AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY;
+  }
+
+  AZ_RETURN_IF_FAILED(
+      az_span_append(mqtt_user_name, client->_internal.iot_hub_hostname, out_mqtt_user_name));
+  AZ_RETURN_IF_FAILED(
+      az_span_append_uint8(*out_mqtt_user_name, hub_client_forward_slash, out_mqtt_user_name));
+  AZ_RETURN_IF_FAILED(
+      az_span_append(*out_mqtt_user_name, client->_internal.device_id, out_mqtt_user_name));
+  AZ_RETURN_IF_FAILED(
+      az_span_append_uint8(*out_mqtt_user_name, hub_client_forward_slash, out_mqtt_user_name));
+  if (az_span_length(*module_id) > 0)
+  {
+    AZ_RETURN_IF_FAILED(az_span_append(*out_mqtt_user_name, *module_id, out_mqtt_user_name));
+    AZ_RETURN_IF_FAILED(
+        az_span_append_uint8(*out_mqtt_user_name, hub_client_forward_slash, out_mqtt_user_name));
+  }
+  AZ_RETURN_IF_FAILED(
+      az_span_append(*out_mqtt_user_name, hub_client_api_version, out_mqtt_user_name));
+  if (az_span_length(*user_agent) > 0)
+  {
+    AZ_RETURN_IF_FAILED(
+        az_span_append_uint8(*out_mqtt_user_name, hub_client_param_separator, out_mqtt_user_name));
+    AZ_RETURN_IF_FAILED(az_span_append(*out_mqtt_user_name, *user_agent, out_mqtt_user_name));
+  }
+  AZ_RETURN_IF_FAILED(
+      az_span_append_uint8(*out_mqtt_user_name, hub_client_null_terminate, out_mqtt_user_name));
+
+  return AZ_OK;
+}
+
+AZ_NODISCARD az_result az_iot_hub_client_id_get(
+    az_iot_hub_client const* client,
+    az_span mqtt_client_id,
+    az_span* out_mqtt_client_id)
+{
+  AZ_PRECONDITION_NOT_NULL(client);
+  AZ_PRECONDITION_VALID_SPAN(mqtt_client_id, 0, false);
+  AZ_PRECONDITION_NOT_NULL(out_mqtt_client_id);
+
+  const az_span* module_id = &(client->_internal.options.module_id);
+
+  if (az_span_capacity(mqtt_client_id)
+      < (int32_t)(
+            az_span_length(client->_internal.device_id) + az_span_length(*module_id)
+            + (az_span_length(*module_id) > 0 ? sizeof(hub_client_forward_slash) : 0)
+            + sizeof(hub_client_null_terminate)))
+  {
+    return AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY;
+  }
+
+  AZ_RETURN_IF_FAILED(
+      az_span_append(mqtt_client_id, client->_internal.device_id, out_mqtt_client_id));
+  if (az_span_length(*module_id) > 0)
+  {
+    AZ_RETURN_IF_FAILED(
+        az_span_append_uint8(*out_mqtt_client_id, hub_client_forward_slash, out_mqtt_client_id));
+    AZ_RETURN_IF_FAILED(az_span_append(*out_mqtt_client_id, *module_id, out_mqtt_client_id));
+  }
+  AZ_RETURN_IF_FAILED(
+      az_span_append_uint8(*out_mqtt_client_id, hub_client_null_terminate, out_mqtt_client_id));
+
+  return AZ_OK;
 }

--- a/sdk/iot/core/src/az_iot_hub_client.c
+++ b/sdk/iot/core/src/az_iot_hub_client.c
@@ -34,8 +34,7 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
 
   client->_internal.iot_hub_hostname = iot_hub_hostname;
   client->_internal.device_id = device_id;
-  client->_internal.options.module_id = options->module_id;
-  client->_internal.options.user_agent = options->user_agent;
+  memcpy(&client->_internal.options, options, sizeof(az_iot_hub_client_options));
 
   return AZ_OK;
 }
@@ -73,20 +72,24 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
       az_span_append(*out_mqtt_user_name, client->_internal.device_id, out_mqtt_user_name));
   AZ_RETURN_IF_FAILED(
       az_span_append_uint8(*out_mqtt_user_name, hub_client_forward_slash, out_mqtt_user_name));
+
   if (az_span_length(*module_id) > 0)
   {
     AZ_RETURN_IF_FAILED(az_span_append(*out_mqtt_user_name, *module_id, out_mqtt_user_name));
     AZ_RETURN_IF_FAILED(
         az_span_append_uint8(*out_mqtt_user_name, hub_client_forward_slash, out_mqtt_user_name));
   }
+
   AZ_RETURN_IF_FAILED(
       az_span_append(*out_mqtt_user_name, hub_client_api_version, out_mqtt_user_name));
+
   if (az_span_length(*user_agent) > 0)
   {
     AZ_RETURN_IF_FAILED(
         az_span_append_uint8(*out_mqtt_user_name, hub_client_param_separator, out_mqtt_user_name));
     AZ_RETURN_IF_FAILED(az_span_append(*out_mqtt_user_name, *user_agent, out_mqtt_user_name));
   }
+
   AZ_RETURN_IF_FAILED(
       az_span_append_uint8(*out_mqtt_user_name, hub_client_null_terminate, out_mqtt_user_name));
 
@@ -115,12 +118,14 @@ AZ_NODISCARD az_result az_iot_hub_client_id_get(
 
   AZ_RETURN_IF_FAILED(
       az_span_append(mqtt_client_id, client->_internal.device_id, out_mqtt_client_id));
+
   if (az_span_length(*module_id) > 0)
   {
     AZ_RETURN_IF_FAILED(
         az_span_append_uint8(*out_mqtt_client_id, hub_client_forward_slash, out_mqtt_client_id));
     AZ_RETURN_IF_FAILED(az_span_append(*out_mqtt_client_id, *module_id, out_mqtt_client_id));
   }
+
   AZ_RETURN_IF_FAILED(
       az_span_append_uint8(*out_mqtt_client_id, hub_client_null_terminate, out_mqtt_client_id));
 

--- a/sdk/iot/core/src/az_iot_hub_client.c
+++ b/sdk/iot/core/src/az_iot_hub_client.c
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 #include "az_iot_hub_client.h"
-#include <az_precondition.h>
+#include <az_precondition_internal.h>
 #include <az_result.h>
 #include <az_span.h>
 
@@ -50,8 +50,8 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
   AZ_PRECONDITION_VALID_SPAN(mqtt_user_name, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_mqtt_user_name);
 
-  const az_span* module_id = &(client->_internal.options.module_id);
-  const az_span* user_agent = &(client->_internal.options.user_agent);
+  const az_span* const module_id = &(client->_internal.options.module_id);
+  const az_span* const user_agent = &(client->_internal.options.user_agent);
 
   if (az_span_capacity(mqtt_user_name)
       < (int32_t)(
@@ -109,7 +109,7 @@ AZ_NODISCARD az_result az_iot_hub_client_id_get(
   AZ_PRECONDITION_VALID_SPAN(mqtt_client_id, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_mqtt_client_id);
 
-  const az_span* module_id = &(client->_internal.options.module_id);
+  const az_span* const module_id = &(client->_internal.options.module_id);
 
   if (az_span_capacity(mqtt_client_id)
       < (int32_t)(

--- a/sdk/iot/core/src/az_iot_hub_client.c
+++ b/sdk/iot/core/src/az_iot_hub_client.c
@@ -40,8 +40,6 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
   return AZ_OK;
 }
 
-//[Format without module id] {iothubhostname}/{device_id}/?api-version=2018-06-30
-//[Format with module id] {iothubhostname}/{device_id}/{module_id}/?api-version=2018-06-30
 AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
     az_iot_hub_client const* client,
     az_span mqtt_user_name,

--- a/sdk/iot/core/src/az_iot_hub_client.c
+++ b/sdk/iot/core/src/az_iot_hub_client.c
@@ -39,6 +39,8 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
   return AZ_OK;
 }
 
+//[Format without module id] {iothubhostname}/{device_id}/?api-version=2018-06-30
+//[Format with module id] {iothubhostname}/{device_id}/{module_id}/?api-version=2018-06-30
 AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
     az_iot_hub_client const* client,
     az_span mqtt_user_name,
@@ -96,6 +98,8 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
   return AZ_OK;
 }
 
+//[Format without module id] {device_id}
+//[Format with module id] {device_id}/{module_id}
 AZ_NODISCARD az_result az_iot_hub_client_id_get(
     az_iot_hub_client const* client,
     az_span mqtt_client_id,

--- a/sdk/iot/core/src/az_iot_hub_client.c
+++ b/sdk/iot/core/src/az_iot_hub_client.c
@@ -57,9 +57,9 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
             az_span_length(client->_internal.iot_hub_hostname) + sizeof(hub_client_forward_slash)
             + az_span_length(client->_internal.device_id) + sizeof(hub_client_forward_slash)
             + az_span_length(*module_id)
-            + (az_span_length(*module_id) != 0 ? sizeof(hub_client_forward_slash) : 0)
+            + (az_span_length(*module_id) > 0 ? sizeof(hub_client_forward_slash) : 0)
             + az_span_length(*user_agent)
-            + (az_span_length(*user_agent) != 0 ? sizeof(hub_client_param_separator) : 0)
+            + (az_span_length(*user_agent) > 0 ? sizeof(hub_client_param_separator) : 0)
             + az_span_length(hub_client_api_version) + sizeof(hub_client_null_terminate)))
   {
     return AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY;

--- a/sdk/iot/core/src/az_iot_hub_client.c
+++ b/sdk/iot/core/src/az_iot_hub_client.c
@@ -82,8 +82,6 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
   return AZ_OK;
 }
 
-//[Format without module id] {device_id}
-//[Format with module id] {device_id}/{module_id}
 AZ_NODISCARD az_result az_iot_hub_client_id_get(
     az_iot_hub_client const* client,
     az_span mqtt_client_id,

--- a/sdk/iot/core/src/az_iot_hub_client.c
+++ b/sdk/iot/core/src/az_iot_hub_client.c
@@ -12,7 +12,6 @@
 
 static const uint8_t hub_client_forward_slash = '/';
 static const uint8_t hub_client_param_separator = '&';
-static const uint8_t hub_client_null_terminate = '\0';
 
 static const az_span hub_client_api_version = AZ_SPAN_LITERAL_FROM_STR("?api-version=2018-06-30");
 
@@ -52,19 +51,6 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
   const az_span* const module_id = &(client->_internal.options.module_id);
   const az_span* const user_agent = &(client->_internal.options.user_agent);
 
-  if (az_span_capacity(mqtt_user_name)
-      < (int32_t)(
-            az_span_length(client->_internal.iot_hub_hostname) + sizeof(hub_client_forward_slash)
-            + az_span_length(client->_internal.device_id) + sizeof(hub_client_forward_slash)
-            + az_span_length(*module_id)
-            + (az_span_length(*module_id) > 0 ? sizeof(hub_client_forward_slash) : 0)
-            + az_span_length(*user_agent)
-            + (az_span_length(*user_agent) > 0 ? sizeof(hub_client_param_separator) : 0)
-            + az_span_length(hub_client_api_version) + sizeof(hub_client_null_terminate)))
-  {
-    return AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY;
-  }
-
   AZ_RETURN_IF_FAILED(
       az_span_append(mqtt_user_name, client->_internal.iot_hub_hostname, &mqtt_user_name));
   AZ_RETURN_IF_FAILED(
@@ -91,9 +77,6 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
     AZ_RETURN_IF_FAILED(az_span_append(mqtt_user_name, *user_agent, &mqtt_user_name));
   }
 
-  AZ_RETURN_IF_FAILED(
-      az_span_append_uint8(mqtt_user_name, hub_client_null_terminate, &mqtt_user_name));
-
   *out_mqtt_user_name = mqtt_user_name;
 
   return AZ_OK;
@@ -112,15 +95,6 @@ AZ_NODISCARD az_result az_iot_hub_client_id_get(
 
   const az_span* const module_id = &(client->_internal.options.module_id);
 
-  if (az_span_capacity(mqtt_client_id)
-      < (int32_t)(
-            az_span_length(client->_internal.device_id) + az_span_length(*module_id)
-            + (az_span_length(*module_id) > 0 ? sizeof(hub_client_forward_slash) : 0)
-            + sizeof(hub_client_null_terminate)))
-  {
-    return AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY;
-  }
-
   AZ_RETURN_IF_FAILED(
       az_span_append(mqtt_client_id, client->_internal.device_id, &mqtt_client_id));
 
@@ -130,9 +104,6 @@ AZ_NODISCARD az_result az_iot_hub_client_id_get(
         az_span_append_uint8(mqtt_client_id, hub_client_forward_slash, &mqtt_client_id));
     AZ_RETURN_IF_FAILED(az_span_append(mqtt_client_id, *module_id, &mqtt_client_id));
   }
-
-  AZ_RETURN_IF_FAILED(
-      az_span_append_uint8(mqtt_client_id, hub_client_null_terminate, &mqtt_client_id));
 
   *out_mqtt_client_id = mqtt_client_id;
 

--- a/sdk/iot/core/src/az_iot_hub_client.c
+++ b/sdk/iot/core/src/az_iot_hub_client.c
@@ -68,33 +68,35 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
   }
 
   AZ_RETURN_IF_FAILED(
-      az_span_append(mqtt_user_name, client->_internal.iot_hub_hostname, out_mqtt_user_name));
+      az_span_append(mqtt_user_name, client->_internal.iot_hub_hostname, &mqtt_user_name));
   AZ_RETURN_IF_FAILED(
-      az_span_append_uint8(*out_mqtt_user_name, hub_client_forward_slash, out_mqtt_user_name));
+      az_span_append_uint8(mqtt_user_name, hub_client_forward_slash, &mqtt_user_name));
   AZ_RETURN_IF_FAILED(
-      az_span_append(*out_mqtt_user_name, client->_internal.device_id, out_mqtt_user_name));
+      az_span_append(mqtt_user_name, client->_internal.device_id, &mqtt_user_name));
   AZ_RETURN_IF_FAILED(
-      az_span_append_uint8(*out_mqtt_user_name, hub_client_forward_slash, out_mqtt_user_name));
+      az_span_append_uint8(mqtt_user_name, hub_client_forward_slash, &mqtt_user_name));
 
   if (az_span_length(*module_id) > 0)
   {
-    AZ_RETURN_IF_FAILED(az_span_append(*out_mqtt_user_name, *module_id, out_mqtt_user_name));
+    AZ_RETURN_IF_FAILED(az_span_append(mqtt_user_name, *module_id, &mqtt_user_name));
     AZ_RETURN_IF_FAILED(
-        az_span_append_uint8(*out_mqtt_user_name, hub_client_forward_slash, out_mqtt_user_name));
+        az_span_append_uint8(mqtt_user_name, hub_client_forward_slash, &mqtt_user_name));
   }
 
   AZ_RETURN_IF_FAILED(
-      az_span_append(*out_mqtt_user_name, hub_client_api_version, out_mqtt_user_name));
+      az_span_append(mqtt_user_name, hub_client_api_version, &mqtt_user_name));
 
   if (az_span_length(*user_agent) > 0)
   {
     AZ_RETURN_IF_FAILED(
-        az_span_append_uint8(*out_mqtt_user_name, hub_client_param_separator, out_mqtt_user_name));
-    AZ_RETURN_IF_FAILED(az_span_append(*out_mqtt_user_name, *user_agent, out_mqtt_user_name));
+        az_span_append_uint8(mqtt_user_name, hub_client_param_separator, &mqtt_user_name));
+    AZ_RETURN_IF_FAILED(az_span_append(mqtt_user_name, *user_agent, &mqtt_user_name));
   }
 
   AZ_RETURN_IF_FAILED(
-      az_span_append_uint8(*out_mqtt_user_name, hub_client_null_terminate, out_mqtt_user_name));
+      az_span_append_uint8(mqtt_user_name, hub_client_null_terminate, &mqtt_user_name));
+
+  *out_mqtt_user_name = mqtt_user_name;
 
   return AZ_OK;
 }
@@ -122,17 +124,19 @@ AZ_NODISCARD az_result az_iot_hub_client_id_get(
   }
 
   AZ_RETURN_IF_FAILED(
-      az_span_append(mqtt_client_id, client->_internal.device_id, out_mqtt_client_id));
+      az_span_append(mqtt_client_id, client->_internal.device_id, &mqtt_client_id));
 
   if (az_span_length(*module_id) > 0)
   {
     AZ_RETURN_IF_FAILED(
-        az_span_append_uint8(*out_mqtt_client_id, hub_client_forward_slash, out_mqtt_client_id));
-    AZ_RETURN_IF_FAILED(az_span_append(*out_mqtt_client_id, *module_id, out_mqtt_client_id));
+        az_span_append_uint8(mqtt_client_id, hub_client_forward_slash, &mqtt_client_id));
+    AZ_RETURN_IF_FAILED(az_span_append(mqtt_client_id, *module_id, &mqtt_client_id));
   }
 
   AZ_RETURN_IF_FAILED(
-      az_span_append_uint8(*out_mqtt_client_id, hub_client_null_terminate, out_mqtt_client_id));
+      az_span_append_uint8(mqtt_client_id, hub_client_null_terminate, &mqtt_client_id));
+
+  *out_mqtt_client_id = mqtt_client_id;
 
   return AZ_OK;
 }

--- a/sdk/iot/core/src/az_iot_hub_client.c
+++ b/sdk/iot/core/src/az_iot_hub_client.c
@@ -34,7 +34,8 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
 
   client->_internal.iot_hub_hostname = iot_hub_hostname;
   client->_internal.device_id = device_id;
-  memcpy(&client->_internal.options, options, sizeof(az_iot_hub_client_options));
+  client->_internal.options.module_id = options->module_id;
+  client->_internal.options.user_agent = options->user_agent;
 
   return AZ_OK;
 }

--- a/sdk/iot/core/src/az_iot_telemetry.c
+++ b/sdk/iot/core/src/az_iot_telemetry.c
@@ -13,7 +13,6 @@
 
 static const uint8_t telemetry_prop_delim = '?';
 static const uint8_t telemetry_prop_separator = '&';
-static const uint8_t telemetry_null_terminator = '\0';
 static const az_span telemetry_topic_prefix = AZ_SPAN_LITERAL_FROM_STR("devices/");
 static const az_span telemetry_topic_modules_mid = AZ_SPAN_LITERAL_FROM_STR("/modules/");
 static const az_span telemetry_topic_suffix = AZ_SPAN_LITERAL_FROM_STR("/messages/events/");
@@ -33,8 +32,7 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
 
   // Required topic parts
   int32_t required_size = az_span_length(telemetry_topic_prefix)
-      + az_span_length(client->_internal.device_id) + az_span_length(telemetry_topic_suffix)
-      + sizeof(telemetry_null_terminator);
+      + az_span_length(client->_internal.device_id) + az_span_length(telemetry_topic_suffix);
 
   // Optional parts
   if (az_span_ptr(*module_id) != NULL)
@@ -89,9 +87,6 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
             : az_span_append_uint8(*out_mqtt_topic, telemetry_prop_separator, out_mqtt_topic));
     AZ_RETURN_IF_FAILED(az_span_append(*out_mqtt_topic, *user_agent, out_mqtt_topic));
   }
-
-  AZ_RETURN_IF_FAILED(
-      az_span_append_uint8(*out_mqtt_topic, telemetry_null_terminator, out_mqtt_topic));
 
   return AZ_OK;
 }

--- a/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
@@ -139,7 +139,7 @@ void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(void** 
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
-void test_az_iot_hub_client_client_id_get_succeed(void** state)
+void test_az_iot_hub_client_id_get_succeed(void** state)
 {
   (void)state;
 
@@ -156,7 +156,7 @@ void test_az_iot_hub_client_client_id_get_succeed(void** state)
   assert_string_equal(test_correct_client_id, az_span_ptr(test_span));
 }
 
-void test_az_iot_hub_client_client_id_get_small_buffer_fail(void** state)
+void test_az_iot_hub_client_id_get_small_buffer_fail(void** state)
 {
   (void)state;
 
@@ -173,7 +173,7 @@ void test_az_iot_hub_client_client_id_get_small_buffer_fail(void** state)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
-void test_az_iot_hub_client_client_id_module_get_succeed(void** state)
+void test_az_iot_hub_client_id_module_get_succeed(void** state)
 {
   (void)state;
 
@@ -191,7 +191,7 @@ void test_az_iot_hub_client_client_id_module_get_succeed(void** state)
   assert_string_equal(test_correct_client_id_with_module_id, az_span_ptr(test_span));
 }
 
-void test_az_iot_hub_client_client_id_module_get_small_buffer_fail(void** state)
+void test_az_iot_hub_client_id_module_get_small_buffer_fail(void** state)
 {
   (void)state;
 

--- a/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
@@ -42,8 +42,8 @@ void test_az_iot_hub_client_init_succeed(void** state)
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  assert_true(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
   assert_string_equal(TEST_DEVICE_ID_STR, az_span_ptr(client._internal.device_id));
   assert_string_equal(TEST_DEVICE_HOSTNAME_STR, az_span_ptr(client._internal.iot_hub_hostname));
@@ -57,8 +57,8 @@ void test_az_iot_hub_client_init_custom_options_succeed(void** state)
   az_iot_hub_client_options options;
   options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
   options.user_agent = AZ_SPAN_FROM_STR(TEST_USER_AGENT);
-  assert_true(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
   assert_string_equal(TEST_DEVICE_ID_STR, az_span_ptr(client._internal.device_id));
   assert_string_equal(TEST_DEVICE_HOSTNAME_STR, az_span_ptr(client._internal.iot_hub_hostname));
@@ -72,13 +72,31 @@ void test_az_iot_hub_client_user_name_get_succeed(void** state)
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  assert_true(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_user_name)];
+  uint8_t test_span_buffer[sizeof(test_correct_user_name) - 1];
   az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
-  assert_true(az_iot_hub_client_user_name_get(&client, test_span, &test_span) == AZ_OK);
+  assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
 
+  assert_memory_equal(
+      test_correct_user_name, az_span_ptr(test_span), sizeof(test_correct_user_name) - 1);
+}
+
+void test_az_iot_hub_client_user_name_get_as_string_succeed(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
+
+  uint8_t test_span_buffer[sizeof(test_correct_user_name)] = { 0 };
+  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
+
+  assert_int_equal(az_span_length(test_span), sizeof(test_correct_user_name) - 1);
   assert_string_equal(test_correct_user_name, az_span_ptr(test_span));
 }
 
@@ -88,14 +106,14 @@ void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  assert_true(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_user_name) - 1];
+  uint8_t test_span_buffer[sizeof(test_correct_user_name) - 2];
   az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
-  assert_true(
-      az_iot_hub_client_user_name_get(&client, test_span, &test_span)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(
+      az_iot_hub_client_user_name_get(&client, test_span, &test_span),
+      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
 void test_az_iot_hub_client_user_name_get_user_options_succeed(void** state)
@@ -106,13 +124,35 @@ void test_az_iot_hub_client_user_name_get_user_options_succeed(void** state)
   az_iot_hub_client_options options;
   options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
   options.user_agent = AZ_SPAN_FROM_STR(TEST_USER_AGENT);
-  assert_true(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id)];
+  uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id) - 1];
   az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
-  assert_true(az_iot_hub_client_user_name_get(&client, test_span, &test_span) == AZ_OK);
+  assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
 
+  assert_memory_equal(
+      test_correct_user_name_with_module_id,
+      az_span_ptr(test_span),
+      sizeof(test_correct_user_name_with_module_id) - 1);
+}
+
+void test_az_iot_hub_client_user_name_get_user_options_as_string_succeed(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options;
+  options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
+  options.user_agent = AZ_SPAN_FROM_STR(TEST_USER_AGENT);
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
+
+  uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id)] = { 0 };
+  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
+
+  assert_int_equal(az_span_length(test_span), sizeof(test_correct_user_name_with_module_id) - 1);
   assert_string_equal(test_correct_user_name_with_module_id, az_span_ptr(test_span));
 }
 
@@ -124,14 +164,14 @@ void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(void** 
   az_iot_hub_client_options options;
   options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
   options.user_agent = AZ_SPAN_FROM_STR(TEST_USER_AGENT);
-  assert_true(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id) - 1];
+  uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id) - 2];
   az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
-  assert_true(
-      az_iot_hub_client_user_name_get(&client, test_span, &test_span)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(
+      az_iot_hub_client_user_name_get(&client, test_span, &test_span),
+      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
 void test_az_iot_hub_client_id_get_succeed(void** state)
@@ -140,13 +180,31 @@ void test_az_iot_hub_client_id_get_succeed(void** state)
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  assert_true(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_client_id)];
+  uint8_t test_span_buffer[sizeof(test_correct_client_id) - 1];
   az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
-  assert_true(az_iot_hub_client_id_get(&client, test_span, &test_span) == AZ_OK);
+  assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
 
+  assert_memory_equal(
+      test_correct_client_id, az_span_ptr(test_span), sizeof(test_correct_client_id) - 1);
+}
+
+void test_az_iot_hub_client_id_get_as_string_succeed(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
+
+  uint8_t test_span_buffer[sizeof(test_correct_client_id)] = { 0 };
+  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
+
+  assert_int_equal(az_span_length(test_span), sizeof(test_correct_client_id) - 1);
   assert_string_equal(test_correct_client_id, az_span_ptr(test_span));
 }
 
@@ -156,48 +214,69 @@ void test_az_iot_hub_client_id_get_small_buffer_fail(void** state)
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  assert_true(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_client_id) - 1];
+  uint8_t test_span_buffer[sizeof(test_correct_client_id) - 2];
   az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
-  assert_true(
-      az_iot_hub_client_id_get(&client, test_span, &test_span)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(
+      az_iot_hub_client_id_get(&client, test_span, &test_span),
+      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
-void test_az_iot_hub_client_id_module_get_succeed(void** state)
+void test_az_iot_hub_client_id_get_module_succeed(void** state)
 {
   (void)state;
 
   az_iot_hub_client client;
   az_iot_hub_client_options options;
   options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
-  assert_true(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
-
-  uint8_t test_span_buffer[sizeof(test_correct_client_id_with_module_id)];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
-  assert_true(az_iot_hub_client_id_get(&client, test_span, &test_span) == AZ_OK);
-
-  assert_string_equal(test_correct_client_id_with_module_id, az_span_ptr(test_span));
-}
-
-void test_az_iot_hub_client_id_module_get_small_buffer_fail(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  az_iot_hub_client_options options;
-  options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
-  assert_true(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correct_client_id_with_module_id) - 1];
   az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
-  assert_true(
-      az_iot_hub_client_id_get(&client, test_span, &test_span)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
+
+  assert_memory_equal(
+      test_correct_client_id_with_module_id,
+      az_span_ptr(test_span),
+      sizeof(test_correct_client_id_with_module_id) - 1);
+}
+
+void test_az_iot_hub_client_id_get_module_as_string_succeed(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options;
+  options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
+
+  uint8_t test_span_buffer[sizeof(test_correct_client_id_with_module_id)] = { 0 };
+  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
+
+  assert_int_equal(az_span_length(test_span), sizeof(test_correct_client_id_with_module_id) - 1);
+  assert_string_equal(test_correct_client_id_with_module_id, az_span_ptr(test_span));
+}
+
+void test_az_iot_hub_client_id_get_module_small_buffer_fail(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options;
+  options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
+
+  uint8_t test_span_buffer[sizeof(test_correct_client_id_with_module_id) - 2];
+  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  assert_int_equal(
+      az_iot_hub_client_id_get(&client, test_span, &test_span),
+      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
 int test_iot_hub_client()
@@ -207,13 +286,17 @@ int test_iot_hub_client()
     cmocka_unit_test(test_az_iot_hub_client_init_succeed),
     cmocka_unit_test(test_az_iot_hub_client_init_custom_options_succeed),
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_user_name_get_as_string_succeed),
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_small_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_user_options_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_user_name_get_user_options_as_string_succeed),
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_id_get_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_id_get_as_string_succeed),
     cmocka_unit_test(test_az_iot_hub_client_id_get_small_buffer_fail),
-    cmocka_unit_test(test_az_iot_hub_client_id_module_get_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_id_module_get_small_buffer_fail),
+    cmocka_unit_test(test_az_iot_hub_client_id_get_module_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_id_get_module_as_string_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_id_get_module_small_buffer_fail),
   };
   return cmocka_run_group_tests_name("az_iot_client", tests, NULL, NULL);
 }

--- a/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
@@ -78,7 +78,7 @@ void test_az_iot_hub_client_user_name_get_succeed(void** state)
 
   uint8_t test_span_buffer[sizeof(test_correct_user_name)];
   az_span test_span
-      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
+      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(az_iot_hub_client_user_name_get(&client, test_span, &test_span) == AZ_OK);
 
   assert_string_equal(test_correct_user_name, az_span_ptr(test_span));
@@ -95,7 +95,7 @@ void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
 
   uint8_t test_span_buffer[sizeof(test_correct_user_name) - 1];
   az_span test_span
-      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
+      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(
       az_iot_hub_client_user_name_get(&client, test_span, &test_span)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
@@ -114,7 +114,7 @@ void test_az_iot_hub_client_user_name_get_user_options_succeed(void** state)
 
   uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id)];
   az_span test_span
-      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
+      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(az_iot_hub_client_user_name_get(&client, test_span, &test_span) == AZ_OK);
 
   assert_string_equal(test_correct_user_name_with_module_id, az_span_ptr(test_span));
@@ -133,7 +133,7 @@ void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(void** 
 
   uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id) - 1];
   az_span test_span
-      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
+      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(
       az_iot_hub_client_user_name_get(&client, test_span, &test_span)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
@@ -150,7 +150,7 @@ void test_az_iot_hub_client_client_id_get_succeed(void** state)
 
   uint8_t test_span_buffer[sizeof(test_correct_client_id)];
   az_span test_span
-      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
+      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(az_iot_hub_client_id_get(&client, test_span, &test_span) == AZ_OK);
 
   assert_string_equal(test_correct_client_id, az_span_ptr(test_span));
@@ -167,7 +167,7 @@ void test_az_iot_hub_client_client_id_get_small_buffer_fail(void** state)
 
   uint8_t test_span_buffer[sizeof(test_correct_client_id) - 1];
   az_span test_span
-      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
+      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(
       az_iot_hub_client_id_get(&client, test_span, &test_span)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
@@ -185,7 +185,7 @@ void test_az_iot_hub_client_client_id_module_get_succeed(void** state)
 
   uint8_t test_span_buffer[sizeof(test_correcet_client_id_with_module_id)];
   az_span test_span
-      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
+      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(az_iot_hub_client_id_get(&client, test_span, &test_span) == AZ_OK);
 
   assert_string_equal(test_correct_client_id_with_module_id, az_span_ptr(test_span));
@@ -203,7 +203,7 @@ void test_az_iot_hub_client_client_id_module_get_small_buffer_fail(void** state)
 
   uint8_t test_span_buffer[sizeof(test_correcet_client_id_with_module_id) - 1];
   az_span test_span
-      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
+      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(
       az_iot_hub_client_id_get(&client, test_span, &test_span)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);

--- a/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
@@ -176,7 +176,7 @@ void test_az_iot_hub_client_id_module_get_succeed(void** state)
   assert_true(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correcet_client_id_with_module_id)];
+  uint8_t test_span_buffer[sizeof(test_correct_client_id_with_module_id)];
   az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(az_iot_hub_client_id_get(&client, test_span, &test_span) == AZ_OK);
 
@@ -193,7 +193,7 @@ void test_az_iot_hub_client_id_module_get_small_buffer_fail(void** state)
   assert_true(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correcet_client_id_with_module_id) - 1];
+  uint8_t test_span_buffer[sizeof(test_correct_client_id_with_module_id) - 1];
   az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(
       az_iot_hub_client_id_get(&client, test_span, &test_span)
@@ -210,10 +210,10 @@ int test_iot_hub_client()
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_small_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_user_options_succeed),
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail),
-    cmocka_unit_test(test_az_iot_hub_client_client_id_get_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_client_id_get_small_buffer_fail),
-    cmocka_unit_test(test_az_iot_hub_client_client_id_module_get_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_client_id_module_get_small_buffer_fail),
+    cmocka_unit_test(test_az_iot_hub_client_id_get_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_id_get_small_buffer_fail),
+    cmocka_unit_test(test_az_iot_hub_client_id_module_get_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_id_module_get_small_buffer_fail),
   };
   return cmocka_run_group_tests_name("az_iot_client", tests, NULL, NULL);
 }

--- a/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
@@ -8,7 +8,6 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #include <cmocka.h>
 

--- a/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
@@ -77,7 +77,8 @@ void test_az_iot_hub_client_user_name_get_succeed(void** state)
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correct_user_name)];
-  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  az_span test_span
+      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
   assert_true(az_iot_hub_client_user_name_get(&client, test_span, &test_span) == AZ_OK);
 
   assert_string_equal(test_correct_user_name, az_span_ptr(test_span));
@@ -93,7 +94,8 @@ void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correct_user_name) - 1];
-  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  az_span test_span
+      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
   assert_true(
       az_iot_hub_client_user_name_get(&client, test_span, &test_span)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
@@ -111,7 +113,8 @@ void test_az_iot_hub_client_user_name_get_user_options_succeed(void** state)
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id)];
-  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  az_span test_span
+      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
   assert_true(az_iot_hub_client_user_name_get(&client, test_span, &test_span) == AZ_OK);
 
   assert_string_equal(test_correct_user_name_with_module_id, az_span_ptr(test_span));
@@ -129,7 +132,8 @@ void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(void** 
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id) - 1];
-  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  az_span test_span
+      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
   assert_true(
       az_iot_hub_client_user_name_get(&client, test_span, &test_span)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
@@ -145,7 +149,8 @@ void test_az_iot_hub_client_client_id_get_succeed(void** state)
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correct_client_id)];
-  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  az_span test_span
+      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
   assert_true(az_iot_hub_client_id_get(&client, test_span, &test_span) == AZ_OK);
 
   assert_string_equal(test_correct_client_id, az_span_ptr(test_span));
@@ -161,7 +166,8 @@ void test_az_iot_hub_client_client_id_get_small_buffer_fail(void** state)
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correct_client_id) - 1];
-  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  az_span test_span
+      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
   assert_true(
       az_iot_hub_client_id_get(&client, test_span, &test_span)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
@@ -177,8 +183,9 @@ void test_az_iot_hub_client_client_id_module_get_succeed(void** state)
   assert_true(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_client_id_with_module_id)];
-  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  uint8_t test_span_buffer[sizeof(test_correcet_client_id_with_module_id)];
+  az_span test_span
+      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
   assert_true(az_iot_hub_client_id_get(&client, test_span, &test_span) == AZ_OK);
 
   assert_string_equal(test_correct_client_id_with_module_id, az_span_ptr(test_span));
@@ -194,8 +201,9 @@ void test_az_iot_hub_client_client_id_module_get_small_buffer_fail(void** state)
   assert_true(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_client_id_with_module_id) - 1];
-  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  uint8_t test_span_buffer[sizeof(test_correcet_client_id_with_module_id) - 1];
+  az_span test_span
+      = az_span_init(test_span_buffer, 0, sizeof(test_span_buffer) / sizeof(test_span_buffer[0]));
   assert_true(
       az_iot_hub_client_id_get(&client, test_span, &test_span)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);

--- a/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
@@ -13,6 +13,21 @@
 
 #include <cmocka.h>
 
+#define TEST_DEVICE_ID_STR "my_device"
+#define TEST_DEVICE_HOSTNAME_STR "myiothub.azure-devices.net"
+#define TEST_MODULE_ID "my_module_id"
+#define TEST_USER_AGENT "os=azrtos"
+
+static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_ID_STR);
+static const az_span test_device_hostname = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_HOSTNAME_STR);
+
+static const char test_correct_user_name[]
+    = "myiothub.azure-devices.net/my_device/?api-version=2018-06-30";
+static const char test_correct_user_name_with_module_id[]
+    = "myiothub.azure-devices.net/my_device/my_module_id/?api-version=2018-06-30&os=azrtos";
+static const char test_correct_client_id[] = "my_device";
+static const char test_correct_client_id_with_module_id[] = "my_device/my_module_id";
+
 void test_az_iot_hub_client_get_default_options_succeed(void** state)
 {
   (void)state;
@@ -22,11 +37,184 @@ void test_az_iot_hub_client_get_default_options_succeed(void** state)
   assert_true(az_span_is_content_equal(options.user_agent, AZ_SPAN_NULL));
 }
 
+void test_az_iot_hub_client_init_succeed(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+
+  assert_string_equal(TEST_DEVICE_ID_STR, az_span_ptr(client._internal.device_id));
+  assert_string_equal(TEST_DEVICE_HOSTNAME_STR, az_span_ptr(client._internal.iot_hub_hostname));
+}
+
+void test_az_iot_hub_client_init_custom_options_succeed(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options;
+  options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
+  options.user_agent = AZ_SPAN_FROM_STR(TEST_USER_AGENT);
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+
+  assert_string_equal(TEST_DEVICE_ID_STR, az_span_ptr(client._internal.device_id));
+  assert_string_equal(TEST_DEVICE_HOSTNAME_STR, az_span_ptr(client._internal.iot_hub_hostname));
+  assert_string_equal(TEST_MODULE_ID, az_span_ptr(client._internal.options.module_id));
+  assert_string_equal(TEST_USER_AGENT, az_span_ptr(client._internal.options.user_agent));
+}
+
+void test_az_iot_hub_client_user_name_get_succeed(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+
+  uint8_t test_span_buffer[sizeof(test_correct_user_name)];
+  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  assert_true(az_iot_hub_client_user_name_get(&client, test_span, &test_span) == AZ_OK);
+
+  assert_string_equal(test_correct_user_name, az_span_ptr(test_span));
+}
+
+void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+
+  uint8_t test_span_buffer[sizeof(test_correct_user_name) - 1];
+  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  assert_true(
+      az_iot_hub_client_user_name_get(&client, test_span, &test_span)
+      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+}
+
+void test_az_iot_hub_client_user_name_get_user_options_succeed(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options;
+  options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
+  options.user_agent = AZ_SPAN_FROM_STR(TEST_USER_AGENT);
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+
+  uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id)];
+  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  assert_true(az_iot_hub_client_user_name_get(&client, test_span, &test_span) == AZ_OK);
+
+  assert_string_equal(test_correct_user_name_with_module_id, az_span_ptr(test_span));
+}
+
+void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options;
+  options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
+  options.user_agent = AZ_SPAN_FROM_STR(TEST_USER_AGENT);
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+
+  uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id) - 1];
+  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  assert_true(
+      az_iot_hub_client_user_name_get(&client, test_span, &test_span)
+      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+}
+
+void test_az_iot_hub_client_client_id_get_succeed(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+
+  uint8_t test_span_buffer[sizeof(test_correct_client_id)];
+  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  assert_true(az_iot_hub_client_id_get(&client, test_span, &test_span) == AZ_OK);
+
+  assert_string_equal(test_correct_client_id, az_span_ptr(test_span));
+}
+
+void test_az_iot_hub_client_client_id_get_small_buffer_fail(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+
+  uint8_t test_span_buffer[sizeof(test_correct_client_id) - 1];
+  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  assert_true(
+      az_iot_hub_client_id_get(&client, test_span, &test_span)
+      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+}
+
+void test_az_iot_hub_client_client_id_module_get_succeed(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options;
+  options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+
+  uint8_t test_span_buffer[sizeof(test_correct_client_id_with_module_id)];
+  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  assert_true(az_iot_hub_client_id_get(&client, test_span, &test_span) == AZ_OK);
+
+  assert_string_equal(test_correct_client_id_with_module_id, az_span_ptr(test_span));
+}
+
+void test_az_iot_hub_client_client_id_module_get_small_buffer_fail(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options;
+  options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+
+  uint8_t test_span_buffer[sizeof(test_correct_client_id_with_module_id) - 1];
+  az_span test_span = AZ_SPAN_FROM_BUFFER(test_span_buffer);
+  assert_true(
+      az_iot_hub_client_id_get(&client, test_span, &test_span)
+      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+}
+
 int test_iot_hub_client()
 {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_az_iot_hub_client_get_default_options_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_init_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_init_custom_options_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_user_name_get_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_user_name_get_small_buffer_fail),
+    cmocka_unit_test(test_az_iot_hub_client_user_name_get_user_options_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail),
+    cmocka_unit_test(test_az_iot_hub_client_client_id_get_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_client_id_get_small_buffer_fail),
+    cmocka_unit_test(test_az_iot_hub_client_client_id_module_get_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_client_id_module_get_small_buffer_fail),
   };
-
   return cmocka_run_group_tests_name("az_iot_client", tests, NULL, NULL);
 }

--- a/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_hub_client_tests.c
@@ -4,12 +4,11 @@
 #include <az_iot_hub_client.h>
 #include <az_span.h>
 
-#include <stdio.h>
-
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #include <cmocka.h>
 
@@ -77,8 +76,7 @@ void test_az_iot_hub_client_user_name_get_succeed(void** state)
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correct_user_name)];
-  az_span test_span
-      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(az_iot_hub_client_user_name_get(&client, test_span, &test_span) == AZ_OK);
 
   assert_string_equal(test_correct_user_name, az_span_ptr(test_span));
@@ -94,8 +92,7 @@ void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correct_user_name) - 1];
-  az_span test_span
-      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(
       az_iot_hub_client_user_name_get(&client, test_span, &test_span)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
@@ -113,8 +110,7 @@ void test_az_iot_hub_client_user_name_get_user_options_succeed(void** state)
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id)];
-  az_span test_span
-      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(az_iot_hub_client_user_name_get(&client, test_span, &test_span) == AZ_OK);
 
   assert_string_equal(test_correct_user_name_with_module_id, az_span_ptr(test_span));
@@ -132,8 +128,7 @@ void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(void** 
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id) - 1];
-  az_span test_span
-      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(
       az_iot_hub_client_user_name_get(&client, test_span, &test_span)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
@@ -149,8 +144,7 @@ void test_az_iot_hub_client_id_get_succeed(void** state)
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correct_client_id)];
-  az_span test_span
-      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(az_iot_hub_client_id_get(&client, test_span, &test_span) == AZ_OK);
 
   assert_string_equal(test_correct_client_id, az_span_ptr(test_span));
@@ -166,8 +160,7 @@ void test_az_iot_hub_client_id_get_small_buffer_fail(void** state)
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correct_client_id) - 1];
-  az_span test_span
-      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(
       az_iot_hub_client_id_get(&client, test_span, &test_span)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
@@ -184,8 +177,7 @@ void test_az_iot_hub_client_id_module_get_succeed(void** state)
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correcet_client_id_with_module_id)];
-  az_span test_span
-      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(az_iot_hub_client_id_get(&client, test_span, &test_span) == AZ_OK);
 
   assert_string_equal(test_correct_client_id_with_module_id, az_span_ptr(test_span));
@@ -202,8 +194,7 @@ void test_az_iot_hub_client_id_module_get_small_buffer_fail(void** state)
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   uint8_t test_span_buffer[sizeof(test_correcet_client_id_with_module_id) - 1];
-  az_span test_span
-      = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
   assert_true(
       az_iot_hub_client_id_get(&client, test_span, &test_span)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);

--- a/sdk/iot/core/tests/cmocka/az_iot_sas_token_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_sas_token_tests.c
@@ -8,7 +8,6 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #include <cmocka.h>
 

--- a/sdk/iot/core/tests/cmocka/az_iot_sas_token_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_sas_token_tests.c
@@ -4,12 +4,11 @@
 #include <az_iot_sas_token.h>
 #include <az_span.h>
 
-#include <stdio.h>
-
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #include <cmocka.h>
 

--- a/sdk/iot/core/tests/cmocka/az_iot_telemetry_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_telemetry_tests.c
@@ -8,7 +8,6 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #include <cmocka.h>
 

--- a/sdk/iot/core/tests/cmocka/az_iot_telemetry_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_telemetry_tests.c
@@ -4,12 +4,11 @@
 #include <az_iot_hub_client.h>
 #include <az_span.h>
 
-#include <stdio.h>
-
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #include <cmocka.h>
 

--- a/sdk/iot/core/tests/cmocka/az_iot_telemetry_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_telemetry_tests.c
@@ -121,7 +121,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_params_suc
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_no_params)];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_no_params) - 1];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -129,6 +129,28 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_params_suc
       az_iot_hub_client_telemetry_publish_topic_get(
           &g_test_valid_client_no_options, NULL, mqtt_topic, &mqtt_topic)
       == AZ_OK);
+  assert_memory_equal(
+      g_test_correct_topic_no_options_no_params,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_no_options_no_params) - 1);
+}
+
+void test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_params_succeed(
+    void** state)
+{
+  (void)state;
+
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_no_params)] = { 0 };
+
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+
+  assert_true(
+      az_iot_hub_client_telemetry_publish_topic_get(
+          &g_test_valid_client_no_options, NULL, mqtt_topic, &mqtt_topic)
+      == AZ_OK);
+  assert_int_equal(
+      az_span_length(mqtt_topic), sizeof(g_test_correct_topic_no_options_no_params) - 1);
+  assert_int_equal(az_span_capacity(mqtt_topic), sizeof(g_test_correct_topic_no_options_no_params));
   assert_string_equal(g_test_correct_topic_no_options_no_params, (char*)az_span_ptr(mqtt_topic));
 }
 
@@ -136,7 +158,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_params_s
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_no_params)];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_no_params) - 1];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -144,7 +166,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_params_s
       az_iot_hub_client_telemetry_publish_topic_get(
           &g_test_valid_client_with_options_both, NULL, mqtt_topic, &mqtt_topic)
       == AZ_OK);
-  assert_string_equal(g_test_correct_topic_with_options_no_params, (char*)az_span_ptr(mqtt_topic));
+  assert_memory_equal(
+      g_test_correct_topic_with_options_no_params,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_with_options_no_params) - 1);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params_succeed(
@@ -152,7 +177,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_params)];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_params) - 1];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -160,8 +185,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params
       az_iot_hub_client_telemetry_publish_topic_get(
           &g_test_valid_client_with_options_both, &g_test_params, mqtt_topic, &mqtt_topic)
       == AZ_OK);
-  assert_string_equal(
-      g_test_correct_topic_with_options_with_params, (char*)az_span_ptr(mqtt_topic));
+  assert_memory_equal(
+      g_test_correct_topic_with_options_with_params,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_with_options_with_params) - 1);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params_small_buffer_fails(
@@ -169,7 +196,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_params) - 1];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_params) - 2];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -183,7 +210,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_s
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_params)];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_params) - 1];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -191,7 +218,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_s
       az_iot_hub_client_telemetry_publish_topic_get(
           &g_test_valid_client_no_options, &g_test_params, mqtt_topic, &mqtt_topic)
       == AZ_OK);
-  assert_string_equal(g_test_correct_topic_no_options_with_params, (char*)az_span_ptr(mqtt_topic));
+  assert_memory_equal(
+      g_test_correct_topic_no_options_with_params,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_no_options_with_params) - 1);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_small_buffer_fails(
@@ -199,7 +229,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_s
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_params) - 1];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_params) - 2];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -214,7 +244,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_w
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_params)];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_params) - 1];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -222,8 +252,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_w
       az_iot_hub_client_telemetry_publish_topic_get(
           &g_test_valid_client_with_options_module_id, &g_test_params, mqtt_topic, &mqtt_topic)
       == AZ_OK);
-  assert_string_equal(
-      g_test_correct_topic_with_options_module_id_with_params, (char*)az_span_ptr(mqtt_topic));
+  assert_memory_equal(
+      g_test_correct_topic_with_options_module_id_with_params,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_with_options_module_id_with_params) - 1);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_params_small_buffer_fails(
@@ -231,7 +263,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_w
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_params) - 1];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_params) - 2];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -246,7 +278,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_user_agent_with_params)];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_user_agent_with_params) - 1];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -254,8 +286,11 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_
       az_iot_hub_client_telemetry_publish_topic_get(
           &g_test_valid_client_with_options_user_agent, &g_test_params, mqtt_topic, &mqtt_topic)
       == AZ_OK);
-  assert_string_equal(
-      g_test_correct_topic_with_options_user_agent_with_params, (char*)az_span_ptr(mqtt_topic));
+
+  assert_memory_equal(
+      g_test_correct_topic_with_options_user_agent_with_params,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_with_options_user_agent_with_params) - 1);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_with_params_small_buffer_fails(
@@ -263,7 +298,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_user_agent_with_params) - 1];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_user_agent_with_params) - 2];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -278,6 +313,8 @@ int test_iot_hub_telemetry()
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(
         test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_params_succeed),
+    cmocka_unit_test(
+        test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_params_succeed),
     cmocka_unit_test(
         test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_params_succeed),
     cmocka_unit_test(


### PR DESCRIPTION
This includes three api's
`az_iot_hub_client_init()`
`az_iot_hub_client_user_name_get()`
`az_iot_hub_client_id_get()`
and associated testing.

If anyone would like to compare the resulting user name and client id to the documented requirements, links to those docs are here:
[Username and Client ID without Modules](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support#using-the-mqtt-protocol-directly-as-a-device)
[Username and Client ID with Modules](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support#using-the-mqtt-protocol-directly-as-a-module)