### PR TITLE
Telemetry testing and implementation rework

### DIFF
--- a/sdk/core/core/test/inc/az_test_precondition.h
+++ b/sdk/core/core/test/inc/az_test_precondition.h
@@ -4,6 +4,7 @@
 #ifndef _az_PRECONDITION_TESTING_H
 #define _az_PRECONDITION_TESTING_H
 
+#include <assert.h>
 #include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
@@ -37,7 +38,7 @@ static void az_precondition_test_failed_fn() \
   precondition_test_count = 0; \
   (void)setjmp(g_precond_test_jmp_buf); \
   if (precondition_test_count == 0) { \
-    fn; \
+    assert(fn); \
   } \
   assert_int_equal(1, precondition_test_count);
 

--- a/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
@@ -27,23 +27,25 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
 
   const az_span* const module_id = &(client->_internal.options.module_id);
 
-  AZ_RETURN_IF_FAILED(az_span_append(mqtt_topic, telemetry_topic_prefix, out_mqtt_topic));
-  AZ_RETURN_IF_FAILED(az_span_append(*out_mqtt_topic, client->_internal.device_id, out_mqtt_topic));
+  AZ_RETURN_IF_FAILED(az_span_append(mqtt_topic, telemetry_topic_prefix, &mqtt_topic));
+  AZ_RETURN_IF_FAILED(az_span_append(mqtt_topic, client->_internal.device_id, &mqtt_topic));
 
   if (az_span_length(*module_id) != 0)
   {
     AZ_RETURN_IF_FAILED(
-        az_span_append(*out_mqtt_topic, telemetry_topic_modules_mid, out_mqtt_topic));
-    AZ_RETURN_IF_FAILED(az_span_append(*out_mqtt_topic, *module_id, out_mqtt_topic));
+        az_span_append(mqtt_topic, telemetry_topic_modules_mid, &mqtt_topic));
+    AZ_RETURN_IF_FAILED(az_span_append(mqtt_topic, *module_id, &mqtt_topic));
   }
 
-  AZ_RETURN_IF_FAILED(az_span_append(*out_mqtt_topic, telemetry_topic_suffix, out_mqtt_topic));
+  AZ_RETURN_IF_FAILED(az_span_append(mqtt_topic, telemetry_topic_suffix, &mqtt_topic));
 
   if (properties != NULL)
   {
     AZ_RETURN_IF_FAILED(
-        az_span_append(*out_mqtt_topic, properties->_internal.properties, out_mqtt_topic));
+        az_span_append(mqtt_topic, properties->_internal.properties, &mqtt_topic));
   }
+
+  *out_mqtt_topic = mqtt_topic;
 
   return AZ_OK;
 }

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -94,7 +94,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_pro
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_no_props) - 1];
+  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1];
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
@@ -102,7 +102,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_pro
   assert_memory_equal(
       g_test_correct_topic_no_options_no_props,
       (char*)az_span_ptr(mqtt_topic),
-      sizeof(g_test_correct_topic_no_options_no_props) - 1);
+      _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1);
 }
 
 static void
@@ -115,15 +115,15 @@ test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_props
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_no_props)] = { 0 };
+  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_no_options_no_props)] = { 0 };
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, &mqtt_topic)
       == AZ_OK);
   assert_int_equal(
-      az_span_length(mqtt_topic), sizeof(g_test_correct_topic_no_options_no_props) - 1);
-  assert_int_equal(az_span_capacity(mqtt_topic), sizeof(g_test_correct_topic_no_options_no_props));
+      az_span_length(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1);
+  assert_int_equal(az_span_capacity(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_no_props));
   assert_string_equal(g_test_correct_topic_no_options_no_props, (char*)az_span_ptr(mqtt_topic));
 }
 
