### PR TITLE
Add _az_countof() macro

### DIFF
--- a/sdk/core/core/inc/_az_cfg.h
+++ b/sdk/core/core/inc/_az_cfg.h
@@ -83,4 +83,7 @@
 #define AZ_NODISCARD
 #endif // _MSC_VER
 
+// Get the number of elements in an array
+#define _az_countof(array) (sizeof(array) / sizeof(array[0]))
+
 #endif // _az_CFG_H

--- a/sdk/core/core/inc/_az_cfg.h
+++ b/sdk/core/core/inc/_az_cfg.h
@@ -84,6 +84,6 @@
 #endif // _MSC_VER
 
 // Get the number of elements in an array
-#define _az_countof(array) (sizeof(array) / sizeof(array[0]))
+#define _az_COUNTOF(array) (sizeof(array) / sizeof(array[0]))
 
 #endif // _az_CFG_H

--- a/sdk/core/core/test/cmocka/test_log.c
+++ b/sdk/core/core/test/cmocka/test_log.c
@@ -189,7 +189,7 @@ void test_az_log(void** state)
     // our code attempts to log a classification that's not in the customer's allow list.
     az_log_classification const classifications[] = { AZ_LOG_HTTP_REQUEST };
     az_log_set_classifications(
-        classifications, _az_countof(classifications));
+        classifications, _az_COUNTOF(classifications));
 
     assert_true(az_log_should_write(AZ_LOG_HTTP_REQUEST) == true);
     assert_true(az_log_should_write(AZ_LOG_HTTP_RESPONSE) == false);

--- a/sdk/core/core/test/cmocka/test_log.c
+++ b/sdk/core/core/test/cmocka/test_log.c
@@ -189,7 +189,7 @@ void test_az_log(void** state)
     // our code attempts to log a classification that's not in the customer's allow list.
     az_log_classification const classifications[] = { AZ_LOG_HTTP_REQUEST };
     az_log_set_classifications(
-        classifications, sizeof(classifications) / sizeof(classifications[0]));
+        classifications, _az_countof(classifications));
 
     assert_true(az_log_should_write(AZ_LOG_HTTP_REQUEST) == true);
     assert_true(az_log_should_write(AZ_LOG_HTTP_RESPONSE) == false);

--- a/sdk/iot/core/tests/cmocka/az_iot_sas_token_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_sas_token_tests.c
@@ -54,7 +54,7 @@ void az_iot_sas_token_get_document_empty_device_id_fails(void** state)
   int32_t expiry_time_secs = TEST_EXPIRATION;
 
   uint8_t raw_document[256];
-  az_span document = az_span_init(raw_document, 0, sizeof(raw_document) / sizeof(raw_document[0]));
+  az_span document = az_span_init(raw_document, 0, _az_countof(raw_document));
 
   assert_true(az_failed(az_iot_sas_token_get_document(
       iothub_fqdn, device_id, expiry_time_secs, document, &document)));
@@ -68,7 +68,7 @@ void az_iot_sas_token_get_document_empty_iothub_fqdn_fails(void** state)
   int32_t expiry_time_secs = TEST_EXPIRATION;
 
   uint8_t raw_document[256];
-  az_span document = az_span_init(raw_document, 0, sizeof(raw_document) / sizeof(raw_document[0]));
+  az_span document = az_span_init(raw_document, 0, _az_countof(raw_document));
 
   assert_true(az_failed(az_iot_sas_token_get_document(
       iothub_fqdn, device_id, expiry_time_secs, document, &document)));
@@ -82,7 +82,7 @@ void az_iot_sas_token_get_document_document_overflow_fails(void** state)
   int32_t expiry_time_secs = TEST_EXPIRATION;
 
   uint8_t raw_document[32];
-  az_span document = az_span_init(raw_document, 0, sizeof(raw_document) / sizeof(raw_document[0]));
+  az_span document = az_span_init(raw_document, 0, _az_countof(raw_document));
 
   assert_true(
       az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document)
@@ -99,7 +99,7 @@ void az_iot_sas_token_get_document_succeeds(void** state)
   int32_t expiry_time_secs = TEST_EXPIRATION;
 
   uint8_t raw_document[256];
-  az_span document = az_span_init(raw_document, 0, sizeof(raw_document) / sizeof(raw_document[0]));
+  az_span document = az_span_init(raw_document, 0, _az_countof(raw_document));
 
   assert_true(az_succeeded(az_iot_sas_token_get_document(
       iothub_fqdn, device_id, expiry_time_secs, document, &document)));
@@ -117,7 +117,7 @@ void az_iot_sas_token_generate_empty_device_id_fails(void** state)
 
   uint8_t raw_sas_token[256];
   az_span sas_token
