### PR TITLE
Remove global macro

### DIFF
--- a/sdk/core/core/inc/_az_cfg.h
+++ b/sdk/core/core/inc/_az_cfg.h
@@ -91,8 +91,4 @@
 // Get the number of elements in an array
 #define _az_COUNTOF(array) (sizeof(array) / sizeof(array[0]))
 
-#ifndef UNUSED
-#define UNUSED(x) (void)(x)
-#endif
-
 #endif // _az_CFG_H

--- a/sdk/iot/hub/src/az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_methods.c
@@ -24,7 +24,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_subscribe_topic_filter_get(
   AZ_PRECONDITION_VALID_SPAN(mqtt_topic_filter, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_mqtt_topic_filter);
 
-  UNUSED(client);
+  (void)client;
 
   int32_t required_length
       = az_span_length(methods_topic_prefix) + az_span_length(methods_topic_filter_suffix) + 1;
@@ -50,7 +50,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_received_topic_parse(
   AZ_PRECONDITION_VALID_SPAN(received_topic, 1, false);
   AZ_PRECONDITION_NOT_NULL(out_request);
 
-  UNUSED(client);
+  (void)client;
 
   int32_t index = az_span_find(received_topic, methods_topic_prefix);
 
@@ -102,7 +102,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_response_publish_topic_get(
   AZ_PRECONDITION_VALID_SPAN(mqtt_topic, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_mqtt_topic);
 
-  UNUSED(client);
+  (void)client;
 
   int32_t required_length
       = az_span_length(methods_topic_prefix) + az_span_length(methods_response_topic_result);

--- a/sdk/iot/provisioning/samples/src/paho_iot_provisioning_example.c
+++ b/sdk/iot/provisioning/samples/src/paho_iot_provisioning_example.c
@@ -121,7 +121,7 @@ static az_result read_configuration_and_init_client()
 
 static int on_received(void* context, char* topicName, int topicLen, MQTTClient_message* message)
 {
-  UNUSED(context);
+  (void)context;
 
   int i;
   char* payloadptr;

--- a/sdk/iot/provisioning/src/az_iot_provisioning_client.c
+++ b/sdk/iot/provisioning/src/az_iot_provisioning_client.c
@@ -111,7 +111,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_subscribe_topic_filte
     az_span mqtt_topic_filter,
     az_span* out_mqtt_topic_filter)
 {
-  UNUSED(client);
+  (void)client;
 
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_VALID_SPAN(mqtt_topic_filter, 0, false);
@@ -141,10 +141,10 @@ AZ_NODISCARD az_result az_iot_provisioning_client_received_topic_payload_parse(
     az_span received_payload,
     az_iot_provisioning_client_register_response* out_response)
 {
-  UNUSED(client);
-  UNUSED(received_topic);
-  UNUSED(received_payload);
-  UNUSED(out_response);
+  (void)client;
+  (void)received_topic;
+  (void)received_payload;
+  (void)out_response;
 
   return AZ_ERROR_NOT_IMPLEMENTED;
 }
@@ -155,7 +155,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_publish_topic_get(
     az_span mqtt_topic,
     az_span* out_mqtt_topic)
 {
-  UNUSED(client);
+  (void)client;
 
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_VALID_SPAN(mqtt_topic, 0, false);
@@ -182,7 +182,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_get_operation_status_publish_t
     az_span mqtt_topic,
     az_span* out_mqtt_topic)
 {
-  UNUSED(client);
+  (void)client;
 
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_VALID_SPAN(mqtt_topic, 0, false);


### PR DESCRIPTION
We should never declare non-prefiexed entities. So, this macro should've been named as `_az_UNUSED` if used internally, and `AZ_UNUSED` if this is the functionality that we provide as part of the SDK, and are committing to support forever in the future.
I don;t think we need this macro at all, because `(void)something` is the language-native way to say that a variable is unused. The same way that `INCREMENT(x)` does not need to be defined as `++x` (unless the implementation is different between platforms/compilers, or if we want it to do different things depending on the variables defined, such as precondition checks).