### PR TITLE
Remove dependancy on Choco

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -254,7 +254,7 @@ jobs:
       - pwsh: |
           $setupFile="doxygen-1.8.15-setup.exe";
           Invoke-WebRequest -MaximumRetryCount 10 -Uri "https://azuresdktooling.blob.core.windows.net/dependencies/doxygen-1.8.15-setup.exe" `
-          -OutFile $setupFile | Wait-Process; Start-Process -Filepath .\$setupFile -ArgumentList @("/VERYSILENT")
+          -OutFile $setupFile | Wait-Process; Start-Process -Filepath .\$setupFile -ArgumentList @("/VERYSILENT") -Wait
         workingDirectory: $(Agent.TempDirectory)
         displayName: Download and Install Doxygen
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -251,9 +251,12 @@ jobs:
               path: $(Build.ArtifactStagingDirectory)/packages
 
       # Generate Documentation
-      - pwsh: >-
-          choco install doxygen.install
-        displayName: Install Doxygen
+      - pwsh: |
+          $setupFile="doxygen-1.8.15-setup.exe";
+          Invoke-WebRequest -MaximumRetryCount 10 -Uri "https://azuresdktooling.blob.core.windows.net/dependencies/doxygen-1.8.15-setup.exe" `
+          -OutFile $setupFile | Wait-Process; Start-Process -Filepath .\$setupFile -ArgumentList @("/VERYSILENT")
+        workingDirectory: $(Agent.TempDirectory)
+        displayName: Download and Install Doxygen
 
       - ${{ each artifact in parameters.Artifacts }}:
         - pwsh: Write-Host "##vso[task.setvariable variable=PackageVersion]$(Get-Content .\sdk\${{ parameters.ServiceDirectory }}\${{ artifact.Path }}\version.txt)"


### PR DESCRIPTION
Remove Choco call and switch to downloading a specific version of Doxygen, 1.8.15. Install arguments from https://chocolatey.org/packages/doxygen.install#files.
Fixes #445 