### PR TITLE
remove AZ_JSON_TOKEN_SPAN support

### DIFF
--- a/sdk/core/core/inc/az_json.h
+++ b/sdk/core/core/inc/az_json.h
@@ -37,9 +37,6 @@ typedef enum
   AZ_JSON_TOKEN_OBJECT_END,
   AZ_JSON_TOKEN_ARRAY_START,
   AZ_JSON_TOKEN_ARRAY_END,
-  // AZ_JSON_TOKEN_SPAN represents a token consisting of nested JSON; the JSON parser never returns
-  // a token of this type.
-  AZ_JSON_TOKEN_SPAN,
 } az_json_token_kind;
 
 /*
@@ -268,8 +265,8 @@ typedef struct
 } az_json_token_member;
 
 /*
- * @brief az_json_parser_init initializes an az_json_parser to parse the JSON payload contained within the passed in buffer.
- * JSON buffer.
+ * @brief az_json_parser_init initializes an az_json_parser to parse the JSON payload contained
+ * within the passed in buffer. JSON buffer.
  *
  * @param json_parser A pointer to an az_json_parser instance to initialize.
  * @param json_buffer A pointer to a buffer containing the JSON document to parse.

--- a/sdk/core/core/src/az_json_string.c
+++ b/sdk/core/core/src/az_json_string.c
@@ -75,49 +75,6 @@ AZ_NODISCARD AZ_INLINE az_result az_json_esc_decode(uint8_t c, uint8_t* out)
 }
 
 /**
- * Encodes the given character into a JSON escape sequence. The function returns an empty span if
- * the given character doesn't require to be escaped.
- */
-AZ_NODISCARD az_span _az_json_esc_encode(uint8_t c)
-{
-  switch (c)
-  {
-    case '\\':
-    {
-      return AZ_SPAN_FROM_STR("\\\\");
-    }
-    case '"':
-    {
-      return AZ_SPAN_FROM_STR("\\\"");
-    }
-    case '\b':
-    {
-      return AZ_SPAN_FROM_STR("\\b");
-    }
-    case '\f':
-    {
-      return AZ_SPAN_FROM_STR("\\f");
-    }
-    case '\n':
-    {
-      return AZ_SPAN_FROM_STR("\\n");
-    }
-    case '\r':
-    {
-      return AZ_SPAN_FROM_STR("\\r");
-    }
-    case '\t':
-    {
-      return AZ_SPAN_FROM_STR("\\t");
-    }
-    default:
-    {
-      return AZ_SPAN_NULL;
-    }
-  }
-}
-
-/**
  * TODO: this function and JSON pointer read functions should return proper UNICODE
  *       code-point to be compatible.
  */

--- a/sdk/core/core/src/az_json_string_private.h
+++ b/sdk/core/core/src/az_json_string_private.h
@@ -13,12 +13,6 @@
 #include <_az_cfg_prefix.h>
 
 /**
- * Encodes the given character into a JSON escape sequence. The function returns an empty span if
- * the given character doesn't require to be escaped.
- */
-AZ_NODISCARD az_span _az_json_esc_encode(uint8_t c);
-
-/**
  * TODO: this function and JSON pointer read functions should return proper UNICODE
  *       code-point to be compatible.
  */