@@ -139,7 +139,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_p
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_no_props) - 1];
+  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_with_options_no_props) - 1];
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
@@ -147,7 +147,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_p
   assert_memory_equal(
       g_test_correct_topic_with_options_no_props,
       (char*)az_span_ptr(mqtt_topic),
-      sizeof(g_test_correct_topic_with_options_no_props) - 1);
+      _az_COUNTOF(g_test_correct_topic_with_options_no_props) - 1);
 }
 
 static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_props_succeed(
@@ -165,7 +165,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with
   az_iot_hub_client_properties props;
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_props) - 1];
+  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_with_options_with_props) - 1];
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
@@ -174,7 +174,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with
   assert_memory_equal(
       g_test_correct_topic_with_options_with_props,
       (char*)az_span_ptr(mqtt_topic),
-      sizeof(g_test_correct_topic_with_options_with_props) - 1);
+      _az_COUNTOF(g_test_correct_topic_with_options_with_props) - 1);
 }
 
 static void
@@ -193,7 +193,7 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_props_small
   az_iot_hub_client_properties props;
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_props) - 2];
+  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_with_options_with_props) - 2];
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
@@ -213,7 +213,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_p
   az_iot_hub_client_properties props;
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_props) - 1];
+  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_no_options_with_props) - 1];
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
@@ -222,7 +222,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_p
   assert_memory_equal(
       g_test_correct_topic_no_options_with_props,
       (char*)az_span_ptr(mqtt_topic),
-      sizeof(g_test_correct_topic_no_options_with_props) - 1);
+      _az_COUNTOF(g_test_correct_topic_no_options_with_props) - 1);
 }
 
 static void
@@ -238,7 +238,7 @@ test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_props_small_b
   az_iot_hub_client_properties props;
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_props) - 2];
+  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_no_options_with_props) - 2];
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
@@ -262,7 +262,7 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_p
   az_iot_hub_client_properties props;
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_props) - 1];
+  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 1];
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
@@ -271,7 +271,7 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_p
   assert_memory_equal(
       g_test_correct_topic_with_options_module_id_with_props,
       (char*)az_span_ptr(mqtt_topic),
-      sizeof(g_test_correct_topic_with_options_module_id_with_props) - 1);
+      _az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 1);
 }
 
 static void
