### PR TITLE
Update IoT unit tests to check all properties of returned span

### DIFF
--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
@@ -12,6 +12,8 @@
 
 #include <cmocka.h>
 
+#define TEST_SPAN_BUFFER_SIZE 128
+
 // Hub Client
 #define TEST_DEVICE_ID_STR "my_device"
 #define TEST_DEVICE_HOSTNAME_STR "myiothub.azure-devices.net"
@@ -60,8 +62,14 @@ static void test_az_iot_hub_client_init_succeed(void** state)
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  assert_memory_equal(TEST_DEVICE_ID_STR, az_span_ptr(client._internal.device_id), _az_COUNTOF(TEST_DEVICE_ID_STR) - 1);
-  assert_memory_equal(TEST_DEVICE_HOSTNAME_STR, az_span_ptr(client._internal.iot_hub_hostname), _az_COUNTOF(TEST_DEVICE_HOSTNAME_STR) - 1);
+  assert_memory_equal(
+      TEST_DEVICE_ID_STR,
+      az_span_ptr(client._internal.device_id),
+      _az_COUNTOF(TEST_DEVICE_ID_STR) - 1);
+  assert_memory_equal(
+      TEST_DEVICE_HOSTNAME_STR,
+      az_span_ptr(client._internal.iot_hub_hostname),
+      _az_COUNTOF(TEST_DEVICE_HOSTNAME_STR) - 1);
 }
 
 static void test_az_iot_hub_client_init_custom_options_succeed(void** state)
@@ -75,10 +83,22 @@ static void test_az_iot_hub_client_init_custom_options_succeed(void** state)
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  assert_memory_equal(TEST_DEVICE_ID_STR, az_span_ptr(client._internal.device_id), _az_COUNTOF(TEST_DEVICE_ID_STR) - 1);
-  assert_memory_equal(TEST_DEVICE_HOSTNAME_STR, az_span_ptr(client._internal.iot_hub_hostname), _az_COUNTOF(TEST_DEVICE_HOSTNAME_STR) - 1);
-  assert_memory_equal(TEST_MODULE_ID, az_span_ptr(client._internal.options.module_id), _az_COUNTOF(TEST_MODULE_ID) - 1);
-  assert_memory_equal(TEST_USER_AGENT, az_span_ptr(client._internal.options.user_agent), _az_COUNTOF(TEST_USER_AGENT) - 1);
+  assert_memory_equal(
+      TEST_DEVICE_ID_STR,
+      az_span_ptr(client._internal.device_id),
+      _az_COUNTOF(TEST_DEVICE_ID_STR) - 1);
+  assert_memory_equal(
+      TEST_DEVICE_HOSTNAME_STR,
+      az_span_ptr(client._internal.iot_hub_hostname),
+      _az_COUNTOF(TEST_DEVICE_HOSTNAME_STR) - 1);
+  assert_memory_equal(
+      TEST_MODULE_ID,
+      az_span_ptr(client._internal.options.module_id),
+      _az_COUNTOF(TEST_MODULE_ID) - 1);
+  assert_memory_equal(
+      TEST_USER_AGENT,
+      az_span_ptr(client._internal.options.user_agent),
+      _az_COUNTOF(TEST_USER_AGENT) - 1);
 }
 
 static void test_az_iot_hub_client_user_name_get_succeed(void** state)
@@ -89,12 +109,16 @@ static void test_az_iot_hub_client_user_name_get_succeed(void** state)
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_user_name) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
+  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
 
   assert_memory_equal(
       test_correct_user_name, az_span_ptr(test_span), sizeof(test_correct_user_name) - 1);
+  assert_int_equal(az_span_length(test_span), _az_COUNTOF(test_correct_user_name) - 1);
+  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
 }
 
 static void test_az_iot_hub_client_user_name_get_as_string_succeed(void** state)
@@ -105,12 +129,16 @@ static void test_az_iot_hub_client_user_name_get_as_string_succeed(void** state)
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_user_name)] = { 0 };
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE] = { 0 };
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
 
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_user_name) - 1);
   assert_string_equal(test_correct_user_name, az_span_ptr(test_span));
+  assert_memory_equal(
+      test_correct_user_name, az_span_ptr(test_span), sizeof(test_correct_user_name) - 1);
+  assert_int_equal(az_span_length(test_span), _az_COUNTOF(test_correct_user_name) - 1);
+  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(test_span_buf[az_span_length(test_span)], 0x0);
 }
 
 static void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
@@ -121,11 +149,13 @@ static void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_user_name) - 2];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[sizeof(test_correct_user_name) - 2];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   assert_int_equal(
       az_iot_hub_client_user_name_get(&client, test_span, &test_span),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(az_span_length(test_span), 0);
+  assert_int_equal(az_span_capacity(test_span), sizeof(test_correct_user_name) - 2);
 }
 
 static void test_az_iot_hub_client_user_name_get_user_options_succeed(void** state)
