### PR TITLE
remove null terminator guarantee from telemetry

### DIFF
--- a/sdk/iot/core/README.md
+++ b/sdk/iot/core/README.md
@@ -26,8 +26,10 @@ void my_telemetry_func()
   //Initialize the client to then pass to the telemetry API
   az_iot_hub_client_init(&my_client, my_iothub_hostname, my_device_id, NULL);
 
-  //Allocate a span to put the telemetry topic
-  uint8_t telemetry_topic_buffer[64];
+  //Allocate a span with capacity large enough to put the telemetry topic.
+  //Optionally, the size can include space for a null terminator.
+  //Here, the buffer is zero initialized to null terminate the topic.
+  uint8_t telemetry_topic_buffer[64] = { 0 };
   az_span topic_span = AZ_SPAN_FROM_BUFFER(telemetry_topic_buffer);
 
   //Get the NULL terminated topic and put in topic_span to send the telemetry

--- a/sdk/iot/core/inc/az_iot_hub_client.h
+++ b/sdk/iot/core/inc/az_iot_hub_client.h
@@ -222,6 +222,10 @@ az_iot_hub_client_properties_next(az_iot_hub_client_properties* properties, az_p
 /**
  * @brief Gets the MQTT topic that must be used for device to cloud telemetry messages.
  * @note Telemetry MQTT Publish messages must have QoS At Least Once (1).
+ * 
+ * Should the user want a null terminated topic string, they may allocate a buffer large enough
+ * to fit the topic plus a null terminator. They must set the last byte themselves or zero initialize
+ * the buffer.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] properties An optional #az_iot_hub_client_properties object (can be NULL).

--- a/sdk/iot/core/src/az_iot_telemetry.c
+++ b/sdk/iot/core/src/az_iot_telemetry.c
@@ -13,7 +13,6 @@
 
 static const uint8_t telemetry_prop_delim = '?';
 static const uint8_t telemetry_prop_separator = '&';
-static const uint8_t telemetry_null_terminator = '\0';
 static const az_span telemetry_topic_prefix = AZ_SPAN_LITERAL_FROM_STR("devices/");
 static const az_span telemetry_topic_modules_mid = AZ_SPAN_LITERAL_FROM_STR("/modules/");
 static const az_span telemetry_topic_suffix = AZ_SPAN_LITERAL_FROM_STR("/messages/events/");
@@ -33,8 +32,7 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
 
   // Required topic parts
   int32_t required_size = az_span_length(telemetry_topic_prefix)
-      + az_span_length(client->_internal.device_id) + az_span_length(telemetry_topic_suffix)
-      + sizeof(telemetry_null_terminator);
+      + az_span_length(client->_internal.device_id) + az_span_length(telemetry_topic_suffix);
 
   // Optional parts
   if (az_span_ptr(*module_id) != NULL)
@@ -89,9 +87,6 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
             : az_span_append_uint8(*out_mqtt_topic, telemetry_prop_separator, out_mqtt_topic));
     AZ_RETURN_IF_FAILED(az_span_append(*out_mqtt_topic, *user_agent, out_mqtt_topic));
   }
-
-  AZ_RETURN_IF_FAILED(
-      az_span_append_uint8(*out_mqtt_topic, telemetry_null_terminator, out_mqtt_topic));
 
   return AZ_OK;
 }

--- a/sdk/iot/core/tests/cmocka/az_iot_telemetry_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_telemetry_tests.c
@@ -121,7 +121,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_params_suc
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_no_params)];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_no_params) - 1];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -129,6 +129,28 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_params_suc
       az_iot_hub_client_telemetry_publish_topic_get(
           &g_test_valid_client_no_options, NULL, mqtt_topic, &mqtt_topic)
       == AZ_OK);
+  assert_memory_equal(
+      g_test_correct_topic_no_options_no_params,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_no_options_no_params) - 1);
+}
+
+void test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_params_succeed(
+    void** state)
+{
+  (void)state;
+
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_no_params)] = { 0 };
+
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+
+  assert_true(
+      az_iot_hub_client_telemetry_publish_topic_get(
+          &g_test_valid_client_no_options, NULL, mqtt_topic, &mqtt_topic)
+      == AZ_OK);
+  assert_int_equal(
+      az_span_length(mqtt_topic), sizeof(g_test_correct_topic_no_options_no_params) - 1);
+  assert_int_equal(az_span_capacity(mqtt_topic), sizeof(g_test_correct_topic_no_options_no_params));
   assert_string_equal(g_test_correct_topic_no_options_no_params, (char*)az_span_ptr(mqtt_topic));
 }
 
@@ -136,7 +158,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_params_s
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_no_params)];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_no_params) - 1];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -144,7 +166,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_params_s
       az_iot_hub_client_telemetry_publish_topic_get(
           &g_test_valid_client_with_options_both, NULL, mqtt_topic, &mqtt_topic)
       == AZ_OK);
-  assert_string_equal(g_test_correct_topic_with_options_no_params, (char*)az_span_ptr(mqtt_topic));
+  assert_memory_equal(
+      g_test_correct_topic_with_options_no_params,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_with_options_no_params) - 1);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params_succeed(
@@ -152,7 +177,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_params)];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_params) - 1];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -160,8 +185,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params
       az_iot_hub_client_telemetry_publish_topic_get(
           &g_test_valid_client_with_options_both, &g_test_params, mqtt_topic, &mqtt_topic)
       == AZ_OK);
-  assert_string_equal(
-      g_test_correct_topic_with_options_with_params, (char*)az_span_ptr(mqtt_topic));
+  assert_memory_equal(
+      g_test_correct_topic_with_options_with_params,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_with_options_with_params) - 1);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params_small_buffer_fails(
@@ -169,7 +196,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_params) - 1];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_params) - 2];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -183,7 +210,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_s
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_params)];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_params) - 1];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -191,7 +218,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_s
       az_iot_hub_client_telemetry_publish_topic_get(
           &g_test_valid_client_no_options, &g_test_params, mqtt_topic, &mqtt_topic)
       == AZ_OK);
-  assert_string_equal(g_test_correct_topic_no_options_with_params, (char*)az_span_ptr(mqtt_topic));
+  assert_memory_equal(
+      g_test_correct_topic_no_options_with_params,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_no_options_with_params) - 1);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_small_buffer_fails(
@@ -199,7 +229,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_s
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_params) - 1];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_params) - 2];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -214,7 +244,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_w
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_params)];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_params) - 1];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -222,8 +252,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_w
       az_iot_hub_client_telemetry_publish_topic_get(
           &g_test_valid_client_with_options_module_id, &g_test_params, mqtt_topic, &mqtt_topic)
       == AZ_OK);
-  assert_string_equal(
-      g_test_correct_topic_with_options_module_id_with_params, (char*)az_span_ptr(mqtt_topic));
+  assert_memory_equal(
+      g_test_correct_topic_with_options_module_id_with_params,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_with_options_module_id_with_params) - 1);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_params_small_buffer_fails(
@@ -231,7 +263,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_w
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_params) - 1];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_params) - 2];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -246,7 +278,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_user_agent_with_params)];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_user_agent_with_params) - 1];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -254,8 +286,11 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_
       az_iot_hub_client_telemetry_publish_topic_get(
           &g_test_valid_client_with_options_user_agent, &g_test_params, mqtt_topic, &mqtt_topic)
       == AZ_OK);
-  assert_string_equal(
-      g_test_correct_topic_with_options_user_agent_with_params, (char*)az_span_ptr(mqtt_topic));
+
+  assert_memory_equal(
+      g_test_correct_topic_with_options_user_agent_with_params,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_with_options_user_agent_with_params) - 1);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_with_params_small_buffer_fails(
@@ -263,7 +298,7 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_user_agent_with_params) - 1];
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_user_agent_with_params) - 2];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -278,6 +313,8 @@ int test_iot_hub_telemetry()
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(
         test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_params_succeed),
+    cmocka_unit_test(
+        test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_params_succeed),
     cmocka_unit_test(
         test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_params_succeed),
     cmocka_unit_test(


### PR DESCRIPTION
After talking with Himanshu we can reach a compromise with the null terminator discussion. In this way, users may get a topic with a null terminator if they would like. Otherwise, they can get one with only the size necessary.