@@ -290,7 +290,7 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_p
   az_iot_hub_client_properties props;
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_props) - 2];
+  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 2];
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -60,7 +60,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_mqtt_topic_f
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_buf[1];
-  az_span bad_mqtt_topic = AZ_SPAN_FROM_INITIALIZED_BUFFER(test_buf);
+  az_span bad_mqtt_topic = az_span_init(test_buf, 0, _az_COUNTOF(test_buf));
   bad_mqtt_topic._internal.ptr = NULL;
 
   assert_precondition_checked(az_iot_hub_client_telemetry_publish_topic_get(

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -5,69 +5,40 @@
 #include <az_iot_hub_client.h>
 #include <az_span.h>
 
+#include <az_precondition.h>
+#include <az_precondition_internal.h>
+
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 
+#include <az_test_precondition.h>
 #include <cmocka.h>
 
-#define TEST_FQDN "myiothub.azure-devices.net"
-#define TEST_DEVICE_ID "my_device"
-#define TEST_MODULE_ID "my_module_id"
-#define TEST_USER_AGENT "api-version=2017-11-08-preview&DeviceClientType=iothubclient"
-#define TEST_PARAMS "key=value&key_two=value2"
 #define TEST_MQTT_SPAN_BUFFER_SIZE 100
 
-#define TEST_BAD_SPAN \
-  { \
-    ._internal = { .ptr = (uint8_t*)0x7FFFFFFF, .length = -1, .capacity = 10 }, \
-  }
-#define TEST_EMPTY_OPTIONS \
-  { \
-    .module_id = AZ_SPAN_LITERAL_NULL, .user_agent = AZ_SPAN_LITERAL_NULL \
-  }
-#define TEST_VALID_OPTIONS_BOTH \
-  { \
-    .module_id = AZ_SPAN_LITERAL_FROM_STR(TEST_MODULE_ID), \
-    .user_agent = AZ_SPAN_LITERAL_NULL \
-  }
-#define TEST_VALID_OPTIONS_MODULE_ID \
-  { \
-    .module_id = AZ_SPAN_LITERAL_FROM_STR(TEST_MODULE_ID), .user_agent = AZ_SPAN_LITERAL_NULL \
-  }
+static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR("my_device");
+static const az_span test_device_hostname = AZ_SPAN_LITERAL_FROM_STR("myiothub.azure-devices.net");
+static const az_span test_module_id = AZ_SPAN_LITERAL_FROM_STR("my_module_id");
+static const az_span test_props = AZ_SPAN_LITERAL_FROM_STR("key=value&key_two=value2");
 
-static const az_iot_hub_client_properties g_test_params
-    = { ._internal
-        = { .properties = AZ_SPAN_LITERAL_FROM_STR(TEST_PARAMS), .current_property = 0 } };
-
-static const char g_test_correct_topic_no_options_no_params[]
-    = "devices/my_device/messages/events/";
-static const char g_test_correct_topic_with_options_no_params[]
+static const char g_test_correct_topic_no_options_no_props[] = "devices/my_device/messages/events/";
+static const char g_test_correct_topic_with_options_no_props[]
     = "devices/my_device/modules/my_module_id/messages/events/";
-static const char g_test_correct_topic_with_options_with_params[]
+static const char g_test_correct_topic_with_options_with_props[]
     = "devices/my_device/modules/my_module_id/messages/events/"
       "key=value&key_two=value2";
-static const char g_test_correct_topic_no_options_with_params[]
+static const char g_test_correct_topic_no_options_with_props[]
     = "devices/my_device/messages/events/"
       "key=value&key_two=value2";
-static const char g_test_correct_topic_with_options_module_id_with_params[]
+static const char g_test_correct_topic_with_options_module_id_with_props[]
     = "devices/my_device/modules/my_module_id/messages/events/key=value&key_two=value2";
 
-static const az_iot_hub_client g_test_valid_client_no_options
-    = { ._internal = { .iot_hub_hostname = AZ_SPAN_LITERAL_FROM_STR(TEST_FQDN),
-                       .device_id = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_ID),
-                       .options = TEST_EMPTY_OPTIONS } };
-static const az_iot_hub_client g_test_valid_client_with_options_both
-    = { ._internal = { .iot_hub_hostname = AZ_SPAN_LITERAL_FROM_STR(TEST_FQDN),
-                       .device_id = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_ID),
-                       .options = TEST_VALID_OPTIONS_BOTH } };
-static const az_iot_hub_client g_test_valid_client_with_options_module_id
-    = { ._internal = { .iot_hub_hostname = AZ_SPAN_LITERAL_FROM_STR(TEST_FQDN),
-                       .device_id = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_ID),
-                       .options = TEST_VALID_OPTIONS_MODULE_ID } };
+#ifndef NO_PRECONDITION_CHECKING
 