@@ -139,14 +169,19 @@ static void test_az_iot_hub_client_user_name_get_user_options_succeed(void** sta
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
+  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
 
   assert_memory_equal(
       test_correct_user_name_with_module_id,
       az_span_ptr(test_span),
       sizeof(test_correct_user_name_with_module_id) - 1);
+  assert_int_equal(
+      az_span_length(test_span), _az_COUNTOF(test_correct_user_name_with_module_id) - 1);
+  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
 }
 
 static void test_az_iot_hub_client_user_name_get_user_options_as_string_succeed(void** state)
@@ -160,12 +195,14 @@ static void test_az_iot_hub_client_user_name_get_user_options_as_string_succeed(
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id)] = { 0 };
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE] = { 0 };
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
 
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_user_name_with_module_id) - 1);
   assert_string_equal(test_correct_user_name_with_module_id, az_span_ptr(test_span));
+  assert_int_equal(az_span_length(test_span), sizeof(test_correct_user_name_with_module_id) - 1);
+  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(test_span_buf[az_span_length(test_span)], 0x0);
 }
 
 static void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(void** state)
@@ -179,11 +216,13 @@ static void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_user_name_with_module_id) - 2];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[sizeof(test_correct_user_name_with_module_id) - 2];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   assert_int_equal(
       az_iot_hub_client_user_name_get(&client, test_span, &test_span),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(az_span_length(test_span), 0);
+  assert_int_equal(az_span_capacity(test_span), sizeof(test_correct_user_name_with_module_id) - 2);
 }
 
 static void test_az_iot_hub_client_id_get_succeed(void** state)
@@ -194,12 +233,16 @@ static void test_az_iot_hub_client_id_get_succeed(void** state)
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_client_id) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
+  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
 
   assert_memory_equal(
       test_correct_client_id, az_span_ptr(test_span), sizeof(test_correct_client_id) - 1);
+  assert_int_equal(az_span_length(test_span), sizeof(test_correct_client_id) - 1);
+  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
 }
 
 static void test_az_iot_hub_client_id_get_as_string_succeed(void** state)
@@ -210,12 +253,14 @@ static void test_az_iot_hub_client_id_get_as_string_succeed(void** state)
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_client_id)] = { 0 };
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE] = { 0 };
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
 
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_client_id) - 1);
   assert_string_equal(test_correct_client_id, az_span_ptr(test_span));
+  assert_int_equal(az_span_length(test_span), sizeof(test_correct_client_id) - 1);
+  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(test_span_buf[az_span_length(test_span)], 0x0);
 }
 
 static void test_az_iot_hub_client_id_get_small_buffer_fail(void** state)
@@ -226,11 +271,13 @@ static void test_az_iot_hub_client_id_get_small_buffer_fail(void** state)
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_client_id) - 2];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[sizeof(test_correct_client_id) - 2];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   assert_int_equal(
       az_iot_hub_client_id_get(&client, test_span, &test_span),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(az_span_length(test_span), 0);
+  assert_int_equal(az_span_capacity(test_span), sizeof(test_correct_client_id) - 2);
 }
 
 static void test_az_iot_hub_client_id_get_module_succeed(void** state)
@@ -243,14 +290,18 @@ static void test_az_iot_hub_client_id_get_module_succeed(void** state)
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_client_id_with_module_id) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
+  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
 
   assert_memory_equal(
       test_correct_client_id_with_module_id,
       az_span_ptr(test_span),
       sizeof(test_correct_client_id_with_module_id) - 1);
+  assert_int_equal(az_span_length(test_span), sizeof(test_correct_client_id_with_module_id) - 1);
+  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
 }
 
 static void test_az_iot_hub_client_id_get_module_as_string_succeed(void** state)
@@ -263,12 +314,14 @@ static void test_az_iot_hub_client_id_get_module_as_string_succeed(void** state)
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_client_id_with_module_id)] = { 0 };
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE] = { 0 };
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
 
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_client_id_with_module_id) - 1);
   assert_string_equal(test_correct_client_id_with_module_id, az_span_ptr(test_span));
+  assert_int_equal(az_span_length(test_span), sizeof(test_correct_client_id_with_module_id) - 1);
+  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(test_span_buf[az_span_length(test_span)], 0x0);
 }
 
 static void test_az_iot_hub_client_id_get_module_small_buffer_fail(void** state)
@@ -281,23 +334,25 @@ static void test_az_iot_hub_client_id_get_module_small_buffer_fail(void** state)
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buffer[sizeof(test_correct_client_id_with_module_id) - 2];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[sizeof(test_correct_client_id_with_module_id) - 2];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   assert_int_equal(
       az_iot_hub_client_id_get(&client, test_span, &test_span),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(az_span_length(test_span), 0);
+  assert_int_equal(az_span_capacity(test_span), sizeof(test_correct_client_id_with_module_id) - 2);
 }
 
 static void test_az_iot_hub_client_properties_init_succeed(void** state)
 {
   (void)state;
 
-  uint8_t test_buf[10] = { 0 };
-  az_span test_span = az_span_init(test_buf, 0, sizeof(test_buf));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE] = { 0 };
+  az_span test_span = az_span_init(test_span_buf, 0, sizeof(test_span_buf));
   az_iot_hub_client_properties props;
 
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
-  assert_ptr_equal(props._internal.current_property, &test_buf[0]);
+  assert_ptr_equal(props._internal.current_property, &test_span_buf[0]);
 }
 
 static void test_az_iot_hub_client_properties_init_user_set_params_succeed(void** state)
