### PR TITLE
Do not attempt to push/pop warnings on older GCC compiler versions that do not support push/pop anyways

### DIFF
--- a/sdk/core/core/inc/_az_cfg_prefix.h
+++ b/sdk/core/core/inc/_az_cfg_prefix.h
@@ -14,7 +14,7 @@ extern "C"
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#elif defined(__GNUC__) // !_MSC_VER
+#elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) // !_MSC_VER
 #pragma GCC diagnostic push
 #elif defined(__clang__) // !_MSC_VER !__clang__
 #pragma clang diagnostic push

--- a/sdk/core/core/inc/_az_cfg_suffix.h
+++ b/sdk/core/core/inc/_az_cfg_suffix.h
@@ -9,7 +9,7 @@
 
 #ifdef _MSC_VER
 #pragma warning(pop)
-#elif defined(__GNUC__) // !_MSC_VER
+#elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) // !_MSC_VER
 #pragma GCC diagnostic pop
 #elif defined(__clang__) // !_MSC_VER !__GNUC__
 #pragma clang diagnostic pop


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-c/issues/456

https://stackoverflow.com/questions/16555585/why-pragma-gcc-diagnostic-push-pop-warning-in-gcc-c