### PR TITLE
Victor/storage/reset response for re use [580]

### DIFF
--- a/sdk/core/core/src/az_http_policy.c
+++ b/sdk/core/core/src/az_http_policy.c
@@ -105,7 +105,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_transport(
   (void)p_policies; // this is the last policy in the pipeline, we just void it
   (void)p_data;
 
-  // make sure the response is reset (in case it is a re-usable response)
+  // make sure the response is resetted
   _az_http_response_reset(p_response);
 
   return az_http_client_send_request(p_request, p_response);

--- a/sdk/core/core/src/az_http_policy.c
+++ b/sdk/core/core/src/az_http_policy.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "az_http_policy_private.h"
+#include "az_http_private.h"
 #include <az_credentials.h>
 #include <az_http.h>
 #include <az_http_internal.h>
@@ -103,6 +104,9 @@ AZ_NODISCARD az_result az_http_pipeline_policy_transport(
 {
   (void)p_policies; // this is the last policy in the pipeline, we just void it
   (void)p_data;
+
+  // make sure the response is reset (in case it is a re-usable response)
+  AZ_RETURN_IF_FAILED(_az_http_response_reset(p_response));
 
   return az_http_client_send_request(p_request, p_response);
 }

--- a/sdk/core/core/src/az_http_policy.c
+++ b/sdk/core/core/src/az_http_policy.c
@@ -106,7 +106,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_transport(
   (void)p_data;
 
   // make sure the response is reset (in case it is a re-usable response)
-  AZ_RETURN_IF_FAILED(_az_http_response_reset(p_response));
+  _az_http_response_reset(p_response);
 
   return az_http_client_send_request(p_request, p_response);
 }

--- a/sdk/core/core/src/az_http_private.h
+++ b/sdk/core/core/src/az_http_private.h
@@ -43,6 +43,25 @@ AZ_NODISCARD AZ_INLINE az_result _az_http_request_remove_retry_headers(_az_http_
   return AZ_OK;
 }
 
+/**
+ * @brief sets buffer and parser to its initial state
+ *
+ */
+AZ_NODISCARD AZ_INLINE az_result _az_http_response_reset(az_http_response* http_response)
+{
+  if (az_span_length(http_response->_internal.http_response) > 0)
+  {
+    // init response with same buffer and make internal parser to be initial state
+    AZ_RETURN_IF_FAILED(az_http_response_init(
+        http_response,
+        az_span_init(
+            http_response->_internal.http_response._internal.ptr,
+            0,
+            az_span_capacity(http_response->_internal.http_response))));
+  }
+  return AZ_OK;
+}
+
 #include <_az_cfg_suffix.h>
 
 #endif // _az_HTTP_PRIVATE_H

--- a/sdk/core/core/src/az_http_private.h
+++ b/sdk/core/core/src/az_http_private.h
@@ -47,20 +47,7 @@ AZ_NODISCARD AZ_INLINE az_result _az_http_request_remove_retry_headers(_az_http_
  * @brief sets buffer and parser to its initial state
  *
  */
-AZ_NODISCARD AZ_INLINE az_result _az_http_response_reset(az_http_response* http_response)
-{
-  if (az_span_length(http_response->_internal.http_response) > 0)
-  {
-    // init response with same buffer and make internal parser to be initial state
-    AZ_RETURN_IF_FAILED(az_http_response_init(
-        http_response,
-        az_span_init(
-            http_response->_internal.http_response._internal.ptr,
-            0,
-            az_span_capacity(http_response->_internal.http_response))));
-  }
-  return AZ_OK;
-}
+void _az_http_response_reset(az_http_response* http_response);
 
 #include <_az_cfg_suffix.h>
 

--- a/sdk/core/core/src/az_http_response.c
+++ b/sdk/core/core/src/az_http_response.c
@@ -3,6 +3,7 @@
 
 #include <az_http.h>
 
+#include "az_http_private.h"
 #include "az_span_private.h"
 #include <az_precondition.h>
 #include <az_precondition_internal.h>
@@ -257,4 +258,16 @@ AZ_NODISCARD az_result az_http_response_get_body(az_http_response* response, az_
 
   response->_internal.parser.next_kind = _az_HTTP_RESPONSE_KIND_EOF;
   return AZ_OK;
+}
+
+void _az_http_response_reset(az_http_response* http_response)
+{
+  // never fails, discard the result
+  az_result result = az_http_response_init(
+      http_response,
+      az_span_init(
+          http_response->_internal.http_response._internal.ptr,
+          0,
+          az_span_capacity(http_response->_internal.http_response)));
+  (void)result;
 }

--- a/sdk/core/core/src/az_http_response.c
+++ b/sdk/core/core/src/az_http_response.c
@@ -263,11 +263,8 @@ AZ_NODISCARD az_result az_http_response_get_body(az_http_response* response, az_
 void _az_http_response_reset(az_http_response* http_response)
 {
   // never fails, discard the result
-  az_result result = az_http_response_init(
-      http_response,
-      az_span_init(
-          http_response->_internal.http_response._internal.ptr,
-          0,
-          az_span_capacity(http_response->_internal.http_response)));
+  // init will set written to 0 and will use the same az_span. Internal parser's state is also
+  // reset
+  az_result result = az_http_response_init(http_response, http_response->_internal.http_response);
   (void)result;
 }

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -98,13 +98,6 @@ int main()
 
   printf("Key created result: \n%s", response_buffer);
 
-  // Reuse response buffer for create Key by creating a new span from response_buffer
-  az_result const reset1_op = az_http_response_init(&http_response, response_span);
-  if (az_failed(reset1_op))
-  {
-    printf("Failed to reset http response (1)");
-  }
-
   az_span_set(http_response._internal.http_response, '.');
 
   /******************  GET KEY latest ver ******************************/
@@ -134,13 +127,6 @@ int main()
     version = az_span_slice(version_builder, 0, az_span_length(version_builder));
   }
 
-  // Reuse response buffer for delete Key by creating a new span from response_buffer
-  az_result const reset2_op = az_http_response_init(&http_response, response_span);
-  if (az_failed(reset2_op))
-  {
-    printf("Failed to reset http response (2)");
-  }
-
   az_span_set(response_span, '.');
 
   /*********************  Create a new key version (use default options) *************/
@@ -160,13 +146,6 @@ int main()
   printf(
       "\n\n*********************************\nKey new version created result: \n%s",
       response_buffer);
-
-  // Reuse response buffer for delete Key by creating a new span from response_buffer
-  az_result const reset3_op = az_http_response_init(&http_response, response_span);
-  if (az_failed(reset3_op))
-  {
-    printf("Failed to reset http response (3)");
-  }
 
   az_span_set(response_span, '.');
 
@@ -191,13 +170,6 @@ int main()
   }
 
   printf("\n\n*********************************\nDELETED Key: \n %s", response_buffer);
-
-  // Reuse response buffer for create Key by creating a new span from response_buffer
-  az_result const reset4_op = az_http_response_init(&http_response, response_span);
-  if (az_failed(reset4_op))
-  {
-    printf("Failed to reset http response (4)");
-  }
 
   az_span_set(response_span, '.');
 

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -98,7 +98,7 @@ int main()
 
   printf("Key created result: \n%s", response_buffer);
 
-  az_span_set(http_response._internal.http_response, '.');
+  az_span_fill(http_response._internal.http_response, '.');
 
   /******************  GET KEY latest ver ******************************/
   az_result get_key_result = az_keyvault_keys_key_get(
@@ -126,7 +126,7 @@ int main()
     version = az_span_slice(version_builder, 0, az_span_size(version));
   }
 
-  az_span_set(response_span, '.');
+  az_span_fill(response_span, '.');
 
   /*********************  Create a new key version (use default options) *************/
   az_result const create_version_result = az_keyvault_keys_key_create(
@@ -146,7 +146,7 @@ int main()
       "\n\n*********************************\nKey new version created result: \n%s",
       response_buffer);
 
-  az_span_set(response_span, '.');
+  az_span_fill(response_span, '.');
 
   /******************  GET KEY previous ver ******************************/
   az_result const get_key_prev_ver_result = az_keyvault_keys_key_get(
@@ -170,7 +170,7 @@ int main()
 
   printf("\n\n*********************************\nDELETED Key: \n %s", response_buffer);
 
-  az_span_set(response_span, '.');
+  az_span_fill(response_span, '.');
 
   /******************  GET KEY (should return failed response ) ******************************/
   az_result get_key_again_result = az_keyvault_keys_key_get(

--- a/sdk/storage/blobs/samples/src/blobs_client_example.c
+++ b/sdk/storage/blobs/samples/src/blobs_client_example.c
@@ -18,16 +18,16 @@
 #define URI_ENV "test_uri"
 
 int exit_code = 0;
-static az_span content_to_upload = AZ_SPAN_LITERAL_FROM_STR("Some test Content");
+static az_span content_to_upload = AZ_SPAN_LITERAL_FROM_STR("Some test content");
 
+// Uncomment below code to enable logging (and the first lines of main function)
 /*
-* uncomment this to enable logging
 static void test_log_func(az_log_classification classification, az_span message)
 {
   (void)classification;
   printf("%.*s\n", az_span_length(message), az_span_ptr(message));
 }
- */
+*/
 
 /**
  * @brief Returns blob content in buffer
@@ -104,10 +104,12 @@ az_storage_blobs_blob_delete(az_storage_blobs_blob_client* client, az_http_respo
 
 int main()
 {
-  /* Uncomment this to enable logging all http responses
+  // Uncomment below code to enable logging
+  /*
   az_log_classification const classifications[] = { AZ_LOG_HTTP_RESPONSE, AZ_LOG_END_OF_LIST };
   az_log_set_classifications(classifications);
-  az_log_set_callback(test_log_func); */
+  az_log_set_callback(test_log_func);
+  */
 
   // Init client.
   //  Example expects the URI_ENV to be a URL w/ SAS token

--- a/sdk/storage/blobs/samples/src/blobs_client_example.c
+++ b/sdk/storage/blobs/samples/src/blobs_client_example.c
@@ -18,6 +18,15 @@
 #define URI_ENV "test_uri"
 
 int exit_code = 0;
+static az_span content_to_upload = AZ_SPAN_LITERAL_FROM_STR("Some test Content");
+
+/*
+* uncomment this to enable logging
+{
+  (void)classification;
+  printf("%.*s\n", az_span_length(message), az_span_ptr(message));
+}
+ */
 
 /**
  * @brief Returns blob content in buffer
@@ -52,7 +61,15 @@ az_storage_blobs_blob_download(az_storage_blobs_blob_client* client, az_http_res
       AZ_SPAN_NULL));
 
   // start pipeline
-  return az_http_pipeline_process(&client->_internal.pipeline, &hrb, response);
+  AZ_RETURN_IF_FAILED(az_http_pipeline_process(&client->_internal.pipeline, &hrb, response));
+
+  az_span body = { 0 };
+  AZ_RETURN_IF_FAILED(az_http_response_get_body(response, &body));
+
+  // do anything with the body, like print it out maybe
+  printf("%.*s\n", az_span_length(body), az_span_ptr(body));
+
+  return AZ_OK;
 }
 
 static AZ_NODISCARD az_result
@@ -86,6 +103,11 @@ az_storage_blobs_blob_delete(az_storage_blobs_blob_client* client, az_http_respo
 
 int main()
 {
+  /* Uncomment this to enable logging all http responses
+  az_log_classification const classifications[] = { AZ_LOG_HTTP_RESPONSE, AZ_LOG_END_OF_LIST };
+  az_log_set_classifications(classifications);
+  az_log_set_callback(test_log_func); */
+
   // Init client.
   //  Example expects the URI_ENV to be a URL w/ SAS token
   az_storage_blobs_blob_client client = { 0 };
@@ -101,7 +123,7 @@ int main()
   /******* Create a buffer for response (will be reused for all requests)   *****/
   uint8_t response_buffer[1024 * 4] = { 0 };
   az_http_response http_response = { 0 };
-  az_result const init_http_response_result
+  az_result init_http_response_result
       = az_http_response_init(&http_response, AZ_SPAN_FROM_BUFFER(response_buffer));
 
   if (az_failed(init_http_response_result))
@@ -109,12 +131,9 @@ int main()
     printf("Failed to init http response");
   }
 
+  printf("Uploading blob...\n");
   az_result const create_result = az_storage_blobs_blob_upload(
-      &client,
-      &az_context_app,
-      AZ_SPAN_FROM_STR("Some Test Content for the new blob"),
-      NULL,
-      &http_response);
+      &client, &az_context_app, content_to_upload, NULL, &http_response);
 
   // validate sample running with no_op http client
   if (create_result == AZ_ERROR_NOT_IMPLEMENTED)
@@ -130,6 +149,11 @@ int main()
     printf("Failed to create blob");
   }
 
+  // clear response to be reused
+  init_http_response_result
+      = az_http_response_init(&http_response, AZ_SPAN_FROM_BUFFER(response_buffer));
+
+  printf("Downloading blob and printing it below:\n\n");
   az_result const get_result = az_storage_blobs_blob_download(&client, &http_response);
 
   if (az_failed(get_result))
@@ -137,6 +161,11 @@ int main()
     printf("Failed to get blob");
   }
 
