### PR TITLE
IoT Improvements

### DIFF
--- a/sdk/iot/core/src/az_iot_telemetry.c
+++ b/sdk/iot/core/src/az_iot_telemetry.c
@@ -27,8 +27,8 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
   AZ_PRECONDITION_VALID_SPAN(mqtt_topic, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_mqtt_topic);
 
-  const az_span* user_agent = &(client->_internal.options.user_agent);
-  const az_span* module_id = &(client->_internal.options.module_id);
+  const az_span* const user_agent = &(client->_internal.options.user_agent);
+  const az_span* const module_id = &(client->_internal.options.module_id);
 
   // Required topic parts
   int32_t required_size = az_span_length(telemetry_topic_prefix)

--- a/sdk/iot/core/tests/cmocka/az_iot_sas_token_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_sas_token_tests.c
@@ -28,9 +28,9 @@ void az_iot_sas_token_get_document_NULL_document_fails(void** state)
   int32_t expiry_time_secs = TEST_EXPIRATION;
   az_span document = AZ_SPAN_NULL;
 
-  assert_true(
-      az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, NULL)
-      == AZ_ERROR_ARG);
+  assert_int_equal(
+      az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, NULL),
+      AZ_ERROR_ARG);
 }
 
 void az_iot_sas_token_get_document_NULL_document_span_fails(void** state)
@@ -84,9 +84,9 @@ void az_iot_sas_token_get_document_document_overflow_fails(void** state)
   uint8_t raw_document[32];
   az_span document = az_span_init(raw_document, 0, _az_COUNTOF(raw_document));
 
-  assert_true(
-      az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(
+      az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document),
+      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
 void az_iot_sas_token_get_document_succeeds(void** state)
@@ -103,7 +103,7 @@ void az_iot_sas_token_get_document_succeeds(void** state)
 
   assert_true(az_succeeded(az_iot_sas_token_get_document(
       iothub_fqdn, device_id, expiry_time_secs, document, &document)));
-  assert_true(strncmp(expected_document, (char*)raw_document, az_span_length(document)) == 0);
+  assert_memory_equal(expected_document, (char*)raw_document, sizeof(expected_document) - 1);
 }
 
 void az_iot_sas_token_generate_empty_device_id_fails(void** state)
@@ -118,10 +118,10 @@ void az_iot_sas_token_generate_empty_device_id_fails(void** state)
   uint8_t raw_sas_token[256];
   az_span sas_token = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
 
-  assert_true(
+  assert_int_equal(
       az_iot_sas_token_generate(
-          iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)
-      == AZ_ERROR_ARG);
+          iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token),
+      AZ_ERROR_ARG);
 }
 
 void az_iot_sas_token_generate_empty_iothub_fqdn_fails(void** state)
@@ -136,10 +136,10 @@ void az_iot_sas_token_generate_empty_iothub_fqdn_fails(void** state)
   uint8_t raw_sas_token[256];
   az_span sas_token = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
 
-  assert_true(
+  assert_int_equal(
       az_iot_sas_token_generate(
-          iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)
-      == AZ_ERROR_ARG);
+          iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token),
+      AZ_ERROR_ARG);
 }
 
 void az_iot_sas_token_generate_EMPTY_signature_fails(void** state)
@@ -154,10 +154,10 @@ void az_iot_sas_token_generate_EMPTY_signature_fails(void** state)
   uint8_t raw_sas_token[256];
   az_span sas_token = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
 
-  assert_true(
+  assert_int_equal(
       az_iot_sas_token_generate(
-          iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)
-      == AZ_ERROR_ARG);
+          iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token),
+      AZ_ERROR_ARG);
 }
 
 void az_iot_sas_token_generate_NULL_sas_token_fails(void** state)
@@ -171,10 +171,10 @@ void az_iot_sas_token_generate_NULL_sas_token_fails(void** state)
 
   az_span sas_token = AZ_SPAN_NULL;
 
-  assert_true(
+  assert_int_equal(
       az_iot_sas_token_generate(
-          iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, NULL)
-      == AZ_ERROR_ARG);
+          iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, NULL),
+      AZ_ERROR_ARG);
 }
 
 void az_iot_sas_token_generate_NULL_sas_token_span_fails(void** state)
@@ -204,10 +204,10 @@ void az_iot_sas_token_generate_sas_token_overflow_fails(void** state)
   uint8_t raw_sas_token[32];
   az_span sas_token = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
 
-  assert_true(
+  assert_int_equal(
       az_iot_sas_token_generate(
-          iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+          iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token),
+      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
 void az_iot_sas_token_generate_succeeds(void** state)
@@ -227,7 +227,7 @@ void az_iot_sas_token_generate_succeeds(void** state)
 
   assert_true(az_succeeded(az_iot_sas_token_generate(
       iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)));
-  assert_true(strncmp(expected_sas_token, (char*)raw_sas_token, az_span_length(sas_token)) == 0);
+  assert_memory_equal(expected_sas_token, (char*)raw_sas_token, sizeof(expected_sas_token) - 1);
 }
 
 void az_iot_sas_token_generate_with_keyname_succeeds(void** state)
@@ -248,7 +248,7 @@ void az_iot_sas_token_generate_with_keyname_succeeds(void** state)
 
   assert_true(az_succeeded(az_iot_sas_token_generate(
       iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)));
-  assert_true(strncmp(expected_sas_token, (char*)raw_sas_token, az_span_length(sas_token)) == 0);
+  assert_memory_equal(expected_sas_token, (char*)raw_sas_token, sizeof(expected_sas_token) - 1);
 }
 
 int test_iot_sas_token()

