### PR TITLE
Remove question mark from telemetry props

### DIFF
--- a/sdk/iot/hub/inc/az_iot_hub_client.h
+++ b/sdk/iot/hub/inc/az_iot_hub_client.h
@@ -237,6 +237,9 @@ az_iot_hub_client_properties_next(az_iot_hub_client_properties* properties, az_p
  * Should the user want a null terminated topic string, they may allocate a buffer large enough
  * to fit the topic plus a null terminator. They must set the last byte themselves or zero initialize
  * the buffer.
+ * 
+ * The telemetry topic will be of the following format:
+ * `devices/{device_id}/messages/events/{property_bag}`
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] properties An optional #az_iot_hub_client_properties object (can be NULL).

--- a/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
@@ -11,7 +11,6 @@
 
 #include <_az_cfg.h>
 
-static const uint8_t telemetry_prop_delim = '?';
 static const az_span telemetry_topic_prefix = AZ_SPAN_LITERAL_FROM_STR("devices/");
 static const az_span telemetry_topic_modules_mid = AZ_SPAN_LITERAL_FROM_STR("/modules/");
 static const az_span telemetry_topic_suffix = AZ_SPAN_LITERAL_FROM_STR("/messages/events/");
@@ -42,8 +41,6 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
 
   if (properties != NULL)
   {
-    AZ_RETURN_IF_FAILED(
-        az_span_append_uint8(*out_mqtt_topic, telemetry_prop_delim, out_mqtt_topic));
     AZ_RETURN_IF_FAILED(
         az_span_append(*out_mqtt_topic, properties->_internal.properties, out_mqtt_topic));
   }

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -47,12 +47,12 @@ static const char g_test_correct_topic_with_options_no_params[]
     = "devices/my_device/modules/my_module_id/messages/events/";
 static const char g_test_correct_topic_with_options_with_params[]
     = "devices/my_device/modules/my_module_id/messages/events/"
-      "?key=value&key_two=value2";
+      "key=value&key_two=value2";
 static const char g_test_correct_topic_no_options_with_params[]
     = "devices/my_device/messages/events/"
-      "?key=value&key_two=value2";
+      "key=value&key_two=value2";
 static const char g_test_correct_topic_with_options_module_id_with_params[]
-    = "devices/my_device/modules/my_module_id/messages/events/?key=value&key_two=value2";
+    = "devices/my_device/modules/my_module_id/messages/events/key=value&key_two=value2";
 
 static const az_iot_hub_client g_test_valid_client_no_options
     = { ._internal = { .iot_hub_hostname = AZ_SPAN_LITERAL_FROM_STR(TEST_FQDN),


### PR DESCRIPTION
The question mark is not needed for telemetry message topic properties.
[Documented here](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support#sending-device-to-cloud-messages) and verified firsthand by me, @hihigupt and @TiejunMS.