@@ -310,36 +365,44 @@ static void test_az_iot_hub_client_properties_init_user_set_params_succeed(void*
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
 
   assert_memory_equal(
-      az_span_ptr(test_span), test_correct_one_key_value, sizeof(test_correct_one_key_value) - 1);
+      az_span_ptr(props._internal.properties), test_correct_one_key_value, sizeof(test_correct_one_key_value) - 1);
 }
 
 static void test_az_iot_hub_client_properties_append_succeed(void** state)
 {
   (void)state;
 
-  uint8_t test_buf[sizeof(test_correct_one_key_value)];
-  az_span test_span = az_span_init(test_buf, 0, sizeof(test_buf));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
+  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, 0, sizeof(test_span_buf));
   az_iot_hub_client_properties props;
 
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
   assert_int_equal(
       az_iot_hub_client_properties_append(&props, test_key_one, test_value_one), AZ_OK);
   assert_memory_equal(
-      test_correct_one_key_value, az_span_ptr(test_span), sizeof(test_correct_one_key_value) - 1);
+      test_correct_one_key_value,
+      az_span_ptr(props._internal.properties),
+      sizeof(test_correct_one_key_value) - 1);
+  assert_int_equal(
+      az_span_length(props._internal.properties), sizeof(test_correct_one_key_value) - 1);
+  assert_int_equal(az_span_capacity(props._internal.properties), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(test_span_buf[az_span_length(props._internal.properties)], 0xFF);
 }
 
 static void test_az_iot_hub_client_properties_append_small_buffer_fail(void** state)
 {
   (void)state;
 
-  uint8_t test_buf[sizeof(test_correct_one_key_value) - 2];
-  az_span test_span = az_span_init(test_buf, 0, sizeof(test_buf));
+  uint8_t test_span_buf[sizeof(test_correct_one_key_value) - 2];
+  az_span test_span = az_span_init(test_span_buf, 0, sizeof(test_span_buf));
   az_iot_hub_client_properties props;
 
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
   assert_int_equal(
       az_iot_hub_client_properties_append(&props, test_key_one, test_value_one),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(az_span_capacity(props._internal.properties), sizeof(test_correct_one_key_value) - 2);
   assert_int_equal(az_span_length(props._internal.properties), 0);
 }
 
@@ -347,8 +410,9 @@ static void test_az_iot_hub_client_properties_append_twice_succeed(void** state)
 {
   (void)state;
 
-  uint8_t test_buf[sizeof(test_correct_two_key_value)];
-  az_span test_span = az_span_init(test_buf, 0, sizeof(test_buf));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
+  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, 0, sizeof(test_span_buf));
   az_iot_hub_client_properties props;
 
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
@@ -357,15 +421,21 @@ static void test_az_iot_hub_client_properties_append_twice_succeed(void** state)
   assert_int_equal(
       az_iot_hub_client_properties_append(&props, test_key_two, test_value_two), AZ_OK);
   assert_memory_equal(
-      test_correct_two_key_value, az_span_ptr(test_span), sizeof(test_correct_two_key_value) - 1);
+      test_correct_two_key_value,
+      az_span_ptr(props._internal.properties),
+      sizeof(test_correct_two_key_value) - 1);
+  assert_int_equal(
+      az_span_length(props._internal.properties), sizeof(test_correct_two_key_value) - 1);
+  assert_int_equal(az_span_capacity(props._internal.properties), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(test_span_buf[az_span_length(props._internal.properties)], 0xFF);
 }
 
 static void test_az_iot_hub_client_properties_append_twice_small_buffer_fail(void** state)
 {
   (void)state;
 
-  uint8_t test_buf[sizeof(test_correct_two_key_value) - 2];
-  az_span test_span = az_span_init(test_buf, 0, sizeof(test_buf));
+  uint8_t test_span_buf[sizeof(test_correct_two_key_value) - 2];
+  az_span test_span = az_span_init(test_span_buf, 0, sizeof(test_span_buf));
   az_iot_hub_client_properties props;
 
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
@@ -376,6 +446,7 @@ static void test_az_iot_hub_client_properties_append_twice_small_buffer_fail(voi
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
   assert_int_equal(
       az_span_length(props._internal.properties), sizeof(test_correct_one_key_value) - 1);
+  assert_int_equal(az_span_capacity(props._internal.properties), sizeof(test_correct_two_key_value) - 2);
 }
 
 int test_iot_hub_client()

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
@@ -121,26 +121,6 @@ static void test_az_iot_hub_client_user_name_get_succeed(void** state)
   assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
 }
 