@@ -36,14 +30,6 @@ AZ_NODISCARD az_result _az_span_reader_read_json_pointer_token(az_span* self, az
  * Returns a next character in the given span reader of JSON pointer reference token.
  */
 AZ_NODISCARD az_result _az_span_reader_read_json_pointer_token_char(az_span* self, uint32_t* out);
-
-AZ_NODISCARD AZ_INLINE az_json_token az_json_token_span(az_span span)
-{
-  return (az_json_token){
-    .kind = AZ_JSON_TOKEN_SPAN,
-    ._internal.span = span,
-  };
-}
 
 #include <_az_cfg_suffix.h>
 

--- a/sdk/core/core/test/cmocka/test_json_builder.c
+++ b/sdk/core/core/test/cmocka/test_json_builder.c
@@ -27,7 +27,7 @@ void test_json_builder(void** state)
     // 0___________________________________________________________________________________________________1
     // 0_________1_________2_________3_________4_________5_________6_________7_________8_________9_________0
     // 01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456
-    // {"name":true,"foo":["bar",null,0,-12],"int-max":9007199254740991,"esc":"_\"_\\_\b\f\n\r\t_","u":"a\u001Fb"}
+    // {"name":true,"foo":["bar",null,0,-12],"int-max":9007199254740991}
     TEST_EXPECT_SUCCESS(az_json_builder_append_token(&builder, az_json_token_object_start()));
 
     TEST_EXPECT_SUCCESS(az_json_builder_append_object(
@@ -47,17 +47,6 @@ void test_json_builder(void** state)
 
     TEST_EXPECT_SUCCESS(az_json_builder_append_object(
         &builder, AZ_SPAN_FROM_STR("int-max"), az_json_token_number(9007199254740991ull)));
-    TEST_EXPECT_SUCCESS(az_json_builder_append_object(
-        &builder,
-        AZ_SPAN_FROM_STR("esc"),
-        az_json_token_span(AZ_SPAN_FROM_STR("_\"_\\_\b\f\n\r\t_"))));
-    TEST_EXPECT_SUCCESS(az_json_builder_append_object(
-        &builder,
-        AZ_SPAN_FROM_STR("u"),
-        az_json_token_span(AZ_SPAN_FROM_STR( //
-            "a"
-            "\x1f"
-            "b"))));
 
     TEST_EXPECT_SUCCESS(az_json_builder_append_token(&builder, az_json_token_object_end()));
 
@@ -67,33 +56,8 @@ void test_json_builder(void** state)
             "{"
             "\"name\":true,"
             "\"foo\":[\"bar\",null,0,-12],"
-            "\"int-max\":9007199254740991,"
-            "\"esc\":\"_\\\"_\\\\_\\b\\f\\n\\r\\t_\","
-            "\"u\":\"a\\u001Fb\""
+            "\"int-max\":9007199254740991"
             "}")));
-  }
-  {
-    // json with AZ_JSON_TOKEN_SPAN
-    uint8_t array[200];
-    az_json_builder builder = { 0 };
-    TEST_EXPECT_SUCCESS(az_json_builder_init(&builder, AZ_SPAN_FROM_BUFFER(array)));
-
-    // this json { "span": "\" } would be scaped to { "span": "\\"" }
-    uint8_t single_char[1] = { '\\' }; // char = '\'
-    az_span single_span = AZ_SPAN_FROM_INITIALIZED_BUFFER(single_char);
-
-    TEST_EXPECT_SUCCESS(az_json_builder_append_token(&builder, az_json_token_object_start()));
-
-    TEST_EXPECT_SUCCESS(az_json_builder_append_object(
-        &builder, AZ_SPAN_FROM_STR("span"), az_json_token_span(single_span)));
-
-    TEST_EXPECT_SUCCESS(az_json_builder_append_token(&builder, az_json_token_object_end()));
-
-    az_span expected = AZ_SPAN_FROM_STR("{"
-                                        "\"span\":\"\\\\\""
-                                        "}");
-
-    assert_true(az_span_is_content_equal(builder._internal.json, expected));
   }
   {
     // json with AZ_JSON_TOKEN_STRING


### PR DESCRIPTION
We want to remove the support for adding an AZ_JSON_TOKEN_SPAN in json builder

when adding AZ_JSON_TOKEN_SPAN what we currently do is escaping characters like `\, \n, \t, etc` to be added with escape char before them,
for example, when adding "byte buffer \n from some source", it would be built in json as "byte buffer \\\n some source"

We currently don't have any use case for this or request to support this. Rather than that, this feature can have costumers confused about what's the difference before AZ_JSON_TOKEN_STRING and this one, and witch one they should use.

So we are better removing this. If someday this is requested again, we can recover the code from fit history 