+  // clear response to be reused
+  init_http_response_result
+      = az_http_response_init(&http_response, AZ_SPAN_FROM_BUFFER(response_buffer));
+
+  printf("\nDeleting blob\n");
   az_result const delete_result = az_storage_blobs_blob_delete(&client, &http_response);
 
   if (az_failed(delete_result))
@@ -144,5 +173,6 @@ int main()
     printf("Failed to delete blob");
   }
 
+  printf("Sample finished\n");
   return exit_code;
 }

--- a/sdk/storage/blobs/samples/src/blobs_client_example.c
+++ b/sdk/storage/blobs/samples/src/blobs_client_example.c
@@ -22,6 +22,7 @@ static az_span content_to_upload = AZ_SPAN_LITERAL_FROM_STR("Some test Content")
 
 /*
 * uncomment this to enable logging
+static void test_log_func(az_log_classification classification, az_span message)
 {
   (void)classification;
   printf("%.*s\n", az_span_length(message), az_span_ptr(message));

--- a/sdk/storage/blobs/samples/src/blobs_client_example.c
+++ b/sdk/storage/blobs/samples/src/blobs_client_example.c
@@ -123,7 +123,7 @@ int main()
   /******* Create a buffer for response (will be reused for all requests)   *****/
   uint8_t response_buffer[1024 * 4] = { 0 };
   az_http_response http_response = { 0 };
-  az_result init_http_response_result
+  az_result const init_http_response_result
       = az_http_response_init(&http_response, AZ_SPAN_FROM_BUFFER(response_buffer));
 
   if (az_failed(init_http_response_result))
@@ -149,10 +149,6 @@ int main()
     printf("Failed to create blob");
   }
 
-  // clear response to be reused
-  init_http_response_result
-      = az_http_response_init(&http_response, AZ_SPAN_FROM_BUFFER(response_buffer));
-
   printf("Downloading blob and printing it below:\n\n");
   az_result const get_result = az_storage_blobs_blob_download(&client, &http_response);
 
@@ -160,10 +156,6 @@ int main()
   {
     printf("Failed to get blob");
   }
-
-  // clear response to be reused
-  init_http_response_result
-      = az_http_response_init(&http_response, AZ_SPAN_FROM_BUFFER(response_buffer));
 
   printf("\nDeleting blob\n");
   az_result const delete_result = az_storage_blobs_blob_delete(&client, &http_response);


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-c/issues/580

Fixing storage sample not resetting response before re-using it by having the transport policy always making sure response size is initially zero before sending request