### PR TITLE
Add AZ_PRECONDITION_IS_NULL

### DIFF
--- a/sdk/core/core/internal/az_precondition_internal.h
+++ b/sdk/core/core/internal/az_precondition_internal.h
@@ -59,6 +59,9 @@ az_precondition_failed_fn az_precondition_failed_get_callback();
 
 #define AZ_PRECONDITION_NOT_NULL(arg) AZ_PRECONDITION((arg != NULL))
 
+#define AZ_PRECONDITION_IS_NULL(arg) AZ_PRECONDITION((arg == NULL))
+
+
 AZ_NODISCARD AZ_INLINE bool az_span_is_valid(az_span span, int32_t min_length, bool null_is_valid)
 {
   int32_t span_length = az_span_length(span);

--- a/sdk/core/core/internal/az_precondition_internal.h
+++ b/sdk/core/core/internal/az_precondition_internal.h
@@ -58,7 +58,6 @@ az_precondition_failed_fn az_precondition_failed_get_callback();
 #define AZ_PRECONDITION_RANGE(low, arg, max) AZ_PRECONDITION((low <= arg && arg <= max))
 
 #define AZ_PRECONDITION_NOT_NULL(arg) AZ_PRECONDITION((arg != NULL))
-
 #define AZ_PRECONDITION_IS_NULL(arg) AZ_PRECONDITION((arg == NULL))
 
 


### PR DESCRIPTION
Add `AZ_PRECONDITION_IS_NULL` macro to internal preconditions.

At least one place we will need this as we move to defining (currently) unused `options` fields with a `void* reserved`.  Callee should check that the reserved is NULL so we can make it accept non-NULL in future without worrying about breaking anything.

Smoke tested this successfully and will get formal CI tests when IoT code I'm working on uses this.