--- a/sdk/iot/core/tests/cmocka/az_iot_telemetry_tests.c
+++ b/sdk/iot/core/tests/cmocka/az_iot_telemetry_tests.c
@@ -88,9 +88,9 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_client_fails(void**
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
-  assert_true(
-      az_iot_hub_client_telemetry_publish_topic_get(NULL, NULL, mqtt_topic, &mqtt_topic)
-      == AZ_ERROR_ARG);
+  assert_int_equal(
+      az_iot_hub_client_telemetry_publish_topic_get(NULL, NULL, mqtt_topic, &mqtt_topic),
+      AZ_ERROR_ARG);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_mqtt_topic_fails(void** state)
@@ -98,10 +98,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_mqtt_topic_fails(vo
   (void)state;
   az_span null_mqtt_topic = TEST_BAD_SPAN;
 
-  assert_true(
+  assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_no_options, NULL, null_mqtt_topic, &null_mqtt_topic)
-      == AZ_ERROR_ARG);
+          &g_test_valid_client_no_options, NULL, null_mqtt_topic, &null_mqtt_topic),
+      AZ_ERROR_ARG);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_out_mqtt_topic_fails(void** state)
@@ -111,10 +111,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_out_mqtt_topic_fail
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
-  assert_true(
+  assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_no_options, NULL, mqtt_topic, NULL)
-      == AZ_ERROR_ARG);
+          &g_test_valid_client_no_options, NULL, mqtt_topic, NULL),
+      AZ_ERROR_ARG);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_params_succeed(void** state)
@@ -125,10 +125,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_params_suc
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
-  assert_true(
+  assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_no_options, NULL, mqtt_topic, &mqtt_topic)
-      == AZ_OK);
+          &g_test_valid_client_no_options, NULL, mqtt_topic, &mqtt_topic),
+      AZ_OK);
   assert_memory_equal(
       g_test_correct_topic_no_options_no_params,
       (char*)az_span_ptr(mqtt_topic),
@@ -162,10 +162,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_params_s
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
-  assert_true(
+  assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_with_options_both, NULL, mqtt_topic, &mqtt_topic)
-      == AZ_OK);
+          &g_test_valid_client_with_options_both, NULL, mqtt_topic, &mqtt_topic),
+      AZ_OK);
   assert_memory_equal(
       g_test_correct_topic_with_options_no_params,
       (char*)az_span_ptr(mqtt_topic),
@@ -181,10 +181,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
-  assert_true(
+  assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_with_options_both, &g_test_params, mqtt_topic, &mqtt_topic)
-      == AZ_OK);
+          &g_test_valid_client_with_options_both, &g_test_params, mqtt_topic, &mqtt_topic),
+      AZ_OK);
   assert_memory_equal(
       g_test_correct_topic_with_options_with_params,
       (char*)az_span_ptr(mqtt_topic),
@@ -200,10 +200,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
-  assert_true(
+  assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_with_options_both, &g_test_params, mqtt_topic, &mqtt_topic)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+          &g_test_valid_client_with_options_both, &g_test_params, mqtt_topic, &mqtt_topic),
+      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_succeed(void** state)
@@ -214,10 +214,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_s
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
-  assert_true(
+  assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_no_options, &g_test_params, mqtt_topic, &mqtt_topic)
-      == AZ_OK);
+          &g_test_valid_client_no_options, &g_test_params, mqtt_topic, &mqtt_topic),
+      AZ_OK);
   assert_memory_equal(
       g_test_correct_topic_no_options_with_params,
       (char*)az_span_ptr(mqtt_topic),
@@ -233,10 +233,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_s
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
-  assert_true(
+  assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_no_options, &g_test_params, mqtt_topic, &mqtt_topic)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+          &g_test_valid_client_no_options, &g_test_params, mqtt_topic, &mqtt_topic),
+      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_params_succeed(
@@ -248,10 +248,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_w
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
-  assert_true(
+  assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_with_options_module_id, &g_test_params, mqtt_topic, &mqtt_topic)
-      == AZ_OK);
+          &g_test_valid_client_with_options_module_id, &g_test_params, mqtt_topic, &mqtt_topic),
+      AZ_OK);
   assert_memory_equal(
       g_test_correct_topic_with_options_module_id_with_params,
       (char*)az_span_ptr(mqtt_topic),
@@ -267,10 +267,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_w
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
-  assert_true(
+  assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_with_options_module_id, &g_test_params, mqtt_topic, &mqtt_topic)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+          &g_test_valid_client_with_options_module_id, &g_test_params, mqtt_topic, &mqtt_topic),
+      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
 void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_with_params_succeed(
@@ -282,10 +282,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
-  assert_true(
+  assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_with_options_user_agent, &g_test_params, mqtt_topic, &mqtt_topic)
-      == AZ_OK);
+          &g_test_valid_client_with_options_user_agent, &g_test_params, mqtt_topic, &mqtt_topic),
+      AZ_OK);
 
   assert_memory_equal(
       g_test_correct_topic_with_options_user_agent_with_params,
@@ -302,10 +302,10 @@ void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_user_agent_
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
-  assert_true(
+  assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_with_options_user_agent, &g_test_params, mqtt_topic, &mqtt_topic)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+          &g_test_valid_client_with_options_user_agent, &g_test_params, mqtt_topic, &mqtt_topic),
+      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
 int test_iot_hub_telemetry()


### PR DESCRIPTION
Some updates as rec'd by @hihigupt and I think @ericwol-msft .
- Uses `assert_int_equal()` for returned values so on failure will show what the two compared values were
- Uses `assert_memory_equal()` to compare non null terminated strings to output compared values on failure.
- Add `const az_span* const` where appropriate.