-static void test_az_iot_hub_client_user_name_get_as_string_succeed(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
-
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE] = { 0 };
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
-  assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
-
-  assert_string_equal(test_correct_user_name, az_span_ptr(test_span));
-  assert_memory_equal(
-      test_correct_user_name, az_span_ptr(test_span), sizeof(test_correct_user_name) - 1);
-  assert_int_equal(az_span_length(test_span), _az_COUNTOF(test_correct_user_name) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0x0);
-}
-
 static void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
 {
   (void)state;
@@ -184,27 +164,6 @@ static void test_az_iot_hub_client_user_name_get_user_options_succeed(void** sta
   assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
 }
 
-static void test_az_iot_hub_client_user_name_get_user_options_as_string_succeed(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
-  options.user_agent = AZ_SPAN_FROM_STR(TEST_USER_AGENT);
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
-
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE] = { 0 };
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
-  assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
-
-  assert_string_equal(test_correct_user_name_with_module_id, az_span_ptr(test_span));
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_user_name_with_module_id) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0x0);
-}
-
 static void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(void** state)
 {
   (void)state;
@@ -243,24 +202,6 @@ static void test_az_iot_hub_client_id_get_succeed(void** state)
   assert_int_equal(az_span_length(test_span), sizeof(test_correct_client_id) - 1);
   assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
   assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
-}
-
-static void test_az_iot_hub_client_id_get_as_string_succeed(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
-
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE] = { 0 };
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
-  assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
-
-  assert_string_equal(test_correct_client_id, az_span_ptr(test_span));
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_client_id) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0x0);
 }
 
 static void test_az_iot_hub_client_id_get_small_buffer_fail(void** state)
@@ -302,26 +243,6 @@ static void test_az_iot_hub_client_id_get_module_succeed(void** state)
   assert_int_equal(az_span_length(test_span), sizeof(test_correct_client_id_with_module_id) - 1);
   assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
   assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
-}
-
-static void test_az_iot_hub_client_id_get_module_as_string_succeed(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
-
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE] = { 0 };
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
-  assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
-
-  assert_string_equal(test_correct_client_id_with_module_id, az_span_ptr(test_span));
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_client_id_with_module_id) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0x0);
 }
 
 static void test_az_iot_hub_client_id_get_module_small_buffer_fail(void** state)
@@ -456,16 +377,12 @@ int test_iot_hub_client()
     cmocka_unit_test(test_az_iot_hub_client_init_succeed),
     cmocka_unit_test(test_az_iot_hub_client_init_custom_options_succeed),
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_user_name_get_as_string_succeed),
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_small_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_user_options_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_user_name_get_user_options_as_string_succeed),
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_id_get_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_id_get_as_string_succeed),
     cmocka_unit_test(test_az_iot_hub_client_id_get_small_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_id_get_module_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_id_get_module_as_string_succeed),
     cmocka_unit_test(test_az_iot_hub_client_id_get_module_small_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_properties_init_succeed),
     cmocka_unit_test(test_az_iot_hub_client_properties_init_user_set_params_succeed),

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
@@ -16,6 +16,8 @@
 #include <cmocka.h>
 #include <az_test_precondition.h>
 
+#define TEST_SPAN_BUFFER_SIZE 128
+
 #define TEST_DEVICE_ID_STR "my_device"
 #define TEST_DEVICE_HOSTNAME_STR "myiothub.azure-devices.net"
 #define TEST_MODULE_ID "my_module_id"
