### PR TITLE
Fix broken curl transport on setting up url and broken retry policy deleting all headers

### DIFF
--- a/sdk/core/core/src/az_aad.c
+++ b/sdk/core/core/src/az_aad.c
@@ -100,7 +100,7 @@ AZ_NODISCARD az_result _az_aad_request_token(_az_http_request* request, _az_toke
   AZ_RETURN_IF_FAILED(az_http_request_append_header(
       request,
       AZ_SPAN_FROM_STR("Content-Type"),
-      AZ_SPAN_FROM_STR("application/x-www-url-form-urlencoded")));
+      AZ_SPAN_FROM_STR("application/x-www-form-urlencoded")));
 
   uint8_t response_buf[_az_AAD_RESPONSE_BUF_SIZE] = { 0 };
   az_http_response response = { 0 };

--- a/sdk/core/core/src/az_http_policy_retry.c
+++ b/sdk/core/core/src/az_http_policy_retry.c
@@ -107,7 +107,7 @@ AZ_INLINE AZ_NODISCARD az_result _az_http_policy_retry_get_retry_after(
     {
       if (az_span_is_content_equal_ignoring_case(header.key, AZ_SPAN_FROM_STR("retry-after-ms"))
           || az_span_is_content_equal_ignoring_case(
-              header.key, AZ_SPAN_FROM_STR("x-ms-retry-after-ms")))
+                 header.key, AZ_SPAN_FROM_STR("x-ms-retry-after-ms")))
       {
         // The value is in milliseconds.
         int32_t const msec = _az_uint32_span_to_int32(header.value);

--- a/sdk/core/core/src/az_http_policy_retry.c
+++ b/sdk/core/core/src/az_http_policy_retry.c
@@ -159,6 +159,8 @@ AZ_NODISCARD az_result az_http_pipeline_policy_retry(
   int32_t const max_retry_delay_msec = retry_options->max_retry_delay_msec;
   az_http_status_code const* const status_codes = retry_options->status_codes;
 
+  AZ_RETURN_IF_FAILED(_az_http_request_mark_retry_headers_start(p_request));
+
   az_context* const context = p_request->_internal.context;
 
   bool const should_log = az_log_should_write(AZ_LOG_HTTP_RETRY);

--- a/sdk/platform/http_client/curl/src/az_curl.c
+++ b/sdk/platform/http_client/curl/src/az_curl.c
@@ -109,7 +109,7 @@ _az_span_append_header_to_buffer(az_span writable_buffer, az_pair header, az_spa
   writable_buffer = az_span_append(writable_buffer, header.key);
   writable_buffer = az_span_append(writable_buffer, separator);
   writable_buffer = az_span_append(writable_buffer, header.value);
-  writable_buffer = az_span_append_uint8(writable_buffer, '0');
+  writable_buffer = az_span_append_uint8(writable_buffer, 0);
 
   return AZ_OK;
 }
@@ -209,7 +209,7 @@ _az_http_client_curl_append_url(az_span writable_buffer, az_span url_from_reques
   AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(writable_buffer, required_length);
 
   writable_buffer = az_span_append(writable_buffer, url_from_request);
-  writable_buffer = az_span_append_uint8(writable_buffer, '0');
+  writable_buffer = az_span_append_uint8(writable_buffer, 0);
 
   return AZ_OK;
 }
@@ -538,8 +538,7 @@ static AZ_NODISCARD az_result _az_http_client_curl_send_request_impl_process(
   {
     AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(response->_internal.http_response, 1);
 
-    response->_internal.http_response
-        = az_span_append_uint8(response->_internal.http_response, '0');
+    response->_internal.http_response = az_span_append_uint8(response->_internal.http_response, 0);
   }
   return result;
 }


### PR DESCRIPTION
Two important fixes here
- Curl transport was appending a '0' and not a \0 at the end of url, this was making curl to write beyond url and returning not found as response all the time

- retry policy was removing all current headers as if they all were retry headers. Fixed by calling set_retry_start as first thing for retry policy