### PR TITLE
Add az_iot_get_status

### DIFF
--- a/sdk/iot/core/inc/az_iot_core.h
+++ b/sdk/iot/core/inc/az_iot_core.h
@@ -60,9 +60,13 @@ typedef enum
 
 /**
  * @brief Get the #az_iot_status from an int
- * 
+ *
  * @param[in] status_int  The int with the status number.
  * @param[out]  status  The #az_iot_status* with the status enum.
+ * @return  The #az_result with the result of the get operation
+ *  @retval #AZ_OK  If the int is an #az_iot_status enum. `status` will be set to the according
+ * enum.
+ *  @retval #AZ_ERROR_ITEM_NOT_FOUND  If the int is NOT an #az_iot_status enum
  */
 
 AZ_NODISCARD az_result az_iot_get_status(uint32_t status_int, az_iot_status* status);

--- a/sdk/iot/core/inc/az_iot_core.h
+++ b/sdk/iot/core/inc/az_iot_core.h
@@ -69,7 +69,7 @@ typedef enum
  *  @retval #AZ_ERROR_ITEM_NOT_FOUND If the int is NOT an #az_iot_status enum
  */
 
-AZ_NODISCARD az_result az_iot_get_status(uint32_t status_int, az_iot_status* status);
+AZ_NODISCARD az_result az_iot_get_status_from_uint32(uint32_t status_int, az_iot_status* status);
 
 /**
  * @brief Checks if the status indicates a successful operation.

--- a/sdk/iot/core/inc/az_iot_core.h
+++ b/sdk/iot/core/inc/az_iot_core.h
@@ -59,14 +59,14 @@ typedef enum
 } az_iot_status;
 
 /**
- * @brief Get the #az_iot_status from an int
+ * @brief Get the #az_iot_status from an int.
  *
  * @param[in] status_int The int with the status number.
  * @param[out] status The #az_iot_status* with the status enum.
- * @return The #az_result with the result of the get operation
+ * @return The #az_result with the result of the get operation.
  *  @retval #AZ_OK If the int is an #az_iot_status enum. `status` will be set to the according
  * enum.
- *  @retval #AZ_ERROR_ITEM_NOT_FOUND If the int is NOT an #az_iot_status enum
+ *  @retval #AZ_ERROR_ITEM_NOT_FOUND If the int is NOT an #az_iot_status enum.
  */
 
 AZ_NODISCARD az_result az_iot_get_status_from_uint32(uint32_t status_int, az_iot_status* status);

--- a/sdk/iot/core/inc/az_iot_core.h
+++ b/sdk/iot/core/inc/az_iot_core.h
@@ -61,12 +61,12 @@ typedef enum
 /**
  * @brief Get the #az_iot_status from an int
  *
- * @param[in] status_int  The int with the status number.
- * @param[out]  status  The #az_iot_status* with the status enum.
- * @return  The #az_result with the result of the get operation
- *  @retval #AZ_OK  If the int is an #az_iot_status enum. `status` will be set to the according
+ * @param[in] status_int The int with the status number.
+ * @param[out] status The #az_iot_status* with the status enum.
+ * @return The #az_result with the result of the get operation
+ *  @retval #AZ_OK If the int is an #az_iot_status enum. `status` will be set to the according
  * enum.
- *  @retval #AZ_ERROR_ITEM_NOT_FOUND  If the int is NOT an #az_iot_status enum
+ *  @retval #AZ_ERROR_ITEM_NOT_FOUND If the int is NOT an #az_iot_status enum
  */
 
 AZ_NODISCARD az_result az_iot_get_status(uint32_t status_int, az_iot_status* status);