@@ -121,7 +123,8 @@ static void test_az_iot_hub_client_c2d_subscribe_topic_filter_get_succeed(void**
 {
   (void)state;
 
-  uint8_t mqtt_sub_topic_buf[_az_COUNTOF(g_test_correct_subscribe_topic)];
+  uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  memset(mqtt_sub_topic_buf, 0xFF, _az_COUNTOF(mqtt_sub_topic_buf));
   az_span mqtt_sub_topic = az_span_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
@@ -134,6 +137,9 @@ static void test_az_iot_hub_client_c2d_subscribe_topic_filter_get_succeed(void**
       == AZ_OK);
 
   assert_memory_equal(g_test_correct_subscribe_topic, az_span_ptr(mqtt_sub_topic), (size_t)az_span_length(mqtt_sub_topic));
+  assert_int_equal(az_span_length(mqtt_sub_topic), _az_COUNTOF(g_test_correct_subscribe_topic) - 1);
+  assert_int_equal(az_span_capacity(mqtt_sub_topic), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(mqtt_sub_topic_buf[az_span_length(mqtt_sub_topic)], 0xFF);
 }
 
 static void test_az_iot_hub_client_c2d_subscribe_topic_filter_get_small_buffer_fail(void** state)
@@ -151,6 +157,8 @@ static void test_az_iot_hub_client_c2d_subscribe_topic_filter_get_small_buffer_f
   assert_true(
       az_iot_hub_client_c2d_subscribe_topic_filter_get(&client, mqtt_sub_topic, &mqtt_sub_topic)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(az_span_length(mqtt_sub_topic), 0);
+  assert_int_equal(az_span_capacity(mqtt_sub_topic), _az_COUNTOF(g_test_correct_subscribe_topic) - 2);
 }
 
 static void test_az_iot_hub_client_c2d_received_topic_parse_URL_DECODED_succeed(void** state)

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -16,7 +16,7 @@
 #include <az_test_precondition.h>
 #include <cmocka.h>
 
-#define TEST_MQTT_SPAN_BUFFER_SIZE 128
+#define TEST_SPAN_BUFFER_SIZE 128
 
 static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR("my_device");
 static const az_span test_device_hostname = AZ_SPAN_LITERAL_FROM_STR("myiothub.azure-devices.net");
@@ -43,7 +43,7 @@ enable_precondition_check_tests()
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
+  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
 
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -76,7 +76,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_out_mqtt_top
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
+  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_precondition_checked(
@@ -94,7 +94,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_pro
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
+  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
   memset(mqtt_topic_buf, 0xFF, _az_COUNTOF(mqtt_topic_buf));
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -106,7 +106,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_pro
       _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1);
   assert_int_equal(
       az_span_length(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1);
-  assert_int_equal(az_span_capacity(mqtt_topic), TEST_MQTT_SPAN_BUFFER_SIZE);
+  assert_int_equal(az_span_capacity(mqtt_topic), TEST_SPAN_BUFFER_SIZE);
   assert_int_equal(mqtt_topic_buf[az_span_length(mqtt_topic)], 0xFF);
 }
 
@@ -120,7 +120,7 @@ test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_props
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE] = { 0 };
+  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE] = { 0 };
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
@@ -128,7 +128,7 @@ test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_props
       == AZ_OK);
   assert_int_equal(
       az_span_length(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1);
-  assert_int_equal(az_span_capacity(mqtt_topic), TEST_MQTT_SPAN_BUFFER_SIZE);
+  assert_int_equal(az_span_capacity(mqtt_topic), TEST_SPAN_BUFFER_SIZE);
   assert_string_equal(g_test_correct_topic_no_options_no_props, (char*)az_span_ptr(mqtt_topic));
 }
 
@@ -144,7 +144,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_p
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
+  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
   memset(mqtt_topic_buf, 0xFF, _az_COUNTOF(mqtt_topic_buf));
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -156,7 +156,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_p
       _az_COUNTOF(g_test_correct_topic_with_options_no_props) - 1);
   assert_int_equal(
       az_span_length(mqtt_topic), _az_COUNTOF(g_test_correct_topic_with_options_no_props) - 1);
-  assert_int_equal(az_span_capacity(mqtt_topic), TEST_MQTT_SPAN_BUFFER_SIZE);
+  assert_int_equal(az_span_capacity(mqtt_topic), TEST_SPAN_BUFFER_SIZE);
   assert_int_equal(mqtt_topic_buf[az_span_length(mqtt_topic)], 0xFF);
 }
 
@@ -175,7 +175,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with
   az_iot_hub_client_properties props;
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
+  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
   memset(mqtt_topic_buf, 0xFF, _az_COUNTOF(mqtt_topic_buf));
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -188,7 +188,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with
       _az_COUNTOF(g_test_correct_topic_with_options_with_props) - 1);
   assert_int_equal(
       az_span_length(mqtt_topic), _az_COUNTOF(g_test_correct_topic_with_options_with_props) - 1);
-  assert_int_equal(az_span_capacity(mqtt_topic), TEST_MQTT_SPAN_BUFFER_SIZE);
+  assert_int_equal(az_span_capacity(mqtt_topic), TEST_SPAN_BUFFER_SIZE);
   assert_int_equal(mqtt_topic_buf[az_span_length(mqtt_topic)], 0xFF);
 }
 
@@ -231,7 +231,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_p
   az_iot_hub_client_properties props;
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
+  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
   memset(mqtt_topic_buf, 0xFF, _az_COUNTOF(mqtt_topic_buf));
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -244,7 +244,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_p
       _az_COUNTOF(g_test_correct_topic_no_options_with_props) - 1);
   assert_int_equal(
       az_span_length(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_with_props) - 1);
-  assert_int_equal(az_span_capacity(mqtt_topic), TEST_MQTT_SPAN_BUFFER_SIZE);
+  assert_int_equal(az_span_capacity(mqtt_topic), TEST_SPAN_BUFFER_SIZE);
   assert_int_equal(mqtt_topic_buf[az_span_length(mqtt_topic)], 0xFF);
 }
 
@@ -288,7 +288,7 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_p
   az_iot_hub_client_properties props;
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
+  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
   memset(mqtt_topic_buf, 0xFF, _az_COUNTOF(mqtt_topic_buf));
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
@@ -302,7 +302,7 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_p
   assert_int_equal(
       az_span_length(mqtt_topic),
       _az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 1);
