### PR TITLE
Adding telemetry default options to client options

### DIFF
--- a/sdk/samples/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/samples/keyvault/keyvault/src/az_keyvault_client.c
@@ -55,7 +55,10 @@ AZ_NODISCARD AZ_INLINE az_span az_keyvault_client_constant_for_application_json(
 AZ_NODISCARD az_keyvault_keys_client_options az_keyvault_keys_client_options_default()
 {
   az_keyvault_keys_client_options options = (az_keyvault_keys_client_options){
-    ._internal = { .api_version = _az_http_policy_apiversion_options_default(), },
+    ._internal = {
+      .api_version = _az_http_policy_apiversion_options_default(),
+      ._telemetry_options = _az_http_policy_telemetry_options_default(),
+    },
     .retry = _az_http_policy_retry_options_default(),
   };
 
@@ -67,8 +70,6 @@ AZ_NODISCARD az_keyvault_keys_client_options az_keyvault_keys_client_options_def
   options.retry.max_retries = 3;
   options.retry.retry_delay_msec = 1 * _az_TIME_MILLISECONDS_PER_SECOND;
   options.retry.max_retry_delay_msec = 30 * _az_TIME_MILLISECONDS_PER_SECOND;
-
-  options._internal._telemetry_options = _az_http_policy_telemetry_options_default();
 
   return options;
 }

--- a/sdk/samples/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/samples/keyvault/keyvault/src/az_keyvault_client.c
@@ -68,6 +68,8 @@ AZ_NODISCARD az_keyvault_keys_client_options az_keyvault_keys_client_options_def
   options.retry.retry_delay_msec = 1 * _az_TIME_MILLISECONDS_PER_SECOND;
   options.retry.max_retry_delay_msec = 30 * _az_TIME_MILLISECONDS_PER_SECOND;
 
+  options._internal._telemetry_options = _az_http_policy_telemetry_options_default();
+
   return options;
 }
 

--- a/sdk/storage/blobs/src/az_storage_blobs_blob_client.c
+++ b/sdk/storage/blobs/src/az_storage_blobs_blob_client.c
@@ -49,6 +49,8 @@ AZ_NODISCARD az_storage_blobs_blob_client_options az_storage_blobs_blob_client_o
   options.retry.retry_delay_msec = 1 * _az_TIME_MILLISECONDS_PER_SECOND;
   options.retry.max_retry_delay_msec = 30 * _az_TIME_MILLISECONDS_PER_SECOND;
 
+  options._internal._telemetry_options = _az_http_policy_telemetry_options_default();
+
   return options;
 }
 

--- a/sdk/storage/blobs/src/az_storage_blobs_blob_client.c
+++ b/sdk/storage/blobs/src/az_storage_blobs_blob_client.c
@@ -49,8 +49,6 @@ AZ_NODISCARD az_storage_blobs_blob_client_options az_storage_blobs_blob_client_o
   options.retry.retry_delay_msec = 1 * _az_TIME_MILLISECONDS_PER_SECOND;
   options.retry.max_retry_delay_msec = 30 * _az_TIME_MILLISECONDS_PER_SECOND;
 
-  options._internal._telemetry_options = _az_http_policy_telemetry_options_default();
-
   return options;
 }
 


### PR DESCRIPTION
This is a hotfix that should be in before preview, IMO

We were missing to add the telemetry options to client default options.
So if user doesn't set an OS to telemetry options after creating the default client options, we would hang the application after violating the PRECONDITION when adding a header to request that requires header name and value length to be greater than 0. (Currently trying to add User-agent:"")

This was not visible without the preconditions since we where adding an empty header that won't affect but makes telemetry useles

This brings up the fact that we need to have the client samples run on CI to make sure any regression like this is catch (didn't see it before until tried to run it recently)