### PR TITLE
Enforce 85% code coverage by line

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -210,7 +210,7 @@ jobs:
     displayName: Publish Code Coverage to DevOps
     condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
-  - task: mspremier.BuildQualityChecks.QualityChecks-task.BuildQualityChecks@5
+  - task: mspremier.BuildQualityChecks.QualityChecks-task.BuildQualityChecks@6
     displayName: Check coverage
     inputs:
       checkCoverage: true

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -227,7 +227,7 @@ jobs:
       coverageFailOption: fixed
       coverageType: branch
       # 60% minimum branch coverage
-      coverageThreshold: 99
+      coverageThreshold: 60
     condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
 # Disable build for c - client 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -217,6 +217,7 @@ jobs:
       coverageFailOption: fixed
       coverageType: line
       coverageThreshold: 99
+    condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
 
 # Disable build for c - client 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -211,7 +211,7 @@ jobs:
     condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
   - task: mspremier.BuildQualityChecks.QualityChecks-task.BuildQualityChecks@6
-    displayName: Check coverage
+    displayName: Check line coverage
     inputs:
       checkCoverage: true
       coverageFailOption: fixed
@@ -220,6 +220,15 @@ jobs:
       coverageThreshold: 85
     condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
+  - task: mspremier.BuildQualityChecks.QualityChecks-task.BuildQualityChecks@6
+    displayName: Check branch coverage
+    inputs:
+      checkCoverage: true
+      coverageFailOption: fixed
+      coverageType: branch
+      # 60% minimum branch coverage
+      coverageThreshold: 99
+    condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
 # Disable build for c - client 
 - ${{ if ne(parameters.ServiceDirectory, 'not-specified' )}}:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -210,6 +210,14 @@ jobs:
     displayName: Publish Code Coverage to DevOps
     condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
+  - task: mspremier.BuildQualityChecks.QualityChecks-task.BuildQualityChecks@5
+    displayName: Check coverage
+    inputs:
+      checkCoverage: true
+      coverageFailOption: fixed
+      coverageType: line
+      coverageThreshold: 99
+
 
 # Disable build for c - client 
 - ${{ if ne(parameters.ServiceDirectory, 'not-specified' )}}:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -216,7 +216,8 @@ jobs:
       checkCoverage: true
       coverageFailOption: fixed
       coverageType: line
-      coverageThreshold: 99
+      # 85% minimum line coverage
+      coverageThreshold: 85
     condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
 


### PR DESCRIPTION
There is an installable Azure DevOps task that gets us this kind of enforcement and it works with numbers reported to DevOps. This validation only runs in the step that uploads coverage, `Validate Linux_x64_with_unit_test`, after coverage is published.