-  assert_int_equal(az_span_capacity(mqtt_topic), TEST_MQTT_SPAN_BUFFER_SIZE);
+  assert_int_equal(az_span_capacity(mqtt_topic), TEST_SPAN_BUFFER_SIZE);
   assert_int_equal(mqtt_topic_buf[az_span_length(mqtt_topic)], 0xFF);
 }
 

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -16,7 +16,7 @@
 #include <az_test_precondition.h>
 #include <cmocka.h>
 
-#define TEST_MQTT_SPAN_BUFFER_SIZE 100
+#define TEST_MQTT_SPAN_BUFFER_SIZE 128
 
 static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR("my_device");
 static const az_span test_device_hostname = AZ_SPAN_LITERAL_FROM_STR("myiothub.azure-devices.net");
@@ -39,7 +39,7 @@ static const char g_test_correct_topic_with_options_module_id_with_props[]
 
 enable_precondition_check_tests()
 
-static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_client_fails(void** state)
+    static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_client_fails(void** state)
 {
   (void)state;
 
@@ -94,7 +94,8 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_pro
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1];
+  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
+  memset(mqtt_topic_buf, 0xFF, _az_COUNTOF(mqtt_topic_buf));
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
@@ -103,6 +104,10 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_pro
       g_test_correct_topic_no_options_no_props,
       (char*)az_span_ptr(mqtt_topic),
       _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1);
+  assert_int_equal(
+      az_span_length(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1);
+  assert_int_equal(az_span_capacity(mqtt_topic), TEST_MQTT_SPAN_BUFFER_SIZE);
+  assert_int_equal(mqtt_topic_buf[az_span_length(mqtt_topic)], 0xFF);
 }
 
 static void
@@ -115,7 +120,7 @@ test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_props
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_no_options_no_props)] = { 0 };
+  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE] = { 0 };
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
@@ -123,7 +128,7 @@ test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_props
       == AZ_OK);
   assert_int_equal(
       az_span_length(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1);
-  assert_int_equal(az_span_capacity(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_no_props));
+  assert_int_equal(az_span_capacity(mqtt_topic), TEST_MQTT_SPAN_BUFFER_SIZE);
   assert_string_equal(g_test_correct_topic_no_options_no_props, (char*)az_span_ptr(mqtt_topic));
 }
 
@@ -139,7 +144,8 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_p
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_with_options_no_props) - 1];
+  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
+  memset(mqtt_topic_buf, 0xFF, _az_COUNTOF(mqtt_topic_buf));
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
@@ -148,6 +154,10 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_p
       g_test_correct_topic_with_options_no_props,
       (char*)az_span_ptr(mqtt_topic),
       _az_COUNTOF(g_test_correct_topic_with_options_no_props) - 1);
+  assert_int_equal(
+      az_span_length(mqtt_topic), _az_COUNTOF(g_test_correct_topic_with_options_no_props) - 1);
+  assert_int_equal(az_span_capacity(mqtt_topic), TEST_MQTT_SPAN_BUFFER_SIZE);
+  assert_int_equal(mqtt_topic_buf[az_span_length(mqtt_topic)], 0xFF);
 }
 
 static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_props_succeed(
@@ -165,7 +175,8 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with
   az_iot_hub_client_properties props;
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
 
-  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_with_options_with_props) - 1];
+  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
+  memset(mqtt_topic_buf, 0xFF, _az_COUNTOF(mqtt_topic_buf));
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
@@ -175,6 +186,10 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with
       g_test_correct_topic_with_options_with_props,
       (char*)az_span_ptr(mqtt_topic),
       _az_COUNTOF(g_test_correct_topic_with_options_with_props) - 1);
+  assert_int_equal(
+      az_span_length(mqtt_topic), _az_COUNTOF(g_test_correct_topic_with_options_with_props) - 1);
+  assert_int_equal(az_span_capacity(mqtt_topic), TEST_MQTT_SPAN_BUFFER_SIZE);
+  assert_int_equal(mqtt_topic_buf[az_span_length(mqtt_topic)], 0xFF);
 }
 
 static void
@@ -199,6 +214,9 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_props_small
   assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(az_span_length(mqtt_topic), 0);
+  assert_int_equal(
+      az_span_capacity(mqtt_topic), _az_COUNTOF(g_test_correct_topic_with_options_with_props) - 2);
 }
 
 static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_props_succeed(
@@ -213,7 +231,8 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_p
   az_iot_hub_client_properties props;
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
 
-  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_no_options_with_props) - 1];
+  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
+  memset(mqtt_topic_buf, 0xFF, _az_COUNTOF(mqtt_topic_buf));
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
@@ -223,6 +242,10 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_p
       g_test_correct_topic_no_options_with_props,
       (char*)az_span_ptr(mqtt_topic),
       _az_COUNTOF(g_test_correct_topic_no_options_with_props) - 1);