-      = az_span_init(raw_sas_token, 0, sizeof(raw_sas_token) / sizeof(raw_sas_token[0]));
+      = az_span_init(raw_sas_token, 0, _az_countof(raw_sas_token));
 
   assert_true(
       az_iot_sas_token_generate(
@@ -136,7 +136,7 @@ void az_iot_sas_token_generate_empty_iothub_fqdn_fails(void** state)
 
   uint8_t raw_sas_token[256];
   az_span sas_token
-      = az_span_init(raw_sas_token, 0, sizeof(raw_sas_token) / sizeof(raw_sas_token[0]));
+      = az_span_init(raw_sas_token, 0, _az_countof(raw_sas_token));
 
   assert_true(
       az_iot_sas_token_generate(
@@ -155,7 +155,7 @@ void az_iot_sas_token_generate_EMPTY_signature_fails(void** state)
 
   uint8_t raw_sas_token[256];
   az_span sas_token
-      = az_span_init(raw_sas_token, 0, sizeof(raw_sas_token) / sizeof(raw_sas_token[0]));
+      = az_span_init(raw_sas_token, 0, _az_countof(raw_sas_token));
 
   assert_true(
       az_iot_sas_token_generate(
@@ -206,7 +206,7 @@ void az_iot_sas_token_generate_sas_token_overflow_fails(void** state)
 
   uint8_t raw_sas_token[32];
   az_span sas_token
-      = az_span_init(raw_sas_token, 0, sizeof(raw_sas_token) / sizeof(raw_sas_token[0]));
+      = az_span_init(raw_sas_token, 0, _az_countof(raw_sas_token));
 
   assert_true(
       az_iot_sas_token_generate(
@@ -228,7 +228,7 @@ void az_iot_sas_token_generate_succeeds(void** state)
 
   uint8_t raw_sas_token[256];
   az_span sas_token
-      = az_span_init(raw_sas_token, 0, sizeof(raw_sas_token) / sizeof(raw_sas_token[0]));
+      = az_span_init(raw_sas_token, 0, _az_countof(raw_sas_token));
 
   assert_true(az_succeeded(az_iot_sas_token_generate(
       iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)));
@@ -250,7 +250,7 @@ void az_iot_sas_token_generate_with_keyname_succeeds(void** state)
 
   uint8_t raw_sas_token[256];
   az_span sas_token
-      = az_span_init(raw_sas_token, 0, sizeof(raw_sas_token) / sizeof(raw_sas_token[0]));
+      = az_span_init(raw_sas_token, 0, _az_countof(raw_sas_token));
 
   assert_true(az_succeeded(az_iot_sas_token_generate(
       iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)));

--- a/sdk/iot/core/tests/cmocka/az_iot_sas_token_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_sas_token_tests.c
@@ -54,7 +54,7 @@ void az_iot_sas_token_get_document_empty_device_id_fails(void** state)
   int32_t expiry_time_secs = TEST_EXPIRATION;
 
   uint8_t raw_document[256];
-  az_span document = az_span_init(raw_document, 0, _az_countof(raw_document));
+  az_span document = az_span_init(raw_document, 0, _az_COUNTOF(raw_document));
 
   assert_true(az_failed(az_iot_sas_token_get_document(
       iothub_fqdn, device_id, expiry_time_secs, document, &document)));
@@ -68,7 +68,7 @@ void az_iot_sas_token_get_document_empty_iothub_fqdn_fails(void** state)
   int32_t expiry_time_secs = TEST_EXPIRATION;
 
   uint8_t raw_document[256];
-  az_span document = az_span_init(raw_document, 0, _az_countof(raw_document));
+  az_span document = az_span_init(raw_document, 0, _az_COUNTOF(raw_document));
 
   assert_true(az_failed(az_iot_sas_token_get_document(
       iothub_fqdn, device_id, expiry_time_secs, document, &document)));
@@ -82,7 +82,7 @@ void az_iot_sas_token_get_document_document_overflow_fails(void** state)
   int32_t expiry_time_secs = TEST_EXPIRATION;
 
   uint8_t raw_document[32];
-  az_span document = az_span_init(raw_document, 0, _az_countof(raw_document));
+  az_span document = az_span_init(raw_document, 0, _az_COUNTOF(raw_document));
 
   assert_true(
       az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document)
@@ -99,7 +99,7 @@ void az_iot_sas_token_get_document_succeeds(void** state)
   int32_t expiry_time_secs = TEST_EXPIRATION;
 
   uint8_t raw_document[256];
-  az_span document = az_span_init(raw_document, 0, _az_countof(raw_document));
+  az_span document = az_span_init(raw_document, 0, _az_COUNTOF(raw_document));
 
   assert_true(az_succeeded(az_iot_sas_token_get_document(
       iothub_fqdn, device_id, expiry_time_secs, document, &document)));
@@ -117,7 +117,7 @@ void az_iot_sas_token_generate_empty_device_id_fails(void** state)
 
   uint8_t raw_sas_token[256];
   az_span sas_token
-      = az_span_init(raw_sas_token, 0, _az_countof(raw_sas_token));
+      = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
 
   assert_true(
       az_iot_sas_token_generate(
@@ -136,7 +136,7 @@ void az_iot_sas_token_generate_empty_iothub_fqdn_fails(void** state)
 
   uint8_t raw_sas_token[256];
   az_span sas_token
-      = az_span_init(raw_sas_token, 0, _az_countof(raw_sas_token));
+      = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
 
   assert_true(
       az_iot_sas_token_generate(
@@ -155,7 +155,7 @@ void az_iot_sas_token_generate_EMPTY_signature_fails(void** state)
 
   uint8_t raw_sas_token[256];
   az_span sas_token
-      = az_span_init(raw_sas_token, 0, _az_countof(raw_sas_token));
+      = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
 
   assert_true(
       az_iot_sas_token_generate(
@@ -206,7 +206,7 @@ void az_iot_sas_token_generate_sas_token_overflow_fails(void** state)
 
   uint8_t raw_sas_token[32];
   az_span sas_token
-      = az_span_init(raw_sas_token, 0, _az_countof(raw_sas_token));
+      = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
 
   assert_true(
       az_iot_sas_token_generate(
@@ -228,7 +228,7 @@ void az_iot_sas_token_generate_succeeds(void** state)
 
   uint8_t raw_sas_token[256];
   az_span sas_token
-      = az_span_init(raw_sas_token, 0, _az_countof(raw_sas_token));
+      = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
 
   assert_true(az_succeeded(az_iot_sas_token_generate(
       iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)));
@@ -250,7 +250,7 @@ void az_iot_sas_token_generate_with_keyname_succeeds(void** state)
 
   uint8_t raw_sas_token[256];
   az_span sas_token
-      = az_span_init(raw_sas_token, 0, _az_countof(raw_sas_token));
+      = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
 
   assert_true(az_succeeded(az_iot_sas_token_generate(
       iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)));

--- a/sdk/iot/core/tests/cmocka/az_iot_telemetry_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_telemetry_tests.c
@@ -87,7 +87,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_client_fails(void**
   uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, sizeof(mqtt_topic_buf) / sizeof(mqtt_topic_buf[0]));
+      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(NULL, NULL, mqtt_topic, &mqtt_topic)
@@ -111,7 +111,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_out_mqtt_topic_fail
   uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, sizeof(mqtt_topic_buf) / sizeof(mqtt_topic_buf[0]));
+      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -126,7 +126,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_params_suc
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_no_params)];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, sizeof(mqtt_topic_buf) / sizeof(mqtt_topic_buf[0]));
+      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -142,7 +142,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_params_s
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_no_params)];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, sizeof(mqtt_topic_buf) / sizeof(mqtt_topic_buf[0]));
+      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -159,7 +159,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_params)];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, sizeof(mqtt_topic_buf) / sizeof(mqtt_topic_buf[0]));
+      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -177,7 +177,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_params) - 1];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, sizeof(mqtt_topic_buf) / sizeof(mqtt_topic_buf[0]));
+      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -192,7 +192,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_s
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_params)];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, sizeof(mqtt_topic_buf) / sizeof(mqtt_topic_buf[0]));
+      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -209,7 +209,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_s
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_params) - 1];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, sizeof(mqtt_topic_buf) / sizeof(mqtt_topic_buf[0]));
+      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -225,7 +225,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_w
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_params)];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, sizeof(mqtt_topic_buf) / sizeof(mqtt_topic_buf[0]));
+      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -243,7 +243,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_w
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_params) - 1];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, sizeof(mqtt_topic_buf) / sizeof(mqtt_topic_buf[0]));
+      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -259,7 +259,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_user_agent_with_params)];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, sizeof(mqtt_topic_buf) / sizeof(mqtt_topic_buf[0]));
+      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -277,7 +277,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_user_agent_with_params) - 1];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, sizeof(mqtt_topic_buf) / sizeof(mqtt_topic_buf[0]));
+      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(

--- a/sdk/iot/core/tests/cmocka/az_iot_telemetry_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_telemetry_tests.c
@@ -87,7 +87,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_client_fails(void**
   uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
+      = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(NULL, NULL, mqtt_topic, &mqtt_topic)
@@ -111,7 +111,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_out_mqtt_topic_fail
   uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
+      = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -126,7 +126,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_params_suc
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_no_params)];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
+      = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -142,7 +142,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_params_s
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_no_params)];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
+      = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -159,7 +159,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_params)];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
+      = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -177,7 +177,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_params) - 1];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
+      = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -192,7 +192,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_s
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_params)];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
+      = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -209,7 +209,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_s
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_params) - 1];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
+      = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -225,7 +225,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_w
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_params)];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
+      = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -243,7 +243,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_w
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_params) - 1];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
+      = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -259,7 +259,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_user_agent_with_params)];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
+      = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(
@@ -277,7 +277,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_
   uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_user_agent_with_params) - 1];
 
   az_span mqtt_topic
-      = az_span_init(mqtt_topic_buf, 0, _az_countof(mqtt_topic_buf));
+      = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(


### PR DESCRIPTION
Add a macro to determine the number of elements in a buffer. Added in the recommended spot by @JeffreyRichter.