-/*
+enable_precondition_check_tests()
+
 static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_client_fails(void** state)
 {
   (void)state;
@@ -76,213 +47,287 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_client_fails
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
-  assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(NULL, NULL, mqtt_topic, &mqtt_topic),
-      AZ_ERROR_ARG);
+  assert_precondition_checked(
+      az_iot_hub_client_telemetry_publish_topic_get(NULL, NULL, mqtt_topic, &mqtt_topic));
 }
 
 static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_mqtt_topic_fails(void** state)
 {
   (void)state;
-  az_span null_mqtt_topic = TEST_BAD_SPAN;
 
+  az_iot_hub_client client;
   assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_no_options, NULL, null_mqtt_topic, &null_mqtt_topic),
-      AZ_ERROR_ARG);
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
+
+  uint8_t test_buf[1];
+  az_span bad_mqtt_topic = AZ_SPAN_FROM_INITIALIZED_BUFFER(test_buf);
+  bad_mqtt_topic._internal.ptr = NULL;
+
+  assert_precondition_checked(az_iot_hub_client_telemetry_publish_topic_get(
+      &client, NULL, bad_mqtt_topic, &bad_mqtt_topic));
 }
 
-static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_out_mqtt_topic_fails(void** state)
-{
-  (void)state;
-  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
-
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
-
-  assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_no_options, NULL, mqtt_topic, NULL),
-      AZ_ERROR_ARG);
-}
-*/
-
-static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_params_succeed(void** state)
-{
-  (void)state;
-
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_no_params) - 1];
-
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
-
-  assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_no_options, NULL, mqtt_topic, &mqtt_topic),
-      AZ_OK);
-  assert_memory_equal(
-      g_test_correct_topic_no_options_no_params,
-      (char*)az_span_ptr(mqtt_topic),
-      sizeof(g_test_correct_topic_no_options_no_params) - 1);
-}
-
-static void test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_params_succeed(
+static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_out_mqtt_topic_fails(
     void** state)
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_no_params)] = { 0 };
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
+  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+
+  assert_precondition_checked(
+      az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, NULL));
+}
+
+#endif // NO_PRECONDITION_CHECKING
+
+static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_succeed(
+    void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
+
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_no_props) - 1];
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+
+  assert_int_equal(
+      az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, &mqtt_topic), AZ_OK);
+  assert_memory_equal(
+      g_test_correct_topic_no_options_no_props,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_no_options_no_props) - 1);
+}
+
+static void
+test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_props_succeed(
+    void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
+
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_no_props)] = { 0 };
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
-      az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_no_options, NULL, mqtt_topic, &mqtt_topic)
+      az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, &mqtt_topic)
       == AZ_OK);
   assert_int_equal(
-      az_span_length(mqtt_topic), sizeof(g_test_correct_topic_no_options_no_params) - 1);
-  assert_int_equal(az_span_capacity(mqtt_topic), sizeof(g_test_correct_topic_no_options_no_params));
-  assert_string_equal(g_test_correct_topic_no_options_no_params, (char*)az_span_ptr(mqtt_topic));
+      az_span_length(mqtt_topic), sizeof(g_test_correct_topic_no_options_no_props) - 1);
+  assert_int_equal(az_span_capacity(mqtt_topic), sizeof(g_test_correct_topic_no_options_no_props));
+  assert_string_equal(g_test_correct_topic_no_options_no_props, (char*)az_span_ptr(mqtt_topic));
 }
 
-static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_params_succeed(void** state)
-{
-  (void)state;
-
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_no_params) - 1];
-
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
-
-  assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_with_options_both, NULL, mqtt_topic, &mqtt_topic),
-      AZ_OK);
-  assert_memory_equal(
-      g_test_correct_topic_with_options_no_params,
-      (char*)az_span_ptr(mqtt_topic),
-      sizeof(g_test_correct_topic_with_options_no_params) - 1);
-}
-
-static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params_succeed(
+static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_props_succeed(
     void** state)
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_params) - 1];
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  options.module_id = test_module_id;
 
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
+
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_no_props) - 1];
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_with_options_both, &g_test_params, mqtt_topic, &mqtt_topic),
-      AZ_OK);
+      az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, &mqtt_topic), AZ_OK);
   assert_memory_equal(
-      g_test_correct_topic_with_options_with_params,
+      g_test_correct_topic_with_options_no_props,
       (char*)az_span_ptr(mqtt_topic),
-      sizeof(g_test_correct_topic_with_options_with_params) - 1);
+      sizeof(g_test_correct_topic_with_options_no_props) - 1);
 }
 