+  assert_int_equal(
+      az_span_length(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_with_props) - 1);
+  assert_int_equal(az_span_capacity(mqtt_topic), TEST_MQTT_SPAN_BUFFER_SIZE);
+  assert_int_equal(mqtt_topic_buf[az_span_length(mqtt_topic)], 0xFF);
 }
 
 static void
@@ -244,6 +267,9 @@ test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_props_small_b
   assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(az_span_length(mqtt_topic), 0);
+  assert_int_equal(
+      az_span_capacity(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_with_props) - 2);
 }
 
 static void
@@ -262,7 +288,8 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_p
   az_iot_hub_client_properties props;
   assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
 
-  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 1];
+  uint8_t mqtt_topic_buf[TEST_MQTT_SPAN_BUFFER_SIZE];
+  memset(mqtt_topic_buf, 0xFF, _az_COUNTOF(mqtt_topic_buf));
   az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
@@ -272,6 +299,11 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_p
       g_test_correct_topic_with_options_module_id_with_props,
       (char*)az_span_ptr(mqtt_topic),
       _az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 1);
+  assert_int_equal(
+      az_span_length(mqtt_topic),
+      _az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 1);
+  assert_int_equal(az_span_capacity(mqtt_topic), TEST_MQTT_SPAN_BUFFER_SIZE);
+  assert_int_equal(mqtt_topic_buf[az_span_length(mqtt_topic)], 0xFF);
 }
 
 static void
@@ -296,6 +328,10 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_p
   assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(az_span_length(mqtt_topic), 0);
+  assert_int_equal(
+      az_span_capacity(mqtt_topic),
+      _az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 2);
 }
 
 int test_iot_hub_telemetry()

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -110,28 +110,6 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_pro
   assert_int_equal(mqtt_topic_buf[az_span_length(mqtt_topic)], 0xFF);
 }
 
-static void
-test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_props_succeed(
-    void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
-
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE] = { 0 };
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
-
-  assert_true(
-      az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, &mqtt_topic)
-      == AZ_OK);
-  assert_int_equal(
-      az_span_length(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1);
-  assert_int_equal(az_span_capacity(mqtt_topic), TEST_SPAN_BUFFER_SIZE);
-  assert_string_equal(g_test_correct_topic_no_options_no_props, (char*)az_span_ptr(mqtt_topic));
-}
-
 static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_props_succeed(
     void** state)
 {
@@ -348,8 +326,6 @@ int test_iot_hub_telemetry()
 #endif // NO_PRECONDITION_CHECKING
     cmocka_unit_test(
         test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_succeed),
-    cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_as_string_no_options_no_props_succeed),
     cmocka_unit_test(
         test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_props_succeed),
     cmocka_unit_test(

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
@@ -16,6 +16,8 @@
 #include <az_test_precondition.h>
 #include <cmocka.h>
 
+#define TEST_SPAN_BUFFER_SIZE 128
+
 static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR("my_device");
 static const az_span test_device_hostname = AZ_SPAN_LITERAL_FROM_STR("myiothub.azure-devices.net");
 static const az_span test_device_request_id = AZ_SPAN_LITERAL_FROM_STR("id_one");
@@ -35,8 +37,8 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_null
 {
   (void)state;
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(
       az_iot_hub_client_twin_response_subscribe_topic_filter_get(NULL, test_span, &test_span));
@@ -51,8 +53,8 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_NULL
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   test_span._internal.ptr = NULL;
 
   assert_precondition_checked(
@@ -68,8 +70,8 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_NULL
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(
       az_iot_hub_client_twin_response_subscribe_topic_filter_get(&client, test_span, NULL));
@@ -80,8 +82,8 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_NULL_cl
 {
   (void)state;
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(
       az_iot_hub_client_twin_patch_subscribe_topic_filter_get(NULL, test_span, &test_span));
@@ -96,8 +98,8 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_NULL_sp
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   test_span._internal.ptr = NULL;
 
   assert_precondition_checked(
@@ -113,8 +115,8 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_NULL_ou
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(
       az_iot_hub_client_twin_patch_subscribe_topic_filter_get(&client, test_span, NULL));
@@ -124,8 +126,8 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_client_fails(
 {
   (void)state;
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(az_iot_hub_client_twin_get_publish_topic_get(
       NULL, test_device_request_id, test_span, &test_span));
@@ -139,8 +141,8 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_request_id_fa
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_get_request_topic) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_get_request_topic) - 1];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   uint8_t test_bad_request_id_buf[1];
   az_span test_bad_request_id
@@ -159,8 +161,8 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_span_fails(vo
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_get_request_topic) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_get_request_topic) - 1];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   test_span._internal.ptr = NULL;
 
   assert_precondition_checked(az_iot_hub_client_twin_get_publish_topic_get(
@@ -175,8 +177,8 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_out_span_fail
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_get_request_topic) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_get_request_topic) - 1];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(az_iot_hub_client_twin_get_publish_topic_get(
       &client, test_device_request_id, test_span, NULL));
@@ -186,8 +188,8 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_NULL_client_fail
 {
   (void)state;
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(az_iot_hub_client_twin_patch_publish_topic_get(
       NULL, test_device_request_id, test_span, &test_span));
@@ -202,8 +204,8 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_invalid_request_
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   uint8_t test_bad_request_id_buf[1];
   az_span test_bad_request_id
@@ -222,8 +224,8 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_NULL_span_fails(
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
   test_span._internal.ptr = NULL;
 
   assert_precondition_checked(az_iot_hub_client_twin_patch_publish_topic_get(
@@ -238,8 +240,8 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_NULL_out_span_fa
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(az_iot_hub_client_twin_patch_publish_topic_get(
       &client, test_device_request_id, test_span, NULL));
@@ -255,8 +257,9 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_succ
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
+  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_response_subscribe_topic_filter_get(&client, test_span, &test_span),
@@ -265,6 +268,9 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_succ
       az_span_ptr(test_span),
       test_correct_twin_response_topic_filter,
       _az_COUNTOF(test_correct_twin_response_topic_filter) - 1);
+  assert_int_equal(az_span_length(test_span), sizeof(test_correct_twin_response_topic_filter) - 1);
+  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
 }
 
 static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_small_buffer_fails(void** state)
@@ -275,12 +281,15 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_smal
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_response_topic_filter) - 2];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 2];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_response_subscribe_topic_filter_get(&client, test_span, &test_span),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(az_span_length(test_span), 0);
+  assert_int_equal(
+      az_span_capacity(test_span), _az_COUNTOF(test_correct_twin_response_topic_filter) - 2);
 }
 
 static void test_az_iot_hub_client_twin_get_publish_topic_get_succeed(void** state)