--- a/sdk/iot/core/inc/az_iot_core.h
+++ b/sdk/iot/core/inc/az_iot_core.h
@@ -59,6 +59,15 @@ typedef enum
 } az_iot_status;
 
 /**
+ * @brief Get the #az_iot_status from an int
+ * 
+ * @param[in] status_int  The int with the status number.
+ * @param[out]  status  The #az_iot_status* with the status enum.
+ */
+
+AZ_NODISCARD az_result az_iot_get_status(uint32_t status_int, az_iot_status* status);
+
+/**
  * @brief Checks if the status indicates a successful operation.
  *
  * @param[in] status The #az_iot_status to verify.

--- a/sdk/iot/core/src/az_iot_core.c
+++ b/sdk/iot/core/src/az_iot_core.c
@@ -10,7 +10,7 @@
 
 #include <_az_cfg.h>
 
-AZ_NODISCARD az_result az_iot_get_status(uint32_t status_int, az_iot_status* status)
+AZ_NODISCARD az_result az_iot_get_status_from_uint32(uint32_t status_int, az_iot_status* status)
 {
   switch (status_int)
   {

--- a/sdk/iot/core/src/az_iot_core.c
+++ b/sdk/iot/core/src/az_iot_core.c
@@ -10,6 +10,71 @@
 
 #include <_az_cfg.h>
 
+az_result az_iot_get_status(uint32_t status_int, az_iot_status* status)
+{
+  switch(status_int)
+  {
+    case AZ_IOT_STATUS_OK:
+      *status = AZ_IOT_STATUS_OK;
+      break;
+    case AZ_IOT_STATUS_ACCEPTED:
+      *status = AZ_IOT_STATUS_ACCEPTED;
+      break;
+    case AZ_IOT_STATUS_NO_CONTENT:
+      *status = AZ_IOT_STATUS_NO_CONTENT;
+      break;
+    case AZ_IOT_STATUS_BAD_REQUEST:
+      *status = AZ_IOT_STATUS_BAD_REQUEST;
+      break;
+    case AZ_IOT_STATUS_UNAUTHORIZED:
+      *status = AZ_IOT_STATUS_UNAUTHORIZED;
+      break;
+    case AZ_IOT_STATUS_FORBIDDEN:
+      *status = AZ_IOT_STATUS_FORBIDDEN;
+      break;
+    case AZ_IOT_STATUS_NOT_FOUND:
+      *status = AZ_IOT_STATUS_NOT_FOUND;
+      break;
+    case AZ_IOT_STATUS_NOT_ALLOWED:
+      *status = AZ_IOT_STATUS_NOT_ALLOWED;
+      break;
+    case AZ_IOT_STATUS_NOT_CONFLICT:
+      *status = AZ_IOT_STATUS_NOT_CONFLICT;
+      break;
+    case AZ_IOT_STATUS_PRECONDITION_FAILED:
+      *status = AZ_IOT_STATUS_PRECONDITION_FAILED;
+      break;
+    case AZ_IOT_STATUS_REQUEST_TOO_LARGE:
+      *status = AZ_IOT_STATUS_REQUEST_TOO_LARGE;
+      break;
+    case AZ_IOT_STATUS_UNSUPPORTED_TYPE:
+      *status = AZ_IOT_STATUS_UNSUPPORTED_TYPE;
+      break;
+    case AZ_IOT_STATUS_THROTTLED:
+      *status = AZ_IOT_STATUS_THROTTLED;
+      break;
+    case AZ_IOT_STATUS_CLIENT_CLOSED:
+      *status = AZ_IOT_STATUS_CLIENT_CLOSED;
+      break;
+    case AZ_IOT_STATUS_SERVER_ERROR:
+      *status = AZ_IOT_STATUS_SERVER_ERROR;
+      break;
+    case AZ_IOT_STATUS_BAD_GATEWAY:
+      *status = AZ_IOT_STATUS_BAD_GATEWAY;
+      break;
+    case AZ_IOT_STATUS_SERVICE_UNAVAILABLE:
+      *status = AZ_IOT_STATUS_SERVICE_UNAVAILABLE;
+      break;
+    case AZ_IOT_STATUS_TIMEOUT:
+      *status = AZ_IOT_STATUS_TIMEOUT;
+      break;
+    default:
+      return AZ_ERROR_ITEM_NOT_FOUND;
+  }
+
+  return AZ_OK;
+}
+
 AZ_NODISCARD az_span az_span_token(az_span source, az_span delimiter, az_span* out_remainder)
 {
   AZ_PRECONDITION_VALID_SPAN(delimiter, 1, false);

--- a/sdk/iot/core/src/az_iot_core.c
+++ b/sdk/iot/core/src/az_iot_core.c
@@ -12,7 +12,7 @@
 
 AZ_NODISCARD az_result az_iot_get_status(uint32_t status_int, az_iot_status* status)
 {
-  switch(status_int)
+  switch (status_int)
   {
     case AZ_IOT_STATUS_OK:
       *status = AZ_IOT_STATUS_OK;
@@ -90,7 +90,8 @@ AZ_NODISCARD az_span az_span_token(az_span source, az_span delimiter, az_span* o
 
     if (index != -1)
     {
-      *out_remainder = az_span_slice(source, index + az_span_length(delimiter), az_span_length(source));
+      *out_remainder
+          = az_span_slice(source, index + az_span_length(delimiter), az_span_length(source));
 
       return az_span_slice(source, 0, index);
     }
@@ -99,6 +100,6 @@ AZ_NODISCARD az_span az_span_token(az_span source, az_span delimiter, az_span* o
       *out_remainder = AZ_SPAN_NULL;
 
       return source;
-    } 
+    }
   }
 }

--- a/sdk/iot/core/src/az_iot_core.c
+++ b/sdk/iot/core/src/az_iot_core.c
@@ -10,7 +10,7 @@
 
 #include <_az_cfg.h>
 
-az_result az_iot_get_status(uint32_t status_int, az_iot_status* status)
+AZ_NODISCARD az_result az_iot_get_status(uint32_t status_int, az_iot_status* status)
 {
   switch(status_int)
   {

--- a/sdk/iot/core/tests/cmocka/test_az_iot_core.c
+++ b/sdk/iot/core/tests/cmocka/test_az_iot_core.c
@@ -72,10 +72,75 @@ static void az_span_token_success(void** state)
   assert_true(az_span_is_content_equal(token, AZ_SPAN_NULL));
 }
 
+static void test_az_iot_get_status(void** state)
+{
+  (void)state;
+
+  az_iot_status status;
+
+  assert_int_equal(az_iot_get_status(200, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_OK, status);
+
+  assert_int_equal(az_iot_get_status(202, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_ACCEPTED, status);
+
+  assert_int_equal(az_iot_get_status(204, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_NO_CONTENT, status);
+
+  assert_int_equal(az_iot_get_status(400, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_BAD_REQUEST, status);
+
+  assert_int_equal(az_iot_get_status(401, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_UNAUTHORIZED, status);
+
+  assert_int_equal(az_iot_get_status(403, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_FORBIDDEN, status);
+
+  assert_int_equal(az_iot_get_status(404, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_NOT_FOUND, status);
+
+  assert_int_equal(az_iot_get_status(405, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_NOT_ALLOWED, status);
+
+  assert_int_equal(az_iot_get_status(409, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_NOT_CONFLICT, status);
+
+  assert_int_equal(az_iot_get_status(412, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_PRECONDITION_FAILED, status);
+
+  assert_int_equal(az_iot_get_status(413, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_REQUEST_TOO_LARGE, status);
+
+  assert_int_equal(az_iot_get_status(415, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_UNSUPPORTED_TYPE, status);
+
+  assert_int_equal(az_iot_get_status(429, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_THROTTLED, status);
+
+  assert_int_equal(az_iot_get_status(499, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_CLIENT_CLOSED, status);
+
+  assert_int_equal(az_iot_get_status(500, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_SERVER_ERROR, status);
+
+  assert_int_equal(az_iot_get_status(502, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_BAD_GATEWAY, status);
+
+  assert_int_equal(az_iot_get_status(503, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_SERVICE_UNAVAILABLE, status);
+
+  assert_int_equal(az_iot_get_status(504, &status), AZ_OK);
+  assert_int_equal(AZ_IOT_STATUS_TIMEOUT, status);
+
+  assert_int_equal(az_iot_get_status(999, &status), AZ_ERROR_ITEM_NOT_FOUND);
+
+}
+
 int test_az_iot_core()
 {
   const struct CMUnitTest tests[] = {
-    cmocka_unit_test(az_span_token_success)
+    cmocka_unit_test(az_span_token_success),
+    cmocka_unit_test(test_az_iot_get_status),
   };
   return cmocka_run_group_tests_name("az_iot_core", tests, NULL, NULL);
 }

--- a/sdk/iot/core/tests/cmocka/test_az_iot_core.c
+++ b/sdk/iot/core/tests/cmocka/test_az_iot_core.c
@@ -72,67 +72,67 @@ static void az_span_token_success(void** state)
   assert_true(az_span_is_content_equal(token, AZ_SPAN_NULL));
 }
 
-static void test_az_iot_get_status(void** state)
+static void test_az_iot_get_status_from_uint32(void** state)
 {
   (void)state;
 
   az_iot_status status;
 
-  assert_int_equal(az_iot_get_status(200, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(200, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_OK, status);
 
-  assert_int_equal(az_iot_get_status(202, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(202, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_ACCEPTED, status);
 
-  assert_int_equal(az_iot_get_status(204, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(204, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_NO_CONTENT, status);
 
-  assert_int_equal(az_iot_get_status(400, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(400, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_BAD_REQUEST, status);
 
-  assert_int_equal(az_iot_get_status(401, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(401, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_UNAUTHORIZED, status);
 
-  assert_int_equal(az_iot_get_status(403, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(403, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_FORBIDDEN, status);
 
-  assert_int_equal(az_iot_get_status(404, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(404, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_NOT_FOUND, status);
 
-  assert_int_equal(az_iot_get_status(405, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(405, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_NOT_ALLOWED, status);
 
-  assert_int_equal(az_iot_get_status(409, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(409, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_NOT_CONFLICT, status);
 
-  assert_int_equal(az_iot_get_status(412, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(412, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_PRECONDITION_FAILED, status);
 
-  assert_int_equal(az_iot_get_status(413, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(413, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_REQUEST_TOO_LARGE, status);
 
-  assert_int_equal(az_iot_get_status(415, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(415, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_UNSUPPORTED_TYPE, status);
 
-  assert_int_equal(az_iot_get_status(429, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(429, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_THROTTLED, status);
 
-  assert_int_equal(az_iot_get_status(499, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(499, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_CLIENT_CLOSED, status);
 
-  assert_int_equal(az_iot_get_status(500, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(500, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_SERVER_ERROR, status);
 
-  assert_int_equal(az_iot_get_status(502, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(502, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_BAD_GATEWAY, status);
 
-  assert_int_equal(az_iot_get_status(503, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(503, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_SERVICE_UNAVAILABLE, status);
 
-  assert_int_equal(az_iot_get_status(504, &status), AZ_OK);
+  assert_int_equal(az_iot_get_status_from_uint32(504, &status), AZ_OK);
   assert_int_equal(AZ_IOT_STATUS_TIMEOUT, status);
 
-  assert_int_equal(az_iot_get_status(999, &status), AZ_ERROR_ITEM_NOT_FOUND);
+  assert_int_equal(az_iot_get_status_from_uint32(999, &status), AZ_ERROR_ITEM_NOT_FOUND);
 
 }
 
@@ -140,7 +140,7 @@ int test_az_iot_core()
 {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(az_span_token_success),
-    cmocka_unit_test(test_az_iot_get_status),
+    cmocka_unit_test(test_az_iot_get_status_from_uint32),
   };
   return cmocka_run_group_tests_name("az_iot_core", tests, NULL, NULL);
 }


### PR DESCRIPTION
While adding the twin parse API, I thought this seems like something we would want. We can set the enum value straight to the number from the response but that could be unsafe. Let me know your thoughts.