-static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params_small_buffer_fails(
+static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_props_succeed(
     void** state)
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_params) - 2];
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  options.module_id = test_module_id;
 
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
+
+  az_iot_hub_client_properties props;
+  assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
+
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_props) - 1];
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_with_options_both, &g_test_params, mqtt_topic, &mqtt_topic),
+      az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
+      AZ_OK);
+  assert_memory_equal(
+      g_test_correct_topic_with_options_with_props,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_with_options_with_props) - 1);
+}
+
+static void
+test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_props_small_buffer_fails(
+    void** state)
+{
+  (void)state;
+
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  options.module_id = test_module_id;
+
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
+
+  az_iot_hub_client_properties props;
+  assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
+
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_with_props) - 2];
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+
+  assert_int_equal(
+      az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
-static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_succeed(void** state)
-{
-  (void)state;
-
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_params) - 1];
-
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
-
-  assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_no_options, &g_test_params, mqtt_topic, &mqtt_topic),
-      AZ_OK);
-  assert_memory_equal(
-      g_test_correct_topic_no_options_with_params,
-      (char*)az_span_ptr(mqtt_topic),
-      sizeof(g_test_correct_topic_no_options_with_params) - 1);
-}
-
-static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_small_buffer_fails(
+static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_props_succeed(
     void** state)
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_params) - 2];
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
+  az_iot_hub_client_properties props;
+  assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
+
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_props) - 1];
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_no_options, &g_test_params, mqtt_topic, &mqtt_topic),
+      az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
+      AZ_OK);
+  assert_memory_equal(
+      g_test_correct_topic_no_options_with_props,
+      (char*)az_span_ptr(mqtt_topic),
+      sizeof(g_test_correct_topic_no_options_with_props) - 1);
+}
+
+static void
+test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_props_small_buffer_fails(
+    void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
+
+  az_iot_hub_client_properties props;
+  assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
+
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_no_options_with_props) - 2];
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+
+  assert_int_equal(
+      az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
-static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_params_succeed(
+static void
+test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_props_succeed(
     void** state)
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_params) - 1];
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  options.module_id = test_module_id;
 
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
+
+  az_iot_hub_client_properties props;
+  assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
+
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_props) - 1];
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_with_options_module_id, &g_test_params, mqtt_topic, &mqtt_topic),
+      az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
       AZ_OK);
   assert_memory_equal(
-      g_test_correct_topic_with_options_module_id_with_params,
+      g_test_correct_topic_with_options_module_id_with_props,
       (char*)az_span_ptr(mqtt_topic),
-      sizeof(g_test_correct_topic_with_options_module_id_with_params) - 1);
+      sizeof(g_test_correct_topic_with_options_module_id_with_props) - 1);
 }
 
-static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_params_small_buffer_fails(
+static void
+test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_props_small_buffer_fails(
     void** state)
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_params) - 2];
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  options.module_id = test_module_id;
 
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
+
+  az_iot_hub_client_properties props;
+  assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
+
+  uint8_t mqtt_topic_buf[sizeof(g_test_correct_topic_with_options_module_id_with_props) - 2];
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(
-          &g_test_valid_client_with_options_module_id, &g_test_params, mqtt_topic, &mqtt_topic),
+      az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
 int test_iot_hub_telemetry()
 {
+#ifndef NO_PRECONDITION_CHECKING
+  setup_precondition_check_tests();
+#endif // NO_PRECONDITION_CHECKING
+
   const struct CMUnitTest tests[] = {
+#ifndef NO_PRECONDITION_CHECKING
+    cmocka_unit_test(test_az_iot_hub_client_telemetry_publish_topic_get_NULL_client_fails),
+    cmocka_unit_test(test_az_iot_hub_client_telemetry_publish_topic_get_NULL_mqtt_topic_fails),
+    cmocka_unit_test(test_az_iot_hub_client_telemetry_publish_topic_get_NULL_out_mqtt_topic_fails),
+#endif // NO_PRECONDITION_CHECKING
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_params_succeed),
+        test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_params_succeed),
+        test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_props_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_params_succeed),
+        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_props_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params_succeed),
+        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_props_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_params_small_buffer_fails),
+        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_props_small_buffer_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_succeed),
+        test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_props_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_params_small_buffer_fails),
+        test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_props_small_buffer_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_params_succeed),
+        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_props_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_params_small_buffer_fails),
+        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_props_small_buffer_fails),
   };
 
   return cmocka_run_group_tests_name("az_iot_hub_client_telemetry", tests, NULL, NULL);


### PR DESCRIPTION
This PR does a few things
1. Updates the telemetry implementation to follow the others which prevent leaking a malformed span in the case of an error (assigned the output span even in the case of a failure).
2. Reworking the unit tests to use API's that have now been implemented instead of creating struct literals.
3. Re-enables the precondition check unit tests with the new precondition check unit testing abilities.
4. Tweaks the precondition check impl to silence the warning on not checking the return of the function called.