@@ -291,8 +300,9 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_succeed(void** sta
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_get_request_topic) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
+  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_get_publish_topic_get(
@@ -302,6 +312,9 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_succeed(void** sta
       az_span_ptr(test_span),
       test_correct_twin_get_request_topic,
       _az_COUNTOF(test_correct_twin_get_request_topic) - 1);
+  assert_int_equal(az_span_length(test_span), sizeof(test_correct_twin_get_request_topic) - 1);
+  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
 }
 
 static void test_az_iot_hub_client_twin_get_publish_topic_get_small_buffer_fails(void** state)
@@ -312,13 +325,16 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_small_buffer_fails
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_get_request_topic) - 2];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_get_request_topic) - 2];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_get_publish_topic_get(
           &client, test_device_request_id, test_span, &test_span),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(az_span_length(test_span), 0);
+  assert_int_equal(
+      az_span_capacity(test_span), _az_COUNTOF(test_correct_twin_get_request_topic) - 2);
 }
 
 static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_succeed(void** state)
@@ -329,8 +345,9 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_succeed
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_path_subscribe_topic) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
+  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_patch_subscribe_topic_filter_get(&client, test_span, &test_span),
@@ -339,6 +356,9 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_succeed
       az_span_ptr(test_span),
       test_correct_twin_path_subscribe_topic,
       _az_COUNTOF(test_correct_twin_path_subscribe_topic) - 1);
+  assert_int_equal(az_span_length(test_span), sizeof(test_correct_twin_path_subscribe_topic) - 1);
+  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
 }
 
 static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_small_buffer_fails(void** state)
@@ -349,12 +369,15 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_small_b
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_path_subscribe_topic) - 2];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_path_subscribe_topic) - 2];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_patch_subscribe_topic_filter_get(&client, test_span, &test_span),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(az_span_length(test_span), 0);
+  assert_int_equal(
+      az_span_capacity(test_span), _az_COUNTOF(test_correct_twin_path_subscribe_topic) - 2);
 }
 
 static void test_az_iot_hub_client_twin_patch_publish_topic_get_succeed(void** state)
@@ -365,8 +388,9 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_succeed(void** s
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
+  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_patch_publish_topic_get(
@@ -376,6 +400,9 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_succeed(void** s
       az_span_ptr(test_span),
       test_correct_twin_patch_pub_topic,
       _az_COUNTOF(test_correct_twin_patch_pub_topic) - 1);
+  assert_int_equal(az_span_length(test_span), sizeof(test_correct_twin_patch_pub_topic) - 1);
+  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
 }
 
 static void test_az_iot_hub_client_twin_patch_publish_topic_get_small_buffer_fails(void** state)
@@ -386,13 +413,16 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_small_buffer_fai
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 2];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 2];
+  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_patch_publish_topic_get(
           &client, test_device_request_id, test_span, &test_span),
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_int_equal(az_span_length(test_span), 0);
+  assert_int_equal(
+      az_span_capacity(test_span), _az_COUNTOF(test_correct_twin_patch_pub_topic) - 2);
 }
 
 int test_az_iot_hub_client_twin()


### PR DESCRIPTION
This PR does the following for unit tests in IoT:
- Checks that the length of the span is correct.
- Checks that the span capacity is untouched.
- Checks that content of the span is as it should.
- Checks that the span wasn't written past its length (ie set buffer to all 0xFF and makes sure `span_buf[span_length] = 0xFF`.