### PR TITLE
Change span to be 2-fields (ptr, size), update API surface, and coding pattern across the repo.

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,16 +1,22 @@
 ﻿{
-    "configurations": [
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": [
         {
-            "name": "x64-Debug",
-            "generator": "Ninja",
-            "configurationType": "Debug",
-            "inheritEnvironments": [ "msvc_x64_x64" ],
-            "buildRoot": "${projectDir}\\out\\build\\${name}",
-            "installRoot": "${projectDir}\\out\\install\\${name}",
-            "cmakeCommandArgs": "",
-            "buildCommandArgs": "-v",
-            "ctestCommandArgs": "",
-            "variables": []
+          "name": "UNIT_TESTING",
+          "value": "True",
+          "type": "BOOL"
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/sdk/core/core/README.md
+++ b/sdk/core/core/README.md
@@ -35,32 +35,11 @@ Create an empty (or NULL) `az_span`:
 az_span span_null = AZ_SPAN_NULL; // size = 0
 ```
 
-Create an `az_span` literal from an uninitialized byte buffer:
-
-```C
-uint8_t buffer[1024];
-az_span span_over_buffer = AZ_SPAN_LITERAL_FROM_BUFFER(buffer); // size = 1024
-```
-
-Create an `az_span` literal from an initialized bytes buffer:
-
-```C
-uint8_t buffer[] = { 1, 2, 3, 4, 5 };
-az_span span_over_buffer = AZ_SPAN_LITERAL_FROM_INITIALIZED_BUFFER(buffer); // size = 5
-```
-
-Create an `az_span` expression from an uninitialized byte buffer:
+Create an `az_span` expression from a byte buffer:
 
 ```C
 uint8_t buffer[1024];
 some_function(AZ_SPAN_FROM_BUFFER(buffer));  // size = 1024
-```
-
-Create an `az_span` expression from an initialized bytes buffer:
-
-```C
-uint8_t buffer[] = { 1, 2, 3, 4, 5 };
-some_function(AZ_SPAN_FROM_INITIALIZED_BUFFER(buffer));  // size = 5
 ```
 
 Create an `az_span` literal from a string (the span does NOT include the 0-terminating byte):

--- a/sdk/core/core/README.md
+++ b/sdk/core/core/README.md
@@ -57,7 +57,7 @@ some_function(AZ_SPAN_FROM_STR("Hello"));  // size = 5
 As shown above, an `az_span` over a string does not include the 0-terminator. If you need to 0-terminate the string, you can call this function to append a 0 byte (if the span's size is large enough to hold the extra byte):
 
 ```C
-az_span az_span_copy_uint8(az_span destination, uint8_t byte);
+az_span az_span_copy_u8(az_span destination, uint8_t byte);
 ```
 
 and then call this function to get the address of the 0-terminated string:
@@ -69,7 +69,7 @@ char* str = (char*) az_span_ptr(span); // str points to a 0-terminated string
 Or, you can call this function to copy the string in the `az_span` to your own `char*` buffer; this function will 0-termiante the string in the `char*` buffer:
 
 ```C
-az_result az_span_to_str(char* destination, int32_t destination_max_size, az_span source);
+void az_span_to_str(char* destination, int32_t destination_max_size, az_span source);
 ```
 
 There are many functions to manipulate `az_span` instances. You can slice (subset an `az_span`), parse an `az_span` containing a string into an number, format a number as a string into an `az_span`, check if two `az_span` instances are equal or the contents of two `az_span` instances are equal, and more.

--- a/sdk/core/core/inc/az_http.h
+++ b/sdk/core/core/inc/az_http.h
@@ -142,6 +142,7 @@ typedef struct
   struct
   {
     az_span http_response;
+    int32_t written;
     struct
     {
       az_span remaining; // the remaining un-parsed portion of the original http_response.
@@ -164,6 +165,7 @@ AZ_NODISCARD AZ_INLINE az_result az_http_response_init(az_http_response* respons
   *response = (az_http_response){
     ._internal = {
       .http_response = buffer,
+      .written = 0,
       .parser = {
         .remaining = AZ_SPAN_NULL,
         .next_kind = _az_HTTP_RESPONSE_KIND_STATUS_LINE,

--- a/sdk/core/core/inc/az_http_transport.h
+++ b/sdk/core/core/inc/az_http_transport.h
@@ -61,8 +61,10 @@ typedef struct
     az_context* context;
     az_http_method method;
     az_span url;
+    int32_t url_length;
     int32_t query_start;
     _az_http_request_headers headers; // Contains az_pairs
+    int32_t headers_length;
     int32_t max_headers;
     int32_t retry_headers_start_byte_offset;
     az_span body;

--- a/sdk/core/core/inc/az_json.h
+++ b/sdk/core/core/inc/az_json.h
@@ -285,7 +285,7 @@ typedef struct
 
 /*
  * @brief az_json_parser_init initializes an az_json_parser to parse the JSON payload contained
- * within the passed in buffer. JSON buffer.
+ * within the passed in buffer.
  *
  * @param json_parser A pointer to an az_json_parser instance to initialize.
  * @param json_buffer A pointer to a buffer containing the JSON document to parse.

--- a/sdk/core/core/inc/az_json.h
+++ b/sdk/core/core/inc/az_json.h
@@ -190,6 +190,7 @@ typedef struct
   struct
   {
     az_span json;
+    int32_t length;
     bool need_comma;
   } _internal;
 } az_json_builder;
@@ -204,7 +205,8 @@ typedef struct
 AZ_NODISCARD AZ_INLINE az_result
 az_json_builder_init(az_json_builder* json_builder, az_span json_buffer)
 {
-  *json_builder = (az_json_builder){ ._internal = { .json = json_buffer, .need_comma = false } };
+  *json_builder
+      = (az_json_builder){ ._internal = { .json = json_buffer, .length = 0, .need_comma = false } };
   return AZ_OK;
 }
 
@@ -216,7 +218,7 @@ az_json_builder_init(az_json_builder* json_builder, az_span json_buffer)
  */
 AZ_NODISCARD AZ_INLINE az_span az_json_builder_span_get(az_json_builder const* json_builder)
 {
-  return json_builder->_internal.json;
+  return az_span_slice(json_builder->_internal.json, 0, json_builder->_internal.length);
 }
 
 /*
@@ -282,8 +284,8 @@ typedef struct
 } az_json_token_member;
 
 /*
- * @brief az_json_parser_init initializes an az_json_parser to parse the JSON payload contained within the passed in buffer.
- * JSON buffer.
+ * @brief az_json_parser_init initializes an az_json_parser to parse the JSON payload contained
+ * within the passed in buffer. JSON buffer.
  *
  * @param json_parser A pointer to an az_json_parser instance to initialize.
  * @param json_buffer A pointer to a buffer containing the JSON document to parse.

--- a/sdk/core/core/inc/az_result.h
+++ b/sdk/core/core/inc/az_result.h
@@ -51,12 +51,12 @@ enum
     } \
   } while (0)
 
-#define AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(span, required_space) \
+#define AZ_RETURN_IF_NOT_ENOUGH_SIZE(span, required_space) \
   do \
   { \
-    if ((az_span_capacity(span) - az_span_length(span)) < required_space) \
+    if (az_span_size(span) < required_space) \
     { \
-      return AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY; \
+      return AZ_ERROR_INSUFFICIENT_SPAN_SIZE; \
     } \
   } while (0)
 
@@ -85,9 +85,9 @@ typedef enum
       _az_FACILITY_CORE,
       1), ///< Input argument does not comply with the requested range of values.
 
-  AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY = _az_RESULT_MAKE_ERROR(
+  AZ_ERROR_INSUFFICIENT_SPAN_SIZE = _az_RESULT_MAKE_ERROR(
       _az_FACILITY_CORE,
-      2), ///< There is not enough capacity in the span provided.
+      2), ///< The size of the provided span is too small.
 
   AZ_ERROR_NOT_IMPLEMENTED
   = _az_RESULT_MAKE_ERROR(_az_FACILITY_CORE, 3), ///< Requested functionality is not implemented.
@@ -128,7 +128,7 @@ typedef enum
   AZ_ERROR_HTTP_RESPONSE_OVERFLOW = _az_RESULT_MAKE_ERROR(_az_FACILITY_HTTP, 5),
   AZ_ERROR_HTTP_RESPONSE_COULDNT_RESOLVE_HOST = _az_RESULT_MAKE_ERROR(_az_FACILITY_HTTP, 6),
 
-  //IoT error codes
+  // IoT error codes
   AZ_ERROR_IOT_TOPIC_NO_MATCH = _az_RESULT_MAKE_ERROR(_az_FACILITY_IOT, 1),
 } az_result;
 

--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -214,15 +214,15 @@ AZ_NODISCARD bool az_span_is_content_equal_ignoring_case(az_span span1, az_span 
  * @brief Copies a \p source #az_span containing a string (that is not 0-terminated) to a \p
  destination char buffer and appends the 0-terminating byte.
  *
- * The buffer referred to by \p destination must have a size that is at least 1 byte bigger
- * than the \p source #az_span for the \p destination string to be zero-terminated.
- * Content is copied from the \p source buffer and then \0 is added at the end.
- *
  * @param[in] destination A pointer to a buffer where the string should be copied into.
  * @param[in] destination_max_size The maximum available space within the buffer referred to by
  * \p destination.
  * @param[in] source The #az_span containing the not-0-terminated string to copy into \p
  destination.
+ *
+ * @remarks The buffer referred to by \p destination must have a size that is at least 1 byte bigger
+ * than the \p source #az_span for the \p destination string to be zero-terminated.
+ * Content is copied from the \p source buffer and then \0 is added at the end.
  */
 void az_span_to_str(char* destination, int32_t destination_max_size, az_span source);
 

--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -4,7 +4,7 @@
 /**
  * @file az_span.h
  *
- * @brief An az_span represents a contiguous byte buffer and is used for string manipulations,
+ * @brief An #az_span represents a contiguous byte buffer and is used for string manipulations,
  * HTTP requests/responses, building/parsing JSON payloads, and more.
  *
  * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
@@ -26,28 +26,28 @@
 #include <_az_cfg_prefix.h>
 
 /**
- * az_span is a "view" over a byte buffer. It contains a pointer to the
- * start of the byte buffer and the buffer's available size.
+ * A span is a "view" over a byte buffer that represents a contiguous region of memory. It contains
+ * a pointer to the start of the byte buffer and the buffer's size.
  */
 typedef struct
 {
   struct
   {
     uint8_t* ptr;
-    int32_t size; ///< size must be >= 0
+    int32_t size; ///< size must be &ge; 0
   } _internal;
 } az_span;
 
 /********************************  SPAN GETTERS */
 
 /**
- * @brief az_span_ptr returns the span byte buffer's starting memory address
+ * @brief Returns the #az_span byte buffer's starting memory address.
  *
  */
 AZ_NODISCARD AZ_INLINE uint8_t* az_span_ptr(az_span span) { return span._internal.ptr; }
 
 /**
- * @brief az_span_size Returns the number of bytes within the span.
+ * @brief Returns the number of bytes within the #az_span.
  *
  */
 AZ_NODISCARD AZ_INLINE int32_t az_span_size(az_span span) { return span._internal.size; }
@@ -55,7 +55,7 @@ AZ_NODISCARD AZ_INLINE int32_t az_span_size(az_span span) { return span._interna
 /********************************  CONSTRUCTORS */
 
 /**
- * @brief The AZ_SPAN_NULL macro returns an empty az_span.
+ * @brief Returns an empty #az_span.
  *
  */
 #define AZ_SPAN_NULL \
@@ -64,18 +64,20 @@ AZ_NODISCARD AZ_INLINE int32_t az_span_size(az_span span) { return span._interna
     ._internal = {.ptr = NULL, .size = 0 } \
   }
 
-// Returns the size (in bytes) of a literal string
+// Returns the size (in bytes) of a literal string.
 // Note: Concatenating "" to S produces a compiler error if S is not a literal string
 //       The stored string's length does not include the \0 terminator.
 #define _az_STRING_LITERAL_LEN(S) (sizeof(S "") - 1)
 
 /**
- * @brief The AZ_SPAN_LITERAL_FROM_STR macro returns a literal az_span over a literal string.
- * An empty ("") literal string results in a span with size set to 0.
- * The size of the span is equal to the length of the string.
+ * @brief Returns a literal #az_span over a literal string.
+ * The size of the #az_span is equal to the length of the string.
+ *
  * For example:
  *
  * `static const az_span hw = AZ_SPAN_LITERAL_FROM_STR("Hello world");`
+ *
+ * @remarks An empty ("") literal string results in an #az_span with size set to 0.
  */
 #define AZ_SPAN_LITERAL_FROM_STR(STRING_LITERAL) \
   { \
@@ -86,24 +88,33 @@ AZ_NODISCARD AZ_INLINE int32_t az_span_size(az_span span) { return span._interna
   }
 
 /**
- * @brief The AZ_SPAN_FROM_STR macro returns an az_span expression over a literal string. For
- * example: `some_function(AZ_SPAN_FROM_STR("Hello world"));` where `void some_function(const
- * az_span span);`
+ * @brief Returns an #az_span expression over a literal string.
+ *
+ * For example:
+ *
+ * `some_function(AZ_SPAN_FROM_STR("Hello world"));`
+ *
+ * where
+ *
+ * `void some_function(const az_span span);`
+ *
  */
 #define AZ_SPAN_FROM_STR(STRING_LITERAL) (az_span) AZ_SPAN_LITERAL_FROM_STR(STRING_LITERAL)
 
-// Returns 1 if the address of the array is equal to the address of its 1st element
-// https://stackoverflow.com/questions/16794900/validate-an-argument-is-array-type-in-c-c-pre-processing-macro-on-compile-time
+// Returns 1 if the address of the array is equal to the address of its 1st element.
 #define _az_IS_ARRAY(array) ((sizeof(array[0]) == 1) && (((void*)&(array)) == ((void*)(&array[0]))))
 
 /**
- * @brief AZ_SPAN_FROM_BUFFER returns an az_span expression over an uninitialized byte buffer. For
- * example:
+ * @brief Returns an #az_span expression over an uninitialized byte buffer.
  *
- * uint8_t buffer[1024];
- * some_function(AZ_SPAN_FROM_BUFFER(buffer));  // Size = 1024
+ * For example:
  *
- * BYTE_BUFFER MUST be an array defined like 'uint8_t buffer[10]'; and not 'uint8_t* buffer'
+ * `uint8_t buffer[1024];`
+ *
+ * `some_function(AZ_SPAN_FROM_BUFFER(buffer));  // Size = 1024`
+ *
+ * @remarks BYTE_BUFFER MUST be an array defined like `uint8_t buffer[10];` and not `uint8_t*
+ * buffer`
  */
 #define AZ_SPAN_FROM_BUFFER(BYTE_BUFFER) \
   (az_span) \
@@ -115,11 +126,11 @@ AZ_NODISCARD AZ_INLINE int32_t az_span_size(az_span span) { return span._interna
   }
 
 /**
- * @brief az_span_init returns a span over a byte buffer.
+ * @brief Returns an #az_span over a byte buffer.
  *
- * @param[in] ptr The memory address of the 1st byte in the byte buffer
- * @param[in] size The number of total bytes in the byte buffer
- * @return az_span The "view" over the byte buffer.
+ * @param[in] ptr The memory address of the 1st byte in the byte buffer.
+ * @param[in] size The number of total bytes in the byte buffer.
+ * @return The "view" over the byte buffer.
  */
 #ifdef NO_PRECONDITION_CHECKING
 // Note: If you are modifying this method, make sure to modify the non-inline version in the
@@ -133,35 +144,36 @@ AZ_NODISCARD az_span az_span_init(uint8_t* ptr, int32_t size);
 #endif // NO_PRECONDITION_CHECKING
 
 /**
- * @brief az_span_from_str returns an az_span from a 0-terminated array of bytes (chars)
+ * @brief Returns an #az_span from a 0-terminated array of bytes (chars).
  *
- * @param[in] str The pointer to the 0-terminated array of bytes (chars)
- * @return az_span An az_span over the byte buffer; size is set to the string's length not including
- * the \0 terminator.
+ * @param[in] str The pointer to the 0-terminated array of bytes (chars).
+ * @return An #az_span over the byte buffer where the size is set to the string's length not
+ * including the \0 terminator.
  */
 AZ_NODISCARD az_span az_span_from_str(char* str);
 
 /******************************  SPAN MANIPULATION */
 
 /**
- * @brief az_span_slice returns a new az_span which is a sub-span of the specified span.
+ * @brief Returns a new #az_span which is a sub-span of the specified \p span.
  *
- * @param[in] span The original az_span.
- * @param[in] start_index An index into the original az_span indicating where the returned az_span
+ * @param[in] span The original #az_span.
+ * @param[in] start_index An index into the original #az_span indicating where the returned #az_span
  * will start.
- * @param[in] end_index An index into the original az_span indicating where the returned az_span
- * should stop. The byte at the high_index is NOT included in the returned az_span.
- * @return An az_span into a portion (from \p start_index to \p end_index - 1) of the original
- * az_span.
+ * @param[in] end_index An index into the original #az_span indicating where the returned #az_span
+ * should stop. The byte at the end_index is NOT included in the returned #az_span.
+ * @return An #az_span into a portion (from \p start_index to \p end_index - 1) of the original
+ * #az_span.
  */
 AZ_NODISCARD az_span az_span_slice(az_span span, int32_t start_index, int32_t end_index);
 
 /**
- * @brief az_span_is_content_equal returns `true` if the sizes and bytes referred by \p span1 and
- * \p span2 are identical.
+ * @brief Determines whether two spans are equal by comparing their bytes.
  *
- * @return Returns true if the sizes of both spans are identical and the bytes in both spans are
- * also identical.
+ * @param[in] span1 The first #az_span to compare.
+ * @param[in] span2 The second #az_span to compare.
+ * @return `true` if the sizes of both spans are identical and the bytes in both spans are
+ * also identical. Otherwise, `false`.
  */
 AZ_NODISCARD AZ_INLINE bool az_span_is_content_equal(az_span span1, az_span span2)
 {
@@ -170,96 +182,99 @@ AZ_NODISCARD AZ_INLINE bool az_span_is_content_equal(az_span span1, az_span span
 }
 
 /**
- * @brief az_span_is_content_equal_ignoring_case returns `true` if the sizes and characters
- * referred to by \p span1 and \p span2 are identical except for case. This function assumes the
- * bytes in both spans are ASCII characters.
+ * @brief Determines whether two spans are equal by comparing their characters, except for casing.
  *
- * @return Returns true if the sizes of both spans are identical and the ASCII characters in both
- * spans are also identical except for case.
+ * @param[in] span1 The first #az_span to compare.
+ * @param[in] span2 The second #az_span to compare.
+ * @return `true` if the sizes of both spans are identical and the ASCII characters in both
+ * spans are also identical, except for casing.
+ * @remarks This function assumes the bytes in both spans are ASCII characters.
  */
 AZ_NODISCARD bool az_span_is_content_equal_ignoring_case(az_span span1, az_span span2);
 
 /**
- * @brief az_span_to_str copies a source span containing a string (not 0-terminated) to a
+ * @brief Copies a \p source #az_span containing a string (that is not 0-terminated) to a \p
  destination char buffer and appends the 0-terminating byte.
  *
- * The buffer referred to by destination must have a size that is at least 1 byte bigger
- * than the \p source az_span. The string \p destination is converted to a zero-terminated str.
- * Content is copied to \p source buffer and then \0 is added at the end.
+ * The buffer referred to by \p destination must have a size that is at least 1 byte bigger
+ * than the \p source #az_span. The \p destination string is zero-terminated.
+ * Content is copied from the \p source buffer and then \0 is added at the end.
  *
- * @param[in] destination A pointer to a buffer where the string should be copied
+ * @param[in] destination A pointer to a buffer where the string should be copied into.
  * @param[in] destination_max_size The maximum available space within the buffer referred to by
- * destination.
- * @param[in] source The az_span containing the not-0-terminated string
- * @return An #az_result value indicating the result of the operation.
- *          #AZ_OK If \p source span content is successfully copied to the destination.
- *          #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination buffer is too small to
- copy the string and 0-terminate it
+ * \p destination.
+ * @param[in] source The #az_span containing the not-0-terminated string.
+ * @return An #az_result value indicating the result of the operation:
+ *         - #AZ_OK if the \p source content is successfully copied to the \p destination
+ *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination buffer is too small to copy the
+ * string and 0-terminate it
  */
 AZ_NODISCARD az_result
 az_span_to_str(char* destination, int32_t destination_max_size, az_span source);
 
 /**
- * @brief az_span_find searches for `target` in `source`, returning an #az_span within `source` if
- * it finds it.
+ * @brief Searches for \p target in \p source, returning an #az_span within \p source if it finds
+ * it.
  *
  * @param[in] source The #az_span with the content to be searched on.
- * @param[in] target The #az_span containing the token to be searched in `source`.
- * @return The position of `target` in `source` if `source` contains `target`,
- *         0 if `target` is empty (if its size is equal zero),
- *         -1 if `source` is empty (if its size is equal zero) and `target` is non-empty,
- *         -1 if `target` is not found in `source`.
+ * @param[in] target The #az_span containing the tokens to be searched within \p source.
+ * @return The position of \p target in \p source if \p source contains the \p target within it:
+ *         - 0 if \p target is empty (if its size is equal zero)
+ *         - -1 if \p source is empty (if its size is equal zero) and \p target is non-empty
+ *         - -1 if \p target is not found in `source`
  */
 AZ_NODISCARD int32_t az_span_find(az_span source, az_span target);
 
 /******************************  SPAN COPYING */
 
 /**
- * @brief az_span_copy copies the content of the source span to the destination span.
+ * @brief Copies the content of the \p source #az_span to the \p destination #az_span.
  *
- * @param[in] destination The span whose bytes will be replaced by the source's bytes.
- * @param[in] source The span containing the bytes to copy to the destination.
- * @return An #az_span that is a slice of the \p destination span (i.e. the remainder) after the
- * source bytes has been copied.
+ * @param[in] destination The #az_span whose bytes will be replaced by the source's bytes.
+ * @param[in] source The #az_span containing the bytes to copy to the destination.
+ * @return An #az_span that is a slice of the \p destination #az_span (i.e. the remainder) after the
+ * source bytes have been copied.
  *
  * @remarks The method assumes that the \p destination has a large enough size to hold the \p
  * source.
- * @remarks This method copies all of source to destination even if source and destination overlap.
+ * @remarks This method copies all of \p source into the \p destination even if they overlap.
  */
 az_span az_span_copy(az_span destination, az_span source);
 
 /**
- * @brief az_span_copy_uint8 copies the uint8 \p byte to the \p destination at its 0-th index.
+ * @brief Copies the uint8 \p byte to the \p destination at its 0-th index.
  *
- * @param[in] destination The az_span where the byte should be copied to.
+ * @param[in] destination The #az_span where the byte should be copied to.
  * @param[in] byte The uint8 to copy into the destination span.
- * @return An #az_span that is a slice of the \p destination span (i.e. the remainder) after the
- * byte has been copied. The method assumes that the \p destination has a large enough size to
- * hold one more byte.
+ * @return An #az_span that is a slice of the \p destination #az_span (i.e. the remainder) after the
+ * byte has been copied.
+ *
+ * @remarks The method assumes that the \p destination has a large enough size to  hold one more
+ * byte.
  */
 az_span az_span_copy_uint8(az_span destination, uint8_t byte);
 
 /**
- * @brief az_span_copy_url_encode Copies a URL in the source span to the destination span by
- * url-encoding the source span characters.
+ * @brief Copies a URL in the \p source #az_span to the \p destination #az_span by url-encoding the
+ * \p source span characters.
  *
- * @param[in] destination The span whose bytes will receive the url-encoded source
- * @param[in] source The span containing the non-url-encoded bytes
- * @param[out] out_span A pointer to an az_span that receives the remainder of the destination span
- * after the url-encoded source has been copied.
- * @return An #az_result value indicating the result of the operation.
- *          #AZ_OK if successful
- *          #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination is not big enough to contain
+ * @param[in] destination The #az_span whose bytes will receive the url-encoded source.
+ * @param[in] source The #az_span containing the non-url-encoded bytes.
+ * @param[out] out_span A pointer to an #az_span that receives the remainder of the \p destination
+ * #az_span after the url-encoded \p source has been copied.
+ * @return An #az_result value indicating the result of the operation:
+ *         - #AZ_OK if successful
+ *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination is not big enough to contain
  * the encoded bytes
  */
 AZ_NODISCARD az_result
 az_span_copy_url_encode(az_span destination, az_span source, az_span* out_span);
 
 /**
- * @brief az_span_fill Fills all the bytes of the destination span with the specified value.
+ * @brief Fills all the bytes of the \p destination #az_span with the specified value.
  *
- * @param[in] destination The span whose bytes will be set to \p value.
- * @param[in] value The byte to be replicated within the destination span.
+ * @param[in] destination The #az_span whose bytes will be set to \p value.
+ * @param[in] value The byte to be replicated within the destination #az_span.
  */
 AZ_INLINE void az_span_fill(az_span destination, uint8_t value)
 {
@@ -269,99 +284,104 @@ AZ_INLINE void az_span_fill(az_span destination, uint8_t value)
 /******************************  SPAN PARSING AND FORMATTING */
 
 /**
- * @brief az_span_atou64 Parses an az_span containing ASCII digits into a uint64 number.
+ * @brief Parses an #az_span containing ASCII digits into a uint64 number.
  *
- * @param[in] span The az_span containing the ASCII digits to be parsed.
- * @param[in] out_number The pointer to the variable that is to receive the number
- * @return An #az_result value indicating the result of the operation.
- *          #AZ_OK if successful
- *          #AZ_ERROR_PARSER_UNEXPECTED_CHAR if a non-ASCII digit is found within the span.
+ * @param[in] span The #az_span containing the ASCII digits to be parsed.
+ * @param[in] out_number The pointer to the variable that is to receive the number.
+ * @return An #az_result value indicating the result of the operation:
+ *         - #AZ_OK if successful
+ *         - #AZ_ERROR_PARSER_UNEXPECTED_CHAR if a non-ASCII digit is found within the span
  */
 
 AZ_NODISCARD az_result az_span_atou64(az_span span, uint64_t* out_number);
 
 /**
- * @brief az_span_atou Parses an az_span containing ASCII digits into a uint32 number.
+ * @brief Parses an #az_span containing ASCII digits into a uint32 number.
  *
- * @param span The az_span containing the ASCII digits to be parsed.
- * @param out_number The pointer to the variable that is to receive the number
- * @return An #az_result value indicating the result of the operation.
- *          #AZ_OK if successful
- *          #AZ_ERROR_PARSER_UNEXPECTED_CHAR if a non-ASCII digit is found within the span.
+ * @param span The #az_span containing the ASCII digits to be parsed.
+ * @param out_number The pointer to the variable that is to receive the number.
+ * @return An #az_result value indicating the result of the operation:
+ *         - #AZ_OK if successful
+ *         - #AZ_ERROR_PARSER_UNEXPECTED_CHAR if a non-ASCII digit is found within the span.
  */
 AZ_NODISCARD az_result az_span_atou(az_span span, uint32_t* out_number);
 
 /**
- * @brief az_span_itoa Converts an int32 into its digit characters and copies them to the
- * destination span starting at its 0-th index.
+ * @brief Converts an int32 into its digit characters and copies them to the \p destination #az_span
+ * starting at its 0-th index.
  *
- * @param[in] destination The az_span where the bytes should be copied to.
- * @param[in] source The int32 whose number is copied to the destination span as ASCII digits.
- * @param[out] out_span A pointer to an az_span that receives the remainder of the destination span
- * after the int32 has been copied.
- * @return An #az_result value indicating the result of the operation.
- *          #AZ_OK if successful
- *          #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination is not big enough to contain
- * the copied bytes
+ * @param[in] destination The #az_span where the bytes should be copied to.
+ * @param[in] source The int32 whose number is copied to the \p destination #az_span as ASCII
+ * digits.
+ * @param[out] out_span A pointer to an #az_span that receives the remainder of the \p destination
+ * #az_span after the int32 has been copied.
+ * @return An #az_result value indicating the result of the operation:
+ *         - #AZ_OK if successful
+ *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination is not big enough to contain the
+ * copied bytes
  */
 AZ_NODISCARD az_result az_span_itoa(az_span destination, int32_t source, az_span* out_span);
 
 /**
- * @brief az_span_utoa Converts a uint32 into its digit characters and copies them to the
- * destination span starting at its 0-th index.
+ * @brief Converts a uint32 into its digit characters and copies them to the \p destination #az_span
+ * starting at its 0-th index.
  *
- * @param[in] destination The az_span where the bytes should be copied to.
- * @param[in] source The uint32 whose number is copied to the destination span as ASCII digits.
- * @param[out] out_span A pointer to an az_span that receives the remainder of the destination span
- * after the uint32 has been copied.
+ * @param[in] destination The #az_span where the bytes should be copied to.
+ * @param[in] source The uint32 whose number is copied to the \p destination #az_span as ASCII
+ * digits.
+ * @param[out] out_span A pointer to an #az_span that receives the remainder of the \p destination
+ * #az_span after the uint32 has been copied.
  * @return An #az_result value indicating the result of the operation:
- *          #AZ_OK if successful
- *          #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the destination is not big enough to contain the
+ *         - #AZ_OK if successful
+ *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination is not big enough to contain the
  * copied bytes
  */
 AZ_NODISCARD az_result az_span_utoa(az_span destination, uint32_t source, az_span* out_span);
 
 /**
- * @brief az_span_i64toa Converts an int64 into its digit characters and copies them to the
- * destination span starting at its 0-th index.
+ * @brief Converts an int64 into its digit characters and copies them to the \p destination #az_span
+ * starting at its 0-th index.
  *
- * @param[in] destination The az_span where the bytes should be copied to.
- * @param[in] source The int64 whose number is copied to the destination span as ASCII digits.
- * @param[out] out_span A pointer to an az_span that receives the remainder of the destination span
- * after the int64 has been copied.
+ * @param[in] destination The #az_span where the bytes should be copied to.
+ * @param[in] source The int64 whose number is copied to the \p destination #az_span as ASCII
+ * digits.
+ * @param[out] out_span A pointer to an #az_span that receives the remainder of the \p destination
+ * #az_span after the int64 has been copied.
  * @return An #az_result value indicating the result of the operation:
- *          #AZ_OK if successful
- *          #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the destination is not big enough to contain the
+ *         - #AZ_OK if successful
+ *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination is not big enough to contain the
  * copied bytes
  */
 AZ_NODISCARD az_result az_span_i64toa(az_span destination, int64_t source, az_span* out_span);
 
 /**
- * @brief az_span_u64toa Converts a uint64 into its digit characters and copies them to the
- * destination span starting at its 0-th index.
+ * @brief Converts a uint64 into its digit characters and copies them to the \p destination #az_span
+ * starting at its 0-th index.
  *
- * @param[in] destination The az_span where the bytes should be copied to.
- * @param[in] source The uint64 whose number is copied to the destination span as ASCII digits.
- * @param[out] out_span A pointer to an az_span that receives the remainder of the destination span
- * after the uint64 has been copied.
+ * @param[in] destination The #az_span where the bytes should be copied to.
+ * @param[in] source The uint64 whose number is copied to the \p destination #az_span as ASCII
+ * digits.
+ * @param[out] out_span A pointer to an #az_span that receives the remainder of the \p destination
+ * #az_span after the uint64 has been copied.
  * @return An #az_result value indicating the result of the operation:
- *          #AZ_OK if successful
- *          #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the destination is not big enough to contain the
+ *         - #AZ_OK if successful
+ *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination is not big enough to contain the
  * copied bytes
  */
 AZ_NODISCARD az_result az_span_u64toa(az_span destination, uint64_t source, az_span* out_span);
 
 /**
- * @brief az_span_dtoa Converts a double into its digit characters and copies them to the
- * destination span starting at its 0-th index.
+ * @brief Converts a double into its digit characters and copies them to the \p destination #az_span
+ * starting at its 0-th index.
  *
- * @param[in] destination The az_span where the bytes should be copied to.
- * @param[in] source The double whose number is copied to the destination span as ASCII digits.
- * @param[out] out_span A pointer to an az_span that receives the remainder of the destination span
- * after the double has been copied.
+ * @param[in] destination The #az_span where the bytes should be copied to.
+ * @param[in] source The double whose number is copied to the \p destination #az_span as ASCII
+ * digits.
+ * @param[out] out_span A pointer to an #az_span that receives the remainder of the \p destination
+ * #az_span after the double has been copied.
  * @return An #az_result value indicating the result of the operation:
- *          #AZ_OK if successful
- *          #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the destination is not big enough to contain the
+ *         - #AZ_OK if successful
+ *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination is not big enough to contain the
  * copied bytes
  */
 AZ_NODISCARD az_result az_span_dtoa(az_span destination, double source, az_span* out_span);
@@ -369,7 +389,7 @@ AZ_NODISCARD az_result az_span_dtoa(az_span destination, double source, az_span*
 /******************************  SPAN PAIR  */
 
 /**
- * An az_pair represents a key/value pair of az_span instances.
+ * An #az_pair represents a key/value pair of #az_span instances.
  * This is typically used for HTTP query parameters and headers.
  */
 typedef struct
@@ -379,20 +399,19 @@ typedef struct
 } az_pair;
 
 /**
- * @brief The AZ_PAIR_NULL macro returns an az_pair instance whose key and value fields are
- * initialized to AZ_SPAN_NULL.
+ * @brief Returns an #az_pair instance whose key and value fields are initialized to #AZ_SPAN_NULL.
  *
  */
 #define AZ_PAIR_NULL \
   (az_pair) { .key = AZ_SPAN_NULL, .value = AZ_SPAN_NULL }
 
 /**
- * @brief az_pair_init returns an az_pair with its key and value fields initialized to the specified
- * key and value parameters.
+ * @brief Returns an #az_pair with its key and value fields initialized to the specified key and
+ * value parameters.
  *
- * @param[in] key A span whose bytes represent the key.
- * @param[in] value A span whose bytes represent the key's value.
- * @return  An az_pair with the field initialized to the parameters' values.
+ * @param[in] key An #az_span whose bytes represent the key.
+ * @param[in] value An #az_span whose bytes represent the key's value.
+ * @return  An #az_pair with the field initialized to the parameters' values.
  */
 AZ_NODISCARD AZ_INLINE az_pair az_pair_init(az_span key, az_span value)
 {
@@ -400,12 +419,12 @@ AZ_NODISCARD AZ_INLINE az_pair az_pair_init(az_span key, az_span value)
 }
 
 /**
- * @brief az_pair_from_str returns an az_pair with its key and value fields initialized to span's
- * over the specified key and value 0-terminated string parameters.
+ * @brief Returns an #az_pair with its key and value fields initialized to spans over the specified
+ * key and value 0-terminated string parameters.
  *
  * @param[in] key A string representing the key.
  * @param[in] value A string representing the key's value.
- * @return  An az_pair with the fields initialized to the az_span instances over the passed-in
+ * @return  An #az_pair with the fields initialized to the #az_span instances over the passed-in
  * strings.
  */
 AZ_NODISCARD AZ_INLINE az_pair az_pair_from_str(char* key, char* value)

--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -121,7 +121,16 @@ AZ_NODISCARD AZ_INLINE int32_t az_span_size(az_span span) { return span._interna
  * @param[in] size The number of total bytes in the byte buffer
  * @return az_span The "view" over the byte buffer.
  */
+#ifdef NO_PRECONDITION_CHECKING
+// Note: If you are modifying this method, make sure to modify the non-inline version in the
+// az_span.c file as well.
+AZ_NODISCARD AZ_INLINE az_span az_span_init(uint8_t* ptr, int32_t size)
+{
+  return (az_span){ ._internal = { .ptr = ptr, .size = size, }, };
+}
+#else
 AZ_NODISCARD az_span az_span_init(uint8_t* ptr, int32_t size);
+#endif // NO_PRECONDITION_CHECKING
 
 /**
  * @brief az_span_from_str returns an az_span from a 0-terminated array of bytes (chars)

--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -215,17 +215,14 @@ AZ_NODISCARD bool az_span_is_content_equal_ignoring_case(az_span span1, az_span 
  destination char buffer and appends the 0-terminating byte.
  *
  * The buffer referred to by \p destination must have a size that is at least 1 byte bigger
- * than the \p source #az_span. The \p destination string is zero-terminated.
+ * than the \p source #az_span for the \p destination string to be zero-terminated.
  * Content is copied from the \p source buffer and then \0 is added at the end.
  *
  * @param[in] destination A pointer to a buffer where the string should be copied into.
  * @param[in] destination_max_size The maximum available space within the buffer referred to by
  * \p destination.
- * @param[in] source The #az_span containing the not-0-terminated string.
- * @return An #az_result value indicating the result of the operation:
- *         - #AZ_OK if the \p source content is successfully copied to the \p destination
- *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination buffer is too small to copy the
- * string and 0-terminate it
+ * @param[in] source The #az_span containing the not-0-terminated string to copy into \p
+ destination.
  */
 void az_span_to_str(char* destination, int32_t destination_max_size, az_span source);
 

--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -209,8 +209,7 @@ AZ_NODISCARD bool az_span_is_content_equal_ignoring_case(az_span span1, az_span 
  *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination buffer is too small to copy the
  * string and 0-terminate it
  */
-AZ_NODISCARD az_result
-az_span_to_str(char* destination, int32_t destination_max_size, az_span source);
+void az_span_to_str(char* destination, int32_t destination_max_size, az_span source);
 
 /**
  * @brief Searches for \p target in \p source, returning an #az_span within \p source if it finds
@@ -252,23 +251,7 @@ az_span az_span_copy(az_span destination, az_span source);
  * @remarks The method assumes that the \p destination has a large enough size to  hold one more
  * byte.
  */
-az_span az_span_copy_uint8(az_span destination, uint8_t byte);
-
-/**
- * @brief Copies a URL in the \p source #az_span to the \p destination #az_span by url-encoding the
- * \p source span characters.
- *
- * @param[in] destination The #az_span whose bytes will receive the url-encoded source.
- * @param[in] source The #az_span containing the non-url-encoded bytes.
- * @param[out] out_span A pointer to an #az_span that receives the remainder of the \p destination
- * #az_span after the url-encoded \p source has been copied.
- * @return An #az_result value indicating the result of the operation:
- *         - #AZ_OK if successful
- *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination is not big enough to contain
- * the encoded bytes
- */
-AZ_NODISCARD az_result
-az_span_copy_url_encode(az_span destination, az_span source, az_span* out_span);
+az_span az_span_copy_u8(az_span destination, uint8_t byte);
 
 /**
  * @brief Fills all the bytes of the \p destination #az_span with the specified value.
@@ -304,7 +287,7 @@ AZ_NODISCARD az_result az_span_atou64(az_span span, uint64_t* out_number);
  *         - #AZ_OK if successful
  *         - #AZ_ERROR_PARSER_UNEXPECTED_CHAR if a non-ASCII digit is found within the span.
  */
-AZ_NODISCARD az_result az_span_atou(az_span span, uint32_t* out_number);
+AZ_NODISCARD az_result az_span_atou32(az_span span, uint32_t* out_number);
 
 /**
  * @brief Converts an int32 into its digit characters and copies them to the \p destination #az_span
@@ -320,7 +303,7 @@ AZ_NODISCARD az_result az_span_atou(az_span span, uint32_t* out_number);
  *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination is not big enough to contain the
  * copied bytes
  */
-AZ_NODISCARD az_result az_span_itoa(az_span destination, int32_t source, az_span* out_span);
+AZ_NODISCARD az_result az_span_i32toa(az_span destination, int32_t source, az_span* out_span);
 
 /**
  * @brief Converts a uint32 into its digit characters and copies them to the \p destination #az_span
@@ -336,7 +319,7 @@ AZ_NODISCARD az_result az_span_itoa(az_span destination, int32_t source, az_span
  *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination is not big enough to contain the
  * copied bytes
  */
-AZ_NODISCARD az_result az_span_utoa(az_span destination, uint32_t source, az_span* out_span);
+AZ_NODISCARD az_result az_span_u32toa(az_span destination, uint32_t source, az_span* out_span);
 
 /**
  * @brief Converts an int64 into its digit characters and copies them to the \p destination #az_span

--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -55,21 +55,14 @@ AZ_NODISCARD AZ_INLINE int32_t az_span_size(az_span span) { return span._interna
 /********************************  CONSTRUCTORS */
 
 /**
- * @brief Creates an empty span literal
- * ptr is NULL
- * size is initialized to 0
+ * @brief The AZ_SPAN_NULL macro returns an empty az_span.
  *
  */
-#define AZ_SPAN_LITERAL_NULL \
+#define AZ_SPAN_NULL \
+  (az_span) \
   { \
     ._internal = {.ptr = NULL, .size = 0 } \
   }
-
-/**
- * @brief The AZ_SPAN_NULL macro returns an empty az_span \see AZ_SPAN_LITERAL_NULL.
- *
- */
-#define AZ_SPAN_NULL (az_span) AZ_SPAN_LITERAL_NULL
 
 // Returns the size (in bytes) of a literal string
 // Note: Concatenating "" to S produces a compiler error if S is not a literal string
@@ -99,6 +92,28 @@ AZ_NODISCARD AZ_INLINE int32_t az_span_size(az_span span) { return span._interna
  */
 #define AZ_SPAN_FROM_STR(STRING_LITERAL) (az_span) AZ_SPAN_LITERAL_FROM_STR(STRING_LITERAL)
 
+// Returns 1 if the address of the array is equal to the address of its 1st element
+// https://stackoverflow.com/questions/16794900/validate-an-argument-is-array-type-in-c-c-pre-processing-macro-on-compile-time
+#define _az_IS_ARRAY(array) ((sizeof(array[0]) == 1) && (((void*)&(array)) == ((void*)(&array[0]))))
+
+/**
+ * @brief AZ_SPAN_FROM_BUFFER returns an az_span expression over an uninitialized byte buffer. For
+ * example:
+ *
+ * uint8_t buffer[1024];
+ * some_function(AZ_SPAN_FROM_BUFFER(buffer));  // Size = 1024
+ *
+ * BYTE_BUFFER MUST be an array defined like 'uint8_t buffer[10]'; and not 'uint8_t* buffer'
+ */
+#define AZ_SPAN_FROM_BUFFER(BYTE_BUFFER) \
+  (az_span) \
+  { \
+    ._internal = { \
+      .ptr = (uint8_t*)BYTE_BUFFER, \
+      .size = (sizeof(BYTE_BUFFER) / _az_IS_ARRAY(BYTE_BUFFER)), \
+    }, \
+  }
+
 /**
  * @brief az_span_init returns a span over a byte buffer.
  *
@@ -116,69 +131,6 @@ AZ_NODISCARD az_span az_span_init(uint8_t* ptr, int32_t size);
  * the \0 terminator.
  */
 AZ_NODISCARD az_span az_span_from_str(char* str);
-
-/**
- * @brief AZ_SPAN_LITERAL_FROM_BUFFER returns a literal az_span over a byte buffer.
- * The size of the resulting az_span is set to the count of items the buffer can store based on
- * the sizeof(BYTE_BUFFER). For example:
- *
- * uint8_t buffer[1024];
- * const az_span buf = AZ_SPAN_LITERAL_FROM_BUFFER(buffer);  // Size = 1024
- */
-#define AZ_SPAN_LITERAL_FROM_BUFFER(BYTE_BUFFER) \
-  { \
-    ._internal = { \
-      .ptr = (uint8_t*)BYTE_BUFFER, \
-      .size = (sizeof(BYTE_BUFFER) / sizeof(BYTE_BUFFER[0])), \
-    }, \
-  }
-
-// Returns 1 if the address of the array is equal to the address of its 1st element
-// https://stackoverflow.com/questions/16794900/validate-an-argument-is-array-type-in-c-c-pre-processing-macro-on-compile-time
-#define AZ_IS_ARRAY(array) ((sizeof(array[0]) == 1) && (((void*)&(array)) == ((void*)(&array[0]))))
-
-/**
- * @brief AZ_SPAN_FROM_BUFFER returns an az_span expression over an uninitialized byte buffer. For
- * example:
- *
- * uint8_t buffer[1024];
- * some_function(AZ_SPAN_FROM_BUFFER(buffer));  // Size = 1024
- *
- * BYTE_BUFFER MUST be an array defined like 'uint8_t buffer[10]'; and not 'uint8_t* buffer'
- */
-#define AZ_SPAN_FROM_BUFFER(BYTE_BUFFER) \
-  (az_span) \
-  { \
-    ._internal = { \
-      .ptr = (uint8_t*)BYTE_BUFFER, \
-      .size = (sizeof(BYTE_BUFFER) / AZ_IS_ARRAY(BYTE_BUFFER)), \
-    }, \
-  }
-
-/**
- * @brief AZ_SPAN_LITERAL_FROM_INITIALIZED_BUFFER returns a literal az_span over an initialized byte
- * buffer. For example:
- *
- * uint8_t buffer[] = { 1, 2, 3 };
- * const az_span buf = AZ_SPAN_LITERAL_FROM_INITIALIZED_BUFFER(buffer); // Size = 3
- */
-#define AZ_SPAN_LITERAL_FROM_INITIALIZED_BUFFER(BYTE_BUFFER) \
-  { \
-    ._internal = { \
-      .ptr = BYTE_BUFFER, \
-      .size = (sizeof(BYTE_BUFFER) / sizeof(BYTE_BUFFER[0])), \
-    }, \
-  }
-
-/**
- * @brief AZ_SPAN_FROM_INITIALIZED_BUFFER returns an az_span expression over an initialized byte
- * buffer. For example
- *
- * uint8_t buffer[] = { 1, 2, 3 };
- * const az_span buf = AZ_SPAN_LITERAL_FROM_INITIALIZED_BUFFER(buffer); // Size = 3
- */
-#define AZ_SPAN_FROM_INITIALIZED_BUFFER(BYTE_BUFFER) \
-  (az_span) AZ_SPAN_LITERAL_FROM_INITIALIZED_BUFFER(BYTE_BUFFER)
 
 /******************************  SPAN MANIPULATION */
 

--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -199,31 +199,6 @@ AZ_NODISCARD bool az_span_is_content_equal_ignoring_case(az_span span1, az_span 
 AZ_NODISCARD az_result
 az_span_to_str(char* destination, int32_t destination_max_size, az_span source);
 
-/******************************  SPAN PARSING */
-
-/**
- * @brief az_span_to_uint64 parses an az_span containing ASCII digits into a uint64 number
- *
- * @param[in] span The az_span containing the ASCII digits to be parsed.
- * @param[in] out_number The pointer to the variable that is to receive the number
- * @return An #az_result value indicating the result of the operation.
- *          #AZ_OK if successful
- *          #AZ_ERROR_PARSER_UNEXPECTED_CHAR if a non-ASCII digit is found within the span.
- */
-
-AZ_NODISCARD az_result az_span_to_uint64(az_span span, uint64_t* out_number);
-
-/**
- * @brief az_span_to_uint32 parses an az_span containing ASCII digits into a uint32 number
- *
- * @param span The az_span containing the ASCII digits to be parsed.
- * @param out_number The pointer to the variable that is to receive the number
- * @return An #az_result value indicating the result of the operation.
- *          #AZ_OK if successful
- *          #AZ_ERROR_PARSER_UNEXPECTED_CHAR if a non-ASCII digit is found within the span.
- */
-AZ_NODISCARD az_result az_span_to_uint32(az_span span, uint32_t* out_number);
-
 /**
  * @brief az_span_find searches for `target` in `source`, returning an #az_span within `source` if
  * it finds it.
@@ -281,8 +256,44 @@ AZ_NODISCARD az_result
 az_span_copy_url_encode(az_span destination, az_span source, az_span* out_span);
 
 /**
- * @brief az_span_copy_i32toa copies an int32 as digit characters to the destination starting at its
- * 0-th index.
+ * @brief az_span_fill Fills all the bytes of the destination span with the specified value.
+ *
+ * @param[in] destination The span whose bytes will be set to \p value.
+ * @param[in] value The byte to be replicated within the destination span.
+ */
+AZ_INLINE void az_span_fill(az_span destination, uint8_t value)
+{
+  memset(az_span_ptr(destination), value, (size_t)az_span_size(destination));
+}
+
+/******************************  SPAN PARSING AND FORMATTING */
+
+/**
+ * @brief az_span_atou64 Parses an az_span containing ASCII digits into a uint64 number.
+ *
+ * @param[in] span The az_span containing the ASCII digits to be parsed.
+ * @param[in] out_number The pointer to the variable that is to receive the number
+ * @return An #az_result value indicating the result of the operation.
+ *          #AZ_OK if successful
+ *          #AZ_ERROR_PARSER_UNEXPECTED_CHAR if a non-ASCII digit is found within the span.
+ */
+
+AZ_NODISCARD az_result az_span_atou64(az_span span, uint64_t* out_number);
+
+/**
+ * @brief az_span_atou Parses an az_span containing ASCII digits into a uint32 number.
+ *
+ * @param span The az_span containing the ASCII digits to be parsed.
+ * @param out_number The pointer to the variable that is to receive the number
+ * @return An #az_result value indicating the result of the operation.
+ *          #AZ_OK if successful
+ *          #AZ_ERROR_PARSER_UNEXPECTED_CHAR if a non-ASCII digit is found within the span.
+ */
+AZ_NODISCARD az_result az_span_atou(az_span span, uint32_t* out_number);
+
+/**
+ * @brief az_span_itoa Converts an int32 into its digit characters and copies them to the
+ * destination span starting at its 0-th index.
  *
  * @param[in] destination The az_span where the bytes should be copied to.
  * @param[in] source The int32 whose number is copied to the destination span as ASCII digits.
@@ -293,11 +304,11 @@ az_span_copy_url_encode(az_span destination, az_span source, az_span* out_span);
  *          #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination is not big enough to contain
  * the copied bytes
  */
-AZ_NODISCARD az_result az_span_copy_i32toa(az_span destination, int32_t source, az_span* out_span);
+AZ_NODISCARD az_result az_span_itoa(az_span destination, int32_t source, az_span* out_span);
 
 /**
- * @brief az_span_copy_u32toa copies a uint32 as digit characters to the destination starting at its
- * 0-th index.
+ * @brief az_span_utoa Converts a uint32 into its digit characters and copies them to the
+ * destination span starting at its 0-th index.
  *
  * @param[in] destination The az_span where the bytes should be copied to.
  * @param[in] source The uint32 whose number is copied to the destination span as ASCII digits.
@@ -308,11 +319,11 @@ AZ_NODISCARD az_result az_span_copy_i32toa(az_span destination, int32_t source, 
  *          #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the destination is not big enough to contain the
  * copied bytes
  */
-AZ_NODISCARD az_result az_span_copy_u32toa(az_span destination, uint32_t source, az_span* out_span);
+AZ_NODISCARD az_result az_span_utoa(az_span destination, uint32_t source, az_span* out_span);
 
 /**
- * @brief az_span_copy_i64toa copies an int64 as digit characters to the destination starting at its
- * 0-th index.
+ * @brief az_span_i64toa Converts an int64 into its digit characters and copies them to the
+ * destination span starting at its 0-th index.
  *
  * @param[in] destination The az_span where the bytes should be copied to.
  * @param[in] source The int64 whose number is copied to the destination span as ASCII digits.
@@ -323,11 +334,11 @@ AZ_NODISCARD az_result az_span_copy_u32toa(az_span destination, uint32_t source,
  *          #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the destination is not big enough to contain the
  * copied bytes
  */
-AZ_NODISCARD az_result az_span_copy_i64toa(az_span destination, int64_t source, az_span* out_span);
+AZ_NODISCARD az_result az_span_i64toa(az_span destination, int64_t source, az_span* out_span);
 
 /**
- * @brief az_span_copy_u64toa copies a uint64 as digit characters to the destination starting at its
- * 0-th index.
+ * @brief az_span_u64toa Converts a uint64 into its digit characters and copies them to the
+ * destination span starting at its 0-th index.
  *
  * @param[in] destination The az_span where the bytes should be copied to.
  * @param[in] source The uint64 whose number is copied to the destination span as ASCII digits.
@@ -338,11 +349,11 @@ AZ_NODISCARD az_result az_span_copy_i64toa(az_span destination, int64_t source, 
  *          #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the destination is not big enough to contain the
  * copied bytes
  */
-AZ_NODISCARD az_result az_span_copy_u64toa(az_span destination, uint64_t source, az_span* out_span);
+AZ_NODISCARD az_result az_span_u64toa(az_span destination, uint64_t source, az_span* out_span);
 
 /**
- * @brief az_span_copy_dtoa copies a double as digit characters to the destination starting at its
- * 0-th index.
+ * @brief az_span_dtoa Converts a double into its digit characters and copies them to the
+ * destination span starting at its 0-th index.
  *
  * @param[in] destination The az_span where the bytes should be copied to.
  * @param[in] source The double whose number is copied to the destination span as ASCII digits.
@@ -353,18 +364,7 @@ AZ_NODISCARD az_result az_span_copy_u64toa(az_span destination, uint64_t source,
  *          #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the destination is not big enough to contain the
  * copied bytes
  */
-AZ_NODISCARD az_result az_span_copy_dtoa(az_span destination, double source, az_span* out_span);
-
-/**
- * @brief az_span_fill Fills all the bytes of the destination span with the specified value.
- *
- * @param[in] destination The span whose bytes will be set to \p value.
- * @param[in] value The byte to be replicated within the destination span.
- */
-AZ_INLINE void az_span_fill(az_span destination, uint8_t value)
-{
-  memset(az_span_ptr(destination), value, (size_t)az_span_size(destination));
-}
+AZ_NODISCARD az_result az_span_dtoa(az_span destination, double source, az_span* out_span);
 
 /******************************  SPAN PAIR  */
 

--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -168,6 +168,17 @@ AZ_NODISCARD az_span az_span_from_str(char* str);
 AZ_NODISCARD az_span az_span_slice(az_span span, int32_t start_index, int32_t end_index);
 
 /**
+ * @brief Returns a new #az_span which is a sub-span of the specified \p span.
+ *
+ * @param[in] span The original #az_span.
+ * @param[in] start_index An index into the original #az_span indicating where the returned #az_span
+ * will start.
+ * @return An #az_span into a portion (from \p start_index to the size) of the original
+ * #az_span.
+ */
+AZ_NODISCARD az_span az_span_slice_to_end(az_span span, int32_t start_index);
+
+/**
  * @brief Determines whether two spans are equal by comparing their bytes.
  *
  * @param[in] span1 The first #az_span to compare.

--- a/sdk/core/core/internal/az_http_internal.h
+++ b/sdk/core/core/internal/az_http_internal.h
@@ -244,7 +244,7 @@ AZ_NODISCARD az_result az_http_request_append_path(_az_http_request* p_request, 
  * @return
  *   - *`AZ_OK`* success.
  *   - *`AZ_ERROR_INSUFFICIENT_SPAN_SIZE`* the `URL` would grow past the `max_url_size`, should
- * the parameter gets set.
+ * the parameter get set.
  *   - *`AZ_ERROR_ARG`*
  *     - `p_request` is _NULL_.
  *     - `name` or `value` are invalid spans (see @ref az_span_is_valid).

--- a/sdk/core/core/internal/az_http_internal.h
+++ b/sdk/core/core/internal/az_http_internal.h
@@ -119,8 +119,7 @@ _az_http_policy_apiversion_options_default()
  */
 AZ_NODISCARD AZ_INLINE int32_t _az_http_request_headers_count(_az_http_request const* request)
 {
-  // Cast the unsigned sizeof result to ensure the divsion is signed/signed
-  return az_span_length(request->_internal.headers) / (int32_t)sizeof(az_pair);
+  return request->_internal.headers_length;
 }
 
 /**
@@ -207,7 +206,7 @@ az_http_client_send_request(_az_http_request* p_request, az_http_response* p_res
  *
  * @return
  *   - *`AZ_OK`* success.
- *   - *`AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY`* `buffer` does not have enough space to fit the
+ *   - *`AZ_ERROR_INSUFFICIENT_SPAN_SIZE`* `buffer` does not have enough space to fit the
  * `max_url_size`.
  *   - *`AZ_ERROR_ARG`*
  *     - `p_request` is _NULL_.
@@ -219,6 +218,7 @@ AZ_NODISCARD az_result az_http_request_init(
     az_context* context,
     az_http_method method,
     az_span url,
+    int32_t url_length,
     az_span headers_buffer,
     az_span body);
 
@@ -243,7 +243,7 @@ AZ_NODISCARD az_result az_http_request_append_path(_az_http_request* p_request, 
  *
  * @return
  *   - *`AZ_OK`* success.
- *   - *`AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY`* the `URL` would grow past the `max_url_size`, should
+ *   - *`AZ_ERROR_INSUFFICIENT_SPAN_SIZE`* the `URL` would grow past the `max_url_size`, should
  * the parameter gets set.
  *   - *`AZ_ERROR_ARG`*
  *     - `p_request` is _NULL_.
@@ -263,7 +263,7 @@ az_http_request_set_query_parameter(_az_http_request* p_request, az_span name, a
  *
  * @return
  *   - *`AZ_OK`* success.
- *   - *`AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY`* there isn't enough space in the `p_request->buffer`
+ *   - *`AZ_ERROR_INSUFFICIENT_SPAN_SIZE`* there isn't enough space in the `p_request->buffer`
  * to add a header.
  *   - *`AZ_ERROR_ARG`*
  *     - `p_request` is _NULL_.

--- a/sdk/core/core/internal/az_precondition_internal.h
+++ b/sdk/core/core/internal/az_precondition_internal.h
@@ -57,14 +57,6 @@ az_precondition_failed_fn az_precondition_failed_get_callback();
 
 #define AZ_PRECONDITION_RANGE(low, arg, max) AZ_PRECONDITION((low <= arg && arg <= max))
 
-/*
- * @brief This precondition is identical to AZ_PRECONDITION_RANGE but must only be called
- * with int32_t arguments since it uses the unsigned int32 range to reduce the number of checks
- * needed.
- */
-#define AZ_PRECONDITION_INT32_RANGE(low, arg, max) \
-  AZ_PRECONDITION((uint32_t)(arg - low) <= (uint32_t)(max - low))
-
 #define AZ_PRECONDITION_NOT_NULL(arg) AZ_PRECONDITION((arg != NULL))
 #define AZ_PRECONDITION_IS_NULL(arg) AZ_PRECONDITION((arg == NULL))
 

--- a/sdk/core/core/internal/az_precondition_internal.h
+++ b/sdk/core/core/internal/az_precondition_internal.h
@@ -82,9 +82,7 @@ AZ_NODISCARD AZ_INLINE bool az_span_is_valid(az_span span, int32_t min_size, boo
     result = ptr != NULL && span_size >= 0;
   }
 
-  result = result && min_size <= span_size;
-
-  return result;
+  return result && min_size <= span_size;
 }
 
 #define AZ_PRECONDITION_VALID_SPAN(span, min_size, null_is_valid) \

--- a/sdk/core/core/internal/az_span_internal.h
+++ b/sdk/core/core/internal/az_span_internal.h
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#ifndef _az_SPAN_INTERNAL_H
+#define _az_SPAN_INTERNAL_H
+
+#include <az_span.h>
+#include <az_precondition_internal.h>
+
+#include <_az_cfg_prefix.h>
+
+AZ_INLINE AZ_NODISCARD int32_t _az_span_diff(az_span new_span, az_span old_span)
+{
+  int32_t answer = az_span_size(old_span) - az_span_size(new_span);
+  AZ_PRECONDITION(answer == (int32_t)(az_span_ptr(new_span) - az_span_ptr(old_span)));
+  return answer;
+}
+
+#include <_az_cfg_suffix.h>
+
+#endif // _az_SPAN_INTERNAL_H

--- a/sdk/core/core/internal/az_span_internal.h
+++ b/sdk/core/core/internal/az_span_internal.h
@@ -4,15 +4,21 @@
 #ifndef _az_SPAN_INTERNAL_H
 #define _az_SPAN_INTERNAL_H
 
-#include <az_span.h>
 #include <az_precondition_internal.h>
+#include <az_span.h>
 
 #include <_az_cfg_prefix.h>
 
-AZ_INLINE AZ_NODISCARD int32_t _az_span_diff(az_span new_span, az_span old_span)
+// Use this helper to figure out how much the sliced_span has moved in comparison to the
+// original_span while writing and slicing a copy of the original.
+// The \p sliced_span must be some slice of the \p original_span (and have the same backing memory).
+AZ_INLINE AZ_NODISCARD int32_t _az_span_diff(az_span sliced_span, az_span original_span)
 {
-  int32_t answer = az_span_size(old_span) - az_span_size(new_span);
-  AZ_PRECONDITION(answer == (int32_t)(az_span_ptr(new_span) - az_span_ptr(old_span)));
+  int32_t answer = az_span_size(original_span) - az_span_size(sliced_span);
+
+  // The passed in span parameters cannot be any two arbitrary spans.
+  // This validates the span parameters are valid and one is a sub-slice of another.
+  AZ_PRECONDITION(answer == (int32_t)(az_span_ptr(sliced_span) - az_span_ptr(original_span)));
   return answer;
 }
 

--- a/sdk/core/core/src/az_aad.c
+++ b/sdk/core/core/src/az_aad.c
@@ -8,6 +8,7 @@
 #include <az_json.h>
 #include <az_platform_internal.h>
 #include <az_precondition_internal.h>
+#include <az_span_internal.h>
 
 #include <stddef.h>
 
@@ -24,13 +25,6 @@ AZ_NODISCARD az_result _az_token_set(_az_token* self, _az_token const* new_token
   // TODO: thread sync
   *self = *new_token;
   return AZ_OK;
-}
-
-static AZ_NODISCARD int32_t _az_span_diff(az_span new_span, az_span old_span)
-{
-  int32_t answer = az_span_size(old_span) - az_span_size(new_span);
-  AZ_PRECONDITION(answer == (int32_t)(az_span_ptr(new_span) - az_span_ptr(old_span)));
-  return answer;
 }
 
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-access-token

--- a/sdk/core/core/src/az_aad.c
+++ b/sdk/core/core/src/az_aad.c
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include "az_aad_private.h"
+#include "az_span_private.h"
+
 #include <az_config_internal.h>
 #include <az_http.h>
 #include <az_http_internal.h>

--- a/sdk/core/core/src/az_aad.c
+++ b/sdk/core/core/src/az_aad.c
@@ -7,6 +7,7 @@
 #include <az_http_internal.h>
 #include <az_json.h>
 #include <az_platform_internal.h>
+#include <az_precondition_internal.h>
 
 #include <stddef.h>
 
@@ -25,39 +26,27 @@ AZ_NODISCARD az_result _az_token_set(_az_token* self, _az_token const* new_token
   return AZ_OK;
 }
 
-static AZ_NODISCARD az_result
-_az_span_append_with_url_encode(az_span dst, az_span src, az_span* out)
+static AZ_NODISCARD int32_t _az_span_diff(az_span new_span, az_span old_span)
 {
-  int32_t dst_length = az_span_length(dst);
-  uint8_t* p_dst = az_span_ptr(dst);
-  int32_t remaining = az_span_capacity(dst) - dst_length;
-  // get remaining from dst
-  az_span span_from_current_length_to_capacity = az_span_init(p_dst + dst_length, 0, remaining);
-
-  // Copy src into remaining with encoded (copy handles overflow)
-  AZ_RETURN_IF_FAILED(az_span_copy_url_encode(
-      span_from_current_length_to_capacity, src, &span_from_current_length_to_capacity));
-  // return new span with updated length
-  *out = az_span_init(
-      az_span_ptr(dst),
-      dst_length + az_span_length(span_from_current_length_to_capacity),
-      az_span_capacity(dst));
-
-  return AZ_OK;
+  int32_t answer = az_span_size(old_span) - az_span_size(new_span);
+  AZ_PRECONDITION(answer == (int32_t)(az_span_ptr(new_span) - az_span_ptr(old_span)));
+  return answer;
 }
 
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-access-token
 AZ_NODISCARD az_result _az_aad_build_url(az_span url, az_span tenant_id, az_span* out_url)
 {
   az_span root_url = AZ_SPAN_FROM_STR("https://login.microsoftonline.com/");
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(url, az_span_length(root_url));
-  *out_url = az_span_append(url, root_url);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(url, az_span_size(root_url));
+  az_span remainder = az_span_copy(url, root_url);
 
-  AZ_RETURN_IF_FAILED(_az_span_append_with_url_encode(*out_url, tenant_id, out_url));
+  AZ_RETURN_IF_FAILED(az_span_copy_url_encode(remainder, tenant_id, &remainder));
 
   az_span oath_token = AZ_SPAN_FROM_STR("/oauth2/v2.0/token");
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*out_url, az_span_length(oath_token));
-  *out_url = az_span_append(*out_url, oath_token);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(oath_token));
+  remainder = az_span_copy(remainder, oath_token);
+
+  *out_url = az_span_slice(url, 0, _az_span_diff(remainder, url));
 
   return AZ_OK;
 }
@@ -72,26 +61,27 @@ AZ_NODISCARD az_result _az_aad_build_body(
 {
   az_span grant_type_and_client_id_key
       = AZ_SPAN_FROM_STR("grant_type=client_credentials&client_id=");
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(body, az_span_length(grant_type_and_client_id_key));
-  *out_body = az_span_append(body, grant_type_and_client_id_key);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(body, az_span_size(grant_type_and_client_id_key));
+  az_span remainder = az_span_copy(body, grant_type_and_client_id_key);
 
-  AZ_RETURN_IF_FAILED(_az_span_append_with_url_encode(*out_body, client_id, out_body));
+  AZ_RETURN_IF_FAILED(az_span_copy_url_encode(remainder, client_id, &remainder));
 
   az_span scope_key = AZ_SPAN_FROM_STR("&scope=");
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*out_body, az_span_length(scope_key));
-  *out_body = az_span_append(*out_body, scope_key);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(scope_key));
+  remainder = az_span_copy(remainder, scope_key);
 
-  AZ_RETURN_IF_FAILED(_az_span_append_with_url_encode(*out_body, scopes, out_body));
+  AZ_RETURN_IF_FAILED(az_span_copy_url_encode(remainder, scopes, &remainder));
 
-  if (az_span_length(client_secret) > 0)
+  if (az_span_size(client_secret) > 0)
   {
     az_span client_secret_key = AZ_SPAN_FROM_STR("&client_secret=");
-    AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*out_body, az_span_length(client_secret_key));
-    *out_body = az_span_append(*out_body, client_secret_key);
+    AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(client_secret_key));
+    remainder = az_span_copy(remainder, client_secret_key);
 
-    AZ_RETURN_IF_FAILED(_az_span_append_with_url_encode(*out_body, client_secret, out_body));
+    AZ_RETURN_IF_FAILED(az_span_copy_url_encode(remainder, client_secret, &remainder));
   }
 
+  *out_body = az_span_slice(body, 0, _az_span_diff(remainder, body));
   return AZ_OK;
 }
 
@@ -165,11 +155,11 @@ AZ_NODISCARD az_result _az_aad_request_token(_az_http_request* request, _az_toke
   };
 
   az_span new_token_span = AZ_SPAN_FROM_BUFFER(new_token._internal.token);
-  new_token_span = az_span_copy(new_token_span, AZ_SPAN_FROM_STR("Bearer "));
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(new_token_span, az_span_length(access_token));
-  new_token_span = az_span_append(new_token_span, access_token);
+  az_span remainder = az_span_copy(new_token_span, AZ_SPAN_FROM_STR("Bearer "));
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(access_token));
+  remainder = az_span_copy(remainder, access_token);
 
-  new_token._internal.token_length = (int16_t)az_span_length(new_token_span);
+  new_token._internal.token_length = (int16_t)_az_span_diff(remainder, new_token_span);
 
   AZ_RETURN_IF_FAILED(_az_token_set(out_token, &new_token));
 

--- a/sdk/core/core/src/az_credential_client_secret.c
+++ b/sdk/core/core/src/az_credential_client_secret.c
@@ -16,8 +16,9 @@ static AZ_NODISCARD az_result _az_credential_client_secret_request_token(
     az_context* context)
 {
   uint8_t url_buf[_az_AAD_REQUEST_URL_BUF_SIZE] = { 0 };
-  az_span url = AZ_SPAN_FROM_BUFFER(url_buf);
-  AZ_RETURN_IF_FAILED(_az_aad_build_url(url, credential->_internal.tenant_id, &url));
+  az_span url_span = AZ_SPAN_FROM_BUFFER(url_buf);
+  az_span url;
+  AZ_RETURN_IF_FAILED(_az_aad_build_url(url_span, credential->_internal.tenant_id, &url));
 
   uint8_t body_buf[_az_AAD_REQUEST_BODY_BUF_SIZE] = { 0 };
   az_span body = AZ_SPAN_FROM_BUFFER(body_buf);
@@ -31,7 +32,7 @@ static AZ_NODISCARD az_result _az_credential_client_secret_request_token(
   uint8_t header_buf[_az_AAD_REQUEST_HEADER_BUF_SIZE];
   _az_http_request request = { 0 };
   AZ_RETURN_IF_FAILED(az_http_request_init(
-      &request, context, az_http_method_post(), url, AZ_SPAN_FROM_BUFFER(header_buf), body));
+      &request, context, az_http_method_post(), url_span, az_span_size(url), AZ_SPAN_FROM_BUFFER(header_buf), body));
 
   return _az_aad_request_token(&request, &credential->_internal.token);
 }
@@ -53,7 +54,7 @@ static AZ_NODISCARD az_result _az_credential_client_secret_apply(
   AZ_RETURN_IF_FAILED(az_http_request_append_header(
       ref_request,
       AZ_SPAN_FROM_STR("authorization"),
-      az_span_init(credential->_internal.token._internal.token, token_length, token_length)));
+      az_span_init(credential->_internal.token._internal.token, token_length)));
 
   return AZ_OK;
 }

--- a/sdk/core/core/src/az_http_policy_logging.c
+++ b/sdk/core/core/src/az_http_policy_logging.c
@@ -81,7 +81,7 @@ static az_result _az_http_policy_logging_append_http_request_msg(
   }
 
   remainder = az_span_copy(remainder, request->_internal.method);
-  remainder = az_span_copy_uint8(remainder, ' ');
+  remainder = az_span_copy_u8(remainder, ' ');
   remainder = az_span_copy(
       remainder, az_span_slice(request->_internal.url, 0, request->_internal.url_length));
 
@@ -154,7 +154,7 @@ static az_result _az_http_policy_logging_append_http_response_msg(
       az_span_u64toa(remainder, (uint64_t)status_line.status_code, &remainder));
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(status_line.reason_phrase) + 1);
-  remainder = az_span_copy_uint8(remainder, ' ');
+  remainder = az_span_copy_u8(remainder, ' ');
   remainder = az_span_copy(remainder, status_line.reason_phrase);
 
   az_span new_line_tab_string = AZ_SPAN_FROM_STR("\n\t");

--- a/sdk/core/core/src/az_http_policy_logging.c
+++ b/sdk/core/core/src/az_http_policy_logging.c
@@ -20,24 +20,22 @@ enum
         // that they don't blow up the logs.
 };
 
-static az_span _az_http_policy_logging_append_lengthy_value(az_span ref_log_msg, az_span value)
+static az_span _az_http_policy_logging_copy_lengthy_value(az_span ref_log_msg, az_span value)
 {
   // The caller should validate that ref_log_msg is large enough to contain the value az_span
   // This means, ref_log_msg must have at least _az_LOG_LENGTHY_VALUE_MAX_LENGTH (i.e. 50) bytes
   // available.
-  AZ_PRECONDITION(
-      (az_span_capacity(ref_log_msg) - az_span_length(ref_log_msg))
-      >= _az_LOG_LENGTHY_VALUE_MAX_LENGTH);
+  AZ_PRECONDITION(az_span_size(ref_log_msg) >= _az_LOG_LENGTHY_VALUE_MAX_LENGTH);
 
-  int32_t value_size = az_span_length(value);
+  int32_t value_size = az_span_size(value);
 
   if (value_size <= _az_LOG_LENGTHY_VALUE_MAX_LENGTH)
   {
-    return az_span_append(ref_log_msg, value);
+    return az_span_copy(ref_log_msg, value);
   }
 
   az_span const ellipsis = AZ_SPAN_FROM_STR(" ... ");
-  int32_t const ellipsis_len = az_span_length(ellipsis);
+  int32_t const ellipsis_len = az_span_size(ellipsis);
 
   int32_t const first
       = (_az_LOG_LENGTHY_VALUE_MAX_LENGTH / 2) - ((ellipsis_len / 2) + (ellipsis_len % 2)); // 22
@@ -46,11 +44,18 @@ static az_span _az_http_policy_logging_append_lengthy_value(az_span ref_log_msg,
       = ((_az_LOG_LENGTHY_VALUE_MAX_LENGTH / 2) + (_az_LOG_LENGTHY_VALUE_MAX_LENGTH % 2)) // 23
       - (ellipsis_len / 2);
 
-  AZ_PRECONDITION((first + last + az_span_length(ellipsis)) == _az_LOG_LENGTHY_VALUE_MAX_LENGTH);
+  AZ_PRECONDITION((first + last + ellipsis_len) == _az_LOG_LENGTHY_VALUE_MAX_LENGTH);
 
-  ref_log_msg = az_span_append(ref_log_msg, az_span_slice(value, 0, first));
-  ref_log_msg = az_span_append(ref_log_msg, ellipsis);
-  return az_span_append(ref_log_msg, az_span_slice(value, value_size - last, value_size));
+  ref_log_msg = az_span_copy(ref_log_msg, az_span_slice(value, 0, first));
+  ref_log_msg = az_span_copy(ref_log_msg, ellipsis);
+  return az_span_copy(ref_log_msg, az_span_slice(value, value_size - last, value_size));
+}
+
+static AZ_NODISCARD int32_t _az_span_diff(az_span new_span, az_span old_span)
+{
+  int32_t answer = az_span_size(old_span) - az_span_size(new_span);
+  AZ_PRECONDITION(answer == (int32_t)(az_span_ptr(new_span) - az_span_ptr(old_span)));
+  return answer;
 }
 
 static az_result _az_http_policy_logging_append_http_request_msg(
@@ -60,30 +65,31 @@ static az_result _az_http_policy_logging_append_http_request_msg(
   az_span http_request_string = AZ_SPAN_FROM_STR("HTTP Request : ");
   az_span null_string = AZ_SPAN_FROM_STR("NULL");
 
-  int32_t required_length = az_span_length(http_request_string);
+  int32_t required_length = az_span_size(http_request_string);
   if (request == NULL)
   {
-    required_length += az_span_length(null_string);
+    required_length += az_span_size(null_string);
   }
   else
   {
-    required_length
-        = az_span_length(request->_internal.method) + az_span_length(request->_internal.url) + 1;
+    required_length = az_span_size(request->_internal.method) + request->_internal.url_length + 1;
   }
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*ref_log_msg, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(*ref_log_msg, required_length);
 
-  *ref_log_msg = az_span_append(*ref_log_msg, http_request_string);
+  az_span remainder = az_span_copy(*ref_log_msg, http_request_string);
 
   if (request == NULL)
   {
-    *ref_log_msg = az_span_append(*ref_log_msg, null_string);
+    remainder = az_span_copy(remainder, null_string);
+    *ref_log_msg = az_span_slice(*ref_log_msg, 0, _az_span_diff(remainder, *ref_log_msg));
     return AZ_OK;
   }
 
-  *ref_log_msg = az_span_append(*ref_log_msg, request->_internal.method);
-  *ref_log_msg = az_span_append_uint8(*ref_log_msg, ' ');
-  *ref_log_msg = az_span_append(*ref_log_msg, request->_internal.url);
+  remainder = az_span_copy(remainder, request->_internal.method);
+  remainder = az_span_copy_uint8(remainder, ' ');
+  remainder = az_span_copy(
+      remainder, az_span_slice(request->_internal.url, 0, request->_internal.url_length));
 
   int32_t const headers_count = _az_http_request_headers_count(request);
 
@@ -95,24 +101,25 @@ static az_result _az_http_policy_logging_append_http_request_msg(
     az_pair header = { 0 };
     AZ_RETURN_IF_FAILED(az_http_request_get_header(request, index, &header));
 
-    required_length = az_span_length(new_line_tab_string) + az_span_length(header.key);
-    if (az_span_length(header.value) > 0)
+    required_length = az_span_size(new_line_tab_string) + az_span_size(header.key);
+    if (az_span_size(header.value) > 0)
     {
-      required_length += _az_LOG_LENGTHY_VALUE_MAX_LENGTH + az_span_length(colon_separator_string);
+      required_length += _az_LOG_LENGTHY_VALUE_MAX_LENGTH + az_span_size(colon_separator_string);
     }
 
-    AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*ref_log_msg, required_length);
+    AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, required_length);
 
-    *ref_log_msg = az_span_append(*ref_log_msg, new_line_tab_string);
+    remainder = az_span_copy(remainder, new_line_tab_string);
 
-    *ref_log_msg = az_span_append(*ref_log_msg, header.key);
+    remainder = az_span_copy(remainder, header.key);
 
-    if (az_span_length(header.value) > 0)
+    if (az_span_size(header.value) > 0)
     {
-      *ref_log_msg = az_span_append(*ref_log_msg, colon_separator_string);
-      *ref_log_msg = _az_http_policy_logging_append_lengthy_value(*ref_log_msg, header.value);
+      remainder = az_span_copy(remainder, colon_separator_string);
+      remainder = _az_http_policy_logging_copy_lengthy_value(remainder, header.value);
     }
   }
+  *ref_log_msg = az_span_slice(*ref_log_msg, 0, _az_span_diff(remainder, *ref_log_msg));
 
   return AZ_OK;
 }
@@ -124,69 +131,73 @@ static az_result _az_http_policy_logging_append_http_response_msg(
     az_span* ref_log_msg)
 {
   az_span http_response_string = AZ_SPAN_FROM_STR("HTTP Response (");
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*ref_log_msg, az_span_length(http_response_string));
-  *ref_log_msg = az_span_append(*ref_log_msg, http_response_string);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(*ref_log_msg, az_span_size(http_response_string));
+  az_span remainder = az_span_copy(*ref_log_msg, http_response_string);
 
-  AZ_RETURN_IF_FAILED(az_span_append_i64toa(*ref_log_msg, duration_msec, ref_log_msg));
+  AZ_RETURN_IF_FAILED(az_span_copy_i64toa(remainder, duration_msec, &remainder));
 
   az_span ms_string = AZ_SPAN_FROM_STR("ms)");
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*ref_log_msg, az_span_length(ms_string));
-  *ref_log_msg = az_span_append(*ref_log_msg, ms_string);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(ms_string));
+  remainder = az_span_copy(remainder, ms_string);
 
-  if (ref_response == NULL || az_span_length(ref_response->_internal.http_response) == 0)
+  if (ref_response == NULL || az_span_size(ref_response->_internal.http_response) == 0)
   {
     az_span is_empty_string = AZ_SPAN_FROM_STR(" is empty");
-    AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*ref_log_msg, az_span_length(is_empty_string));
-    *ref_log_msg = az_span_append(*ref_log_msg, is_empty_string);
+    AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(is_empty_string));
+    remainder = az_span_copy(remainder, is_empty_string);
+
+    *ref_log_msg = az_span_slice(*ref_log_msg, 0, _az_span_diff(remainder, *ref_log_msg));
     return AZ_OK;
   }
 
   az_span colon_separator_string = AZ_SPAN_FROM_STR(" : ");
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*ref_log_msg, az_span_length(colon_separator_string));
-  *ref_log_msg = az_span_append(*ref_log_msg, colon_separator_string);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(colon_separator_string));
+  remainder = az_span_copy(remainder, colon_separator_string);
 
   az_http_response_status_line status_line = { 0 };
   AZ_RETURN_IF_FAILED(az_http_response_get_status_line(ref_response, &status_line));
   AZ_RETURN_IF_FAILED(
-      az_span_append_u64toa(*ref_log_msg, (uint64_t)status_line.status_code, ref_log_msg));
+      az_span_copy_u64toa(remainder, (uint64_t)status_line.status_code, &remainder));
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*ref_log_msg, az_span_length(status_line.reason_phrase) + 1);
-  *ref_log_msg = az_span_append_uint8(*ref_log_msg, ' ');
-  *ref_log_msg = az_span_append(*ref_log_msg, status_line.reason_phrase);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(status_line.reason_phrase) + 1);
+  remainder = az_span_copy_uint8(remainder, ' ');
+  remainder = az_span_copy(remainder, status_line.reason_phrase);
 
   az_span new_line_tab_string = AZ_SPAN_FROM_STR("\n\t");
 
   for (az_pair header;
        az_http_response_get_next_header(ref_response, &header) != AZ_ERROR_ITEM_NOT_FOUND;)
   {
-    int32_t required_length = az_span_length(new_line_tab_string) + az_span_length(header.key);
-    if (az_span_length(header.value) > 0)
+    int32_t required_length = az_span_size(new_line_tab_string) + az_span_size(header.key);
+    if (az_span_size(header.value) > 0)
     {
-      required_length += _az_LOG_LENGTHY_VALUE_MAX_LENGTH + az_span_length(colon_separator_string);
+      required_length += _az_LOG_LENGTHY_VALUE_MAX_LENGTH + az_span_size(colon_separator_string);
     }
 
-    AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*ref_log_msg, required_length);
+    AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, required_length);
 
-    *ref_log_msg = az_span_append(*ref_log_msg, new_line_tab_string);
-    *ref_log_msg = az_span_append(*ref_log_msg, header.key);
+    remainder = az_span_copy(remainder, new_line_tab_string);
+    remainder = az_span_copy(remainder, header.key);
 
-    if (az_span_length(header.value) > 0)
+    if (az_span_size(header.value) > 0)
     {
-      *ref_log_msg = az_span_append(*ref_log_msg, colon_separator_string);
-      *ref_log_msg = _az_http_policy_logging_append_lengthy_value(*ref_log_msg, header.value);
+      remainder = az_span_copy(remainder, colon_separator_string);
+      remainder = _az_http_policy_logging_copy_lengthy_value(remainder, header.value);
     }
   }
 
   az_span new_lines_string = AZ_SPAN_FROM_STR("\n\n");
   az_span arrow_separator_string = AZ_SPAN_FROM_STR(" -> ");
-  int32_t required_length
-      = az_span_length(new_lines_string) + az_span_length(arrow_separator_string);
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*ref_log_msg, required_length);
+  int32_t required_length = az_span_size(new_lines_string) + az_span_size(arrow_separator_string);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, required_length);
 
-  *ref_log_msg = az_span_append(*ref_log_msg, new_lines_string);
-  *ref_log_msg = az_span_append(*ref_log_msg, arrow_separator_string);
-  AZ_RETURN_IF_FAILED(_az_http_policy_logging_append_http_request_msg(request, ref_log_msg));
+  remainder = az_span_copy(remainder, new_lines_string);
+  remainder = az_span_copy(remainder, arrow_separator_string);
 
+  az_span append_request = remainder;
+  AZ_RETURN_IF_FAILED(_az_http_policy_logging_append_http_request_msg(request, &append_request));
+
+  *ref_log_msg = az_span_slice(*ref_log_msg, 0, _az_span_diff(remainder, *ref_log_msg) + az_span_size(append_request));
   return AZ_OK;
 }
 

--- a/sdk/core/core/src/az_http_policy_logging.c
+++ b/sdk/core/core/src/az_http_policy_logging.c
@@ -8,6 +8,7 @@
 #include <az_http_transport.h>
 #include <az_log_internal.h>
 #include <az_platform_internal.h>
+#include <az_span_internal.h>
 
 #include <_az_cfg.h>
 
@@ -49,13 +50,6 @@ static az_span _az_http_policy_logging_copy_lengthy_value(az_span ref_log_msg, a
   ref_log_msg = az_span_copy(ref_log_msg, az_span_slice(value, 0, first));
   ref_log_msg = az_span_copy(ref_log_msg, ellipsis);
   return az_span_copy(ref_log_msg, az_span_slice(value, value_size - last, value_size));
-}
-
-static AZ_NODISCARD int32_t _az_span_diff(az_span new_span, az_span old_span)
-{
-  int32_t answer = az_span_size(old_span) - az_span_size(new_span);
-  AZ_PRECONDITION(answer == (int32_t)(az_span_ptr(new_span) - az_span_ptr(old_span)));
-  return answer;
 }
 
 static az_result _az_http_policy_logging_append_http_request_msg(
@@ -197,7 +191,8 @@ static az_result _az_http_policy_logging_append_http_response_msg(
   az_span append_request = remainder;
   AZ_RETURN_IF_FAILED(_az_http_policy_logging_append_http_request_msg(request, &append_request));
 
-  *ref_log_msg = az_span_slice(*ref_log_msg, 0, _az_span_diff(remainder, *ref_log_msg) + az_span_size(append_request));
+  *ref_log_msg = az_span_slice(
+      *ref_log_msg, 0, _az_span_diff(remainder, *ref_log_msg) + az_span_size(append_request));
   return AZ_OK;
 }
 

--- a/sdk/core/core/src/az_http_policy_logging.c
+++ b/sdk/core/core/src/az_http_policy_logging.c
@@ -128,7 +128,7 @@ static az_result _az_http_policy_logging_append_http_response_msg(
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(*ref_log_msg, az_span_size(http_response_string));
   az_span remainder = az_span_copy(*ref_log_msg, http_response_string);
 
-  AZ_RETURN_IF_FAILED(az_span_copy_i64toa(remainder, duration_msec, &remainder));
+  AZ_RETURN_IF_FAILED(az_span_i64toa(remainder, duration_msec, &remainder));
 
   az_span ms_string = AZ_SPAN_FROM_STR("ms)");
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(ms_string));
@@ -151,7 +151,7 @@ static az_result _az_http_policy_logging_append_http_response_msg(
   az_http_response_status_line status_line = { 0 };
   AZ_RETURN_IF_FAILED(az_http_response_get_status_line(ref_response, &status_line));
   AZ_RETURN_IF_FAILED(
-      az_span_copy_u64toa(remainder, (uint64_t)status_line.status_code, &remainder));
+      az_span_u64toa(remainder, (uint64_t)status_line.status_code, &remainder));
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(status_line.reason_phrase) + 1);
   remainder = az_span_copy_uint8(remainder, ' ');

--- a/sdk/core/core/src/az_http_policy_logging.c
+++ b/sdk/core/core/src/az_http_policy_logging.c
@@ -23,12 +23,14 @@ enum
 
 static az_span _az_http_policy_logging_copy_lengthy_value(az_span ref_log_msg, az_span value)
 {
-  // The caller should validate that ref_log_msg is large enough to contain the value az_span
-  // This means, ref_log_msg must have at least _az_LOG_LENGTHY_VALUE_MAX_LENGTH (i.e. 50) bytes
-  // available.
-  AZ_PRECONDITION(az_span_size(ref_log_msg) >= _az_LOG_LENGTHY_VALUE_MAX_LENGTH);
-
   int32_t value_size = az_span_size(value);
+
+  // The caller should validate that ref_log_msg is large enough to contain the value az_span
+  // This means, ref_log_msg must have available at least _az_LOG_LENGTHY_VALUE_MAX_LENGTH (i.e. 50)
+  // bytes or as much as the size of the value az_span, whichever is smaller.
+  AZ_PRECONDITION(
+      az_span_size(ref_log_msg) >= _az_LOG_LENGTHY_VALUE_MAX_LENGTH
+      || az_span_size(ref_log_msg) >= value_size);
 
   if (value_size <= _az_LOG_LENGTHY_VALUE_MAX_LENGTH)
   {
@@ -150,8 +152,7 @@ static az_result _az_http_policy_logging_append_http_response_msg(
 
   az_http_response_status_line status_line = { 0 };
   AZ_RETURN_IF_FAILED(az_http_response_get_status_line(ref_response, &status_line));
-  AZ_RETURN_IF_FAILED(
-      az_span_u64toa(remainder, (uint64_t)status_line.status_code, &remainder));
+  AZ_RETURN_IF_FAILED(az_span_u64toa(remainder, (uint64_t)status_line.status_code, &remainder));
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(status_line.reason_phrase) + 1);
   remainder = az_span_copy_u8(remainder, ' ');

--- a/sdk/core/core/src/az_http_policy_retry.c
+++ b/sdk/core/core/src/az_http_policy_retry.c
@@ -9,6 +9,7 @@
 #include <az_log_internal.h>
 #include <az_platform_internal.h>
 #include <az_retry_internal.h>
+#include <az_span_internal.h>
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -25,13 +26,6 @@ static az_http_status_code const _default_status_codes[] = {
   AZ_HTTP_STATUS_CODE_GATEWAY_TIMEOUT,
   AZ_HTTP_STATUS_CODE_NONE,
 };
-
-static AZ_NODISCARD int32_t _az_span_diff(az_span new_span, az_span old_span)
-{
-  int32_t answer = az_span_size(old_span) - az_span_size(new_span);
-  AZ_PRECONDITION(answer == (int32_t)(az_span_ptr(new_span) - az_span_ptr(old_span)));
-  return answer;
-}
 
 AZ_NODISCARD az_http_policy_retry_options _az_http_policy_retry_options_default()
 {

--- a/sdk/core/core/src/az_http_policy_retry.c
+++ b/sdk/core/core/src/az_http_policy_retry.c
@@ -48,13 +48,13 @@ AZ_INLINE az_result _az_http_policy_retry_append_http_retry_msg(
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(*ref_log_msg, az_span_size(retry_count_string));
   az_span remainder = az_span_copy(*ref_log_msg, retry_count_string);
 
-  AZ_RETURN_IF_FAILED(az_span_copy_i32toa(remainder, (int32_t)attempt, &remainder));
+  AZ_RETURN_IF_FAILED(az_span_itoa(remainder, (int32_t)attempt, &remainder));
 
   az_span infix_string = AZ_SPAN_FROM_STR(" will be made in ");
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(infix_string));
   remainder = az_span_copy(remainder, infix_string);
 
-  AZ_RETURN_IF_FAILED(az_span_copy_i32toa(remainder, delay_msec, &remainder));
+  AZ_RETURN_IF_FAILED(az_span_itoa(remainder, delay_msec, &remainder));
 
   az_span suffix_string = AZ_SPAN_FROM_STR("ms.");
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(suffix_string));
@@ -78,7 +78,7 @@ AZ_INLINE void _az_http_policy_retry_log(int16_t attempt, int32_t delay_msec)
 AZ_INLINE AZ_NODISCARD int32_t _az_uint32_span_to_int32(az_span span)
 {
   uint32_t value = 0;
-  if (az_succeeded(az_span_to_uint32(span, &value)))
+  if (az_succeeded(az_span_atou(span, &value)))
   {
     return value < INT32_MAX ? (int32_t)value : INT32_MAX;
   }

--- a/sdk/core/core/src/az_http_policy_retry.c
+++ b/sdk/core/core/src/az_http_policy_retry.c
@@ -48,13 +48,13 @@ AZ_INLINE az_result _az_http_policy_retry_append_http_retry_msg(
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(*ref_log_msg, az_span_size(retry_count_string));
   az_span remainder = az_span_copy(*ref_log_msg, retry_count_string);
 
-  AZ_RETURN_IF_FAILED(az_span_itoa(remainder, (int32_t)attempt, &remainder));
+  AZ_RETURN_IF_FAILED(az_span_i32toa(remainder, (int32_t)attempt, &remainder));
 
   az_span infix_string = AZ_SPAN_FROM_STR(" will be made in ");
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(infix_string));
   remainder = az_span_copy(remainder, infix_string);
 
-  AZ_RETURN_IF_FAILED(az_span_itoa(remainder, delay_msec, &remainder));
+  AZ_RETURN_IF_FAILED(az_span_i32toa(remainder, delay_msec, &remainder));
 
   az_span suffix_string = AZ_SPAN_FROM_STR("ms.");
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(suffix_string));
@@ -78,7 +78,7 @@ AZ_INLINE void _az_http_policy_retry_log(int16_t attempt, int32_t delay_msec)
 AZ_INLINE AZ_NODISCARD int32_t _az_uint32_span_to_int32(az_span span)
 {
   uint32_t value = 0;
-  if (az_succeeded(az_span_atou(span, &value)))
+  if (az_succeeded(az_span_atou32(span, &value)))
   {
     return value < INT32_MAX ? (int32_t)value : INT32_MAX;
   }

--- a/sdk/core/core/src/az_http_private.h
+++ b/sdk/core/core/src/az_http_private.h
@@ -16,7 +16,7 @@
 
 /**
  * @brief Mark that the HTTP headers that are gong to be added via
- * `az_http_request_builder_append_header` are going to be considered as retry headers.
+ * `az_http_request_append_header` are going to be considered as retry headers.
  *
  * @param p_hrb HTTP request builder.
  *
@@ -27,19 +27,14 @@
 AZ_NODISCARD AZ_INLINE az_result _az_http_request_mark_retry_headers_start(_az_http_request* p_hrb)
 {
   AZ_PRECONDITION_NOT_NULL(p_hrb);
-  p_hrb->_internal.retry_headers_start_byte_offset = az_span_length(p_hrb->_internal.headers);
+  p_hrb->_internal.retry_headers_start_byte_offset = p_hrb->_internal.headers_length * (int32_t)sizeof(az_pair);
   return AZ_OK;
 }
 
 AZ_NODISCARD AZ_INLINE az_result _az_http_request_remove_retry_headers(_az_http_request* p_hrb)
 {
   AZ_PRECONDITION_NOT_NULL(p_hrb);
-
-  az_span* headers_ptr = &p_hrb->_internal.headers;
-  *headers_ptr = az_span_init(
-      az_span_ptr(*headers_ptr),
-      p_hrb->_internal.retry_headers_start_byte_offset,
-      az_span_capacity(*headers_ptr));
+  p_hrb->_internal.headers_length = p_hrb->_internal.retry_headers_start_byte_offset / (int32_t)sizeof(az_pair);
   return AZ_OK;
 }
 

--- a/sdk/core/core/src/az_http_request.c
+++ b/sdk/core/core/src/az_http_request.c
@@ -24,6 +24,7 @@ AZ_NODISCARD az_result az_http_request_init(
     az_context* context,
     az_span method,
     az_span url,
+    int32_t url_length,
     az_span headers_buffer,
     az_span body)
 {
@@ -40,14 +41,16 @@ AZ_NODISCARD az_result az_http_request_init(
                                 .context = context,
                                 .method = method,
                                 .url = url,
+                                .url_length = url_length,
                                 /* query start is set to 0 if there is not a question mark so the
                                    next time query parameter is appended, a question mark will be
                                    added at url length */
                                 .query_start
                                 = url_with_query == AZ_ERROR_ITEM_NOT_FOUND ? 0 : query_start,
                                 .headers = headers_buffer,
+                                .headers_length = 0,
                                 .max_headers
-                                = az_span_capacity(headers_buffer) / (int32_t)sizeof(az_pair),
+                                = az_span_size(headers_buffer) / (int32_t)sizeof(az_pair),
                                 .retry_headers_start_byte_offset = 0,
                                 .body = body,
                             } };
@@ -62,7 +65,7 @@ AZ_NODISCARD az_result az_http_request_append_path(_az_http_request* p_request, 
   // get the query starting point.
   bool url_with_question_mark = p_request->_internal.query_start > 0;
   int32_t query_start = url_with_question_mark ? p_request->_internal.query_start - 1
-                                               : az_span_length(p_request->_internal.url);
+                                               : p_request->_internal.url_length;
 
   /* use replace twice. Yes, we will have 2 right shift (one on each replace), but we rely on
    * replace functionfor doing this movements only and avoid updating manually. We could also create
@@ -70,10 +73,13 @@ AZ_NODISCARD az_result az_http_request_append_path(_az_http_request* p_request, 
    * memory.
    */
   AZ_RETURN_IF_FAILED(
-      _az_span_replace(&p_request->_internal.url, query_start, query_start, AZ_SPAN_FROM_STR("/")));
+      _az_span_replace(p_request->_internal.url, p_request->_internal.url_length, query_start, query_start, AZ_SPAN_FROM_STR("/")));
   query_start += 1; // a size of "/"
-  AZ_RETURN_IF_FAILED(_az_span_replace(&p_request->_internal.url, query_start, query_start, path));
-  query_start += az_span_length(path);
+  p_request->_internal.url_length++;
+
+  AZ_RETURN_IF_FAILED(_az_span_replace(p_request->_internal.url, p_request->_internal.url_length, query_start, query_start, path));
+  query_start += az_span_size(path);
+  p_request->_internal.url_length += az_span_size(path);
 
   // update query start
   if (url_with_question_mark)
@@ -92,11 +98,14 @@ az_http_request_set_query_parameter(_az_http_request* p_request, az_span name, a
   AZ_PRECONDITION_VALID_SPAN(value, 1, false);
 
   // name or value can't be empty
-  AZ_PRECONDITION(az_span_length(name) > 0 && az_span_length(value) > 0);
+  AZ_PRECONDITION(az_span_size(name) > 0 && az_span_size(value) > 0);
 
-  int32_t required_length = az_span_length(name) + az_span_length(name) + 2;
+  int32_t required_length = az_span_size(name) + az_span_size(value) + 2;
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(p_request->_internal.url, required_length);
+  az_span url_remainder
+      = az_span_slice(p_request->_internal.url, p_request->_internal.url_length, -1);
+
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(url_remainder, required_length);
 
   // Append either '?' or '&'
   uint8_t separator;
@@ -105,23 +114,25 @@ az_http_request_set_query_parameter(_az_http_request* p_request, az_span name, a
     separator = '?';
 
     // update QPs starting position when it's 0
-    p_request->_internal.query_start = az_span_length(p_request->_internal.url) + 1;
+    p_request->_internal.query_start = p_request->_internal.url_length + 1;
   }
   else
   {
     separator = '&';
   }
 
-  p_request->_internal.url = az_span_append_uint8(p_request->_internal.url, separator);
+  url_remainder = az_span_copy_uint8(url_remainder, separator);
 
   // Append parameter name
-  p_request->_internal.url = az_span_append(p_request->_internal.url, name);
+  url_remainder = az_span_copy(url_remainder, name);
 
   // Append equal sym
-  p_request->_internal.url = az_span_append_uint8(p_request->_internal.url, '=');
+  url_remainder = az_span_copy_uint8(url_remainder, '=');
 
   // Parameter value
-  p_request->_internal.url = az_span_append(p_request->_internal.url, value);
+  url_remainder = az_span_copy(url_remainder, value);
+
+  p_request->_internal.url_length += required_length;
 
   return AZ_OK;
 }
@@ -133,17 +144,19 @@ az_http_request_append_header(_az_http_request* p_request, az_span key, az_span 
   AZ_PRECONDITION_VALID_SPAN(key, 1, false);
   AZ_PRECONDITION_VALID_SPAN(value, 1, false);
 
-  AZ_PRECONDITION(az_span_length(key) > 0 || az_span_length(value) > 0);
+  AZ_PRECONDITION(az_span_size(key) > 0 || az_span_size(value) > 0);
 
-  az_span* headers_ptr = &p_request->_internal.headers;
+  az_span headers = p_request->_internal.headers;
 
   az_pair header_to_append = az_pair_init(key, value);
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*headers_ptr, (int32_t)sizeof header_to_append);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(headers, (int32_t)sizeof header_to_append);
 
-  *headers_ptr = az_span_append(
-      *headers_ptr,
-      az_span_init((uint8_t*)&header_to_append, sizeof header_to_append, sizeof header_to_append));
+  az_span_copy(
+      az_span_slice(headers, (int32_t)sizeof(az_pair) * p_request->_internal.headers_length, -1),
+      az_span_init((uint8_t*)&header_to_append, sizeof header_to_append));
+
+  p_request->_internal.headers_length++;
 
   return AZ_OK;
 }
@@ -170,7 +183,7 @@ AZ_NODISCARD az_result az_http_request_get_parts(
     az_span* out_body)
 {
   *out_method = request->_internal.method;
-  *out_url = request->_internal.url;
+  *out_url = az_span_slice(request->_internal.url, 0, request->_internal.url_length);
   *out_body = request->_internal.body;
   return AZ_OK;
 }

--- a/sdk/core/core/src/az_http_request.c
+++ b/sdk/core/core/src/az_http_request.c
@@ -72,12 +72,17 @@ AZ_NODISCARD az_result az_http_request_append_path(_az_http_request* p_request, 
    * a temp buffer to join "/" and path and then use replace. But that will cost us more stack
    * memory.
    */
-  AZ_RETURN_IF_FAILED(
-      _az_span_replace(p_request->_internal.url, p_request->_internal.url_length, query_start, query_start, AZ_SPAN_FROM_STR("/")));
+  AZ_RETURN_IF_FAILED(_az_span_replace(
+      p_request->_internal.url,
+      p_request->_internal.url_length,
+      query_start,
+      query_start,
+      AZ_SPAN_FROM_STR("/")));
   query_start += 1; // a size of "/"
   p_request->_internal.url_length++;
 
-  AZ_RETURN_IF_FAILED(_az_span_replace(p_request->_internal.url, p_request->_internal.url_length, query_start, query_start, path));
+  AZ_RETURN_IF_FAILED(_az_span_replace(
+      p_request->_internal.url, p_request->_internal.url_length, query_start, query_start, path));
   query_start += az_span_size(path);
   p_request->_internal.url_length += az_span_size(path);
 
@@ -103,7 +108,7 @@ az_http_request_set_query_parameter(_az_http_request* p_request, az_span name, a
   int32_t required_length = az_span_size(name) + az_span_size(value) + 2;
 
   az_span url_remainder
-      = az_span_slice(p_request->_internal.url, p_request->_internal.url_length, -1);
+      = az_span_slice_to_end(p_request->_internal.url, p_request->_internal.url_length);
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(url_remainder, required_length);
 
@@ -153,7 +158,7 @@ az_http_request_append_header(_az_http_request* p_request, az_span key, az_span 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(headers, (int32_t)sizeof header_to_append);
 
   az_span_copy(
-      az_span_slice(headers, (int32_t)sizeof(az_pair) * p_request->_internal.headers_length, -1),
+      az_span_slice_to_end(headers, (int32_t)sizeof(az_pair) * p_request->_internal.headers_length),
       az_span_init((uint8_t*)&header_to_append, sizeof header_to_append));
 
   p_request->_internal.headers_length++;

--- a/sdk/core/core/src/az_http_request.c
+++ b/sdk/core/core/src/az_http_request.c
@@ -121,13 +121,13 @@ az_http_request_set_query_parameter(_az_http_request* p_request, az_span name, a
     separator = '&';
   }
 
-  url_remainder = az_span_copy_uint8(url_remainder, separator);
+  url_remainder = az_span_copy_u8(url_remainder, separator);
 
   // Append parameter name
   url_remainder = az_span_copy(url_remainder, name);
 
   // Append equal sym
-  url_remainder = az_span_copy_uint8(url_remainder, '=');
+  url_remainder = az_span_copy_u8(url_remainder, '=');
 
   // Parameter value
   url_remainder = az_span_copy(url_remainder, value);

--- a/sdk/core/core/src/az_http_response.c
+++ b/sdk/core/core/src/az_http_response.c
@@ -82,7 +82,7 @@ _az_get_http_status_line(az_span* self, az_http_response_status_line* out_status
   // status-code = 3DIGIT
   {
     uint64_t code = 0;
-    AZ_RETURN_IF_FAILED(az_span_to_uint64(az_span_init(az_span_ptr(*self), 3, 3), &code));
+    AZ_RETURN_IF_FAILED(az_span_to_uint64(az_span_init(az_span_ptr(*self), 3), &code));
     out_status_line->status_code = (az_http_status_code)code;
     // move reader
     *self = az_span_slice(*self, 3, -1);

--- a/sdk/core/core/src/az_http_response.c
+++ b/sdk/core/core/src/az_http_response.c
@@ -82,7 +82,7 @@ _az_get_http_status_line(az_span* self, az_http_response_status_line* out_status
   // status-code = 3DIGIT
   {
     uint64_t code = 0;
-    AZ_RETURN_IF_FAILED(az_span_to_uint64(az_span_init(az_span_ptr(*self), 3), &code));
+    AZ_RETURN_IF_FAILED(az_span_atou64(az_span_init(az_span_ptr(*self), 3), &code));
     out_status_line->status_code = (az_http_status_code)code;
     // move reader
     *self = az_span_slice(*self, 3, -1);

--- a/sdk/core/core/src/az_json_builder.c
+++ b/sdk/core/core/src/az_json_builder.c
@@ -5,15 +5,9 @@
 #include "az_json_string_private.h"
 #include "az_span_private.h"
 #include <az_json.h>
+#include <az_span_internal.h>
 
 #include <_az_cfg.h>
-
-static AZ_NODISCARD int32_t _az_span_diff(az_span new_span, az_span old_span)
-{
-  int32_t answer = az_span_size(old_span) - az_span_size(new_span);
-  AZ_PRECONDITION(answer == (int32_t)(az_span_ptr(new_span) - az_span_ptr(old_span)));
-  return answer;
-}
 
 static AZ_NODISCARD az_span _get_remaining_span(az_json_builder* json_builder)
 {

--- a/sdk/core/core/src/az_json_builder.c
+++ b/sdk/core/core/src/az_json_builder.c
@@ -24,9 +24,9 @@ AZ_NODISCARD static az_result az_json_builder_append_str(az_json_builder* self, 
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remaining_json, required_length);
 
-  remaining_json = az_span_copy_uint8(remaining_json, '"');
+  remaining_json = az_span_copy_u8(remaining_json, '"');
   remaining_json = az_span_copy(remaining_json, value);
-  az_span_copy_uint8(remaining_json, '"');
+  az_span_copy_u8(remaining_json, '"');
 
   self->_internal.length += required_length;
   return AZ_OK;
@@ -39,7 +39,7 @@ static AZ_NODISCARD az_result _az_json_builder_write_span(az_json_builder* self,
   az_span remaining_json = _get_remaining_span(self);
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remaining_json, 1);
-  remaining_json = az_span_copy_uint8(remaining_json, '"');
+  remaining_json = az_span_copy_u8(remaining_json, '"');
   self->_internal.length++;
 
   for (int32_t i = 0; i < az_span_size(value); ++i)
@@ -77,11 +77,11 @@ static AZ_NODISCARD az_result _az_json_builder_write_span(az_json_builder* self,
     }
 
     AZ_RETURN_IF_NOT_ENOUGH_SIZE(remaining_json, 1);
-    remaining_json = az_span_copy_uint8(remaining_json, az_span_ptr(value)[i]);
+    remaining_json = az_span_copy_u8(remaining_json, az_span_ptr(value)[i]);
     self->_internal.length++;
   }
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remaining_json, 1);
-  remaining_json = az_span_copy_uint8(remaining_json, '"');
+  remaining_json = az_span_copy_u8(remaining_json, '"');
   self->_internal.length++;
 
   return AZ_OK;
@@ -140,28 +140,28 @@ az_json_builder_append_token(az_json_builder* json_builder, az_json_token token)
     case AZ_JSON_TOKEN_OBJECT_START:
     {
       json_builder->_internal.need_comma = false;
-      remaining_json = az_span_copy_uint8(remaining_json, '{');
+      remaining_json = az_span_copy_u8(remaining_json, '{');
       json_builder->_internal.length++;
       break;
     }
     case AZ_JSON_TOKEN_OBJECT_END:
     {
       json_builder->_internal.need_comma = true;
-      remaining_json = az_span_copy_uint8(remaining_json, '}');
+      remaining_json = az_span_copy_u8(remaining_json, '}');
       json_builder->_internal.length++;
       break;
     }
     case AZ_JSON_TOKEN_ARRAY_START:
     {
       json_builder->_internal.need_comma = false;
-      remaining_json = az_span_copy_uint8(remaining_json, '[');
+      remaining_json = az_span_copy_u8(remaining_json, '[');
       json_builder->_internal.length++;
       break;
     }
     case AZ_JSON_TOKEN_ARRAY_END:
     {
       json_builder->_internal.need_comma = true;
-      remaining_json = az_span_copy_uint8(remaining_json, ']');
+      remaining_json = az_span_copy_u8(remaining_json, ']');
       json_builder->_internal.length++;
       break;
     }
@@ -187,7 +187,7 @@ AZ_NODISCARD static az_result az_json_builder_write_comma(az_json_builder* self)
   {
     az_span remaining_json = _get_remaining_span(self);
     AZ_RETURN_IF_NOT_ENOUGH_SIZE(remaining_json, 1);
-    az_span_copy_uint8(remaining_json, ',');
+    az_span_copy_u8(remaining_json, ',');
     self->_internal.length++;
   }
   return AZ_OK;
@@ -203,7 +203,7 @@ az_json_builder_append_object(az_json_builder* json_builder, az_span name, az_js
 
   az_span remaining_json = _get_remaining_span(json_builder);
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remaining_json, 1);
-  az_span_copy_uint8(remaining_json, ':');
+  az_span_copy_u8(remaining_json, ':');
   json_builder->_internal.length++;
 
   AZ_RETURN_IF_FAILED(az_json_builder_append_token(json_builder, token));

--- a/sdk/core/core/src/az_json_builder.c
+++ b/sdk/core/core/src/az_json_builder.c
@@ -77,7 +77,7 @@ static AZ_NODISCARD az_result _az_json_builder_write_span(az_json_builder* self,
       };
 
       AZ_RETURN_IF_NOT_ENOUGH_SIZE(remaining_json, (int32_t)sizeof(array));
-      remaining_json = az_span_copy(remaining_json, AZ_SPAN_FROM_INITIALIZED_BUFFER(array));
+      remaining_json = az_span_copy(remaining_json, AZ_SPAN_FROM_BUFFER(array));
       self->_internal.length += (int32_t)sizeof(array);
       continue;
     }

--- a/sdk/core/core/src/az_json_builder.c
+++ b/sdk/core/core/src/az_json_builder.c
@@ -119,7 +119,7 @@ az_json_builder_append_token(az_json_builder* json_builder, az_json_token token)
     {
       json_builder->_internal.need_comma = true;
       az_span remainder;
-      AZ_RETURN_IF_FAILED(az_span_copy_dtoa(remaining_json, token._internal.number, &remainder));
+      AZ_RETURN_IF_FAILED(az_span_dtoa(remaining_json, token._internal.number, &remainder));
       json_builder->_internal.length += _az_span_diff(remainder, remaining_json);
       remaining_json = remainder;
       break;

--- a/sdk/core/core/src/az_json_builder.c
+++ b/sdk/core/core/src/az_json_builder.c
@@ -11,7 +11,7 @@
 
 static AZ_NODISCARD az_span _get_remaining_span(az_json_builder* json_builder)
 {
-  return az_span_slice(json_builder->_internal.json, json_builder->_internal.length, -1);
+  return az_span_slice_to_end(json_builder->_internal.json, json_builder->_internal.length);
 }
 
 AZ_NODISCARD static az_result az_json_builder_append_str(az_json_builder* self, az_span value)

--- a/sdk/core/core/src/az_json_pointer.c
+++ b/sdk/core/core/src/az_json_pointer.c
@@ -29,7 +29,7 @@ static AZ_NODISCARD az_result _az_span_reader_read_json_pointer_char(az_span* se
     case '~':
     {
       // move reader to next position
-      *self = az_span_slice(*self, 1, -1);
+      *self = az_span_slice_to_end(*self, 1);
       // check for EOF
       if (az_span_size(*self) == 0)
       {
@@ -38,7 +38,7 @@ static AZ_NODISCARD az_result _az_span_reader_read_json_pointer_char(az_span* se
       // get char
       uint8_t const e = az_span_ptr(*self)[0];
       // move to next position again
-      *self = az_span_slice(*self, 1, -1);
+      *self = az_span_slice_to_end(*self, 1);
       switch (e)
       {
         case '0':
@@ -60,7 +60,7 @@ static AZ_NODISCARD az_result _az_span_reader_read_json_pointer_char(az_span* se
     default:
     {
       // move reader to next position
-      *self = az_span_slice(*self, 1, -1);
+      *self = az_span_slice_to_end(*self, 1);
 
       *out = (uint8_t)result;
       return AZ_OK;
@@ -89,7 +89,7 @@ AZ_NODISCARD az_result _az_span_reader_read_json_pointer_token(az_span* self, az
     }
   }
   // move forward
-  *self = az_span_slice(*self, 1, -1);
+  *self = az_span_slice_to_end(*self, 1);
   if (az_span_size(*self) == 0)
   {
     *out = *self;

--- a/sdk/core/core/src/az_json_pointer.c
+++ b/sdk/core/core/src/az_json_pointer.c
@@ -173,7 +173,7 @@ AZ_NODISCARD static az_result az_json_parser_get_by_pointer_token(
     case AZ_JSON_TOKEN_ARRAY_START:
     {
       uint64_t i = 0;
-      AZ_RETURN_IF_FAILED(az_span_to_uint64(pointer_token, &i));
+      AZ_RETURN_IF_FAILED(az_span_atou64(pointer_token, &i));
       while (true)
       {
         AZ_RETURN_IF_FAILED(az_json_parser_parse_array_item(json_parser, inout_token));

--- a/sdk/core/core/src/az_json_pointer.c
+++ b/sdk/core/core/src/az_json_pointer.c
@@ -4,6 +4,7 @@
 #include "az_json_string_private.h"
 #include <az_json.h>
 #include <az_precondition.h>
+#include <az_precondition_internal.h>
 
 #include <_az_cfg.h>
 

--- a/sdk/core/core/src/az_json_pointer.c
+++ b/sdk/core/core/src/az_json_pointer.c
@@ -10,7 +10,7 @@
 static AZ_NODISCARD az_result _az_span_reader_read_json_pointer_char(az_span* self, uint32_t* out)
 {
   AZ_PRECONDITION_NOT_NULL(self);
-  int32_t reader_current_length = az_span_length(*self);
+  int32_t reader_current_length = az_span_size(*self);
 
   // check for EOF
   if (reader_current_length == 0)
@@ -30,7 +30,7 @@ static AZ_NODISCARD az_result _az_span_reader_read_json_pointer_char(az_span* se
       // move reader to next position
       *self = az_span_slice(*self, 1, -1);
       // check for EOF
-      if (az_span_length(*self) == 0)
+      if (az_span_size(*self) == 0)
       {
         return AZ_ERROR_EOF;
       }
@@ -77,7 +77,7 @@ AZ_NODISCARD az_result _az_span_reader_read_json_pointer_token(az_span* self, az
   // read `/` if any.
   {
     // check there is something still to read
-    if (az_span_length(*self) == 0)
+    if (az_span_size(*self) == 0)
     {
       return AZ_ERROR_ITEM_NOT_FOUND;
     }
@@ -89,7 +89,7 @@ AZ_NODISCARD az_result _az_span_reader_read_json_pointer_token(az_span* self, az
   }
   // move forward
   *self = az_span_slice(*self, 1, -1);
-  if (az_span_length(*self) == 0)
+  if (az_span_size(*self) == 0)
   {
     *out = *self;
     return AZ_OK;
@@ -99,7 +99,7 @@ AZ_NODISCARD az_result _az_span_reader_read_json_pointer_token(az_span* self, az
   // end of a Json token. var begin will record the number of bytes read until token_end or
   // pointer_end. TODO: We might be able to implement _az_span_scan_until() here, since we ignore
   // the out of _az_span_reader_read_json_pointer_char()
-  int32_t initial_capacity = az_span_capacity(*self);
+  int32_t initial_capacity = az_span_size(*self);
   uint8_t* p_reader = az_span_ptr(*self);
   while (true)
   {
@@ -110,8 +110,8 @@ AZ_NODISCARD az_result _az_span_reader_read_json_pointer_token(az_span* self, az
       case AZ_ERROR_ITEM_NOT_FOUND:
       case AZ_ERROR_JSON_POINTER_TOKEN_END:
       {
-        int32_t current_capacity = initial_capacity - az_span_capacity(*self);
-        *out = az_span_init(p_reader, current_capacity, current_capacity);
+        int32_t current_capacity = initial_capacity - az_span_size(*self);
+        *out = az_span_init(p_reader, current_capacity);
         return AZ_OK;
       }
       default:

--- a/sdk/core/core/src/az_json_string.c
+++ b/sdk/core/core/src/az_json_string.c
@@ -139,13 +139,13 @@ AZ_NODISCARD az_result _az_span_reader_read_json_string_char(az_span* json_strin
     case '\\':
     {
       // moving reader fw
-      *json_string = az_span_slice(*json_string, 1, -1);
+      *json_string = az_span_slice_to_end(*json_string, 1);
       if (az_span_size(*json_string) == 0)
       {
         return AZ_ERROR_EOF;
       }
       uint8_t const c = az_span_ptr(*json_string)[0];
-      *json_string = az_span_slice(*json_string, 1, -1);
+      *json_string = az_span_slice_to_end(*json_string, 1);
 
       if (c == 'u')
       {
@@ -159,7 +159,7 @@ AZ_NODISCARD az_result _az_span_reader_read_json_string_char(az_span* json_strin
           }
           AZ_RETURN_IF_FAILED(az_hex_to_digit(az_span_ptr(*json_string)[0], &digit));
           r = (r << 4) + digit;
-          *json_string = az_span_slice(*json_string, 1, -1);
+          *json_string = az_span_slice_to_end(*json_string, 1);
         }
         *out = r;
       }
@@ -177,7 +177,7 @@ AZ_NODISCARD az_result _az_span_reader_read_json_string_char(az_span* json_strin
       {
         return AZ_ERROR_PARSER_UNEXPECTED_CHAR;
       }
-      *json_string = az_span_slice(*json_string, 1, -1);
+      *json_string = az_span_slice_to_end(*json_string, 1);
       *out = (uint16_t)result;
       return AZ_OK;
     }

--- a/sdk/core/core/src/az_json_string.c
+++ b/sdk/core/core/src/az_json_string.c
@@ -123,7 +123,7 @@ AZ_NODISCARD az_span _az_json_esc_encode(uint8_t c)
  */
 AZ_NODISCARD az_result _az_span_reader_read_json_string_char(az_span* json_string, uint32_t* out)
 {
-  int32_t reader_length = az_span_length(*json_string);
+  int32_t reader_length = az_span_size(*json_string);
   if (reader_length == 0)
   {
     return AZ_ERROR_ITEM_NOT_FOUND;
@@ -140,7 +140,7 @@ AZ_NODISCARD az_result _az_span_reader_read_json_string_char(az_span* json_strin
     {
       // moving reader fw
       *json_string = az_span_slice(*json_string, 1, -1);
-      if (az_span_length(*json_string) == 0)
+      if (az_span_size(*json_string) == 0)
       {
         return AZ_ERROR_EOF;
       }
@@ -153,7 +153,7 @@ AZ_NODISCARD az_result _az_span_reader_read_json_string_char(az_span* json_strin
         for (size_t i = 0; i < 4; ++i)
         {
           uint8_t digit = 0;
-          if (az_span_length(*json_string) == 0)
+          if (az_span_size(*json_string) == 0)
           {
             return AZ_ERROR_EOF;
           }

--- a/sdk/core/core/src/az_json_string_private.h
+++ b/sdk/core/core/src/az_json_string_private.h
@@ -4,7 +4,6 @@
 #ifndef _az_JSON_STRING_PRIVATE_H
 #define _az_JSON_STRING_PRIVATE_H
 
-#include "az_span_private.h"
 #include <az_json.h>
 #include <az_span.h>
 

--- a/sdk/core/core/src/az_precondition.c
+++ b/sdk/core/core/src/az_precondition.c
@@ -10,11 +10,12 @@
 
 static void az_precondition_failed_default()
 {
-  /* By default, when a precondition fails the calling thread is suspended forever */
-  while (true)
-  {
-    az_platform_sleep_msec(INT32_MAX);
-  }
+  ///* By default, when a precondition fails the calling thread is suspended forever */
+  //while (true)
+  //{
+  //  az_platform_sleep_msec(INT32_MAX);
+  //}
+  *(char*)NULL = 0;
 }
 
 az_precondition_failed_fn _az_precondition_failed_callback = az_precondition_failed_default;

--- a/sdk/core/core/src/az_precondition.c
+++ b/sdk/core/core/src/az_precondition.c
@@ -10,12 +10,11 @@
 
 static void az_precondition_failed_default()
 {
-  ///* By default, when a precondition fails the calling thread is suspended forever */
-  //while (true)
-  //{
-  //  az_platform_sleep_msec(INT32_MAX);
-  //}
-  *(char*)NULL = 0;
+  /* By default, when a precondition fails the calling thread is suspended forever */
+  while (true)
+  {
+    az_platform_sleep_msec(INT32_MAX);
+  }
 }
 
 az_precondition_failed_fn _az_precondition_failed_callback = az_precondition_failed_default;

--- a/sdk/core/core/src/az_span.c
+++ b/sdk/core/core/src/az_span.c
@@ -62,7 +62,7 @@ AZ_NODISCARD az_span az_span_slice(az_span span, int32_t start_index, int32_t en
   //        0 <= start_index <= span.size
   //    Otherwise
   //        0 <= start_index <= end_index
-  AZ_PRECONDITION_INT32_RANGE(-1, end_index, az_span_size(span));
+  AZ_PRECONDITION_RANGE(-1, end_index, az_span_size(span));
 
   // Do not reorder the OR conditions, since we are relying on short-circuiting.
   AZ_PRECONDITION(

--- a/sdk/core/core/src/az_span.c
+++ b/sdk/core/core/src/az_span.c
@@ -114,7 +114,7 @@ AZ_NODISCARD bool az_span_is_content_equal_ignoring_case(az_span span1, az_span 
   return true;
 }
 
-AZ_NODISCARD az_result az_span_to_uint64(az_span span, uint64_t* out_number)
+AZ_NODISCARD az_result az_span_atou64(az_span span, uint64_t* out_number)
 {
   AZ_PRECONDITION_VALID_SPAN(span, 1, false);
   AZ_PRECONDITION_NOT_NULL(out_number);
@@ -142,7 +142,7 @@ AZ_NODISCARD az_result az_span_to_uint64(az_span span, uint64_t* out_number)
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_span_to_uint32(az_span span, uint32_t* out_number)
+AZ_NODISCARD az_result az_span_atou(az_span span, uint32_t* out_number)
 {
   AZ_PRECONDITION_VALID_SPAN(span, 1, false);
   AZ_PRECONDITION_NOT_NULL(out_number);
@@ -426,7 +426,7 @@ _az_span_replace(az_span self, int32_t current_size, int32_t start, int32_t end,
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_span_copy_dtoa(az_span destination, double source, az_span* out_span)
+AZ_NODISCARD az_result az_span_dtoa(az_span destination, double source, az_span* out_span)
 {
   AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_span);
@@ -533,7 +533,7 @@ static AZ_NODISCARD az_result _az_span_builder_append_uint64(az_span* self, uint
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_span_copy_u64toa(az_span destination, uint64_t source, az_span* out_span)
+AZ_NODISCARD az_result az_span_u64toa(az_span destination, uint64_t source, az_span* out_span)
 {
   AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_span);
@@ -542,7 +542,7 @@ AZ_NODISCARD az_result az_span_copy_u64toa(az_span destination, uint64_t source,
   return _az_span_builder_append_uint64(out_span, source);
 }
 
-AZ_NODISCARD az_result az_span_copy_i64toa(az_span destination, int64_t source, az_span* out_span)
+AZ_NODISCARD az_result az_span_i64toa(az_span destination, int64_t source, az_span* out_span)
 {
   AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_span);
@@ -595,14 +595,14 @@ _az_span_builder_append_u32toa(az_span self, uint32_t n, az_span* out_span)
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_span_copy_u32toa(az_span destination, uint32_t source, az_span* out_span)
+AZ_NODISCARD az_result az_span_utoa(az_span destination, uint32_t source, az_span* out_span)
 {
   AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_span);
   return _az_span_builder_append_u32toa(destination, source, out_span);
 }
 
-AZ_NODISCARD az_result az_span_copy_i32toa(az_span destination, int32_t source, az_span* out_span)
+AZ_NODISCARD az_result az_span_itoa(az_span destination, int32_t source, az_span* out_span)
 {
   AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_span);

--- a/sdk/core/core/src/az_span.c
+++ b/sdk/core/core/src/az_span.c
@@ -18,48 +18,87 @@ enum
   _az_ASCII_LOWER_DIF = 'a' - 'A',
 };
 
-AZ_NODISCARD az_span az_span_init(uint8_t* ptr, int32_t length, int32_t capacity)
+AZ_NODISCARD az_span az_span_init(uint8_t* ptr, int32_t size)
 {
-  AZ_PRECONDITION_RANGE(0, capacity, INT32_MAX);
-  AZ_PRECONDITION_RANGE(0, length, capacity);
+  // If ptr is not null, then:
+  //   size >= 0
+  // Otherwise, if ptr is null, then:
+  //   size == 0
+  AZ_PRECONDITION((ptr != NULL && size >= 0) || (ptr + (uint32_t)size == 0));
 
-  return (az_span){ ._internal = { .ptr = ptr, .length = length, .capacity = capacity, }, };
+  // Make sure that the user can't create an invalid az_span with a negative size.
+  if (ptr == NULL || size < 0)
+  {
+    size = 0;
+  }
+
+  return (az_span){ ._internal = { .ptr = ptr, .size = size, }, };
+}
+
+AZ_NODISCARD AZ_INLINE az_span _az_span_init_unchecked(uint8_t* ptr, int32_t size)
+{
+  return (az_span){ ._internal = { .ptr = ptr, .size = size, }, };
 }
 
 AZ_NODISCARD az_span az_span_from_str(char* str)
 {
   AZ_PRECONDITION_NOT_NULL(str);
 
+  if (str == NULL)
+  {
+    return AZ_SPAN_NULL;
+  }
+
   int32_t const length = (int32_t)strlen(str);
-  return az_span_init((uint8_t*)str, length, length);
+
+  AZ_PRECONDITION(length >= 0);
+
+  return _az_span_init_unchecked((uint8_t*)str, length);
 }
 
 AZ_NODISCARD az_span az_span_slice(az_span span, int32_t start_index, int32_t end_index)
 {
-  AZ_PRECONDITION_RANGE(-1, end_index, az_span_capacity(span));
-  AZ_PRECONDITION(end_index == -1 || (end_index >= 0 && start_index <= end_index));
+  AZ_PRECONDITION_VALID_SPAN(span, 0, true);
 
-  int32_t const capacity = az_span_capacity(span);
+  // The following set of preconditions validate that:
+  //    -1 <= end_index <= span.size
+  // And
+  //    If end_index == -1:
+  //        0 <= start_index <= span.size
+  //    Otherwise
+  //        0 <= start_index <= end_index
+  AZ_PRECONDITION_INT32_RANGE(-1, end_index, az_span_size(span));
 
-  int32_t new_length;
+  // Do not reorder the OR conditions, since we are relying on short-circuiting.
+  AZ_PRECONDITION(
+      (end_index == -1 && ((uint32_t)start_index <= (uint32_t)az_span_size(span)))
+      || ((uint32_t)start_index <= (uint32_t)end_index));
 
-  // If end_index == -1, slice to the end of the span's length.
+  int32_t const size = az_span_size(span);
+
+  // Slicing beyond the span's size is not allowed.
+  // Also make sure that start_index is not negative and it is not larger than end_index.
+  if (((uint32_t)(end_index + 1) > (uint32_t)(size + 1)) || ((uint32_t)start_index > (uint32_t)size)
+      || ((uint32_t)start_index > (uint32_t)end_index))
+  {
+    return span;
+  }
+
+  int32_t new_size;
+
+  // If end_index == -1, slice to the end of the span's size.
   if (end_index == -1)
   {
-    new_length = az_span_length(span) - start_index;
-    // Slicing beyond the length is allowed as long as it is within its capacity.
-    // Make sure that length is clamped at the bottom by 0, so it doesn't become negative.
-    if (new_length < 0)
-    {
-      new_length = 0;
-    }
+    new_size = size - start_index;
   }
   else
   {
-    new_length = end_index - start_index;
+    new_size = end_index - start_index;
   }
 
-  return az_span_init(az_span_ptr(span) + start_index, new_length, capacity - start_index);
+  AZ_PRECONDITION(new_size >= 0);
+
+  return _az_span_init_unchecked(az_span_ptr(span) + start_index, new_size);
 }
 
 AZ_NODISCARD AZ_INLINE uint8_t _az_tolower(uint8_t value)
@@ -75,8 +114,8 @@ AZ_NODISCARD AZ_INLINE uint8_t _az_tolower(uint8_t value)
 
 AZ_NODISCARD bool az_span_is_content_equal_ignoring_case(az_span span1, az_span span2)
 {
-  int32_t const size = az_span_length(span1);
-  if (size != az_span_length(span2))
+  int32_t const size = az_span_size(span1);
+  if (size != az_span_size(span2))
   {
     return false;
   }
@@ -95,10 +134,10 @@ AZ_NODISCARD az_result az_span_to_uint64(az_span span, uint64_t* out_number)
   AZ_PRECONDITION_VALID_SPAN(span, 1, false);
   AZ_PRECONDITION_NOT_NULL(out_number);
 
-  int32_t self_length = az_span_length(span);
+  int32_t self_size = az_span_size(span);
   uint64_t value = 0;
 
-  for (int32_t i = 0; i < self_length; ++i)
+  for (int32_t i = 0; i < self_size; ++i)
   {
     uint8_t result = az_span_ptr(span)[i];
     if (!isdigit(result))
@@ -123,10 +162,10 @@ AZ_NODISCARD az_result az_span_to_uint32(az_span span, uint32_t* out_number)
   AZ_PRECONDITION_VALID_SPAN(span, 1, false);
   AZ_PRECONDITION_NOT_NULL(out_number);
 
-  int32_t self_length = az_span_length(span);
+  int32_t self_size = az_span_size(span);
   uint32_t value = 0;
 
-  for (int32_t i = 0; i < self_length; ++i)
+  for (int32_t i = 0; i < self_size; ++i)
   {
     uint8_t result = az_span_ptr(span)[i];
     if (!isdigit(result))
@@ -168,15 +207,15 @@ AZ_NODISCARD int32_t az_span_find(az_span source, az_span target)
    *         to be checked).
    */
 
-  int32_t source_length = az_span_length(source);
-  int32_t target_length = az_span_length(target);
+  int32_t source_size = az_span_size(source);
+  int32_t target_size = az_span_size(target);
   const int32_t target_not_found = -1;
 
-  if (target_length == 0)
+  if (target_size == 0)
   {
     return 0;
   }
-  else if (source_length < target_length)
+  else if (source_size < target_size)
   {
     return target_not_found;
   }
@@ -186,7 +225,7 @@ AZ_NODISCARD int32_t az_span_find(az_span source, az_span target)
     uint8_t* target_ptr = az_span_ptr(target);
 
     // This loop traverses `source` position by position (step 1.)
-    for (int32_t i = 0; i < (source_length - target_length + 1); i++)
+    for (int32_t i = 0; i < (source_size - target_size + 1); i++)
     {
       // This is the check done in step 1. above.
       if (source_ptr[i] == target_ptr[0])
@@ -196,7 +235,7 @@ AZ_NODISCARD int32_t az_span_find(az_span source, az_span target)
         // This is the loop defined in step 3.
         // The loop must be broken if it reaches the ends of `target` (step 3.) OR `source`
         // (step 5.).
-        for (j = 1; j < target_length && (i + j) < source_length; j++)
+        for (j = 1; j < target_size && (i + j) < source_size; j++)
         {
           // Condition defined in step 5.
           if (source_ptr[i + j] != target_ptr[j])
@@ -205,7 +244,7 @@ AZ_NODISCARD int32_t az_span_find(az_span source, az_span target)
           }
         }
 
-        if (j == target_length)
+        if (j == target_size)
         {
           // All bytes in `target` have been checked and matched the corresponding bytes in `source`
           // (from the start point `i`), so this is indeed an instance of `target` in that position
@@ -224,12 +263,41 @@ AZ_NODISCARD int32_t az_span_find(az_span source, az_span target)
 
 az_span az_span_copy(az_span destination, az_span source)
 {
-  AZ_PRECONDITION(az_span_capacity(destination) >= az_span_length(source));
+  AZ_PRECONDITION_VALID_SPAN(source, 0, true);
 
-  int32_t src_len = az_span_length(source);
+  int32_t src_size = az_span_size(source);
+
+  AZ_PRECONDITION_VALID_SPAN(destination, src_size, false);
+
+  // Even though the contract of the copy method is that the destination must be larger than source,
+  // cap the data copy if the source is too large, to avoid memory corruption.
+  int32_t dest_size = az_span_size(destination);
+  if (src_size > dest_size)
+  {
+    src_size = dest_size;
+  }
+
   uint8_t* ptr = az_span_ptr(destination);
-  memmove((void*)ptr, (void const*)az_span_ptr(source), (size_t)src_len);
-  return az_span_init(ptr, src_len, az_span_capacity(destination));
+  memmove((void*)ptr, (void const*)az_span_ptr(source), (size_t)src_size);
+
+  return az_span_slice(destination, src_size, -1);
+}
+
+az_span az_span_copy_uint8(az_span destination, uint8_t byte)
+{
+  AZ_PRECONDITION_VALID_SPAN(destination, 1, false);
+
+  // Even though the contract of the method is that the destination must be at least 1 byte large,
+  // no-op if it is empty to avoid memory corruption.
+  int32_t dest_size = az_span_size(destination);
+  if (dest_size < 1)
+  {
+    return destination;
+  }
+
+  uint8_t* dst_ptr = az_span_ptr(destination);
+  dst_ptr[0] = byte;
+  return az_span_init(dst_ptr + 1, dest_size - 1);
 }
 
 AZ_NODISCARD AZ_INLINE bool should_encode(uint8_t c)
@@ -253,7 +321,7 @@ az_span_copy_url_encode(az_span destination, az_span source, az_span* out_span)
   AZ_PRECONDITION_VALID_SPAN(destination, 0, true);
   AZ_PRECONDITION_VALID_SPAN(source, 0, true);
 
-  int32_t const input_size = az_span_length(source);
+  int32_t const input_size = az_span_size(source);
 
   int32_t result_size = 0;
   for (int32_t i = 0; i < input_size; ++i)
@@ -261,9 +329,9 @@ az_span_copy_url_encode(az_span destination, az_span source, az_span* out_span)
     result_size += should_encode(az_span_ptr(source)[i]) ? 3 : 1;
   }
 
-  if (az_span_capacity(destination) < result_size)
+  if (az_span_size(destination) < result_size)
   {
-    return AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY;
+    return AZ_ERROR_INSUFFICIENT_SPAN_SIZE;
   }
 
   uint8_t* p_s = az_span_ptr(source);
@@ -287,7 +355,7 @@ az_span_copy_url_encode(az_span destination, az_span source, az_span* out_span)
       s += 3;
     }
   }
-  *out_span = az_span_init(az_span_ptr(destination), s, az_span_capacity(destination));
+  *out_span = az_span_slice(destination, result_size, -1);
 
   return AZ_OK;
 }
@@ -295,34 +363,21 @@ az_span_copy_url_encode(az_span destination, az_span source, az_span* out_span)
 AZ_NODISCARD az_result
 az_span_to_str(char* destination, int32_t destination_max_size, az_span source)
 {
+  AZ_PRECONDITION_NOT_NULL(destination);
+  AZ_PRECONDITION(destination_max_size > 0);
   AZ_PRECONDITION_VALID_SPAN(source, 0, true);
 
-  int32_t span_length = az_span_length(source);
-  if (span_length + 1 > destination_max_size)
+  int32_t span_size = az_span_size(source);
+  if (destination_max_size < 0 || (uint32_t)(span_size + 1) > (uint32_t)destination_max_size)
   {
-    return AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY;
+    return AZ_ERROR_ARG;
   }
 
-  memmove((void*)destination, (void const*)az_span_ptr(source), (size_t)span_length);
+  memmove((void*)destination, (void const*)az_span_ptr(source), (size_t)span_size);
 
-  destination[span_length] = 0;
+  destination[span_size] = 0;
 
   return AZ_OK;
-}
-
-az_span az_span_append(az_span destination, az_span source)
-{
-  AZ_PRECONDITION(
-      (az_span_length(destination) + az_span_length(source)) <= az_span_capacity(destination));
-
-  int32_t const dest_length = az_span_length(destination);
-  int32_t const dest_capacity = az_span_capacity(destination);
-  int32_t const src_length = az_span_length(source);
-  int32_t const dest_length_after_appending = dest_length + src_length;
-
-  uint8_t* ptr = az_span_ptr(destination);
-  memmove((void*)(&ptr[dest_length]), (void const*)az_span_ptr(source), (size_t)src_length);
-  return az_span_init(ptr, dest_length_after_appending, dest_capacity);
 }
 
 /**
@@ -335,33 +390,25 @@ az_span az_span_append(az_span destination, az_span source)
  * @param span content to use for replacement
  * @return AZ_NODISCARD az_span_replace
  */
-AZ_NODISCARD az_result _az_span_replace(az_span* self, int32_t start, int32_t end, az_span span)
+AZ_NODISCARD az_result
+_az_span_replace(az_span self, int32_t current_size, int32_t start, int32_t end, az_span span)
 {
-  AZ_PRECONDITION_NOT_NULL(self);
-
-  int32_t const current_size = az_span_length(*self);
-  int32_t const span_length = az_span_length(span);
+  int32_t const span_size = az_span_size(span);
   int32_t const replaced_size = end - start;
-  int32_t const size_after_replace = current_size - replaced_size + span_length;
+  int32_t const size_after_replace = current_size - replaced_size + span_size;
 
-  // replaced size must be less or equal to current builder size. Can't replace more than what
-  // current is available
-  if (replaced_size > current_size)
+  // Start and end position must be within the self span and be positive.
+  // Start position must be less or equal than end position.
+  if ((uint32_t)start > (uint32_t)current_size || (uint32_t)end > (uint32_t)current_size
+      || start > end)
   {
     return AZ_ERROR_ARG;
   };
-  // start and end position must be before the end of current builder size
-  if (start > current_size || end > current_size)
-  {
-    return AZ_ERROR_ARG;
-  };
-  // Start position must be less or equal than end position
-  if (start > end)
-  {
-    return AZ_ERROR_ARG;
-  };
-  // size after replacing must be less o equal than buffer size
-  if (size_after_replace > az_span_capacity(*self))
+
+  // The replaced size must be less or equal to current span size. Can't replace more than what
+  // current is available. The size after replacing must be less than or equal to the size of self
+  // span.
+  if (replaced_size > current_size || size_after_replace > az_span_size(self))
   {
     return AZ_ERROR_ARG;
   };
@@ -369,55 +416,53 @@ AZ_NODISCARD az_result _az_span_replace(az_span* self, int32_t start, int32_t en
   // insert at the end case (no need to make left or right shift)
   if (start == current_size)
   {
-    *self = az_span_append(*self, span);
+    self = az_span_copy(az_span_slice(self, start, -1), span);
     return AZ_OK;
   }
   // replace all content case (no need to make left or right shift, only copy)
   // TODO: Verify and fix this check, if needed.
   if (current_size == replaced_size)
   {
-    *self = az_span_copy(*self, span);
+    self = az_span_copy(self, span);
     return AZ_OK;
   }
 
   // get the span needed to be moved before adding a new span
-  az_span dst = az_span_slice(*self, start + span_length, current_size);
+  az_span dst = az_span_slice(self, start + span_size, -1);
   // get the span where to move content
-  az_span src = az_span_slice(*self, end, current_size);
+  az_span src = az_span_slice(self, end, current_size);
   {
     // move content left or right so new span can be added
-    dst = az_span_copy(dst, src);
+    az_span_copy(dst, src);
     // add the new span
-    az_span_copy(az_span_slice(*self, start, -1), span);
+    az_span_copy(az_span_slice(self, start, -1), span);
   }
-
-  // update builder size
-  self->_internal.length = size_after_replace;
 
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_span_append_dtoa(az_span destination, double source, az_span* out_span)
+AZ_NODISCARD az_result az_span_copy_dtoa(az_span destination, double source, az_span* out_span)
 {
+  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_span);
 
   // Verify to make sure that the destination has at least one byte up front (for either a digit or
   // the sign), since that's is common across all branches.
   // We verify that the destination is large enough for more digits later.
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(destination, 1);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(destination, 1);
 
   uint64_t const* const source_bin_rep_view = (uint64_t*)&source;
 
   if (*source_bin_rep_view == 0)
   {
-    *out_span = az_span_append(destination, AZ_SPAN_FROM_STR("0"));
+    *out_span = az_span_copy_uint8(destination, '0');
     return AZ_OK;
   }
   *out_span = destination;
 
   if (source < 0)
   {
-    *out_span = az_span_append(*out_span, AZ_SPAN_FROM_STR("-"));
+    *out_span = az_span_copy_uint8(*out_span, '-');
     source = -source;
   }
 
@@ -439,14 +484,14 @@ AZ_NODISCARD az_result az_span_append_dtoa(az_span destination, double source, a
         }
       }
 
-      AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*out_span, digit_count);
+      AZ_RETURN_IF_NOT_ENOUGH_SIZE(*out_span, digit_count);
 
       do
       {
         uint8_t dec = (uint8_t)((u / base) + '0');
         u %= base;
         base /= 10;
-        *out_span = az_span_append_uint8(*out_span, dec);
+        *out_span = az_span_copy_uint8(*out_span, dec);
       } while (1 <= base);
       return AZ_OK;
     }
@@ -472,11 +517,11 @@ AZ_INLINE uint8_t _az_decimal_to_ascii(uint8_t d) { return (uint8_t)(('0' + d) &
 
 static AZ_NODISCARD az_result _az_span_builder_append_uint64(az_span* self, uint64_t n)
 {
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*self, 1);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(*self, 1);
 
   if (n == 0)
   {
-    *self = az_span_append(*self, AZ_SPAN_FROM_STR("0"));
+    *self = az_span_copy_uint8(*self, '0');
     return AZ_OK;
   }
 
@@ -489,37 +534,38 @@ static AZ_NODISCARD az_result _az_span_builder_append_uint64(az_span* self, uint
     digit_count--;
   }
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*self, digit_count);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(*self, digit_count);
 
   while (div > 1)
   {
     uint8_t value_to_append = _az_decimal_to_ascii((uint8_t)(nn / div));
-    *self = az_span_append_uint8(*self, value_to_append);
+    *self = az_span_copy_uint8(*self, value_to_append);
     nn %= div;
     div /= 10;
   }
   uint8_t value_to_append = _az_decimal_to_ascii((uint8_t)nn);
-  *self = az_span_append_uint8(*self, value_to_append);
+  *self = az_span_copy_uint8(*self, value_to_append);
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result
-az_span_append_u64toa(az_span destination, uint64_t source, az_span* out_span)
+AZ_NODISCARD az_result az_span_copy_u64toa(az_span destination, uint64_t source, az_span* out_span)
 {
+  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_span);
   *out_span = destination;
 
   return _az_span_builder_append_uint64(out_span, source);
 }
 
-AZ_NODISCARD az_result az_span_append_i64toa(az_span destination, int64_t source, az_span* out_span)
+AZ_NODISCARD az_result az_span_copy_i64toa(az_span destination, int64_t source, az_span* out_span)
 {
+  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_span);
 
   if (source < 0)
   {
-    AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(destination, 1);
-    *out_span = az_span_append(destination, AZ_SPAN_FROM_STR("-"));
+    AZ_RETURN_IF_NOT_ENOUGH_SIZE(destination, 1);
+    *out_span = az_span_copy_uint8(destination, '-');
     return _az_span_builder_append_uint64(out_span, (uint64_t)-source);
   }
 
@@ -529,11 +575,11 @@ AZ_NODISCARD az_result az_span_append_i64toa(az_span destination, int64_t source
 static AZ_NODISCARD az_result
 _az_span_builder_append_u32toa(az_span self, uint32_t n, az_span* out_span)
 {
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(self, 1);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(self, 1);
 
   if (n == 0)
   {
-    *out_span = az_span_append_uint8(self, '0');
+    *out_span = az_span_copy_uint8(self, '0');
     return AZ_OK;
   }
 
@@ -546,41 +592,42 @@ _az_span_builder_append_u32toa(az_span self, uint32_t n, az_span* out_span)
     digit_count--;
   }
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(self, digit_count);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(self, digit_count);
 
   *out_span = self;
 
   while (div > 1)
   {
     uint8_t value_to_append = _az_decimal_to_ascii((uint8_t)(nn / div));
-    *out_span = az_span_append_uint8(*out_span, value_to_append);
+    *out_span = az_span_copy_uint8(*out_span, value_to_append);
 
     nn %= div;
     div /= 10;
   }
 
   uint8_t value_to_append = _az_decimal_to_ascii((uint8_t)nn);
-  *out_span = az_span_append_uint8(*out_span, value_to_append);
+  *out_span = az_span_copy_uint8(*out_span, value_to_append);
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result
-az_span_append_u32toa(az_span destination, uint32_t source, az_span* out_span)
+AZ_NODISCARD az_result az_span_copy_u32toa(az_span destination, uint32_t source, az_span* out_span)
 {
+  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_span);
   return _az_span_builder_append_u32toa(destination, source, out_span);
 }
 
-AZ_NODISCARD az_result az_span_append_i32toa(az_span destination, int32_t source, az_span* out_span)
+AZ_NODISCARD az_result az_span_copy_i32toa(az_span destination, int32_t source, az_span* out_span)
 {
+  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_span);
 
   *out_span = destination;
 
   if (source < 0)
   {
-    AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(*out_span, 1);
-    *out_span = az_span_append_uint8(*out_span, '-');
+    AZ_RETURN_IF_NOT_ENOUGH_SIZE(*out_span, 1);
+    *out_span = az_span_copy_uint8(*out_span, '-');
     source = -source;
   }
 
@@ -592,22 +639,22 @@ AZ_NODISCARD az_result _az_is_expected_span(az_span* self, az_span expected)
 {
   az_span actual_span = { 0 };
 
-  int32_t expected_length = az_span_length(expected);
+  int32_t expected_size = az_span_size(expected);
 
   // EOF because self is smaller than the expected span
-  if (expected_length > az_span_length(*self))
+  if (expected_size > az_span_size(*self))
   {
     return AZ_ERROR_EOF;
   }
 
-  actual_span = az_span_slice(*self, 0, expected_length);
+  actual_span = az_span_slice(*self, 0, expected_size);
 
   if (!az_span_is_content_equal(actual_span, expected))
   {
     return AZ_ERROR_PARSER_UNEXPECTED_CHAR;
   }
   // move reader after the expected span (means it was parsed as expected)
-  *self = az_span_slice(*self, expected_length, -1);
+  *self = az_span_slice(*self, expected_size, -1);
 
   return AZ_OK;
 }
@@ -616,7 +663,7 @@ AZ_NODISCARD az_result _az_is_expected_span(az_span* self, az_span expected)
 // Then return number of positions read with output parameter
 AZ_NODISCARD az_result _az_scan_until(az_span self, _az_predicate predicate, int32_t* out_index)
 {
-  for (int32_t index = 0; index < az_span_length(self); ++index)
+  for (int32_t index = 0; index < az_span_size(self); ++index)
   {
     az_span s = az_span_slice(self, index, -1);
     az_result predicate_result = predicate(s);
@@ -638,9 +685,4 @@ AZ_NODISCARD az_result _az_scan_until(az_span self, _az_predicate predicate, int
     }
   }
   return AZ_ERROR_ITEM_NOT_FOUND;
-}
-
-az_span az_span_append_uint8(az_span destination, uint8_t byte)
-{
-  return az_span_append(destination, az_span_init(&byte, 1, 1));
 }

--- a/sdk/core/core/src/az_span_private.h
+++ b/sdk/core/core/src/az_span_private.h
@@ -14,17 +14,6 @@
 #include <_az_cfg_prefix.h>
 
 /**
- * @brief Use this only to create a span from uint8_t object.
- * The size of the returned span is always one.
- * Don't use this function for arrays. Use @var AZ_SPAN_FROM_ARRAY instead.
- * Don't us
- */
-AZ_NODISCARD AZ_INLINE az_span az_span_from_single_item(uint8_t* ptr)
-{
-  return az_span_init(ptr, 1, 1);
-}
-
-/**
  * @brief Replace all contents from a starting position to an end position with the content of a
  * provided span
  *
@@ -34,7 +23,7 @@ AZ_NODISCARD AZ_INLINE az_span az_span_from_single_item(uint8_t* ptr)
  * @param span content to use for replacement
  * @return AZ_NODISCARD az_span_replace
  */
-AZ_NODISCARD az_result _az_span_replace(az_span* self, int32_t start, int32_t end, az_span span);
+AZ_NODISCARD az_result _az_span_replace(az_span self, int32_t self_length, int32_t start, int32_t end, az_span span);
 
 typedef az_result (*_az_predicate)(az_span slice);
 

--- a/sdk/core/core/src/az_span_private.h
+++ b/sdk/core/core/src/az_span_private.h
@@ -23,7 +23,24 @@
  * @param span content to use for replacement
  * @return AZ_NODISCARD az_span_replace
  */
-AZ_NODISCARD az_result _az_span_replace(az_span self, int32_t self_length, int32_t start, int32_t end, az_span span);
+AZ_NODISCARD az_result
+_az_span_replace(az_span self, int32_t self_length, int32_t start, int32_t end, az_span span);
+
+/**
+ * @brief Copies a URL in the \p source #az_span to the \p destination #az_span by url-encoding the
+ * \p source span characters.
+ *
+ * @param[in] destination The #az_span whose bytes will receive the url-encoded source.
+ * @param[in] source The #az_span containing the non-url-encoded bytes.
+ * @param[out] out_span A pointer to an #az_span that receives the remainder of the \p destination
+ * #az_span after the url-encoded \p source has been copied.
+ * @return An #az_result value indicating the result of the operation:
+ *         - #AZ_OK if successful
+ *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination is not big enough to contain
+ * the encoded bytes
+ */
+AZ_NODISCARD az_result
+az_span_copy_url_encode(az_span destination, az_span source, az_span* out_span);
 
 typedef az_result (*_az_predicate)(az_span slice);
 

--- a/sdk/core/core/test/cmocka/test_az_aad.c
+++ b/sdk/core/core/test/cmocka/test_az_aad.c
@@ -76,6 +76,7 @@ static void test_az_aad_request_token()
           &az_context_app,
           az_http_method_get(),
           AZ_SPAN_FROM_STR("url"),
+          3,
           AZ_SPAN_FROM_BUFFER(headers),
           AZ_SPAN_FROM_BUFFER(body)),
       AZ_OK);

--- a/sdk/core/core/test/cmocka/test_az_http_policy.c
+++ b/sdk/core/core/test/cmocka/test_az_http_policy.c
@@ -88,14 +88,20 @@ void test_az_http_pipeline_policy_telemetry()
   memset(header_buf, 0, sizeof(header_buf));
 
   az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
-  url_span = az_span_append(url_span, AZ_SPAN_FROM_STR("url"));
-  assert_int_equal(az_span_length(url_span), 3);
+  az_span remainder = az_span_copy(url_span, AZ_SPAN_FROM_STR("url"));
+  assert_int_equal(az_span_size(remainder), 97);
   az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
   _az_http_request hrb;
 
   assert_return_code(
       az_http_request_init(
-          &hrb, &az_context_app, az_http_method_get(), url_span, header_span, AZ_SPAN_NULL),
+          &hrb,
+          &az_context_app,
+          az_http_method_get(),
+          url_span,
+          3,
+          header_span,
+          AZ_SPAN_NULL),
       AZ_OK);
 
   // Create policy options
@@ -121,14 +127,20 @@ void test_az_http_pipeline_policy_apiversion()
   memset(header_buf, 0, sizeof(header_buf));
 
   az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
-  url_span = az_span_append(url_span, AZ_SPAN_FROM_STR("url"));
-  assert_int_equal(az_span_length(url_span), 3);
+  az_span remainder = az_span_copy(url_span, AZ_SPAN_FROM_STR("url"));
+  assert_int_equal(az_span_size(remainder), 97);
   az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
   _az_http_request hrb;
 
   assert_return_code(
       az_http_request_init(
-          &hrb, &az_context_app, az_http_method_get(), url_span, header_span, AZ_SPAN_NULL),
+          &hrb,
+          &az_context_app,
+          az_http_method_get(),
+          url_span,
+          3,
+          header_span,
+          AZ_SPAN_NULL),
       AZ_OK);
 
   // Create policy options
@@ -161,14 +173,20 @@ void test_az_http_pipeline_policy_uniquerequestid()
   memset(header_buf, 0, sizeof(header_buf));
 
   az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
-  url_span = az_span_append(url_span, AZ_SPAN_FROM_STR("url"));
-  assert_int_equal(az_span_length(url_span), 3);
+  az_span remainder = az_span_copy(url_span, AZ_SPAN_FROM_STR("url"));
+  assert_int_equal(az_span_size(remainder), 97);
   az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
   _az_http_request hrb;
 
   assert_return_code(
       az_http_request_init(
-          &hrb, &az_context_app, az_http_method_get(), url_span, header_span, AZ_SPAN_NULL),
+          &hrb,
+          &az_context_app,
+          az_http_method_get(),
+          url_span,
+          3,
+          header_span,
+          AZ_SPAN_NULL),
       AZ_OK);
 
   _az_http_policy policies[1] = {            
@@ -258,14 +276,19 @@ void test_az_http_pipeline_policy_credential()
   memset(header_buf, 0, sizeof(header_buf));
 
   az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
-  url_span = az_span_append(url_span, AZ_SPAN_FROM_STR("url"));
-  assert_int_equal(az_span_length(url_span), 3);
+  az_span remainder = az_span_copy(url_span, AZ_SPAN_FROM_STR("url"));
+  assert_int_equal(az_span_size(remainder), 97);
   az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
   _az_http_request hrb;
 
   assert_return_code(
       az_http_request_init(
-          &hrb, &az_context_app, az_http_method_get(), url_span, header_span, AZ_SPAN_NULL),
+          &hrb,
+          &az_context_app,
+          az_http_method_get(),
+          az_span_slice(url_span, 0, 3),
+          header_span,
+          AZ_SPAN_NULL),
       AZ_OK);
 
   // Create a credential sample
@@ -300,14 +323,19 @@ void test_az_http_pipeline_policy_retry()
   memset(header_buf, 0, sizeof(header_buf));
 
   az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
-  url_span = az_span_append(url_span, AZ_SPAN_FROM_STR("url"));
-  assert_int_equal(az_span_length(url_span), 3);
+  az_span remainder = az_span_copy(url_span, AZ_SPAN_FROM_STR("url"));
+  assert_int_equal(az_span_size(remainder), 97);
   az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
   _az_http_request hrb;
 
   assert_return_code(
       az_http_request_init(
-          &hrb, &az_context_app, az_http_method_get(), url_span, header_span, AZ_SPAN_NULL),
+          &hrb,
+          &az_context_app,
+          az_http_method_get(),
+          az_span_slice(url_span, 0, 3),
+          header_span,
+          AZ_SPAN_NULL),
       AZ_OK);
 
   // Create policy options
@@ -340,14 +368,19 @@ void test_az_http_pipeline_policy_retry_with_header()
   memset(header_buf, 0, sizeof(header_buf));
 
   az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
-  url_span = az_span_append(url_span, AZ_SPAN_FROM_STR("url"));
-  assert_int_equal(az_span_length(url_span), 3);
+  az_span remainder = az_span_copy(url_span, AZ_SPAN_FROM_STR("url"));
+  assert_int_equal(az_span_size(remainder), 97);
   az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
   _az_http_request hrb;
 
   assert_return_code(
       az_http_request_init(
-          &hrb, &az_context_app, az_http_method_get(), url_span, header_span, AZ_SPAN_NULL),
+          &hrb,
+          &az_context_app,
+          az_http_method_get(),
+          az_span_slice(url_span, 0, 3),
+          header_span,
+          AZ_SPAN_NULL),
       AZ_OK);
 
   // Create policy options
@@ -380,14 +413,19 @@ void test_az_http_pipeline_policy_retry_with_header_2()
   memset(header_buf, 0, sizeof(header_buf));
 
   az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
-  url_span = az_span_append(url_span, AZ_SPAN_FROM_STR("url"));
-  assert_int_equal(az_span_length(url_span), 3);
+  az_span remainder = az_span_copy(url_span, AZ_SPAN_FROM_STR("url"));
+  assert_int_equal(az_span_size(remainder), 97);
   az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
   _az_http_request hrb;
 
   assert_return_code(
       az_http_request_init(
-          &hrb, &az_context_app, az_http_method_get(), url_span, header_span, AZ_SPAN_NULL),
+          &hrb,
+          &az_context_app,
+          az_http_method_get(),
+          az_span_slice(url_span, 0, 3),
+          header_span,
+          AZ_SPAN_NULL),
       AZ_OK);
 
   // Create policy options

--- a/sdk/core/core/test/cmocka/test_az_http_policy.c
+++ b/sdk/core/core/test/cmocka/test_az_http_policy.c
@@ -95,13 +95,7 @@ void test_az_http_pipeline_policy_telemetry()
 
   assert_return_code(
       az_http_request_init(
-          &hrb,
-          &az_context_app,
-          az_http_method_get(),
-          url_span,
-          3,
-          header_span,
-          AZ_SPAN_NULL),
+          &hrb, &az_context_app, az_http_method_get(), url_span, 3, header_span, AZ_SPAN_NULL),
       AZ_OK);
 
   // Create policy options
@@ -134,13 +128,7 @@ void test_az_http_pipeline_policy_apiversion()
 
   assert_return_code(
       az_http_request_init(
-          &hrb,
-          &az_context_app,
-          az_http_method_get(),
-          url_span,
-          3,
-          header_span,
-          AZ_SPAN_NULL),
+          &hrb, &az_context_app, az_http_method_get(), url_span, 3, header_span, AZ_SPAN_NULL),
       AZ_OK);
 
   // Create policy options
@@ -180,13 +168,7 @@ void test_az_http_pipeline_policy_uniquerequestid()
 
   assert_return_code(
       az_http_request_init(
-          &hrb,
-          &az_context_app,
-          az_http_method_get(),
-          url_span,
-          3,
-          header_span,
-          AZ_SPAN_NULL),
+          &hrb, &az_context_app, az_http_method_get(), url_span, 3, header_span, AZ_SPAN_NULL),
       AZ_OK);
 
   _az_http_policy policies[1] = {            
@@ -283,12 +265,7 @@ void test_az_http_pipeline_policy_credential()
 
   assert_return_code(
       az_http_request_init(
-          &hrb,
-          &az_context_app,
-          az_http_method_get(),
-          az_span_slice(url_span, 0, 3),
-          header_span,
-          AZ_SPAN_NULL),
+          &hrb, &az_context_app, az_http_method_get(), url_span, 3, header_span, AZ_SPAN_NULL),
       AZ_OK);
 
   // Create a credential sample
@@ -330,12 +307,7 @@ void test_az_http_pipeline_policy_retry()
 
   assert_return_code(
       az_http_request_init(
-          &hrb,
-          &az_context_app,
-          az_http_method_get(),
-          az_span_slice(url_span, 0, 3),
-          header_span,
-          AZ_SPAN_NULL),
+          &hrb, &az_context_app, az_http_method_get(), url_span, 3, header_span, AZ_SPAN_NULL),
       AZ_OK);
 
   // Create policy options
@@ -375,12 +347,7 @@ void test_az_http_pipeline_policy_retry_with_header()
 
   assert_return_code(
       az_http_request_init(
-          &hrb,
-          &az_context_app,
-          az_http_method_get(),
-          az_span_slice(url_span, 0, 3),
-          header_span,
-          AZ_SPAN_NULL),
+          &hrb, &az_context_app, az_http_method_get(), url_span, 3, header_span, AZ_SPAN_NULL),
       AZ_OK);
 
   // Create policy options
@@ -420,12 +387,7 @@ void test_az_http_pipeline_policy_retry_with_header_2()
 
   assert_return_code(
       az_http_request_init(
-          &hrb,
-          &az_context_app,
-          az_http_method_get(),
-          az_span_slice(url_span, 0, 3),
-          header_span,
-          AZ_SPAN_NULL),
+          &hrb, &az_context_app, az_http_method_get(), url_span, 3, header_span, AZ_SPAN_NULL),
       AZ_OK);
 
   // Create policy options

--- a/sdk/core/core/test/cmocka/test_az_json.c
+++ b/sdk/core/core/test/cmocka/test_az_json.c
@@ -21,12 +21,10 @@ void test_json_token_null(void** state)
   assert_int_equal(token._internal.number, 0);
 
   assert_ptr_equal(az_span_ptr(token._internal.string), NULL);
-  assert_int_equal(az_span_capacity(token._internal.string), 0);
-  assert_int_equal(az_span_length(token._internal.string), 0);
+  assert_int_equal(az_span_size(token._internal.string), 0);
 
   assert_ptr_equal(az_span_ptr(token._internal.span), NULL);
-  assert_int_equal(az_span_capacity(token._internal.span), 0);
-  assert_int_equal(az_span_length(token._internal.span), 0);
+  assert_int_equal(az_span_size(token._internal.span), 0);
 }
 
 void test_json_token_boolean(void** state)

--- a/sdk/core/core/test/cmocka/test_az_pipeline.c
+++ b/sdk/core/core/test/cmocka/test_az_pipeline.c
@@ -45,14 +45,14 @@ void test_az_http_pipeline_process()
   memset(header_buf, 0, sizeof(header_buf));
 
   az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
-  url_span = az_span_append(url_span, AZ_SPAN_FROM_STR("url"));
-  assert_int_equal(az_span_length(url_span), 3);
+  az_span remainder = az_span_copy(url_span, AZ_SPAN_FROM_STR("url"));
+  assert_int_equal(az_span_size(remainder), 97);
   az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
   _az_http_request hrb;
 
   assert_return_code(
       az_http_request_init(
-          &hrb, &az_context_app, az_http_method_get(), url_span, header_span, AZ_SPAN_NULL),
+          &hrb, &az_context_app, az_http_method_get(), url_span, 3, header_span, AZ_SPAN_NULL),
       AZ_OK);
 
   _az_http_pipeline pipeline = (_az_http_pipeline){

--- a/sdk/core/core/test/cmocka/test_az_span.c
+++ b/sdk/core/core/test/cmocka/test_az_span.c
@@ -19,7 +19,7 @@ void test_az_span_getters(void** state)
   (void)state;
 
   uint8_t example[] = "example";
-  az_span span = AZ_SPAN_FROM_INITIALIZED_BUFFER(example);
+  az_span span = AZ_SPAN_FROM_BUFFER(example);
   assert_int_equal(az_span_size(span), 8);
   assert_ptr_equal(az_span_ptr(span), &example);
 }

--- a/sdk/core/core/test/cmocka/test_az_span.c
+++ b/sdk/core/core/test/cmocka/test_az_span.c
@@ -20,7 +20,6 @@ void test_az_span_getters(void** state)
 
   uint8_t example[] = "example";
   az_span span = AZ_SPAN_FROM_INITIALIZED_BUFFER(example);
-  assert_int_equal(az_span_capacity(span), 8);
-  assert_int_equal(az_span_length(span), 8);
+  assert_int_equal(az_span_size(span), 8);
   assert_ptr_equal(az_span_ptr(span), &example);
 }

--- a/sdk/core/core/test/cmocka/test_http_request.c
+++ b/sdk/core/core/test/cmocka/test_http_request.c
@@ -53,8 +53,8 @@ void test_http_request(void** state)
     memset(header_buf, 0, sizeof(header_buf));
 
     az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
-    url_span = az_span_append(url_span, hrb_url);
-    assert_int_equal(az_span_length(url_span), az_span_length(hrb_url));
+    az_span remainder = az_span_copy(url_span, hrb_url);
+    assert_int_equal(az_span_size(remainder), 100 - az_span_size(hrb_url));
     az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
     _az_http_request hrb;
 
@@ -63,21 +63,25 @@ void test_http_request(void** state)
         &az_context_app,
         az_http_method_get(),
         url_span,
+        az_span_size(hrb_url),
         header_span,
         AZ_SPAN_FROM_STR("body")));
     assert_true(az_span_is_content_equal(hrb._internal.method, az_http_method_get()));
     assert_true(az_span_is_content_equal(hrb._internal.url, url_span));
-    assert_true(az_span_capacity(hrb._internal.url) == 100);
+    assert_int_equal(az_span_size(hrb._internal.url), 100);
+    assert_int_equal(hrb._internal.url_length, 54);
     assert_true(hrb._internal.max_headers == 2);
     assert_true(hrb._internal.retry_headers_start_byte_offset == 0);
 
     TEST_EXPECT_SUCCESS(az_http_request_set_query_parameter(
         &hrb, hrb_param_api_version_name, hrb_param_api_version_token));
-    assert_true(az_span_is_content_equal(hrb._internal.url, hrb_url2));
+    assert_int_equal(hrb._internal.url_length, az_span_size(hrb_url2));
+    assert_true(az_span_is_content_equal(az_span_slice(hrb._internal.url, 0, hrb._internal.url_length), hrb_url2));
 
     TEST_EXPECT_SUCCESS(az_http_request_set_query_parameter(
         &hrb, hrb_param_test_param_name, hrb_param_test_param_token));
-    assert_true(az_span_is_content_equal(hrb._internal.url, hrb_url3));
+    assert_int_equal(hrb._internal.url_length, az_span_size(hrb_url3));
+    assert_true(az_span_is_content_equal(az_span_slice(hrb._internal.url, 0, hrb._internal.url_length), hrb_url3));
 
     TEST_EXPECT_SUCCESS(az_http_request_append_header(
         &hrb, hrb_header_content_type_name, hrb_header_content_type_token));
@@ -85,19 +89,19 @@ void test_http_request(void** state)
     assert_true(hrb._internal.retry_headers_start_byte_offset == 0);
 
     TEST_EXPECT_SUCCESS(_az_http_request_mark_retry_headers_start(&hrb));
-    assert_true(hrb._internal.retry_headers_start_byte_offset == sizeof(az_pair));
+    assert_int_equal(hrb._internal.retry_headers_start_byte_offset, sizeof(az_pair));
 
     TEST_EXPECT_SUCCESS(az_http_request_append_header(
         &hrb, hrb_header_authorization_name, hrb_header_authorization_token1));
 
-    assert_true(az_span_length(hrb._internal.headers) / (int32_t)sizeof(az_pair) == 2);
+    assert_true(az_span_size(hrb._internal.headers) / (int32_t)sizeof(az_pair) == 2);
     assert_true(hrb._internal.retry_headers_start_byte_offset == sizeof(az_pair));
 
     az_pair expected_headers1[2] = {
       { .key = hrb_header_content_type_name, .value = hrb_header_content_type_token },
       { .key = hrb_header_authorization_name, .value = hrb_header_authorization_token1 },
     };
-    for (uint16_t i = 0; i < az_span_length(hrb._internal.headers) / (int32_t)sizeof(az_pair); ++i)
+    for (uint16_t i = 0; i < az_span_size(hrb._internal.headers) / (int32_t)sizeof(az_pair); ++i)
     {
       az_pair header = { 0 };
       TEST_EXPECT_SUCCESS(az_http_request_get_header(&hrb, i, &header));
@@ -111,14 +115,15 @@ void test_http_request(void** state)
 
     TEST_EXPECT_SUCCESS(az_http_request_append_header(
         &hrb, hrb_header_authorization_name, hrb_header_authorization_token2));
-    assert_true(az_span_length(hrb._internal.headers) / (int32_t)sizeof(az_pair) == 2);
+    assert_int_equal(hrb._internal.headers_length, 2);
+    assert_int_equal(az_span_size(hrb._internal.headers) / (int32_t)sizeof(az_pair), 2);
     assert_true(hrb._internal.retry_headers_start_byte_offset == sizeof(az_pair));
 
     az_pair expected_headers2[2] = {
       { .key = hrb_header_content_type_name, .value = hrb_header_content_type_token },
       { .key = hrb_header_authorization_name, .value = hrb_header_authorization_token2 },
     };
-    for (uint16_t i = 0; i < az_span_length(hrb._internal.headers) / (int32_t)sizeof(az_pair); ++i)
+    for (uint16_t i = 0; i < az_span_size(hrb._internal.headers) / (int32_t)sizeof(az_pair); ++i)
     {
       az_pair header = { 0 };
       TEST_EXPECT_SUCCESS(az_http_request_get_header(&hrb, i, &header));

--- a/sdk/core/core/test/cmocka/test_json_builder.c
+++ b/sdk/core/core/test/cmocka/test_json_builder.c
@@ -62,7 +62,7 @@ void test_json_builder(void** state)
     TEST_EXPECT_SUCCESS(az_json_builder_append_token(&builder, az_json_token_object_end()));
 
     assert_true(az_span_is_content_equal(
-        builder._internal.json,
+        az_json_builder_span_get(&builder),
         AZ_SPAN_FROM_STR( //
             "{"
             "\"name\":true,"
@@ -93,7 +93,7 @@ void test_json_builder(void** state)
                                         "\"span\":\"\\\\\""
                                         "}");
 
-    assert_true(az_span_is_content_equal(builder._internal.json, expected));
+    assert_true(az_span_is_content_equal(az_json_builder_span_get(&builder), expected));
   }
   {
     // json with AZ_JSON_TOKEN_STRING
@@ -113,7 +113,7 @@ void test_json_builder(void** state)
     TEST_EXPECT_SUCCESS(az_json_builder_append_token(&builder, az_json_token_object_end()));
 
     assert_true(az_span_is_content_equal(
-        builder._internal.json,
+        az_json_builder_span_get(&builder),
         AZ_SPAN_FROM_STR( //
             "{"
             "\"span\":\"\\\""
@@ -145,7 +145,7 @@ void test_json_builder(void** state)
     TEST_EXPECT_SUCCESS(az_json_builder_append_token(&builder, az_json_token_object_end()));
 
     assert_true(az_span_is_content_equal(
-        builder._internal.json,
+        az_json_builder_span_get(&builder),
         AZ_SPAN_FROM_STR( //
             "{"
             "\"array\":[1,2,\"sd\":{},3]"
@@ -172,7 +172,7 @@ void test_json_builder(void** state)
           az_json_builder_append_token(&nested_object_builder, az_json_token_object_end()));
 
       assert_true(az_span_is_content_equal(
-          nested_object_builder._internal.json,
+          az_json_builder_span_get(&nested_object_builder),
           AZ_SPAN_FROM_STR( //
               "{"
               "\"bar\":true"
@@ -190,14 +190,14 @@ void test_json_builder(void** state)
       TEST_EXPECT_SUCCESS(az_json_builder_append_object(
           &builder, AZ_SPAN_FROM_STR("foo"), az_json_token_array_start()));
       TEST_EXPECT_SUCCESS(az_json_builder_append_array_item(
-          &builder, az_json_token_object(nested_object_builder._internal.json)));
+          &builder, az_json_token_object(az_json_builder_span_get(&nested_object_builder))));
       TEST_EXPECT_SUCCESS(az_json_builder_append_token(&builder, az_json_token_array_end()));
     }
 
     TEST_EXPECT_SUCCESS(az_json_builder_append_token(&builder, az_json_token_object_end()));
 
     assert_true(az_span_is_content_equal(
-        builder._internal.json,
+        az_json_builder_span_get(&builder),
         AZ_SPAN_FROM_STR( //
             "{"
             "\"foo\":["
@@ -228,7 +228,7 @@ void test_json_builder(void** state)
           az_json_builder_append_token(&nested_object_builder, az_json_token_object_end()));
 
       assert_true(az_span_is_content_equal(
-          nested_object_builder._internal.json,
+          az_json_builder_span_get(&nested_object_builder),
           AZ_SPAN_FROM_STR( //
               "{"
               "\"bar\":true"
@@ -246,16 +246,16 @@ void test_json_builder(void** state)
       TEST_EXPECT_SUCCESS(az_json_builder_append_object(
           &builder, AZ_SPAN_FROM_STR("foo"), az_json_token_array_start()));
       TEST_EXPECT_SUCCESS(az_json_builder_append_array_item(
-          &builder, az_json_token_object(nested_object_builder._internal.json)));
+          &builder, az_json_token_object(az_json_builder_span_get(&nested_object_builder))));
       TEST_EXPECT_SUCCESS(az_json_builder_append_array_item(
-          &builder, az_json_token_object(nested_object_builder._internal.json)));
+          &builder, az_json_token_object(az_json_builder_span_get(&nested_object_builder))));
       TEST_EXPECT_SUCCESS(az_json_builder_append_token(&builder, az_json_token_array_end()));
     }
 
     TEST_EXPECT_SUCCESS(az_json_builder_append_token(&builder, az_json_token_object_end()));
 
     assert_true(az_span_is_content_equal(
-        builder._internal.json,
+        az_json_builder_span_get(&builder),
         AZ_SPAN_FROM_STR( //
             "{"
             "\"foo\":["

--- a/sdk/core/core/test/cmocka/test_json_builder.c
+++ b/sdk/core/core/test/cmocka/test_json_builder.c
@@ -80,7 +80,7 @@ void test_json_builder(void** state)
 
     // this json { "span": "\" } would be scaped to { "span": "\\"" }
     uint8_t single_char[1] = { '\\' }; // char = '\'
-    az_span single_span = AZ_SPAN_FROM_INITIALIZED_BUFFER(single_char);
+    az_span single_span = AZ_SPAN_FROM_BUFFER(single_char);
 
     TEST_EXPECT_SUCCESS(az_json_builder_append_token(&builder, az_json_token_object_start()));
 
@@ -103,7 +103,7 @@ void test_json_builder(void** state)
 
     // this json { "span": "\" } would be written as { "span": \"" } with no extra scaping
     uint8_t single_char[1] = { 92 }; // char = '\'
-    az_span single_span = AZ_SPAN_FROM_INITIALIZED_BUFFER(single_char);
+    az_span single_span = AZ_SPAN_FROM_BUFFER(single_char);
 
     TEST_EXPECT_SUCCESS(az_json_builder_append_token(&builder, az_json_token_object_start()));
 

--- a/sdk/core/core/test/cmocka/test_json_parser.c
+++ b/sdk/core/core/test/cmocka/test_json_parser.c
@@ -404,7 +404,7 @@ az_result read_write_token(
     case AZ_JSON_TOKEN_NUMBER:
     {
       AZ_RETURN_IF_NOT_ENOUGH_SIZE(*output, 1);
-      *output = az_span_copy_uint8(*output, '0');
+      *output = az_span_copy_u8(*output, '0');
       *written += 1;
       return AZ_OK;
     }
@@ -415,7 +415,7 @@ az_result read_write_token(
     case AZ_JSON_TOKEN_OBJECT_START:
     {
       AZ_RETURN_IF_NOT_ENOUGH_SIZE(*output, 1);
-      *output = az_span_copy_uint8(*output, '{');
+      *output = az_span_copy_u8(*output, '{');
       *written += 1;
       bool need_comma = false;
       while (true)
@@ -430,7 +430,7 @@ az_result read_write_token(
         if (need_comma)
         {
           AZ_RETURN_IF_NOT_ENOUGH_SIZE(*output, 1);
-          *output = az_span_copy_uint8(*output, ',');
+          *output = az_span_copy_u8(*output, ',');
           *written += 1;
         }
         else
@@ -439,19 +439,19 @@ az_result read_write_token(
         }
         AZ_RETURN_IF_FAILED(write_str(*output, member.name, output, written));
         AZ_RETURN_IF_NOT_ENOUGH_SIZE(*output, 1);
-        *output = az_span_copy_uint8(*output, ':');
+        *output = az_span_copy_u8(*output, ':');
         *written += 1;
         AZ_RETURN_IF_FAILED(read_write_token(output, written, o, state, member.token));
       }
       AZ_RETURN_IF_NOT_ENOUGH_SIZE(*output, 1);
-      *output = az_span_copy_uint8(*output, '}');
+      *output = az_span_copy_u8(*output, '}');
       *written += 1;
       return AZ_OK;
     }
     case AZ_JSON_TOKEN_ARRAY_START:
     {
       AZ_RETURN_IF_NOT_ENOUGH_SIZE(*output, 1);
-      *output = az_span_copy_uint8(*output, '[');
+      *output = az_span_copy_u8(*output, '[');
       *written += 1;
       bool need_comma = false;
       while (true)
@@ -466,7 +466,7 @@ az_result read_write_token(
         if (need_comma)
         {
           AZ_RETURN_IF_NOT_ENOUGH_SIZE(*output, 1);
-          *output = az_span_copy_uint8(*output, ',');
+          *output = az_span_copy_u8(*output, ',');
           *written += 1;
         }
         else
@@ -476,7 +476,7 @@ az_result read_write_token(
         AZ_RETURN_IF_FAILED(read_write_token(output, written, o, state, element));
       }
       AZ_RETURN_IF_NOT_ENOUGH_SIZE(*output, 1);
-      *output = az_span_copy_uint8(*output, ']');
+      *output = az_span_copy_u8(*output, ']');
       *written += 1;
       return AZ_OK;
     }
@@ -492,9 +492,9 @@ az_result write_str(az_span span, az_span s, az_span* out, int32_t* written)
   int32_t required_length = az_span_size(s) + 2;
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(*out, required_length);
-  *out = az_span_copy_uint8(*out, '"');
+  *out = az_span_copy_u8(*out, '"');
   *out = az_span_copy(*out, s);
-  *out = az_span_copy_uint8(*out, '"');
+  *out = az_span_copy_u8(*out, '"');
 
   *written += required_length;
   return AZ_OK;

--- a/sdk/core/core/test/cmocka/test_json_pointer.c
+++ b/sdk/core/core/test/cmocka/test_json_pointer.c
@@ -50,7 +50,7 @@ void test_json_pointer(void** state)
         buffer[i] = (uint8_t)code_point;
         ++i;
       }
-      az_span const b = az_span_init(buffer, i, i);
+      az_span const b = az_span_init(buffer, i);
       assert_true(az_span_is_content_equal(b, AZ_SPAN_FROM_STR("abc")));
     }
     assert_true(_az_span_reader_read_json_pointer_token(&parser, &p) == AZ_ERROR_ITEM_NOT_FOUND);
@@ -78,7 +78,7 @@ void test_json_pointer(void** state)
         buffer[i] = (uint8_t)code_point;
         ++i;
       }
-      az_span const b = az_span_init(buffer, i, i);
+      az_span const b = az_span_init(buffer, i);
       assert_true(az_span_is_content_equal(b, AZ_SPAN_FROM_STR("abc")));
     }
     assert_true(_az_span_reader_read_json_pointer_token(&parser, &p) == AZ_OK);
@@ -110,7 +110,7 @@ void test_json_pointer(void** state)
         buffer[i] = (uint8_t)code_point;
         ++i;
       }
-      az_span const b = az_span_init(buffer, i, i);
+      az_span const b = az_span_init(buffer, i);
       assert_true(az_span_is_content_equal(b, AZ_SPAN_FROM_STR("ab/c")));
     }
     assert_true(_az_span_reader_read_json_pointer_token(&parser, &p) == AZ_OK);
@@ -133,7 +133,7 @@ void test_json_pointer(void** state)
         buffer[i] = (uint8_t)code_point;
         ++i;
       }
-      az_span const b = az_span_init(buffer, i, i);
+      az_span const b = az_span_init(buffer, i);
       assert_true(az_span_is_content_equal(b, AZ_SPAN_FROM_STR("dff~x")));
     }
     assert_true(_az_span_reader_read_json_pointer_token(&parser, &p) == AZ_ERROR_ITEM_NOT_FOUND);

--- a/sdk/core/core/test/cmocka/test_log.c
+++ b/sdk/core/core/test/cmocka/test_log.c
@@ -88,11 +88,13 @@ void test_az_log(void** state)
   //  uint8_t hrb_buf[4 * 1024] = { 0 };
   uint8_t headers[4 * 1024] = { 0 };
   _az_http_request hrb = { 0 };
+  az_span url = AZ_SPAN_FROM_STR("https://www.example.com");
   TEST_EXPECT_SUCCESS(az_http_request_init(
       &hrb,
       &az_context_app,
       az_http_method_get(),
-      AZ_SPAN_FROM_STR("https://www.example.com"),
+      url,
+      az_span_size(url),
       AZ_SPAN_FROM_BUFFER(headers),
       AZ_SPAN_FROM_STR("AAAAABBBBBCCCCCDDDDDEEEEEFFFFFGGGGGHHHHHIIIIIJJJJJKKKKK")));
 
@@ -122,8 +124,9 @@ void test_az_log(void** state)
                          "Header44: cba888888777777666666555555444444333333222222111111\r\n"
                          "\r\n"
                          "KKKKKJJJJJIIIIIHHHHHGGGGGFFFFFEEEEEDDDDDCCCCCBBBBBAAAAA");
-  response_builder = az_span_append(response_builder, response_span);
-  assert_int_equal(az_span_length(response_builder), az_span_length(response_span));
+  az_span_copy(response_builder, response_span);
+  response_builder = az_span_slice(response_builder, 0, az_span_size(response_span));
+  assert_int_equal(az_span_size(response_builder), az_span_size(response_span));
 
   az_http_response response = { 0 };
   TEST_EXPECT_SUCCESS(az_http_response_init(&response, response_builder));

--- a/sdk/core/core/test/cmocka/test_span.c
+++ b/sdk/core/core/test/cmocka/test_span.c
@@ -18,21 +18,14 @@ static void az_span_slice_test()
 {
   uint8_t raw_buffer[20];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
-  buffer = az_span_append_uint8(buffer, 'a');
-  buffer = az_span_append_uint8(buffer, 'b');
-  buffer = az_span_append_uint8(buffer, 'c');
-  buffer = az_span_append_uint8(buffer, 'd');
 
-  assert_int_equal(az_span_length(buffer), 4);
-  assert_int_equal(az_span_capacity(buffer), 20);
+  assert_int_equal(az_span_size(buffer), 20);
 
   az_span result = az_span_slice(buffer, 1, -1);
-  assert_int_equal(az_span_length(result), 3);
-  assert_int_equal(az_span_capacity(result), 19);
+  assert_int_equal(az_span_size(result), 19);
 
   result = az_span_slice(buffer, 5, -1);
-  assert_int_equal(az_span_length(result), 0);
-  assert_int_equal(az_span_capacity(result), 15);
+  assert_int_equal(az_span_size(result), 15);
 }
 
 static void az_single_char_ascii_lower_test()
@@ -86,79 +79,77 @@ static void az_span_append_uint8_succeeds()
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
 
-  buffer = az_span_append_uint8(buffer, 'a');
-  assert_int_equal(az_span_length(buffer), 1);
-  buffer = az_span_append_uint8(buffer, 'b');
-  assert_int_equal(az_span_length(buffer), 2);
-  buffer = az_span_append_uint8(buffer, 'c');
-  assert_int_equal(az_span_length(buffer), 3);
+  buffer = az_span_copy_uint8(buffer, 'a');
+  assert_int_equal(az_span_size(buffer), 14);
+  buffer = az_span_copy_uint8(buffer, 'b');
+  assert_int_equal(az_span_size(buffer), 13);
+  buffer = az_span_copy_uint8(buffer, 'c');
+  assert_int_equal(az_span_size(buffer), 12);
 
-  assert_true(az_span_is_content_equal(buffer, AZ_SPAN_FROM_STR("abc")));
+  assert_true(az_span_is_content_equal(
+      az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 3), AZ_SPAN_FROM_STR("abc")));
 }
 
-static void az_span_append_i32toa_succeeds()
+static void az_span_copy_i32toa_succeeds()
 {
   int32_t v = 12345;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_append_i32toa(buffer, v, &out_span)));
-  assert_true(az_span_is_content_equal(out_span, AZ_SPAN_FROM_STR("12345")));
+  assert_true(az_succeeded(az_span_copy_i32toa(buffer, v, &out_span)));
+  assert_int_equal(az_span_size(out_span), 10);
+  assert_true(az_span_is_content_equal(
+      az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 5), AZ_SPAN_FROM_STR("12345")));
 }
 
-static void az_span_append_i32toa_negative_succeeds()
+static void az_span_copy_i32toa_negative_succeeds()
 {
   int32_t v = -12345;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_append_i32toa(buffer, v, &out_span)));
-  assert_true(az_span_is_content_equal(out_span, AZ_SPAN_FROM_STR("-12345")));
+  assert_true(az_succeeded(az_span_copy_i32toa(buffer, v, &out_span)));
+  assert_int_equal(az_span_size(out_span), 9);
+  assert_true(az_span_is_content_equal(
+      az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 6), AZ_SPAN_FROM_STR("-12345")));
 }
 
-static void az_span_append_i32toa_zero_succeeds()
+static void az_span_copy_i32toa_zero_succeeds()
 {
   int32_t v = 0;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_append_i32toa(buffer, v, &out_span)));
-  assert_true(az_span_is_content_equal(out_span, AZ_SPAN_FROM_STR("0")));
+  assert_true(az_succeeded(az_span_copy_i32toa(buffer, v, &out_span)));
+  assert_int_equal(az_span_size(out_span), 14);
+  assert_true(az_span_is_content_equal(
+      az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 1), AZ_SPAN_FROM_STR("0")));
 }
 
-static void az_span_append_i32toa_max_int_succeeds()
+static void az_span_copy_i32toa_max_int_succeeds()
 {
   int32_t v = 2147483647;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_append_i32toa(buffer, v, &out_span)));
-  assert_true(az_span_is_content_equal(out_span, AZ_SPAN_FROM_STR("2147483647")));
+  assert_true(az_succeeded(az_span_copy_i32toa(buffer, v, &out_span)));
+  assert_int_equal(az_span_size(out_span), 5);
+  assert_true(az_span_is_content_equal(
+      az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 10), AZ_SPAN_FROM_STR("2147483647")));
 }
 
-static void az_span_append_i32toa_NULL_span_fails()
-{
-  int32_t v = 2147483647;
-  uint8_t raw_buffer[15];
-  az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
-  az_span out_span;
-
-  assert_true(az_succeeded(az_span_append_i32toa(buffer, v, &out_span)));
-  assert_true(az_span_is_content_equal(out_span, AZ_SPAN_FROM_STR("2147483647")));
-}
-
-static void az_span_append_i32toa_overflow_fails()
+static void az_span_copy_i32toa_overflow_fails()
 {
   int32_t v = 2147483647;
   uint8_t raw_buffer[4];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_span_append_i32toa(buffer, v, &out_span) == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_true(az_span_copy_i32toa(buffer, v, &out_span) == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void az_span_append_u32toa_succeeds()
@@ -168,8 +159,10 @@ static void az_span_append_u32toa_succeeds()
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_append_u32toa(buffer, v, &out_span)));
-  assert_true(az_span_is_content_equal(out_span, AZ_SPAN_FROM_STR("12345")));
+  assert_true(az_succeeded(az_span_copy_u32toa(buffer, v, &out_span)));
+  assert_int_equal(az_span_size(out_span), 10);
+  assert_true(az_span_is_content_equal(
+      az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 5), AZ_SPAN_FROM_STR("12345")));
 }
 
 static void az_span_append_u32toa_zero_succeeds()
@@ -179,8 +172,10 @@ static void az_span_append_u32toa_zero_succeeds()
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_append_u32toa(buffer, v, &out_span)));
-  assert_true(az_span_is_content_equal(out_span, AZ_SPAN_FROM_STR("0")));
+  assert_true(az_succeeded(az_span_copy_u32toa(buffer, v, &out_span)));
+  assert_int_equal(az_span_size(out_span), 14);
+  assert_true(az_span_is_content_equal(
+      az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 1), AZ_SPAN_FROM_STR("0")));
 }
 
 static void az_span_append_u32toa_max_uint_succeeds()
@@ -190,19 +185,10 @@ static void az_span_append_u32toa_max_uint_succeeds()
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_append_u32toa(buffer, v, &out_span)));
-  assert_true(az_span_is_content_equal(out_span, AZ_SPAN_FROM_STR("4294967295")));
-}
-
-static void az_span_append_u32toa_NULL_span_fails()
-{
-  uint32_t v = 2147483647;
-  uint8_t raw_buffer[15];
-  az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
-  az_span out_span;
-
-  assert_true(az_succeeded(az_span_append_u32toa(buffer, v, &out_span)));
-  assert_true(az_span_is_content_equal(out_span, AZ_SPAN_FROM_STR("2147483647")));
+  assert_true(az_succeeded(az_span_copy_u32toa(buffer, v, &out_span)));
+  assert_int_equal(az_span_size(out_span), 5);
+  assert_true(az_span_is_content_equal(
+      az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 10), AZ_SPAN_FROM_STR("4294967295")));
 }
 
 static void az_span_append_u32toa_overflow_fails()
@@ -212,7 +198,7 @@ static void az_span_append_u32toa_overflow_fails()
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_span_append_u32toa(buffer, v, &out_span) == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+  assert_true(az_span_copy_u32toa(buffer, v, &out_span) == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void az_span_to_lower_test()
@@ -347,10 +333,15 @@ static void az_span_find_capacity_checks_success()
 {
   uint8_t* buffer = (uint8_t*)"aaaa";
 
-  assert_int_equal(az_span_find(az_span_init(buffer, 2, 4), az_span_init(buffer, 2, 3)), 0);
-  assert_int_equal(az_span_find(az_span_init(buffer, 2, 3), az_span_init(buffer, 2, 4)), 0);
-  assert_int_equal(az_span_find(az_span_init(buffer, 2, 3), az_span_init(buffer, 0, 2)), 0);
-  assert_int_equal(az_span_find(az_span_init(buffer, 0, 2), az_span_init(buffer, 0, 2)), 0);
+  assert_int_equal(az_span_find(az_span_init(buffer, 2), az_span_init(buffer, 2)), 0);
+  assert_int_equal(az_span_find(az_span_init(buffer, 2), az_span_init(buffer, 0)), 0);
+  assert_int_equal(az_span_find(az_span_init(buffer, 0), az_span_init(buffer, 0)), 0);
+
+  assert_int_equal(az_span_find(az_span_init(buffer, 2), az_span_init(buffer + 1, 2)), 0);
+  assert_int_equal(az_span_find(az_span_init(buffer + 1, 2), az_span_init(buffer, 2)), 0);
+  assert_int_equal(az_span_find(az_span_init(buffer + 1, 2), az_span_init(buffer + 1, 2)), 0);
+  assert_int_equal(az_span_find(az_span_init(buffer, 2), az_span_init(buffer + 2, 2)), 0);
+  assert_int_equal(az_span_find(az_span_init(buffer + 2, 2), az_span_init(buffer, 2)), 0);
 }
 
 static void az_span_find_overlapping_checks_success()
@@ -371,17 +362,15 @@ void test_az_span(void** state)
 
   az_span_append_uint8_succeeds();
 
-  az_span_append_i32toa_succeeds();
-  az_span_append_i32toa_negative_succeeds();
-  az_span_append_i32toa_max_int_succeeds();
-  az_span_append_i32toa_zero_succeeds();
-  az_span_append_i32toa_NULL_span_fails();
-  az_span_append_i32toa_overflow_fails();
+  az_span_copy_i32toa_succeeds();
+  az_span_copy_i32toa_negative_succeeds();
+  az_span_copy_i32toa_max_int_succeeds();
+  az_span_copy_i32toa_zero_succeeds();
+  az_span_copy_i32toa_overflow_fails();
 
   az_span_append_u32toa_succeeds();
   az_span_append_u32toa_zero_succeeds();
   az_span_append_u32toa_max_uint_succeeds();
-  az_span_append_u32toa_NULL_span_fails();
   az_span_append_u32toa_overflow_fails();
 
   az_single_char_ascii_lower_test();

--- a/sdk/core/core/test/cmocka/test_span.c
+++ b/sdk/core/core/test/cmocka/test_span.c
@@ -33,7 +33,7 @@ static void az_single_char_ascii_lower_test()
   for (uint8_t i = 0; i <= SCHAR_MAX; ++i)
   {
     uint8_t buffer[1] = { i };
-    az_span span = AZ_SPAN_LITERAL_FROM_INITIALIZED_BUFFER(buffer);
+    az_span span = AZ_SPAN_FROM_BUFFER(buffer);
 
     // Comparison to itself should return true for all values in the range.
     assert_true(az_span_is_content_equal_ignoring_case(span, span));
@@ -42,14 +42,14 @@ static void az_single_char_ascii_lower_test()
     if (i >= 'A' && i <= 'Z')
     {
       uint8_t lower[1] = { (uint8_t)(i + 32) };
-      az_span lowerSpan = AZ_SPAN_LITERAL_FROM_INITIALIZED_BUFFER(lower);
+      az_span lowerSpan = AZ_SPAN_FROM_BUFFER(lower);
       assert_true(az_span_is_content_equal_ignoring_case(span, lowerSpan));
       assert_true(az_span_is_content_equal_ignoring_case(lowerSpan, span));
     }
     else if (i >= 'a' && i <= 'z')
     {
       uint8_t upper[1] = { (uint8_t)(i - 32) };
-      az_span upperSpan = AZ_SPAN_LITERAL_FROM_INITIALIZED_BUFFER(upper);
+      az_span upperSpan = AZ_SPAN_FROM_BUFFER(upper);
       assert_true(az_span_is_content_equal_ignoring_case(span, upperSpan));
       assert_true(az_span_is_content_equal_ignoring_case(upperSpan, span));
     }
@@ -59,7 +59,7 @@ static void az_single_char_ascii_lower_test()
       for (uint8_t j = 0; j <= SCHAR_MAX; ++j)
       {
         uint8_t other[1] = { j };
-        az_span otherSpan = AZ_SPAN_LITERAL_FROM_INITIALIZED_BUFFER(other);
+        az_span otherSpan = AZ_SPAN_FROM_BUFFER(other);
 
         if (i == j)
         {

--- a/sdk/core/core/test/cmocka/test_span.c
+++ b/sdk/core/core/test/cmocka/test_span.c
@@ -89,126 +89,126 @@ static void az_span_copy_uint8_succeeds()
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
 
-  buffer = az_span_copy_uint8(buffer, 'a');
+  buffer = az_span_copy_u8(buffer, 'a');
   assert_int_equal(az_span_size(buffer), 14);
-  buffer = az_span_copy_uint8(buffer, 'b');
+  buffer = az_span_copy_u8(buffer, 'b');
   assert_int_equal(az_span_size(buffer), 13);
-  buffer = az_span_copy_uint8(buffer, 'c');
+  buffer = az_span_copy_u8(buffer, 'c');
   assert_int_equal(az_span_size(buffer), 12);
 
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 3), AZ_SPAN_FROM_STR("abc")));
 }
 
-static void az_span_itoa_succeeds()
+static void az_span_i32toa_succeeds()
 {
   int32_t v = 12345;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_itoa(buffer, v, &out_span)));
+  assert_true(az_succeeded(az_span_i32toa(buffer, v, &out_span)));
   assert_int_equal(az_span_size(out_span), 10);
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 5), AZ_SPAN_FROM_STR("12345")));
 }
 
-static void az_span_itoa_negative_succeeds()
+static void az_span_i32toa_negative_succeeds()
 {
   int32_t v = -12345;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_itoa(buffer, v, &out_span)));
+  assert_true(az_succeeded(az_span_i32toa(buffer, v, &out_span)));
   assert_int_equal(az_span_size(out_span), 9);
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 6), AZ_SPAN_FROM_STR("-12345")));
 }
 
-static void az_span_itoa_zero_succeeds()
+static void az_span_i32toa_zero_succeeds()
 {
   int32_t v = 0;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_itoa(buffer, v, &out_span)));
+  assert_true(az_succeeded(az_span_i32toa(buffer, v, &out_span)));
   assert_int_equal(az_span_size(out_span), 14);
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 1), AZ_SPAN_FROM_STR("0")));
 }
 
-static void az_span_itoa_max_int_succeeds()
+static void az_span_i32toa_max_int_succeeds()
 {
   int32_t v = 2147483647;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_itoa(buffer, v, &out_span)));
+  assert_true(az_succeeded(az_span_i32toa(buffer, v, &out_span)));
   assert_int_equal(az_span_size(out_span), 5);
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 10), AZ_SPAN_FROM_STR("2147483647")));
 }
 
-static void az_span_itoa_overflow_fails()
+static void az_span_i32toa_overflow_fails()
 {
   int32_t v = 2147483647;
   uint8_t raw_buffer[4];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_span_itoa(buffer, v, &out_span) == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+  assert_true(az_span_i32toa(buffer, v, &out_span) == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-static void az_span_utoa_succeeds()
+static void az_span_u32toa_succeeds()
 {
   uint32_t v = 12345;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_utoa(buffer, v, &out_span)));
+  assert_true(az_succeeded(az_span_u32toa(buffer, v, &out_span)));
   assert_int_equal(az_span_size(out_span), 10);
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 5), AZ_SPAN_FROM_STR("12345")));
 }
 
-static void az_span_utoa_zero_succeeds()
+static void az_span_u32toa_zero_succeeds()
 {
   uint32_t v = 0;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_utoa(buffer, v, &out_span)));
+  assert_true(az_succeeded(az_span_u32toa(buffer, v, &out_span)));
   assert_int_equal(az_span_size(out_span), 14);
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 1), AZ_SPAN_FROM_STR("0")));
 }
 
-static void az_span_utoa_max_uint_succeeds()
+static void az_span_u32toa_max_uint_succeeds()
 {
   uint32_t v = 4294967295;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_utoa(buffer, v, &out_span)));
+  assert_true(az_succeeded(az_span_u32toa(buffer, v, &out_span)));
   assert_int_equal(az_span_size(out_span), 5);
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 10), AZ_SPAN_FROM_STR("4294967295")));
 }
 
-static void az_span_utoa_overflow_fails()
+static void az_span_u32toa_overflow_fails()
 {
   uint32_t v = 2147483647;
   uint8_t raw_buffer[4];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_span_utoa(buffer, v, &out_span) == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+  assert_true(az_span_u32toa(buffer, v, &out_span) == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void az_span_to_lower_test()
@@ -231,12 +231,12 @@ static void az_span_atou64_return_errors()
   assert_true(az_span_atou64(sample, &out) == AZ_ERROR_PARSER_UNEXPECTED_CHAR);
 }
 
-static void az_span_atou_test()
+static void az_span_atou32_test()
 {
   az_span number = AZ_SPAN_FROM_STR("1024");
   uint32_t value = 0;
 
-  assert_return_code(az_span_atou(number, &value), AZ_OK);
+  assert_return_code(az_span_atou32(number, &value), AZ_OK);
   assert_int_equal(value, 1024);
 }
 
@@ -245,7 +245,7 @@ static void az_span_to_str_test()
   az_span sample = AZ_SPAN_FROM_STR("hello World!");
   char str[20];
 
-  assert_return_code(az_span_to_str(str, 20, sample), AZ_OK);
+  az_span_to_str(str, 20, sample);
   assert_string_equal(str, "hello World!");
 }
 
@@ -374,20 +374,20 @@ void test_az_span(void** state)
 
   az_span_copy_uint8_succeeds();
 
-  az_span_itoa_succeeds();
-  az_span_itoa_negative_succeeds();
-  az_span_itoa_max_int_succeeds();
-  az_span_itoa_zero_succeeds();
-  az_span_itoa_overflow_fails();
+  az_span_i32toa_succeeds();
+  az_span_i32toa_negative_succeeds();
+  az_span_i32toa_max_int_succeeds();
+  az_span_i32toa_zero_succeeds();
+  az_span_i32toa_overflow_fails();
 
-  az_span_utoa_succeeds();
-  az_span_utoa_zero_succeeds();
-  az_span_utoa_max_uint_succeeds();
-  az_span_utoa_overflow_fails();
+  az_span_u32toa_succeeds();
+  az_span_u32toa_zero_succeeds();
+  az_span_u32toa_max_uint_succeeds();
+  az_span_u32toa_overflow_fails();
 
   az_single_char_ascii_lower_test();
   az_span_to_lower_test();
-  az_span_atou_test();
+  az_span_atou32_test();
   az_span_to_str_test();
   az_span_atou64_return_errors();
 

--- a/sdk/core/core/test/cmocka/test_span.c
+++ b/sdk/core/core/test/cmocka/test_span.c
@@ -84,7 +84,7 @@ static void az_single_char_ascii_lower_test()
   }
 }
 
-static void az_span_append_uint8_succeeds()
+static void az_span_copy_uint8_succeeds()
 {
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
@@ -100,115 +100,115 @@ static void az_span_append_uint8_succeeds()
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 3), AZ_SPAN_FROM_STR("abc")));
 }
 
-static void az_span_copy_i32toa_succeeds()
+static void az_span_itoa_succeeds()
 {
   int32_t v = 12345;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_copy_i32toa(buffer, v, &out_span)));
+  assert_true(az_succeeded(az_span_itoa(buffer, v, &out_span)));
   assert_int_equal(az_span_size(out_span), 10);
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 5), AZ_SPAN_FROM_STR("12345")));
 }
 
-static void az_span_copy_i32toa_negative_succeeds()
+static void az_span_itoa_negative_succeeds()
 {
   int32_t v = -12345;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_copy_i32toa(buffer, v, &out_span)));
+  assert_true(az_succeeded(az_span_itoa(buffer, v, &out_span)));
   assert_int_equal(az_span_size(out_span), 9);
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 6), AZ_SPAN_FROM_STR("-12345")));
 }
 
-static void az_span_copy_i32toa_zero_succeeds()
+static void az_span_itoa_zero_succeeds()
 {
   int32_t v = 0;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_copy_i32toa(buffer, v, &out_span)));
+  assert_true(az_succeeded(az_span_itoa(buffer, v, &out_span)));
   assert_int_equal(az_span_size(out_span), 14);
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 1), AZ_SPAN_FROM_STR("0")));
 }
 
-static void az_span_copy_i32toa_max_int_succeeds()
+static void az_span_itoa_max_int_succeeds()
 {
   int32_t v = 2147483647;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_copy_i32toa(buffer, v, &out_span)));
+  assert_true(az_succeeded(az_span_itoa(buffer, v, &out_span)));
   assert_int_equal(az_span_size(out_span), 5);
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 10), AZ_SPAN_FROM_STR("2147483647")));
 }
 
-static void az_span_copy_i32toa_overflow_fails()
+static void az_span_itoa_overflow_fails()
 {
   int32_t v = 2147483647;
   uint8_t raw_buffer[4];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_span_copy_i32toa(buffer, v, &out_span) == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+  assert_true(az_span_itoa(buffer, v, &out_span) == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-static void az_span_append_u32toa_succeeds()
+static void az_span_utoa_succeeds()
 {
   uint32_t v = 12345;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_copy_u32toa(buffer, v, &out_span)));
+  assert_true(az_succeeded(az_span_utoa(buffer, v, &out_span)));
   assert_int_equal(az_span_size(out_span), 10);
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 5), AZ_SPAN_FROM_STR("12345")));
 }
 
-static void az_span_append_u32toa_zero_succeeds()
+static void az_span_utoa_zero_succeeds()
 {
   uint32_t v = 0;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_copy_u32toa(buffer, v, &out_span)));
+  assert_true(az_succeeded(az_span_utoa(buffer, v, &out_span)));
   assert_int_equal(az_span_size(out_span), 14);
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 1), AZ_SPAN_FROM_STR("0")));
 }
 
-static void az_span_append_u32toa_max_uint_succeeds()
+static void az_span_utoa_max_uint_succeeds()
 {
   uint32_t v = 4294967295;
   uint8_t raw_buffer[15];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_succeeded(az_span_copy_u32toa(buffer, v, &out_span)));
+  assert_true(az_succeeded(az_span_utoa(buffer, v, &out_span)));
   assert_int_equal(az_span_size(out_span), 5);
   assert_true(az_span_is_content_equal(
       az_span_slice(AZ_SPAN_FROM_BUFFER(raw_buffer), 0, 10), AZ_SPAN_FROM_STR("4294967295")));
 }
 
-static void az_span_append_u32toa_overflow_fails()
+static void az_span_utoa_overflow_fails()
 {
   uint32_t v = 2147483647;
   uint8_t raw_buffer[4];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span out_span;
 
-  assert_true(az_span_copy_u32toa(buffer, v, &out_span) == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+  assert_true(az_span_utoa(buffer, v, &out_span) == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void az_span_to_lower_test()
@@ -222,21 +222,21 @@ static void az_span_to_lower_test()
   assert_false(az_span_is_content_equal_ignoring_case(a, d));
 }
 
-static void az_span_to_uint64_return_errors()
+static void az_span_atou64_return_errors()
 {
   // sample span
   az_span sample = AZ_SPAN_FROM_STR("test");
   uint64_t out = 0;
 
-  assert_true(az_span_to_uint64(sample, &out) == AZ_ERROR_PARSER_UNEXPECTED_CHAR);
+  assert_true(az_span_atou64(sample, &out) == AZ_ERROR_PARSER_UNEXPECTED_CHAR);
 }
 
-static void az_span_to_uint32_test()
+static void az_span_atou_test()
 {
   az_span number = AZ_SPAN_FROM_STR("1024");
   uint32_t value = 0;
 
-  assert_return_code(az_span_to_uint32(number, &value), AZ_OK);
+  assert_return_code(az_span_atou(number, &value), AZ_OK);
   assert_int_equal(value, 1024);
 }
 
@@ -372,24 +372,24 @@ void test_az_span(void** state)
 
   az_span_from_str_succeeds();
 
-  az_span_append_uint8_succeeds();
+  az_span_copy_uint8_succeeds();
 
-  az_span_copy_i32toa_succeeds();
-  az_span_copy_i32toa_negative_succeeds();
-  az_span_copy_i32toa_max_int_succeeds();
-  az_span_copy_i32toa_zero_succeeds();
-  az_span_copy_i32toa_overflow_fails();
+  az_span_itoa_succeeds();
+  az_span_itoa_negative_succeeds();
+  az_span_itoa_max_int_succeeds();
+  az_span_itoa_zero_succeeds();
+  az_span_itoa_overflow_fails();
 
-  az_span_append_u32toa_succeeds();
-  az_span_append_u32toa_zero_succeeds();
-  az_span_append_u32toa_max_uint_succeeds();
-  az_span_append_u32toa_overflow_fails();
+  az_span_utoa_succeeds();
+  az_span_utoa_zero_succeeds();
+  az_span_utoa_max_uint_succeeds();
+  az_span_utoa_overflow_fails();
 
   az_single_char_ascii_lower_test();
   az_span_to_lower_test();
-  az_span_to_uint32_test();
+  az_span_atou_test();
   az_span_to_str_test();
-  az_span_to_uint64_return_errors();
+  az_span_atou64_return_errors();
 
   az_span_find_beginning_success();
   az_span_find_middle_success();

--- a/sdk/core/core/test/cmocka/test_span.c
+++ b/sdk/core/core/test/cmocka/test_span.c
@@ -14,17 +14,17 @@
 
 #include <_az_cfg.h>
 
-static void az_span_slice_test()
+static void az_span_slice_to_end_test()
 {
   uint8_t raw_buffer[20];
   az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);
 
   assert_int_equal(az_span_size(buffer), 20);
 
-  az_span result = az_span_slice(buffer, 1, -1);
+  az_span result = az_span_slice_to_end(buffer, 1);
   assert_int_equal(az_span_size(result), 19);
 
-  result = az_span_slice(buffer, 5, -1);
+  result = az_span_slice_to_end(buffer, 5);
   assert_int_equal(az_span_size(result), 15);
 }
 
@@ -368,7 +368,7 @@ void test_az_span(void** state)
 {
   (void)state;
 
-  az_span_slice_test();
+  az_span_slice_to_end_test();
 
   az_span_from_str_succeeds();
 

--- a/sdk/core/core/test/cmocka/test_span.c
+++ b/sdk/core/core/test/cmocka/test_span.c
@@ -28,6 +28,44 @@ static void az_span_slice_to_end_test()
   assert_int_equal(az_span_size(result), 15);
 }
 
+static void az_span_test_macro_only_allows_byte_buffers()
+{
+  {
+    uint8_t uint8_buffer[2];
+    assert_int_equal(_az_IS_ARRAY(uint8_buffer), 1);
+    assert_int_equal(_az_IS_BYTE_ARRAY(uint8_buffer), 1);
+    az_span valid = AZ_SPAN_FROM_BUFFER(uint8_buffer);
+    assert_int_equal(az_span_size(valid), 2);
+  }
+
+  {
+    char char_buffer[2];
+    assert_int_equal(_az_IS_ARRAY(char_buffer), 1);
+    assert_int_equal(_az_IS_BYTE_ARRAY(char_buffer), 1);
+    az_span valid = AZ_SPAN_FROM_BUFFER(char_buffer);
+    assert_int_equal(az_span_size(valid), 2);
+  }
+
+  {
+    uint32_t uint32_buffer[2];
+    assert_int_equal(_az_IS_ARRAY(uint32_buffer), 1);
+    assert_int_equal(_az_IS_BYTE_ARRAY(uint32_buffer), 0);
+  }
+
+  {
+    uint8_t x = 1;
+    uint8_t* p1 = &x;
+    assert_int_equal(_az_IS_ARRAY(p1), 0);
+    assert_int_equal(_az_IS_BYTE_ARRAY(p1), 0);
+  }
+
+  {
+    char* p1 = "HELLO";
+    assert_int_equal(_az_IS_ARRAY(p1), 0);
+    assert_int_equal(_az_IS_BYTE_ARRAY(p1), 0);
+  }
+}
+
 static void az_span_from_str_succeeds()
 {
   char* str = "HelloWorld";
@@ -369,6 +407,8 @@ void test_az_span(void** state)
   (void)state;
 
   az_span_slice_to_end_test();
+
+  az_span_test_macro_only_allows_byte_buffers();
 
   az_span_from_str_succeeds();
 

--- a/sdk/core/core/test/cmocka/test_span.c
+++ b/sdk/core/core/test/cmocka/test_span.c
@@ -28,6 +28,16 @@ static void az_span_slice_test()
   assert_int_equal(az_span_size(result), 15);
 }
 
+static void az_span_from_str_succeeds()
+{
+  char* str = "HelloWorld";
+  az_span buffer = az_span_from_str(str);
+
+  assert_int_equal(az_span_size(buffer), 10);
+  assert_true(az_span_ptr(buffer) != NULL);
+  assert_true((char*)az_span_ptr(buffer) == str);
+}
+
 static void az_single_char_ascii_lower_test()
 {
   for (uint8_t i = 0; i <= SCHAR_MAX; ++i)
@@ -359,6 +369,8 @@ void test_az_span(void** state)
   (void)state;
 
   az_span_slice_test();
+
+  az_span_from_str_succeeds();
 
   az_span_append_uint8_succeeds();
 

--- a/sdk/core/core/test/cmocka/test_span_replace.c
+++ b/sdk/core/core/test/cmocka/test_span_replace.c
@@ -24,12 +24,16 @@ void test_az_span_replace(void** state)
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
     az_span initial_state = AZ_SPAN_FROM_STR("12345678");
     az_span expected = AZ_SPAN_FROM_STR("1X78");
-    builder = az_span_append(builder, initial_state);
-    assert_int_equal(az_span_length(builder), az_span_length(initial_state));
+    az_span remainder = az_span_copy(builder, initial_state);
 
-    assert_true(_az_span_replace(&builder, 1, 6, AZ_SPAN_FROM_STR("X")) == AZ_OK);
+    int32_t expected_remainder_size = 200 - az_span_size(initial_state);
+    assert_int_equal(az_span_size(remainder), expected_remainder_size);
 
-    az_span const result = builder;
+    assert_true(
+        _az_span_replace(builder, az_span_size(initial_state), 1, 6, AZ_SPAN_FROM_STR("X"))
+        == AZ_OK);
+
+    az_span const result = az_span_slice(builder, 0, 4);
     assert_true(az_span_is_content_equal(result, expected));
   }
   {
@@ -38,12 +42,14 @@ void test_az_span_replace(void** state)
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
     az_span initial_state = AZ_SPAN_FROM_STR("12345678");
     az_span expected = AZ_SPAN_FROM_STR("12X345678");
-    builder = az_span_append(builder, initial_state);
-    assert_int_equal(az_span_length(builder), az_span_length(initial_state));
+    az_span remainder = az_span_copy(builder, initial_state);
+    assert_int_equal(az_span_size(remainder), 200 - az_span_size(initial_state));
 
-    assert_true(_az_span_replace(&builder, 2, 2, AZ_SPAN_FROM_STR("X")) == AZ_OK);
+    assert_true(
+        _az_span_replace(builder, az_span_size(initial_state), 2, 2, AZ_SPAN_FROM_STR("X"))
+        == AZ_OK);
 
-    az_span const result = builder;
+    az_span const result = az_span_slice(builder, 0, 9);
     assert_true(az_span_is_content_equal(result, expected));
   }
   {
@@ -52,12 +58,14 @@ void test_az_span_replace(void** state)
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
     az_span initial_state = AZ_SPAN_FROM_STR("12345678");
     az_span expected = AZ_SPAN_FROM_STR("1234567890");
-    builder = az_span_append(builder, initial_state);
-    assert_int_equal(az_span_length(builder), az_span_length(initial_state));
+    az_span remainder = az_span_copy(builder, initial_state);
+    assert_int_equal(az_span_size(remainder), 200 - az_span_size(initial_state));
 
-    assert_true(_az_span_replace(&builder, 8, 8, AZ_SPAN_FROM_STR("90")) == AZ_OK);
+    assert_true(
+        _az_span_replace(builder, az_span_size(initial_state), 8, 8, AZ_SPAN_FROM_STR("90"))
+        == AZ_OK);
 
-    az_span const result = builder;
+    az_span const result = az_span_slice(builder, 0, 10);
     assert_true(az_span_is_content_equal(result, expected));
   }
   {
@@ -66,12 +74,14 @@ void test_az_span_replace(void** state)
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
     az_span initial_state = AZ_SPAN_FROM_STR("12345678");
     az_span expected = AZ_SPAN_FROM_STR("X");
-    builder = az_span_append(builder, initial_state);
-    assert_int_equal(az_span_length(builder), az_span_length(initial_state));
+    az_span remainder = az_span_copy(builder, initial_state);
+    assert_int_equal(az_span_size(remainder), 200 - az_span_size(initial_state));
 
-    assert_true(_az_span_replace(&builder, 0, 8, AZ_SPAN_FROM_STR("X")) == AZ_OK);
+    assert_true(
+        _az_span_replace(builder, az_span_size(initial_state), 0, 8, AZ_SPAN_FROM_STR("X"))
+        == AZ_OK);
 
-    az_span const result = builder;
+    az_span const result = az_span_slice(builder, 0, 1);
     assert_true(az_span_is_content_equal(result, expected));
   }
   {
@@ -80,12 +90,14 @@ void test_az_span_replace(void** state)
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
     az_span initial_state = AZ_SPAN_FROM_STR("12345678");
     az_span expected = AZ_SPAN_FROM_STR("X12345678X");
-    builder = az_span_append(builder, initial_state);
-    assert_int_equal(az_span_length(builder), az_span_length(initial_state));
+    az_span remainder = az_span_copy(builder, initial_state);
+    assert_int_equal(az_span_size(remainder), 200 - az_span_size(initial_state));
 
-    assert_true(_az_span_replace(&builder, 0, 8, AZ_SPAN_FROM_STR("X12345678X")) == AZ_OK);
+    assert_true(
+        _az_span_replace(builder, az_span_size(initial_state), 0, 8, AZ_SPAN_FROM_STR("X12345678X"))
+        == AZ_OK);
 
-    az_span const result = builder;
+    az_span const result = az_span_slice(builder, 0, 10);
     assert_true(az_span_is_content_equal(result, expected));
   }
   {
@@ -94,12 +106,14 @@ void test_az_span_replace(void** state)
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
     az_span initial_state = AZ_SPAN_FROM_STR("12345678");
     az_span expected = AZ_SPAN_FROM_STR("XXX12345678");
-    builder = az_span_append(builder, initial_state);
-    assert_int_equal(az_span_length(builder), az_span_length(initial_state));
+    az_span remainder = az_span_copy(builder, initial_state);
+    assert_int_equal(az_span_size(remainder), 200 - az_span_size(initial_state));
 
-    assert_true(_az_span_replace(&builder, 0, 0, AZ_SPAN_FROM_STR("XXX")) == AZ_OK);
+    assert_true(
+        _az_span_replace(builder, az_span_size(initial_state), 0, 0, AZ_SPAN_FROM_STR("XXX"))
+        == AZ_OK);
 
-    az_span const result = builder;
+    az_span const result = az_span_slice(builder, 0, 11);
     assert_true(az_span_is_content_equal(result, expected));
   }
   {
@@ -108,12 +122,14 @@ void test_az_span_replace(void** state)
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
     az_span initial_state = AZ_SPAN_FROM_STR("1");
     az_span expected = AZ_SPAN_FROM_STR("2");
-    builder = az_span_append(builder, initial_state);
-    assert_int_equal(az_span_length(builder), az_span_length(initial_state));
+    az_span remainder = az_span_copy(builder, initial_state);
+    assert_int_equal(az_span_size(remainder), 200 - az_span_size(initial_state));
 
-    assert_true(_az_span_replace(&builder, 0, 1, AZ_SPAN_FROM_STR("2")) == AZ_OK);
+    assert_true(
+        _az_span_replace(builder, az_span_size(initial_state), 0, 1, AZ_SPAN_FROM_STR("2"))
+        == AZ_OK);
 
-    az_span const result = builder;
+    az_span const result = az_span_slice(builder, 0, 1);
     assert_true(az_span_is_content_equal(result, expected));
   }
   {
@@ -122,12 +138,14 @@ void test_az_span_replace(void** state)
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
     az_span initial_state = AZ_SPAN_FROM_STR("1234");
     az_span expected = AZ_SPAN_FROM_STR("4321");
-    builder = az_span_append(builder, initial_state);
-    assert_int_equal(az_span_length(builder), az_span_length(initial_state));
+    az_span remainder = az_span_copy(builder, initial_state);
+    assert_int_equal(az_span_size(remainder), 4 - az_span_size(initial_state));
 
-    assert_true(_az_span_replace(&builder, 0, 4, AZ_SPAN_FROM_STR("4321")) == AZ_OK);
+    assert_true(
+        _az_span_replace(builder, az_span_size(initial_state), 0, 4, AZ_SPAN_FROM_STR("4321"))
+        == AZ_OK);
 
-    az_span const result = builder;
+    az_span const result = az_span_slice(builder, 0, 4);
     assert_true(az_span_is_content_equal(result, expected));
   }
   {
@@ -136,17 +154,19 @@ void test_az_span_replace(void** state)
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
     az_span initial_state = AZ_SPAN_FROM_STR("1234");
     az_span expected = AZ_SPAN_FROM_STR("1X34AB");
-    builder = az_span_append(builder, initial_state);
-    assert_int_equal(az_span_length(builder), az_span_length(initial_state));
+    az_span remainder = az_span_copy(builder, initial_state);
+    assert_int_equal(az_span_size(remainder), 10 - az_span_size(initial_state));
 
-    TEST_EXPECT_SUCCESS(_az_span_replace(&builder, 1, 2, AZ_SPAN_FROM_STR("X")));
+    TEST_EXPECT_SUCCESS(
+        _az_span_replace(builder, az_span_size(initial_state), 1, 2, AZ_SPAN_FROM_STR("X")));
 
-    builder = az_span_append(builder, AZ_SPAN_FROM_STR("AB"));
-    assert_int_equal(
-        az_span_length(builder),
-        az_span_length(AZ_SPAN_FROM_STR("AB")) + az_span_length(initial_state));
+    remainder = az_span_copy(remainder, AZ_SPAN_FROM_STR("AB"));
 
-    az_span const result = builder;
+    int32_t expected_remainder_size
+        = 10 - (az_span_size(AZ_SPAN_FROM_STR("AB")) + az_span_size(initial_state));
+    assert_int_equal(az_span_size(remainder), expected_remainder_size);
+
+    az_span const result = az_span_slice(builder, 0, 6);
     assert_true(az_span_is_content_equal(result, expected));
   }
   {
@@ -156,12 +176,13 @@ void test_az_span_replace(void** state)
     az_span initial_state = AZ_SPAN_FROM_STR("123");
     az_span expected = AZ_SPAN_FROM_STR("1234");
 
-    builder = az_span_append(builder, initial_state);
-    assert_int_equal(az_span_length(builder), az_span_length(initial_state));
+    az_span remainder = az_span_copy(builder, initial_state);
+    assert_int_equal(az_span_size(remainder), 4 - az_span_size(initial_state));
 
-    TEST_EXPECT_SUCCESS(_az_span_replace(&builder, 3, 3, AZ_SPAN_FROM_STR("4")));
+    TEST_EXPECT_SUCCESS(
+        _az_span_replace(builder, az_span_size(initial_state), 3, 3, AZ_SPAN_FROM_STR("4")));
 
-    az_span const result = builder;
+    az_span const result = az_span_slice(builder, 0, 4);
     assert_true(az_span_is_content_equal(result, expected));
   }
   {
@@ -169,23 +190,25 @@ void test_az_span_replace(void** state)
     uint8_t array[4];
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
     az_span initial_state = AZ_SPAN_FROM_STR("1234");
-    builder = az_span_append(builder, initial_state);
-    assert_int_equal(az_span_length(builder), az_span_length(initial_state));
+    az_span remainder = az_span_copy(builder, initial_state);
+    assert_int_equal(az_span_size(remainder), 4 - az_span_size(initial_state));
 
-    assert_true(_az_span_replace(&builder, 0, 4, AZ_SPAN_FROM_STR("4321X")) == AZ_ERROR_ARG);
+    assert_true(
+        _az_span_replace(builder, az_span_size(initial_state), 0, 4, AZ_SPAN_FROM_STR("4321X"))
+        == AZ_ERROR_ARG);
   }
   {
     // Fail on builder empty -> try to replace content from empty builder
     uint8_t array[200];
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
-    assert_true(_az_span_replace(&builder, 0, 1, AZ_SPAN_FROM_STR("2")) == AZ_ERROR_ARG);
+    assert_true(_az_span_replace(builder, 0, 0, 1, AZ_SPAN_FROM_STR("2")) == AZ_ERROR_ARG);
   }
   {
     // Replace content on empty builder -> insert at the end
     uint8_t array[200];
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
-    assert_true(_az_span_replace(&builder, 0, 0, AZ_SPAN_FROM_STR("2")) == AZ_OK);
-    az_span const result = builder;
+    assert_true(_az_span_replace(builder, 0, 0, 0, AZ_SPAN_FROM_STR("2")) == AZ_OK);
+    az_span const result = az_span_slice(builder, 0, 1);
     az_span const expected = AZ_SPAN_FROM_STR("2");
     assert_true(az_span_is_content_equal(result, expected));
   }
@@ -194,29 +217,35 @@ void test_az_span_replace(void** state)
     uint8_t array[400];
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
     az_span initial_state = AZ_SPAN_FROM_STR("1234");
-    builder = az_span_append(builder, initial_state);
-    assert_int_equal(az_span_length(builder), az_span_length(initial_state));
+    az_span remainder = az_span_copy(builder, initial_state);
+    assert_int_equal(az_span_size(remainder), 400 - az_span_size(initial_state));
 
-    assert_true(_az_span_replace(&builder, 30, 31, AZ_SPAN_FROM_STR("4321X")) == AZ_ERROR_ARG);
+    assert_true(
+        _az_span_replace(builder, az_span_size(initial_state), 30, 31, AZ_SPAN_FROM_STR("4321X"))
+        == AZ_ERROR_ARG);
   }
   {
     // Fail when trying to replace out of bounds -> end position out
     uint8_t array[40];
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
     az_span initial_state = AZ_SPAN_FROM_STR("1234");
-    builder = az_span_append(builder, initial_state);
-    assert_int_equal(az_span_length(builder), az_span_length(initial_state));
+    az_span remainder = az_span_copy(builder, initial_state);
+    assert_int_equal(az_span_size(remainder), 40 - az_span_size(initial_state));
 
-    assert_true(_az_span_replace(&builder, 4, 5, AZ_SPAN_FROM_STR("4321X")) == AZ_ERROR_ARG);
+    assert_true(
+        _az_span_replace(builder, az_span_size(initial_state), 4, 5, AZ_SPAN_FROM_STR("4321X"))
+        == AZ_ERROR_ARG);
   }
   {
     // Fail when start is greater than end
     uint8_t array[40];
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
     az_span initial_state = AZ_SPAN_FROM_STR("1234");
-    builder = az_span_append(builder, initial_state);
-    assert_int_equal(az_span_length(builder), az_span_length(initial_state));
+    az_span remainder = az_span_copy(builder, initial_state);
+    assert_int_equal(az_span_size(remainder), 40 - az_span_size(initial_state));
 
-    assert_true(_az_span_replace(&builder, 3, 1, AZ_SPAN_FROM_STR("4321X")) == AZ_ERROR_ARG);
+    assert_true(
+        _az_span_replace(builder, az_span_size(initial_state), 3, 1, AZ_SPAN_FROM_STR("4321X"))
+        == AZ_ERROR_ARG);
   }
 }

--- a/sdk/core/core/test/cmocka/test_url_encode.c
+++ b/sdk/core/core/test/cmocka/test_url_encode.c
@@ -53,13 +53,14 @@ void test_url_encode(void** state)
     uint8_t buf[256 * 3];
     az_span builder = AZ_SPAN_FROM_BUFFER(buf);
 
+    az_span remainder;
     TEST_EXPECT_SUCCESS(
-        az_span_copy_url_encode(builder, AZ_SPAN_FROM_STR("https://vault.azure.net"), &builder));
+        az_span_copy_url_encode(builder, AZ_SPAN_FROM_STR("https://vault.azure.net"), &remainder));
     assert_true(
-        az_span_is_content_equal(builder, AZ_SPAN_FROM_STR("https%3A%2F%2Fvault.azure.net")));
+        az_span_is_content_equal(az_span_slice(builder, 0, 29), AZ_SPAN_FROM_STR("https%3A%2F%2Fvault.azure.net")));
 
     builder = AZ_SPAN_FROM_BUFFER(buffer);
-    TEST_EXPECT_SUCCESS(az_span_copy_url_encode(builder, uri_decoded, &builder));
-    assert_true(az_span_is_content_equal(builder, uri_encoded));
+    TEST_EXPECT_SUCCESS(az_span_copy_url_encode(builder, uri_decoded, &remainder));
+    assert_true(az_span_is_content_equal(az_span_slice(builder, 0, 636), uri_encoded));
   }
 }

--- a/sdk/core/core/test/cmocka/test_url_encode.c
+++ b/sdk/core/core/test/cmocka/test_url_encode.c
@@ -43,8 +43,6 @@ static uint8_t uri_decoded_buf[] = {
   0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF
 };
 
-static az_span uri_decoded = AZ_SPAN_LITERAL_FROM_INITIALIZED_BUFFER(uri_decoded_buf);
-
 void test_url_encode(void** state)
 {
   (void)state;
@@ -56,11 +54,12 @@ void test_url_encode(void** state)
     az_span remainder;
     TEST_EXPECT_SUCCESS(
         az_span_copy_url_encode(builder, AZ_SPAN_FROM_STR("https://vault.azure.net"), &remainder));
-    assert_true(
-        az_span_is_content_equal(az_span_slice(builder, 0, 29), AZ_SPAN_FROM_STR("https%3A%2F%2Fvault.azure.net")));
+    assert_true(az_span_is_content_equal(
+        az_span_slice(builder, 0, 29), AZ_SPAN_FROM_STR("https%3A%2F%2Fvault.azure.net")));
 
     builder = AZ_SPAN_FROM_BUFFER(buffer);
-    TEST_EXPECT_SUCCESS(az_span_copy_url_encode(builder, uri_decoded, &remainder));
+    TEST_EXPECT_SUCCESS(
+        az_span_copy_url_encode(builder, AZ_SPAN_FROM_BUFFER(uri_decoded_buf), &remainder));
     assert_true(az_span_is_content_equal(az_span_slice(builder, 0, 636), uri_encoded));
   }
 }

--- a/sdk/core/core/test/cmocka/test_url_encode.c
+++ b/sdk/core/core/test/cmocka/test_url_encode.c
@@ -1,12 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include "az_json_string_private.h"
+#include "az_span_private.h"
 #include "az_test_definitions.h"
-#include <az_json.h>
-
-#include <setjmp.h>
-#include <stdarg.h>
 
 #include <cmocka.h>
 

--- a/sdk/core/core/test/inc/az_test_span.h
+++ b/sdk/core/core/test/inc/az_test_span.h
@@ -10,8 +10,10 @@
 #ifndef _az_SPAN_TESTING_H
 #define _az_SPAN_TESTING_H
 
-// This header must be included prior to including cmocka.h.
+// These headers must be included prior to including cmocka.h.
 #include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
 
 #include <assert.h>
 #include <cmocka.h>

--- a/sdk/core/core/test/inc/az_test_span.h
+++ b/sdk/core/core/test/inc/az_test_span.h
@@ -30,14 +30,13 @@
  * #az_span_init.  The buffer is initialized with 0xcc to help tests check against buffer overflow.
  *
  * @param[in] ptr The memory address of the 1st byte in the byte buffer.
- * @param[in] length The number of bytes initialized in the byte buffer.
- * @param[in] capacity The number of total bytes in the byte buffer.
+ * @param[in] size The number of total bytes in the byte buffer.
  * @return az_span The "view" over the byte buffer, with the buffer filled with 0xcc.
  */
-AZ_NODISCARD AZ_INLINE az_span az_span_for_test_init(uint8_t* ptr, int32_t length, int32_t capacity)
+AZ_NODISCARD AZ_INLINE az_span az_span_for_test_init(uint8_t* ptr, int32_t size)
 {
-  az_span new_span = az_span_init(ptr, length, capacity);
-  az_span_set(new_span, 0xcc);
+  az_span new_span = az_span_init(ptr, size);
+  az_span_fill(new_span, 0xcc);
   return new_span;
 }
 
@@ -50,22 +49,23 @@ AZ_NODISCARD AZ_INLINE az_span az_span_for_test_init(uint8_t* ptr, int32_t lengt
  * @param[in] result_span Span that has the result of the test run.
  * @param[in] buffer_expected Buffer that contains expected results of the test and that result_span
  * will match on success.
- * @param[in] length_expected The expected length of result_span.
- * @param[in] capacity_expected The expected capacity of result_span.
+ * @param[in] size_expected The expected size of result_span.
  */
 AZ_INLINE void az_span_for_test_verify(
     az_span result_span,
     const void* const buffer_expected,
     int32_t length_expected,
-    int32_t capacity_expected)
+    az_span original_buffer,
+    int32_t size_expected)
 {
-  assert_int_equal(az_span_length(result_span), length_expected);
-  assert_int_equal(az_span_capacity(result_span), capacity_expected);
+  assert_int_equal(az_span_size(original_buffer), size_expected);
   assert_memory_equal(az_span_ptr(result_span), (size_t)buffer_expected, (size_t)length_expected);
+  assert_memory_equal(
+      az_span_ptr(original_buffer), (size_t)buffer_expected, (size_t)length_expected);
 
-  for (int32_t i = az_span_length(result_span); i < az_span_capacity(result_span); i++)
+  for (int32_t i = length_expected; i < size_expected; i++)
   {
-    assert_true(*(uint8_t*)(az_span_ptr(result_span) + i) == 0xcc);
+    assert_true(*(uint8_t*)(az_span_ptr(original_buffer) + i) == 0xcc);
   }
 }
 

--- a/sdk/iot/README.md
+++ b/sdk/iot/README.md
@@ -67,11 +67,11 @@ void my_property_func()
 {
   //Allocate a span to put the properties
   uint8_t property_buffer[64];
-  az_span property_span = az_span_init(property_buffer, 0, sizeof(property_buffer));
+  az_span property_span = az_span_init(property_buffer, sizeof(property_buffer));
   
   //Initialize the property struct with the span
   az_iot_hub_client_properties props;
-  az_iot_hub_client_properties_init(&props, property_span);
+  az_iot_hub_client_properties_init(&props, property_span, 0);
   //Append properties
   az_iot_hub_client_properties_append(&props, AZ_SPAN_FROM_STR("key"), AZ_SPAN_FROM_STR("value"));
   //At this point, you are able to pass the `props` to other API's with property parameters.
@@ -87,7 +87,7 @@ void my_property_func()
 {
   //Initialize the property struct with the span
   az_iot_hub_client_properties props;
-  az_iot_hub_client_properties_init(&props, my_prop_span);
+  az_iot_hub_client_properties_init(&props, my_prop_span, az_span_size(my_prop_span));
   //At this point, you are able to pass the `props` to other API's with property parameters.
 }
 ```
@@ -112,7 +112,7 @@ void my_telemetry_func()
   //Optionally, the size can include space for a null terminator.
   //Here, the buffer is zero initialized to null terminate the topic.
   uint8_t telemetry_topic_buffer[64] = { 0 };
-  az_span topic_span = az_span_init(telemetry_topic_buffer, 0,
+  az_span topic_span = az_span_init(telemetry_topic_buffer,
                 sizeof(telemetry_topic_buffer) / sizeof(telemetry_topic_buffer[0]));
 
   //Get the NULL terminated topic and put in topic_span to send the telemetry

--- a/sdk/iot/core/src/az_iot_core.c
+++ b/sdk/iot/core/src/az_iot_core.c
@@ -80,7 +80,7 @@ AZ_NODISCARD az_span az_span_token(az_span source, az_span delimiter, az_span* o
   AZ_PRECONDITION_VALID_SPAN(delimiter, 1, false);
   AZ_PRECONDITION_NOT_NULL(out_remainder);
 
-  if (az_span_length(source) == 0)
+  if (az_span_size(source) == 0)
   {
     return AZ_SPAN_NULL;
   }
@@ -90,8 +90,7 @@ AZ_NODISCARD az_span az_span_token(az_span source, az_span delimiter, az_span* o
 
     if (index != -1)
     {
-      *out_remainder
-          = az_span_slice(source, index + az_span_length(delimiter), az_span_length(source));
+      *out_remainder = az_span_slice(source, index + az_span_size(delimiter), az_span_size(source));
 
       return az_span_slice(source, 0, index);
     }

--- a/sdk/iot/core/tests/cmocka/test_az_iot_core.c
+++ b/sdk/iot/core/tests/cmocka/test_az_iot_core.c
@@ -5,16 +5,16 @@
 #include <az_iot_core.h>
 #include <az_span.h>
 
-#include <az_precondition_internal.h>
 #include <az_precondition.h>
+#include <az_precondition_internal.h>
 
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 
-#include <cmocka.h>
 #include <az_test_precondition.h>
+#include <cmocka.h>
 
 static void az_span_token_success(void** state)
 {
@@ -27,47 +27,44 @@ static void az_span_token_success(void** state)
   // token: ""
   token = az_span_token(span, delim, &out_span);
   assert_non_null(az_span_ptr(token));
-  assert_true(az_span_length(token) == 0);
-  assert_true(az_span_ptr(out_span) == (az_span_ptr(span) + az_span_length(delim)));
-  assert_true(az_span_length(out_span) == (az_span_length(span) - az_span_length(delim)));
-  assert_true(az_span_capacity(out_span) == (az_span_capacity(span) - az_span_capacity(delim)));
+  assert_true(az_span_size(token) == 0);
+  assert_true(az_span_ptr(out_span) == (az_span_ptr(span) + az_span_size(delim)));
+  assert_true(az_span_size(out_span) == (az_span_size(span) - az_span_size(delim)));
 
   // token: "defg" (span+3)
   span = out_span;
 
   token = az_span_token(span, delim, &out_span);
   assert_true(az_span_ptr(token) == az_span_ptr(span));
-  assert_true(az_span_length(token) == 4);
-  assert_true(az_span_capacity(token) == az_span_capacity(span));
-  assert_true(az_span_ptr(out_span) == (az_span_ptr(span) + az_span_length(token) + az_span_length(delim)));
-  assert_true(az_span_length(out_span) == (az_span_length(span) - az_span_length(token) - az_span_length(delim)));
-  assert_true(az_span_capacity(out_span) == (az_span_capacity(span) - az_span_length(token) - az_span_length(delim)));
+  assert_int_equal(az_span_size(token), 4);
+  assert_true(
+      az_span_ptr(out_span) == (az_span_ptr(span) + az_span_size(token) + az_span_size(delim)));
+  assert_true(
+      az_span_size(out_span) == (az_span_size(span) - az_span_size(token) - az_span_size(delim)));
 
   // token: "defg" (span+10)
   span = out_span;
 
   token = az_span_token(span, delim, &out_span);
   assert_true(az_span_ptr(token) == az_span_ptr(span));
-  assert_true(az_span_length(token) == 4);
-  assert_true(az_span_capacity(token) == az_span_length(span));
-  assert_true(az_span_ptr(out_span) == (az_span_ptr(span) + az_span_length(token) + az_span_length(delim)));
-  assert_true(az_span_length(out_span) == (az_span_length(span) - az_span_length(token) - az_span_length(delim)));
-  assert_true(az_span_capacity(out_span) == (az_span_capacity(span) - az_span_length(token) - az_span_length(delim)));
+  assert_int_equal(az_span_size(token), 4);
+  assert_true(
+      az_span_ptr(out_span) == (az_span_ptr(span) + az_span_size(token) + az_span_size(delim)));
+  assert_true(
+      az_span_size(out_span) == (az_span_size(span) - az_span_size(token) - az_span_size(delim)));
 
   // token: "defg" (span+17)
   span = out_span;
 
   token = az_span_token(span, delim, &out_span);
   assert_true(az_span_ptr(token) == az_span_ptr(span));
-  assert_true(az_span_length(token) == 4);
-  assert_true(az_span_capacity(token) == az_span_length(span));
+  assert_int_equal(az_span_size(token), 4);
   assert_true(az_span_ptr(out_span) == NULL);
-  assert_true(az_span_length(out_span) == 0);
-  assert_true(az_span_capacity(out_span) == 0);
+  assert_true(az_span_size(out_span) == 0);
 
   // Out_span is empty.
   span = out_span;
-  
+
   token = az_span_token(span, delim, &out_span);
   assert_true(az_span_is_content_equal(token, AZ_SPAN_NULL));
 }
@@ -133,7 +130,6 @@ static void test_az_iot_get_status_from_uint32(void** state)
   assert_int_equal(AZ_IOT_STATUS_TIMEOUT, status);
 
   assert_int_equal(az_iot_get_status_from_uint32(999, &status), AZ_ERROR_ITEM_NOT_FOUND);
-
 }
 
 int test_az_iot_core()

--- a/sdk/iot/hub/inc/az_iot_hub_client.h
+++ b/sdk/iot/hub/inc/az_iot_hub_client.h
@@ -181,8 +181,8 @@ typedef struct az_iot_hub_client_properties
 {
   struct
   {
-    az_span properties;
-    int32_t properties_length;
+    az_span properties_buffer;
+    int32_t properties_written;
     uint32_t current_property_index;
   } _internal;
 } az_iot_hub_client_properties;

--- a/sdk/iot/hub/inc/az_iot_hub_client.h
+++ b/sdk/iot/hub/inc/az_iot_hub_client.h
@@ -10,15 +10,14 @@
 #ifndef _az_IOT_HUB_CLIENT_H
 #define _az_IOT_HUB_CLIENT_H
 
+#include <az_iot_core.h>
 #include <az_result.h>
 #include <az_span.h>
-#include <az_iot_core.h>
 
 #include <stdbool.h>
 #include <stdint.h>
 
 #include <_az_cfg_prefix.h>
-
 
 /**
  * @brief Azure IoT service MQTT bit field properties for telemetry publish messages.
@@ -29,7 +28,7 @@ enum
   AZ_HUB_CLIENT_DEFAULT_MQTT_TELEMETRY_QOS = 0,
   AZ_HUB_CLIENT_DEFAULT_MQTT_TELEMETRY_DUPLICATE = 0,
   AZ_HUB_CLIENT_DEFAULT_MQTT_TELEMETRY_RETAIN = 1
-};  
+};
 
 /**
  * @brief Azure IoT Hub Client options.
@@ -83,10 +82,11 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
 
 /**
  * @brief Gets the MQTT user name.
- * 
+ *
  * The user name will be of the following format:
  * [Format without module id] {iothubhostname}/{device_id}/?api-version=2018-06-30&{user_agent}
- * [Format with module id] {iothubhostname}/{device_id}/{module_id}/?api-version=2018-06-30&{user_agent}
+ * [Format with module id]
+ * {iothubhostname}/{device_id}/{module_id}/?api-version=2018-06-30&{user_agent}
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] mqtt_user_name An empty #az_span with sufficient capacity to hold the MQTT user name.
@@ -100,7 +100,7 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
 
 /**
  * @brief Gets the MQTT client id.
- * 
+ *
  * The client id will be of the following format:
  * [Format without module id] {device_id}
  * [Format with module id] {device_id}/{module_id}
@@ -182,15 +182,16 @@ typedef struct az_iot_hub_client_properties
   struct
   {
     az_span properties;
+    int32_t properties_length;
     uint32_t current_property_index;
   } _internal;
 } az_iot_hub_client_properties;
 
 /**
  * @brief Initializes the Telemetry or C2D properties.
- * 
+ *
  * @note The properties init API will not encode properties. In order to support
- *       the following characters, they must be percent-encoded (RFC3986) as follows: 
+ *       the following characters, they must be percent-encoded (RFC3986) as follows:
  *          `/` : `%2F`
  *          `%` : `%25`
  *          `#` : `%23`
@@ -200,16 +201,20 @@ typedef struct az_iot_hub_client_properties
  *
  * @param[in] properties The #az_iot_hub_client_properties to initialize
  * @param[in] buffer Can either be an empty #az_span or an #az_span containing properly formatted
- *                   (with above mentioned characters encoded if applicable) properties with the 
+ *                   (with above mentioned characters encoded if applicable) properties with the
  *                   following format: {key}={value}&{key}={value}.
+ * @param[in] written_length The length of the properly formatted properties already initialized
+ * within the buffer. If the \p buffer is empty (uninitialized), this should be 0.
  * @return #az_result
  */
-AZ_NODISCARD az_result
-az_iot_hub_client_properties_init(az_iot_hub_client_properties* properties, az_span buffer);
+AZ_NODISCARD az_result az_iot_hub_client_properties_init(
+    az_iot_hub_client_properties* properties,
+    az_span buffer,
+    int32_t written_length);
 
 /**
  * @brief Appends a key-value property to the list of properties.
- * 
+ *
  * @note The properties append API will not encode properties. In order to support
  *       the following characters, they must be percent-encoded (RFC3986) as follows:
  *          `/` : `%2F`
@@ -264,11 +269,11 @@ az_iot_hub_client_properties_next(az_iot_hub_client_properties* properties, az_p
  * @brief Gets the MQTT topic that must be used for device to cloud telemetry messages.
  * @note Telemetry MQTT Publish messages must have QoS At Least Once (1).
  * @note This topic can also be used to set the MQTT Will message in the Connect message.
- * 
+ *
  * Should the user want a null terminated topic string, they may allocate a buffer large enough
- * to fit the topic plus a null terminator. They must set the last byte themselves or zero initialize
- * the buffer.
- * 
+ * to fit the topic plus a null terminator. They must set the last byte themselves or zero
+ * initialize the buffer.
+ *
  * The telemetry topic will be of the following format:
  * `devices/{device_id}/messages/events/{property_bag}`
  *

--- a/sdk/iot/hub/inc/az_iot_sas_token.h
+++ b/sdk/iot/hub/inc/az_iot_sas_token.h
@@ -26,7 +26,7 @@
  * @param[out] out_document       A pointer to #az_span where to write the SAS token document to be encrypted.
  * @return                        An #az_result with the result of the operation.
  *   @retval                      #AZ_OK                       If no failures occur. 
- *   @retval                      #AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY    If the buffer provided in #az_iot_sas_params or `document` are insufficient in size.
+ *   @retval                      #AZ_ERROR_INSUFFICIENT_SPAN_SIZE    If the buffer provided in #az_iot_sas_params or `document` are insufficient in size.
  *   @retval                      #AZ_ERROR_ARG                If `params` is NULL or any of its components are NULL or a NULL #az_span, or 
  *                                                          if `document` is a NULL pointer or a NULL #az_span.
  */
@@ -47,7 +47,7 @@ az_result az_iot_sas_token_get_document(az_span iothub_fqdn, az_span device_id, 
  * @param[out] out_sas_token      An pointer to #az_span where to write the SAS token.
  * @return                        An #az_result with the result of the operation.
  *   @retval                      #AZ_OK                       If no failures occur. 
- *   @retval                      #AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY    If the buffer provided in #az_iot_sas_params or `sas_token` are insufficient in size.
+ *   @retval                      #AZ_ERROR_INSUFFICIENT_SPAN_SIZE    If the buffer provided in #az_iot_sas_params or `sas_token` are insufficient in size.
  *   @retval                      #AZ_ERROR_ARG                If `params` is NULL or any of its components are NULL or a NULL #az_span, or
  *                                                             if `signature` is a NULL #az_span, or
  *                                                             if `document` is a NULL pointer or a NULL #az_span.

--- a/sdk/iot/hub/src/az_iot_hub_client.c
+++ b/sdk/iot/hub/src/az_iot_hub_client.c
@@ -118,8 +118,10 @@ AZ_NODISCARD az_result az_iot_hub_client_id_get(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result
-az_iot_hub_client_properties_init(az_iot_hub_client_properties* properties, az_span buffer, int32_t written_length)
+AZ_NODISCARD az_result az_iot_hub_client_properties_init(
+    az_iot_hub_client_properties* properties,
+    az_span buffer,
+    int32_t written_length)
 {
   AZ_PRECONDITION_NOT_NULL(properties);
   AZ_PRECONDITION_VALID_SPAN(buffer, 0, false);
@@ -143,10 +145,10 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_append(
 
   int32_t prop_length = properties->_internal.properties_length;
 
-  az_span remainder = az_span_slice(properties->_internal.properties, prop_length, -1);
+  az_span remainder = az_span_slice_to_end(properties->_internal.properties, prop_length);
 
   int32_t required_length = az_span_size(name) + az_span_size(value) + 1;
-  
+
   if (prop_length > 0)
   {
     required_length += 1;

--- a/sdk/iot/hub/src/az_iot_hub_client.c
+++ b/sdk/iot/hub/src/az_iot_hub_client.c
@@ -50,39 +50,38 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
   const az_span* const module_id = &(client->_internal.options.module_id);
   const az_span* const user_agent = &(client->_internal.options.user_agent);
 
-  int32_t required_length = az_span_length(client->_internal.iot_hub_hostname)
-      + az_span_length(client->_internal.device_id) + az_span_length(hub_service_api_version) + 1;
-  if (az_span_length(*module_id) > 0)
+  int32_t required_length = az_span_size(client->_internal.iot_hub_hostname)
+      + az_span_size(client->_internal.device_id) + az_span_size(hub_service_api_version) + 1;
+  if (az_span_size(*module_id) > 0)
   {
-    required_length += az_span_length(*module_id) + 1;
+    required_length += az_span_size(*module_id) + 1;
   }
-  if (az_span_length(*user_agent) > 0)
+  if (az_span_size(*user_agent) > 0)
   {
-    required_length += az_span_length(*user_agent) + 1;
-  }
-
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_user_name, required_length);
-
-  mqtt_user_name = az_span_copy(mqtt_user_name, client->_internal.iot_hub_hostname);
-  mqtt_user_name = az_span_append_uint8(mqtt_user_name, hub_client_forward_slash);
-  mqtt_user_name = az_span_append(mqtt_user_name, client->_internal.device_id);
-
-  if (az_span_length(*module_id) > 0)
-  {
-    mqtt_user_name = az_span_append_uint8(mqtt_user_name, hub_client_forward_slash);
-    mqtt_user_name = az_span_append(mqtt_user_name, *module_id);
+    required_length += az_span_size(*user_agent) + 1;
   }
 
-  mqtt_user_name = az_span_append(mqtt_user_name, hub_service_api_version);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_user_name, required_length);
 
-  if (az_span_length(*user_agent) > 0)
+  az_span remainder = az_span_copy(mqtt_user_name, client->_internal.iot_hub_hostname);
+  remainder = az_span_copy_uint8(remainder, hub_client_forward_slash);
+  remainder = az_span_copy(remainder, client->_internal.device_id);
+
+  if (az_span_size(*module_id) > 0)
   {
-    mqtt_user_name
-        = az_span_append_uint8(mqtt_user_name, *az_span_ptr(hub_client_param_separator_span));
-    mqtt_user_name = az_span_append(mqtt_user_name, *user_agent);
+    remainder = az_span_copy_uint8(remainder, hub_client_forward_slash);
+    remainder = az_span_copy(remainder, *module_id);
   }
 
-  *out_mqtt_user_name = mqtt_user_name;
+  remainder = az_span_copy(remainder, hub_service_api_version);
+
+  if (az_span_size(*user_agent) > 0)
+  {
+    remainder = az_span_copy_uint8(remainder, *az_span_ptr(hub_client_param_separator_span));
+    az_span_copy(remainder, *user_agent);
+  }
+
+  *out_mqtt_user_name = az_span_slice(mqtt_user_name, 0, required_length);
 
   return AZ_OK;
 }
@@ -98,34 +97,36 @@ AZ_NODISCARD az_result az_iot_hub_client_id_get(
 
   const az_span* const module_id = &(client->_internal.options.module_id);
 
-  int32_t required_length = az_span_length(client->_internal.device_id);
-  if (az_span_length(*module_id) > 0)
+  int32_t required_length = az_span_size(client->_internal.device_id);
+  if (az_span_size(*module_id) > 0)
   {
-    required_length += az_span_length(*module_id) + 1;
+    required_length += az_span_size(*module_id) + 1;
   }
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_client_id, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_client_id, required_length);
 
-  mqtt_client_id = az_span_copy(mqtt_client_id, client->_internal.device_id);
+  az_span remainder = az_span_copy(mqtt_client_id, client->_internal.device_id);
 
-  if (az_span_length(*module_id) > 0)
+  if (az_span_size(*module_id) > 0)
   {
-    mqtt_client_id = az_span_append_uint8(mqtt_client_id, hub_client_forward_slash);
-    mqtt_client_id = az_span_append(mqtt_client_id, *module_id);
+    remainder = az_span_copy_uint8(remainder, hub_client_forward_slash);
+    az_span_copy(remainder, *module_id);
   }
 
-  *out_mqtt_client_id = mqtt_client_id;
+  *out_mqtt_client_id = az_span_slice(mqtt_client_id, 0, required_length);
 
   return AZ_OK;
 }
 
 AZ_NODISCARD az_result
-az_iot_hub_client_properties_init(az_iot_hub_client_properties* properties, az_span buffer)
+az_iot_hub_client_properties_init(az_iot_hub_client_properties* properties, az_span buffer, int32_t written_length)
 {
   AZ_PRECONDITION_NOT_NULL(properties);
   AZ_PRECONDITION_VALID_SPAN(buffer, 0, false);
+  AZ_PRECONDITION(written_length >= 0);
 
   properties->_internal.properties = buffer;
+  properties->_internal.properties_length = written_length;
   properties->_internal.current_property_index = 0;
 
   return AZ_OK;
@@ -140,27 +141,29 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_append(
   AZ_PRECONDITION_VALID_SPAN(name, 1, false);
   AZ_PRECONDITION_VALID_SPAN(value, 1, false);
 
-  az_span prop_span = properties->_internal.properties;
+  int32_t prop_length = properties->_internal.properties_length;
 
-  int32_t required_length = az_span_length(name) + az_span_length(value) + 1;
-  int32_t prop_length = az_span_length(prop_span);
+  az_span remainder = az_span_slice(properties->_internal.properties, prop_length, -1);
+
+  int32_t required_length = az_span_size(name) + az_span_size(value) + 1;
+  
   if (prop_length > 0)
   {
-    required_length += prop_length + 1;
+    required_length += 1;
   }
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(prop_span, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, required_length);
 
   if (prop_length > 0)
   {
-    prop_span = az_span_append_uint8(prop_span, *az_span_ptr(hub_client_param_separator_span));
+    remainder = az_span_copy_uint8(remainder, *az_span_ptr(hub_client_param_separator_span));
   }
 
-  prop_span = az_span_append(prop_span, name);
-  prop_span = az_span_append_uint8(prop_span, *az_span_ptr(hub_client_param_equals_span));
-  prop_span = az_span_append(prop_span, value);
+  remainder = az_span_copy(remainder, name);
+  remainder = az_span_copy_uint8(remainder, *az_span_ptr(hub_client_param_equals_span));
+  az_span_copy(remainder, value);
 
-  properties->_internal.properties = prop_span;
+  properties->_internal.properties_length += required_length;
 
   return AZ_OK;
 }
@@ -174,9 +177,10 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_find(
   AZ_PRECONDITION_VALID_SPAN(name, 1, false);
   AZ_PRECONDITION_NOT_NULL(out_value);
 
-  az_span remaining = properties->_internal.properties;
+  az_span remaining
+      = az_span_slice(properties->_internal.properties, 0, properties->_internal.properties_length);
 
-  while (az_span_length(remaining) != 0)
+  while (az_span_size(remaining) != 0)
   {
     az_span delim_span = az_span_token(remaining, hub_client_param_equals_span, &remaining);
     if (az_span_is_content_equal(delim_span, name))
@@ -202,7 +206,7 @@ az_iot_hub_client_properties_next(az_iot_hub_client_properties* properties, az_p
   AZ_PRECONDITION_NOT_NULL(out);
 
   int32_t index = (int32_t)properties->_internal.current_property_index;
-  int32_t prop_length = az_span_length(properties->_internal.properties);
+  int32_t prop_length = properties->_internal.properties_length;
 
   if (index == prop_length)
   {
@@ -215,7 +219,7 @@ az_iot_hub_client_properties_next(az_iot_hub_client_properties* properties, az_p
 
   out->key = az_span_token(prop_span, hub_client_param_equals_span, &remainder);
   out->value = az_span_token(remainder, hub_client_param_separator_span, &remainder);
-  if (az_span_length(remainder) == 0)
+  if (az_span_size(remainder) == 0)
   {
     properties->_internal.current_property_index = (uint32_t)prop_length;
   }

--- a/sdk/iot/hub/src/az_iot_hub_client.c
+++ b/sdk/iot/hub/src/az_iot_hub_client.c
@@ -64,12 +64,12 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_user_name, required_length);
 
   az_span remainder = az_span_copy(mqtt_user_name, client->_internal.iot_hub_hostname);
-  remainder = az_span_copy_uint8(remainder, hub_client_forward_slash);
+  remainder = az_span_copy_u8(remainder, hub_client_forward_slash);
   remainder = az_span_copy(remainder, client->_internal.device_id);
 
   if (az_span_size(*module_id) > 0)
   {
-    remainder = az_span_copy_uint8(remainder, hub_client_forward_slash);
+    remainder = az_span_copy_u8(remainder, hub_client_forward_slash);
     remainder = az_span_copy(remainder, *module_id);
   }
 
@@ -77,7 +77,7 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
 
   if (az_span_size(*user_agent) > 0)
   {
-    remainder = az_span_copy_uint8(remainder, *az_span_ptr(hub_client_param_separator_span));
+    remainder = az_span_copy_u8(remainder, *az_span_ptr(hub_client_param_separator_span));
     az_span_copy(remainder, *user_agent);
   }
 
@@ -109,7 +109,7 @@ AZ_NODISCARD az_result az_iot_hub_client_id_get(
 
   if (az_span_size(*module_id) > 0)
   {
-    remainder = az_span_copy_uint8(remainder, hub_client_forward_slash);
+    remainder = az_span_copy_u8(remainder, hub_client_forward_slash);
     az_span_copy(remainder, *module_id);
   }
 
@@ -156,11 +156,11 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_append(
 
   if (prop_length > 0)
   {
-    remainder = az_span_copy_uint8(remainder, *az_span_ptr(hub_client_param_separator_span));
+    remainder = az_span_copy_u8(remainder, *az_span_ptr(hub_client_param_separator_span));
   }
 
   remainder = az_span_copy(remainder, name);
-  remainder = az_span_copy_uint8(remainder, *az_span_ptr(hub_client_param_equals_span));
+  remainder = az_span_copy_u8(remainder, *az_span_ptr(hub_client_param_equals_span));
   az_span_copy(remainder, value);
 
   properties->_internal.properties_length += required_length;

--- a/sdk/iot/hub/src/az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_c2d.c
@@ -50,7 +50,8 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_received_topic_parse(
   az_span token;
   token = az_span_token(received_topic, c2d_topic_suffix, &received_topic);
   token = az_span_token(received_topic, c2d_topic_suffix, &received_topic);
-  AZ_RETURN_IF_FAILED(az_iot_hub_client_properties_init(&out_request->properties, token, az_span_size(token)));
+  AZ_RETURN_IF_FAILED(
+      az_iot_hub_client_properties_init(&out_request->properties, token, az_span_size(token)));
 
   return AZ_OK;
 }

--- a/sdk/iot/hub/src/az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_c2d.c
@@ -31,7 +31,7 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_subscribe_topic_filter_get(
   az_span remainder = az_span_copy(mqtt_topic_filter, c2d_topic_prefix);
   remainder = az_span_copy(remainder, client->_internal.device_id);
   remainder = az_span_copy(remainder, c2d_topic_suffix);
-  az_span_copy_uint8(remainder, hash_tag);
+  az_span_copy_u8(remainder, hash_tag);
 
   *out_mqtt_topic_filter = az_span_slice(mqtt_topic_filter, 0, required_length);
 

--- a/sdk/iot/hub/src/az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_c2d.c
@@ -23,17 +23,17 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_subscribe_topic_filter_get(
   AZ_PRECONDITION_VALID_SPAN(mqtt_topic_filter, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_mqtt_topic_filter);
 
-  int32_t required_length = az_span_length(c2d_topic_prefix)
-      + az_span_length(client->_internal.device_id) + az_span_length(c2d_topic_suffix) + 1;
+  int32_t required_length = az_span_size(c2d_topic_prefix)
+      + az_span_size(client->_internal.device_id) + az_span_size(c2d_topic_suffix) + 1;
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_topic_filter, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_filter, required_length);
 
-  mqtt_topic_filter = az_span_copy(mqtt_topic_filter, c2d_topic_prefix);
-  mqtt_topic_filter = az_span_append(mqtt_topic_filter, client->_internal.device_id);
-  mqtt_topic_filter = az_span_append(mqtt_topic_filter, c2d_topic_suffix);
-  mqtt_topic_filter = az_span_append_uint8(mqtt_topic_filter, hash_tag);
+  az_span remainder = az_span_copy(mqtt_topic_filter, c2d_topic_prefix);
+  remainder = az_span_copy(remainder, client->_internal.device_id);
+  remainder = az_span_copy(remainder, c2d_topic_suffix);
+  az_span_copy_uint8(remainder, hash_tag);
 
-  *out_mqtt_topic_filter = mqtt_topic_filter;
+  *out_mqtt_topic_filter = az_span_slice(mqtt_topic_filter, 0, required_length);
 
   return AZ_OK;
 }
@@ -50,7 +50,7 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_received_topic_parse(
   az_span token;
   token = az_span_token(received_topic, c2d_topic_suffix, &received_topic);
   token = az_span_token(received_topic, c2d_topic_suffix, &received_topic);
-  AZ_RETURN_IF_FAILED(az_iot_hub_client_properties_init(&out_request->properties, token));
+  AZ_RETURN_IF_FAILED(az_iot_hub_client_properties_init(&out_request->properties, token, az_span_size(token)));
 
   return AZ_OK;
 }

--- a/sdk/iot/hub/src/az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_methods.c
@@ -15,6 +15,13 @@ static const az_span methods_topic_filter_suffix = AZ_SPAN_LITERAL_FROM_STR("POS
 static const az_span methods_response_topic_result = AZ_SPAN_LITERAL_FROM_STR("res/");
 static const az_span methods_response_topic_properties = AZ_SPAN_LITERAL_FROM_STR("/?$rid=");
 
+static AZ_NODISCARD int32_t _az_span_diff(az_span new_span, az_span old_span)
+{
+  int32_t answer = az_span_size(old_span) - az_span_size(new_span);
+  AZ_PRECONDITION(answer == (int32_t)(az_span_ptr(new_span) - az_span_ptr(old_span)));
+  return answer;
+}
+
 AZ_NODISCARD az_result az_iot_hub_client_methods_subscribe_topic_filter_get(
     az_iot_hub_client const* client,
     az_span mqtt_topic_filter,
@@ -27,16 +34,16 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_subscribe_topic_filter_get(
   UNUSED(client);
 
   int32_t required_length
-      = az_span_length(methods_topic_prefix) + az_span_length(methods_topic_filter_suffix) + 1;
+      = az_span_size(methods_topic_prefix) + az_span_size(methods_topic_filter_suffix) + 1;
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_topic_filter, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_filter, required_length);
 
   // TODO: Merge these two calls into one since they are copying two strings literals.
-  mqtt_topic_filter = az_span_copy(mqtt_topic_filter, methods_topic_prefix);
-  mqtt_topic_filter = az_span_append(mqtt_topic_filter, methods_topic_filter_suffix);
-  mqtt_topic_filter = az_span_append_uint8(mqtt_topic_filter, '#');
+  az_span remainder = az_span_copy(mqtt_topic_filter, methods_topic_prefix);
+  remainder = az_span_copy(remainder, methods_topic_filter_suffix);
+  az_span_copy_uint8(remainder, '#');
 
-  *out_mqtt_topic_filter = mqtt_topic_filter;
+  *out_mqtt_topic_filter = az_span_slice(mqtt_topic_filter, 0, required_length);
 
   return AZ_OK;
 }
@@ -60,7 +67,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_received_topic_parse(
   }
 
   received_topic = az_span_slice(
-      received_topic, index + az_span_length(methods_topic_prefix), az_span_length(received_topic));
+      received_topic, index + az_span_size(methods_topic_prefix), az_span_size(received_topic));
 
   index = az_span_find(received_topic, methods_topic_filter_suffix);
 
@@ -71,8 +78,8 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_received_topic_parse(
 
   received_topic = az_span_slice(
       received_topic,
-      index + az_span_length(methods_topic_filter_suffix),
-      az_span_length(received_topic));
+      index + az_span_size(methods_topic_filter_suffix),
+      az_span_size(received_topic));
 
   index = az_span_find(received_topic, methods_response_topic_properties);
 
@@ -84,8 +91,8 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_received_topic_parse(
   out_request->name = az_span_slice(received_topic, 0, index);
   out_request->request_id = az_span_slice(
       received_topic,
-      index + az_span_length(methods_response_topic_properties),
-      az_span_length(received_topic));
+      index + az_span_size(methods_response_topic_properties),
+      az_span_size(received_topic));
 
   return AZ_OK;
 }
@@ -105,23 +112,23 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_response_publish_topic_get(
   UNUSED(client);
 
   int32_t required_length
-      = az_span_length(methods_topic_prefix) + az_span_length(methods_response_topic_result);
+      = az_span_size(methods_topic_prefix) + az_span_size(methods_response_topic_result);
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_topic, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic, required_length);
 
-  mqtt_topic = az_span_copy(mqtt_topic, methods_topic_prefix);
-  mqtt_topic = az_span_append(mqtt_topic, methods_response_topic_result);
+  az_span remainder = az_span_copy(mqtt_topic, methods_topic_prefix);
+  remainder = az_span_copy(remainder, methods_response_topic_result);
 
-  AZ_RETURN_IF_FAILED(az_span_append_u32toa(mqtt_topic, (uint32_t)status, &mqtt_topic));
+  AZ_RETURN_IF_FAILED(az_span_copy_u32toa(remainder, (uint32_t)status, &remainder));
 
-  required_length = az_span_length(methods_response_topic_properties) + az_span_length(request_id);
+  required_length = az_span_size(methods_response_topic_properties) + az_span_size(request_id);
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_topic, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, required_length);
 
-  mqtt_topic = az_span_append(mqtt_topic, methods_response_topic_properties);
-  mqtt_topic = az_span_append(mqtt_topic, request_id);
+  remainder = az_span_copy(remainder, methods_response_topic_properties);
+  az_span_copy(remainder, request_id);
 
-  *out_mqtt_topic = mqtt_topic;
+  *out_mqtt_topic = az_span_slice(mqtt_topic, 0, _az_span_diff(remainder, mqtt_topic));
 
   return AZ_OK;
 }

--- a/sdk/iot/hub/src/az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_methods.c
@@ -35,7 +35,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_subscribe_topic_filter_get(
   // TODO: Merge these two calls into one since they are copying two strings literals.
   az_span remainder = az_span_copy(mqtt_topic_filter, methods_topic_prefix);
   remainder = az_span_copy(remainder, methods_topic_filter_suffix);
-  az_span_copy_uint8(remainder, '#');
+  az_span_copy_u8(remainder, '#');
 
   *out_mqtt_topic_filter = az_span_slice(mqtt_topic_filter, 0, required_length);
 
@@ -113,7 +113,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_response_publish_topic_get(
   az_span remainder = az_span_copy(mqtt_topic, methods_topic_prefix);
   remainder = az_span_copy(remainder, methods_response_topic_result);
 
-  AZ_RETURN_IF_FAILED(az_span_utoa(remainder, (uint32_t)status, &remainder));
+  AZ_RETURN_IF_FAILED(az_span_u32toa(remainder, (uint32_t)status, &remainder));
 
   required_length = az_span_size(methods_response_topic_properties) + az_span_size(request_id);
 

--- a/sdk/iot/hub/src/az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_methods.c
@@ -120,7 +120,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_response_publish_topic_get(
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, required_length);
 
   remainder = az_span_copy(remainder, methods_response_topic_properties);
-  az_span_copy(remainder, request_id);
+  remainder = az_span_copy(remainder, request_id);
 
   *out_mqtt_topic = az_span_slice(mqtt_topic, 0, _az_span_diff(remainder, mqtt_topic));
 

--- a/sdk/iot/hub/src/az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_methods.c
@@ -113,7 +113,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_response_publish_topic_get(
   az_span remainder = az_span_copy(mqtt_topic, methods_topic_prefix);
   remainder = az_span_copy(remainder, methods_response_topic_result);
 
-  AZ_RETURN_IF_FAILED(az_span_copy_u32toa(remainder, (uint32_t)status, &remainder));
+  AZ_RETURN_IF_FAILED(az_span_utoa(remainder, (uint32_t)status, &remainder));
 
   required_length = az_span_size(methods_response_topic_properties) + az_span_size(request_id);
 

--- a/sdk/iot/hub/src/az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_methods.c
@@ -7,6 +7,7 @@
 #include <az_precondition_internal.h>
 #include <az_result.h>
 #include <az_span.h>
+#include <az_span_internal.h>
 
 #include <_az_cfg.h>
 
@@ -14,13 +15,6 @@ static const az_span methods_topic_prefix = AZ_SPAN_LITERAL_FROM_STR("$iothub/me
 static const az_span methods_topic_filter_suffix = AZ_SPAN_LITERAL_FROM_STR("POST/");
 static const az_span methods_response_topic_result = AZ_SPAN_LITERAL_FROM_STR("res/");
 static const az_span methods_response_topic_properties = AZ_SPAN_LITERAL_FROM_STR("/?$rid=");
-
-static AZ_NODISCARD int32_t _az_span_diff(az_span new_span, az_span old_span)
-{
-  int32_t answer = az_span_size(old_span) - az_span_size(new_span);
-  AZ_PRECONDITION(answer == (int32_t)(az_span_ptr(new_span) - az_span_ptr(old_span)));
-  return answer;
-}
 
 AZ_NODISCARD az_result az_iot_hub_client_methods_subscribe_topic_filter_get(
     az_iot_hub_client const* client,

--- a/sdk/iot/hub/src/az_iot_hub_client_sas.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_sas.c
@@ -43,9 +43,9 @@ az_result az_iot_sas_token_get_document(
   remainder = az_span_copy(remainder, iothub_fqdn);
   remainder = az_span_copy(remainder, devices_string);
   remainder = az_span_copy(remainder, device_id);
-  remainder = az_span_copy_uint8(remainder, LF);
+  remainder = az_span_copy_u8(remainder, LF);
 
-  AZ_RETURN_IF_FAILED(az_span_itoa(remainder, expiry_time_secs, &remainder));
+  AZ_RETURN_IF_FAILED(az_span_i32toa(remainder, expiry_time_secs, &remainder));
 
   *out_document = az_span_slice(document, 0, _az_span_diff(remainder, document));
 
@@ -85,22 +85,22 @@ az_result az_iot_sas_token_generate(
 
   // SharedAccessSignature
   remainder = az_span_copy(remainder, sr_string);
-  remainder = az_span_copy_uint8(remainder, EQUAL_SIGN);
+  remainder = az_span_copy_u8(remainder, EQUAL_SIGN);
   remainder = az_span_copy(remainder, iothub_fqdn);
   remainder = az_span_copy(remainder, devices_string);
   remainder = az_span_copy(remainder, device_id);
 
   // Signature
-  remainder = az_span_copy_uint8(remainder, AMPERSAND);
+  remainder = az_span_copy_u8(remainder, AMPERSAND);
   remainder = az_span_copy(remainder, sig_string);
-  remainder = az_span_copy_uint8(remainder, EQUAL_SIGN);
+  remainder = az_span_copy_u8(remainder, EQUAL_SIGN);
   remainder = az_span_copy(remainder, signature);
 
   // Expiration
-  remainder = az_span_copy_uint8(remainder, AMPERSAND);
+  remainder = az_span_copy_u8(remainder, AMPERSAND);
   remainder = az_span_copy(remainder, se_string);
-  remainder = az_span_copy_uint8(remainder, EQUAL_SIGN);
-  AZ_RETURN_IF_FAILED(az_span_itoa(remainder, expiry_time_secs, &remainder));
+  remainder = az_span_copy_u8(remainder, EQUAL_SIGN);
+  AZ_RETURN_IF_FAILED(az_span_i32toa(remainder, expiry_time_secs, &remainder));
 
   if (az_span_ptr(key_name) != NULL && az_span_size(key_name) > 0)
   {
@@ -110,9 +110,9 @@ az_result az_iot_sas_token_generate(
     AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, required_length);
 
     // Key Name
-    remainder = az_span_copy_uint8(remainder, AMPERSAND);
+    remainder = az_span_copy_u8(remainder, AMPERSAND);
     remainder = az_span_copy(remainder, skn_string);
-    remainder = az_span_copy_uint8(remainder, EQUAL_SIGN);
+    remainder = az_span_copy_u8(remainder, EQUAL_SIGN);
     az_span_copy(remainder, key_name);
   }
 

--- a/sdk/iot/hub/src/az_iot_hub_client_sas.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_sas.c
@@ -45,7 +45,7 @@ az_result az_iot_sas_token_get_document(
   remainder = az_span_copy(remainder, device_id);
   remainder = az_span_copy_uint8(remainder, LF);
 
-  AZ_RETURN_IF_FAILED(az_span_copy_i32toa(remainder, expiry_time_secs, &remainder));
+  AZ_RETURN_IF_FAILED(az_span_itoa(remainder, expiry_time_secs, &remainder));
 
   *out_document = az_span_slice(document, 0, _az_span_diff(remainder, document));
 
@@ -100,7 +100,7 @@ az_result az_iot_sas_token_generate(
   remainder = az_span_copy_uint8(remainder, AMPERSAND);
   remainder = az_span_copy(remainder, se_string);
   remainder = az_span_copy_uint8(remainder, EQUAL_SIGN);
-  AZ_RETURN_IF_FAILED(az_span_copy_i32toa(remainder, expiry_time_secs, &remainder));
+  AZ_RETURN_IF_FAILED(az_span_itoa(remainder, expiry_time_secs, &remainder));
 
   if (az_span_ptr(key_name) != NULL && az_span_size(key_name) > 0)
   {

--- a/sdk/iot/hub/src/az_iot_hub_client_sas.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_sas.c
@@ -5,6 +5,7 @@
 #include <az_precondition.h>
 #include <az_precondition_internal.h>
 #include <az_span.h>
+#include <az_span_internal.h>
 
 #include <stdint.h>
 
@@ -18,13 +19,6 @@
 #define SAS_TOKEN_SE "se"
 #define SAS_TOKEN_SIG "sig"
 #define SAS_TOKEN_SKN "skn"
-
-static AZ_NODISCARD int32_t _az_span_diff(az_span new_span, az_span old_span)
-{
-  int32_t answer = az_span_size(old_span) - az_span_size(new_span);
-  AZ_PRECONDITION(answer == (int32_t)(az_span_ptr(new_span) - az_span_ptr(old_span)));
-  return answer;
-}
 
 az_result az_iot_sas_token_get_document(
     az_span iothub_fqdn,

--- a/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
@@ -32,7 +32,7 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
   int32_t module_id_length = az_span_size(*module_id);
   if (module_id_length > 0)
   {
-    required_length += az_span_size(telemetry_topic_modules_mid) + az_span_size(*module_id);
+    required_length += az_span_size(telemetry_topic_modules_mid) + module_id_length;
   }
   if (properties != NULL)
   {
@@ -54,7 +54,7 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
 
   if (properties != NULL)
   {
-      az_span_copy(remainder, properties->_internal.properties);
+    az_span_copy(remainder, properties->_internal.properties);
   }
 
   *out_mqtt_topic = az_span_slice(mqtt_topic, 0, required_length);

--- a/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
@@ -27,37 +27,37 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
 
   const az_span* const module_id = &(client->_internal.options.module_id);
 
-  int32_t required_length = az_span_length(telemetry_topic_prefix)
-      + az_span_length(client->_internal.device_id) + az_span_length(telemetry_topic_suffix);
-  int32_t module_id_length = az_span_length(*module_id);
+  int32_t required_length = az_span_size(telemetry_topic_prefix)
+      + az_span_size(client->_internal.device_id) + az_span_size(telemetry_topic_suffix);
+  int32_t module_id_length = az_span_size(*module_id);
   if (module_id_length > 0)
   {
-    required_length += az_span_length(telemetry_topic_modules_mid) + az_span_length(*module_id);
+    required_length += az_span_size(telemetry_topic_modules_mid) + az_span_size(*module_id);
   }
   if (properties != NULL)
   {
-    required_length += az_span_length(properties->_internal.properties);
+    required_length += az_span_size(properties->_internal.properties);
   }
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_topic, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic, required_length);
 
-  mqtt_topic = az_span_copy(mqtt_topic, telemetry_topic_prefix);
-  mqtt_topic = az_span_append(mqtt_topic, client->_internal.device_id);
+  az_span remainder = az_span_copy(mqtt_topic, telemetry_topic_prefix);
+  remainder = az_span_copy(remainder, client->_internal.device_id);
 
   if (module_id_length > 0)
   {
-    mqtt_topic = az_span_append(mqtt_topic, telemetry_topic_modules_mid);
-    mqtt_topic = az_span_append(mqtt_topic, *module_id);
+    remainder = az_span_copy(remainder, telemetry_topic_modules_mid);
+    remainder = az_span_copy(remainder, *module_id);
   }
 
-  mqtt_topic = az_span_append(mqtt_topic, telemetry_topic_suffix);
+  remainder = az_span_copy(remainder, telemetry_topic_suffix);
 
   if (properties != NULL)
   {
-    mqtt_topic = az_span_append(mqtt_topic, properties->_internal.properties);
+      az_span_copy(remainder, properties->_internal.properties);
   }
 
-  *out_mqtt_topic = mqtt_topic;
+  *out_mqtt_topic = az_span_slice(mqtt_topic, 0, required_length);
 
   return AZ_OK;
 }

--- a/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
@@ -36,7 +36,7 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
   }
   if (properties != NULL)
   {
-    required_length += az_span_size(properties->_internal.properties);
+    required_length += az_span_size(properties->_internal.properties_buffer);
   }
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic, required_length);
@@ -54,7 +54,7 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
 
   if (properties != NULL)
   {
-    az_span_copy(remainder, properties->_internal.properties);
+    az_span_copy(remainder, properties->_internal.properties_buffer);
   }
 
   *out_mqtt_topic = az_span_slice(mqtt_topic, 0, required_length);

--- a/sdk/iot/hub/src/az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_twin.c
@@ -31,14 +31,14 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_response_subscribe_topic_filter_ge
   AZ_PRECONDITION_VALID_SPAN(mqtt_topic_filter, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_mqtt_topic_filter);
 
-  int32_t required_length = az_span_length(az_iot_hub_twin_response_sub_topic) + 1;
+  int32_t required_length = az_span_size(az_iot_hub_twin_response_sub_topic) + 1;
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_topic_filter, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_filter, required_length);
 
-  mqtt_topic_filter = az_span_copy(mqtt_topic_filter, az_iot_hub_twin_response_sub_topic);
-  mqtt_topic_filter = az_span_append_uint8(mqtt_topic_filter, az_iot_hub_client_twin_hashtag);
+  az_span remainder = az_span_copy(mqtt_topic_filter, az_iot_hub_twin_response_sub_topic);
+  az_span_copy_uint8(remainder, az_iot_hub_client_twin_hashtag);
 
-  *out_mqtt_topic_filter = mqtt_topic_filter;
+  *out_mqtt_topic_filter = az_span_slice(mqtt_topic_filter, 0, required_length);
 
   return AZ_OK;
 }
@@ -52,13 +52,13 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_patch_subscribe_topic_filter_get(
   AZ_PRECONDITION_VALID_SPAN(mqtt_topic_filter, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_mqtt_topic_filter);
 
-  int32_t required_length = az_span_length(az_iot_hub_twin_patch_sub_topic);
+  int32_t required_length = az_span_size(az_iot_hub_twin_patch_sub_topic);
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_topic_filter, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_filter, required_length);
 
-  mqtt_topic_filter = az_span_copy(mqtt_topic_filter, az_iot_hub_twin_patch_sub_topic);
+  az_span_copy(mqtt_topic_filter, az_iot_hub_twin_patch_sub_topic);
 
-  *out_mqtt_topic_filter = mqtt_topic_filter;
+  *out_mqtt_topic_filter = az_span_slice(mqtt_topic_filter, 0, required_length);
 
   return AZ_OK;
 }
@@ -74,16 +74,16 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_publish_topic_get(
   AZ_PRECONDITION_VALID_SPAN(mqtt_topic, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_mqtt_topic);
 
-  int32_t required_length = az_span_length(az_iot_hub_twin_get_pub_topic)
-      + az_span_length(az_iot_hub_client_twin_request_id_suffix) + az_span_length(request_id);
+  int32_t required_length = az_span_size(az_iot_hub_twin_get_pub_topic)
+      + az_span_size(az_iot_hub_client_twin_request_id_suffix) + az_span_size(request_id);
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_topic, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic, required_length);
 
-  mqtt_topic = az_span_copy(mqtt_topic, az_iot_hub_twin_get_pub_topic);
-  mqtt_topic = az_span_append(mqtt_topic, az_iot_hub_client_twin_request_id_suffix);
-  mqtt_topic = az_span_append(mqtt_topic, request_id);
+  az_span remainder = az_span_copy(mqtt_topic, az_iot_hub_twin_get_pub_topic);
+  remainder = az_span_copy(remainder, az_iot_hub_client_twin_request_id_suffix);
+  az_span_copy(remainder, request_id);
 
-  *out_mqtt_topic = mqtt_topic;
+  *out_mqtt_topic = az_span_slice(mqtt_topic, 0, required_length);
 
   return AZ_OK;
 }
@@ -99,16 +99,16 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_patch_publish_topic_get(
   AZ_PRECONDITION_VALID_SPAN(mqtt_topic, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_mqtt_topic);
 
-  int32_t required_length = az_span_length(az_iot_hub_twin_patch_pub_topic)
-      + az_span_length(az_iot_hub_client_twin_request_id_suffix) + az_span_length(request_id);
+  int32_t required_length = az_span_size(az_iot_hub_twin_patch_pub_topic)
+      + az_span_size(az_iot_hub_client_twin_request_id_suffix) + az_span_size(request_id);
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_topic, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic, required_length);
 
-  mqtt_topic = az_span_copy(mqtt_topic, az_iot_hub_twin_patch_pub_topic);
-  mqtt_topic = az_span_append(mqtt_topic, az_iot_hub_client_twin_request_id_suffix);
-  mqtt_topic = az_span_append(mqtt_topic, request_id);
+  az_span remainder = az_span_copy(mqtt_topic, az_iot_hub_twin_patch_pub_topic);
+  remainder = az_span_copy(remainder, az_iot_hub_client_twin_request_id_suffix);
+  az_span_copy(remainder, request_id);
 
-  *out_mqtt_topic = mqtt_topic;
+  *out_mqtt_topic = az_span_slice(mqtt_topic, 0, required_length);
 
   return AZ_OK;
 }

--- a/sdk/iot/hub/src/az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_twin.c
@@ -36,7 +36,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_response_subscribe_topic_filter_ge
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_filter, required_length);
 
   az_span remainder = az_span_copy(mqtt_topic_filter, az_iot_hub_twin_response_sub_topic);
-  az_span_copy_uint8(remainder, az_iot_hub_client_twin_hashtag);
+  az_span_copy_u8(remainder, az_iot_hub_client_twin_hashtag);
 
   *out_mqtt_topic_filter = az_span_slice(mqtt_topic_filter, 0, required_length);
 

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
@@ -64,7 +64,7 @@ static const char test_correct_two_key_value[] = "key_one=value_one&key_two=valu
 
 enable_precondition_check_tests()
 
-static void test_az_iot_hub_client_init_NULL_client_fails(void** state)
+    static void test_az_iot_hub_client_init_NULL_client_fails(void** state)
 {
   (void)state;
 
@@ -88,8 +88,7 @@ static void test_az_iot_hub_client_init_NULL_hub_hostname_id_fails(void** state)
 
   az_iot_hub_client client;
 
-  assert_precondition_checked(
-      az_iot_hub_client_init(&client, test_device_id, AZ_SPAN_NULL, NULL));
+  assert_precondition_checked(az_iot_hub_client_init(&client, test_device_id, AZ_SPAN_NULL, NULL));
 }
 
 static void test_az_iot_hub_client_user_name_get_NULL_client_fails(void** state)
@@ -97,7 +96,7 @@ static void test_az_iot_hub_client_user_name_get_NULL_client_fails(void** state)
   (void)state;
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(az_iot_hub_client_user_name_get(NULL, test_span, &test_span));
 }
@@ -108,7 +107,7 @@ static void test_az_iot_hub_client_user_name_get_NULL_input_span_fails(void** st
 
   az_iot_hub_client client;
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(az_iot_hub_client_user_name_get(&client, AZ_SPAN_NULL, &test_span));
 }
@@ -119,7 +118,7 @@ static void test_az_iot_hub_client_user_name_get_NULL_output_span_fails(void** s
 
   az_iot_hub_client client;
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(az_iot_hub_client_user_name_get(&client, test_span, NULL));
 }
@@ -129,7 +128,7 @@ static void test_az_iot_hub_client_id_get_NULL_client_fails(void** state)
   (void)state;
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(az_iot_hub_client_id_get(NULL, test_span, &test_span));
 }
@@ -140,7 +139,7 @@ static void test_az_iot_hub_client_id_get_NULL_input_span_fails(void** state)
 
   az_iot_hub_client client;
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(az_iot_hub_client_id_get(&client, AZ_SPAN_NULL, &test_span));
 }
@@ -151,7 +150,7 @@ static void test_az_iot_hub_client_id_get_NULL_output_span_fails(void** state)
 
   az_iot_hub_client client;
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(az_iot_hub_client_id_get(&client, test_span, NULL));
 }
@@ -161,9 +160,9 @@ static void test_az_iot_hub_client_properties_init_NULL_props_fails(void** state
   (void)state;
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
-  assert_precondition_checked(az_iot_hub_client_properties_init(NULL, test_span));
+  assert_precondition_checked(az_iot_hub_client_properties_init(NULL, test_span, 0));
 }
 
 static void test_az_iot_hub_client_properties_init_NULL_buffer_fails(void** state)
@@ -172,14 +171,15 @@ static void test_az_iot_hub_client_properties_init_NULL_buffer_fails(void** stat
 
   az_iot_hub_client_properties props;
 
-  assert_precondition_checked(az_iot_hub_client_properties_init(&props, AZ_SPAN_NULL));
+  assert_precondition_checked(az_iot_hub_client_properties_init(&props, AZ_SPAN_NULL, 0));
 }
 
 static void test_az_iot_hub_client_properties_append_get_NULL_props_fails(void** state)
 {
   (void)state;
 
-  assert_precondition_checked(az_iot_hub_client_properties_append(NULL, test_key_one, test_value_one));
+  assert_precondition_checked(
+      az_iot_hub_client_properties_append(NULL, test_key_one, test_value_one));
 }
 
 static void test_az_iot_hub_client_properties_append_NULL_name_span_fails(void** state)
@@ -188,7 +188,8 @@ static void test_az_iot_hub_client_properties_append_NULL_name_span_fails(void**
 
   az_iot_hub_client_properties props;
 
-  assert_precondition_checked(az_iot_hub_client_properties_append(&props, AZ_SPAN_NULL, test_value_one));
+  assert_precondition_checked(
+      az_iot_hub_client_properties_append(&props, AZ_SPAN_NULL, test_value_one));
 }
 
 static void test_az_iot_hub_client_properties_append_NULL_value_span_fails(void** state)
@@ -197,7 +198,8 @@ static void test_az_iot_hub_client_properties_append_NULL_value_span_fails(void*
 
   az_iot_hub_client_properties props;
 
-  assert_precondition_checked(az_iot_hub_client_properties_append(&props, test_key_one, AZ_SPAN_NULL));
+  assert_precondition_checked(
+      az_iot_hub_client_properties_append(&props, test_key_one, AZ_SPAN_NULL));
 }
 
 static void test_az_iot_hub_client_properties_find_NULL_props_fail(void** state)
@@ -263,8 +265,7 @@ static void test_az_iot_hub_client_init_succeed(void** state)
   (void)state;
 
   az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
+  assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
   assert_memory_equal(
       TEST_DEVICE_ID_STR,
@@ -310,17 +311,17 @@ static void test_az_iot_hub_client_user_name_get_succeed(void** state)
   (void)state;
 
   az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
+  assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
   az_span_for_test_verify(
       test_span,
       test_correct_user_name,
       _az_COUNTOF(test_correct_user_name) - 1,
+      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -329,25 +330,22 @@ static void test_az_iot_hub_client_user_name_get_twice_succeed(void** state)
   (void)state;
 
   az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
+  assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
   memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
   assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
 
   assert_memory_equal(
       test_correct_user_name, az_span_ptr(test_span), sizeof(test_correct_user_name) - 1);
-  assert_int_equal(az_span_length(test_span), _az_COUNTOF(test_correct_user_name) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
+  assert_int_equal(az_span_size(test_span), _az_COUNTOF(test_correct_user_name) - 1);
+  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
 
   assert_memory_equal(
       test_correct_user_name, az_span_ptr(test_span), sizeof(test_correct_user_name) - 1);
-  assert_int_equal(az_span_length(test_span), _az_COUNTOF(test_correct_user_name) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
+  assert_int_equal(az_span_size(test_span), _az_COUNTOF(test_correct_user_name) - 1);
+  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
 }
 
 static void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
@@ -355,16 +353,14 @@ static void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
   (void)state;
 
   az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
+  assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[sizeof(test_correct_user_name) - 2];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
   assert_int_equal(
       az_iot_hub_client_user_name_get(&client, test_span, &test_span),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
-  assert_int_equal(az_span_length(test_span), 0);
-  assert_int_equal(az_span_capacity(test_span), sizeof(test_correct_user_name) - 2);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+  assert_int_equal(az_span_size(test_span), sizeof(test_correct_user_name) - 2);
 }
 
 static void test_az_iot_hub_client_user_name_get_user_options_succeed(void** state)
@@ -379,13 +375,14 @@ static void test_az_iot_hub_client_user_name_get_user_options_succeed(void** sta
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
   az_span_for_test_verify(
       test_span,
       test_correct_user_name_with_module_id,
       _az_COUNTOF(test_correct_user_name_with_module_id) - 1,
+      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -401,12 +398,11 @@ static void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
 
   uint8_t test_span_buf[sizeof(test_correct_user_name_with_module_id) - 2];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
   assert_int_equal(
       az_iot_hub_client_user_name_get(&client, test_span, &test_span),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
-  assert_int_equal(az_span_length(test_span), 0);
-  assert_int_equal(az_span_capacity(test_span), sizeof(test_correct_user_name_with_module_id) - 2);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+  assert_int_equal(az_span_size(test_span), sizeof(test_correct_user_name_with_module_id) - 2);
 }
 
 static void test_az_iot_hub_client_id_get_succeed(void** state)
@@ -414,17 +410,17 @@ static void test_az_iot_hub_client_id_get_succeed(void** state)
   (void)state;
 
   az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
+  assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
   az_span_for_test_verify(
       test_span,
       test_correct_client_id,
       _az_COUNTOF(test_correct_client_id) - 1,
+      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -433,25 +429,22 @@ static void test_az_iot_hub_client_id_get_twice_succeed(void** state)
   (void)state;
 
   az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
+  assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
   memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
   assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
 
   assert_memory_equal(
       test_correct_client_id, az_span_ptr(test_span), sizeof(test_correct_client_id) - 1);
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_client_id) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
+  assert_int_equal(az_span_size(test_span), sizeof(test_correct_client_id) - 1);
+  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
 
   assert_memory_equal(
       test_correct_client_id, az_span_ptr(test_span), sizeof(test_correct_client_id) - 1);
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_client_id) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
+  assert_int_equal(az_span_size(test_span), sizeof(test_correct_client_id) - 1);
+  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
 }
 
 static void test_az_iot_hub_client_id_get_small_buffer_fail(void** state)
@@ -459,16 +452,13 @@ static void test_az_iot_hub_client_id_get_small_buffer_fail(void** state)
   (void)state;
 
   az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
+  assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[sizeof(test_correct_client_id) - 2];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
   assert_int_equal(
-      az_iot_hub_client_id_get(&client, test_span, &test_span),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
-  assert_int_equal(az_span_length(test_span), 0);
-  assert_int_equal(az_span_capacity(test_span), sizeof(test_correct_client_id) - 2);
+      az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+  assert_int_equal(az_span_size(test_span), sizeof(test_correct_client_id) - 2);
 }
 
 static void test_az_iot_hub_client_id_get_module_succeed(void** state)
@@ -482,13 +472,14 @@ static void test_az_iot_hub_client_id_get_module_succeed(void** state)
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
   az_span_for_test_verify(
       test_span,
       test_correct_client_id_with_module_id,
       _az_COUNTOF(test_correct_client_id_with_module_id) - 1,
+      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -503,12 +494,10 @@ static void test_az_iot_hub_client_id_get_module_small_buffer_fail(void** state)
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
 
   uint8_t test_span_buf[sizeof(test_correct_client_id_with_module_id) - 2];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
   assert_int_equal(
-      az_iot_hub_client_id_get(&client, test_span, &test_span),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
-  assert_int_equal(az_span_length(test_span), 0);
-  assert_int_equal(az_span_capacity(test_span), sizeof(test_correct_client_id_with_module_id) - 2);
+      az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+  assert_int_equal(az_span_size(test_span), sizeof(test_correct_client_id_with_module_id) - 2);
 }
 
 static void test_az_iot_hub_client_properties_init_succeed(void** state)
@@ -516,10 +505,10 @@ static void test_az_iot_hub_client_properties_init_succeed(void** state)
   (void)state;
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE] = { 0 };
-  az_span test_span = az_span_init(test_span_buf, 0, sizeof(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, sizeof(test_span_buf));
   az_iot_hub_client_properties props;
 
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span, 0), AZ_OK);
   assert_int_equal(props._internal.current_property_index, 0);
 }
 
@@ -530,10 +519,13 @@ static void test_az_iot_hub_client_properties_init_user_set_params_succeed(void*
   az_span test_span = az_span_from_str(TEST_KEY_VALUE_ONE);
   az_iot_hub_client_properties props;
 
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   assert_memory_equal(
-      az_span_ptr(props._internal.properties), test_correct_one_key_value, sizeof(test_correct_one_key_value) - 1);
+      az_span_ptr(props._internal.properties),
+      test_correct_one_key_value,
+      sizeof(test_correct_one_key_value) - 1);
 }
 
 static void test_az_iot_hub_client_properties_append_succeed(void** state)
@@ -541,10 +533,10 @@ static void test_az_iot_hub_client_properties_append_succeed(void** state)
   (void)state;
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, sizeof(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, sizeof(test_span_buf));
 
   az_iot_hub_client_properties props;
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span, 0), AZ_OK);
 
   assert_int_equal(
       az_iot_hub_client_properties_append(&props, test_key_one, test_value_one), AZ_OK);
@@ -552,6 +544,7 @@ static void test_az_iot_hub_client_properties_append_succeed(void** state)
       props._internal.properties,
       test_correct_one_key_value,
       _az_COUNTOF(test_correct_one_key_value) - 1,
+      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -560,15 +553,15 @@ static void test_az_iot_hub_client_properties_append_small_buffer_fail(void** st
   (void)state;
 
   uint8_t test_span_buf[sizeof(test_correct_one_key_value) - 2];
-  az_span test_span = az_span_init(test_span_buf, 0, sizeof(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, sizeof(test_span_buf));
   az_iot_hub_client_properties props;
 
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span, 0), AZ_OK);
   assert_int_equal(
       az_iot_hub_client_properties_append(&props, test_key_one, test_value_one),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
-  assert_int_equal(az_span_capacity(props._internal.properties), sizeof(test_correct_one_key_value) - 2);
-  assert_int_equal(az_span_length(props._internal.properties), 0);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+  assert_int_equal(
+      az_span_size(props._internal.properties), sizeof(test_correct_one_key_value) - 2);
 }
 
 static void test_az_iot_hub_client_properties_append_twice_succeed(void** state)
@@ -576,10 +569,10 @@ static void test_az_iot_hub_client_properties_append_twice_succeed(void** state)
   (void)state;
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, sizeof(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, sizeof(test_span_buf));
 
   az_iot_hub_client_properties props;
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span, 0), AZ_OK);
 
   assert_int_equal(
       az_iot_hub_client_properties_append(&props, test_key_one, test_value_one), AZ_OK);
@@ -589,6 +582,7 @@ static void test_az_iot_hub_client_properties_append_twice_succeed(void** state)
       props._internal.properties,
       test_correct_two_key_value,
       _az_COUNTOF(test_correct_two_key_value) - 1,
+      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -597,18 +591,18 @@ static void test_az_iot_hub_client_properties_append_twice_small_buffer_fail(voi
   (void)state;
 
   uint8_t test_span_buf[sizeof(test_correct_two_key_value) - 2];
-  az_span test_span = az_span_init(test_span_buf, 0, sizeof(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, sizeof(test_span_buf));
   az_iot_hub_client_properties props;
 
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span, 0), AZ_OK);
   assert_int_equal(
       az_iot_hub_client_properties_append(&props, test_key_one, test_value_one), AZ_OK);
   assert_int_equal(
       az_iot_hub_client_properties_append(&props, test_key_two, test_value_two),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+  assert_int_equal(props._internal.properties_length, sizeof(test_correct_one_key_value) - 1);
   assert_int_equal(
-      az_span_length(props._internal.properties), sizeof(test_correct_one_key_value) - 1);
-  assert_int_equal(az_span_capacity(props._internal.properties), sizeof(test_correct_two_key_value) - 2);
+      az_span_size(props._internal.properties), sizeof(test_correct_two_key_value) - 2);
 }
 
 static void test_az_iot_hub_client_properties_find_succeed(void** state)
@@ -618,12 +612,13 @@ static void test_az_iot_hub_client_properties_find_succeed(void** state)
   az_span test_span = az_span_from_str(TEST_KEY_VALUE_ONE);
   az_iot_hub_client_properties props;
 
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   az_span out_value;
   assert_int_equal(az_iot_hub_client_properties_find(&props, test_key_one, &out_value), AZ_OK);
   assert_memory_equal(
-      az_span_ptr(out_value), az_span_ptr(test_value_one), (size_t)az_span_length(test_value_one));
+      az_span_ptr(out_value), az_span_ptr(test_value_one), (size_t)az_span_size(test_value_one));
 }
 
 static void test_az_iot_hub_client_properties_find_middle_succeed(void** state)
@@ -633,12 +628,13 @@ static void test_az_iot_hub_client_properties_find_middle_succeed(void** state)
   az_span test_span = az_span_from_str(TEST_KEY_VALUE_THREE);
   az_iot_hub_client_properties props;
 
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   az_span out_value;
   assert_int_equal(az_iot_hub_client_properties_find(&props, test_key_two, &out_value), AZ_OK);
   assert_memory_equal(
-      az_span_ptr(out_value), az_span_ptr(test_value_two), (size_t)az_span_length(test_value_two));
+      az_span_ptr(out_value), az_span_ptr(test_value_two), (size_t)az_span_size(test_value_two));
 }
 
 static void test_az_iot_hub_client_properties_find_end_succeed(void** state)
@@ -648,12 +644,13 @@ static void test_az_iot_hub_client_properties_find_end_succeed(void** state)
   az_span test_span = az_span_from_str(TEST_KEY_VALUE_TWO);
   az_iot_hub_client_properties props;
 
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   az_span out_value;
   assert_int_equal(az_iot_hub_client_properties_find(&props, test_key_two, &out_value), AZ_OK);
   assert_memory_equal(
-      az_span_ptr(out_value), az_span_ptr(test_value_two), (size_t)az_span_length(test_value_two));
+      az_span_ptr(out_value), az_span_ptr(test_value_two), (size_t)az_span_size(test_value_two));
 }
 
 static void test_az_iot_hub_client_properties_find_substring_succeed(void** state)
@@ -663,12 +660,13 @@ static void test_az_iot_hub_client_properties_find_substring_succeed(void** stat
   az_span test_span = az_span_from_str(TEST_KEY_VALUE_SUBSTRING);
   az_iot_hub_client_properties props;
 
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   az_span out_value;
   assert_int_equal(az_iot_hub_client_properties_find(&props, test_key, &out_value), AZ_OK);
   assert_memory_equal(
-      az_span_ptr(out_value), az_span_ptr(test_value_two), (size_t)az_span_length(test_value_two));
+      az_span_ptr(out_value), az_span_ptr(test_value_two), (size_t)az_span_size(test_value_two));
 }
 
 static void test_az_iot_hub_client_properties_find_name_value_same_succeed(void** state)
@@ -678,12 +676,13 @@ static void test_az_iot_hub_client_properties_find_name_value_same_succeed(void*
   az_span test_span = az_span_from_str(TEST_KEY_VALUE_SAME);
   az_iot_hub_client_properties props;
 
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   az_span out_value;
   assert_int_equal(az_iot_hub_client_properties_find(&props, test_key, &out_value), AZ_OK);
   assert_memory_equal(
-      az_span_ptr(out_value), az_span_ptr(test_value_two), (size_t)az_span_length(test_value_two));
+      az_span_ptr(out_value), az_span_ptr(test_value_two), (size_t)az_span_size(test_value_two));
 }
 
 static void test_az_iot_hub_client_properties_find_fail(void** state)
@@ -693,7 +692,8 @@ static void test_az_iot_hub_client_properties_find_fail(void** state)
   az_span test_span = az_span_from_str(TEST_KEY_VALUE_ONE);
   az_iot_hub_client_properties props;
 
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   az_span out_value;
   assert_int_equal(
@@ -708,7 +708,8 @@ static void test_az_iot_hub_client_properties_find_substring_fail(void** state)
   az_span test_span = az_span_from_str(TEST_KEY_VALUE_TWO);
   az_iot_hub_client_properties props;
 
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   az_span out_value;
   assert_int_equal(
@@ -723,7 +724,8 @@ static void test_az_iot_hub_client_properties_find_substring_suffix_fail(void** 
   az_span test_span = az_span_from_str(TEST_KEY_VALUE_TWO);
   az_iot_hub_client_properties props;
 
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   az_span out_value;
   assert_int_equal(
@@ -738,7 +740,8 @@ static void test_az_iot_hub_client_properties_find_value_match_fail(void** state
   az_span test_span = az_span_from_str(TEST_KEY_VALUE_THREE);
   az_iot_hub_client_properties props;
 
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   az_span out_value;
   assert_int_equal(
@@ -753,7 +756,8 @@ static void test_az_iot_hub_client_properties_find_value_match_end_fail(void** s
   az_span test_span = az_span_from_str(TEST_KEY_VALUE_THREE);
   az_iot_hub_client_properties props;
 
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   az_span out_value;
   assert_int_equal(
@@ -767,33 +771,34 @@ static void test_az_iot_hub_client_properties_next_succeed(void** state)
 
   az_span test_span = az_span_from_str(TEST_KEY_VALUE_THREE);
   az_iot_hub_client_properties props;
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   az_pair pair_out;
 
   assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_OK);
   assert_memory_equal(
-      az_span_ptr(pair_out.key), az_span_ptr(test_key_one), (size_t)az_span_length(test_key_one));
+      az_span_ptr(pair_out.key), az_span_ptr(test_key_one), (size_t)az_span_size(test_key_one));
   assert_memory_equal(
       az_span_ptr(pair_out.value),
       az_span_ptr(test_value_one),
-      (size_t)az_span_length(test_value_one));
+      (size_t)az_span_size(test_value_one));
 
   assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_OK);
   assert_memory_equal(
-      az_span_ptr(pair_out.key), az_span_ptr(test_key_two), (size_t)az_span_length(test_key_two));
+      az_span_ptr(pair_out.key), az_span_ptr(test_key_two), (size_t)az_span_size(test_key_two));
   assert_memory_equal(
       az_span_ptr(pair_out.value),
       az_span_ptr(test_value_two),
-      (size_t)az_span_length(test_value_two));
+      (size_t)az_span_size(test_value_two));
 
   assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_OK);
   assert_memory_equal(
-      az_span_ptr(pair_out.key), az_span_ptr(test_key_three), (size_t)az_span_length(test_key_three));
+      az_span_ptr(pair_out.key), az_span_ptr(test_key_three), (size_t)az_span_size(test_key_three));
   assert_memory_equal(
       az_span_ptr(pair_out.value),
       az_span_ptr(test_value_three),
-      (size_t)az_span_length(test_value_three));
+      (size_t)az_span_size(test_value_three));
 
   assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_ERROR_EOF);
 }
@@ -804,46 +809,48 @@ static void test_az_iot_hub_client_properties_next_twice_succeed(void** state)
 
   az_span test_span = az_span_from_str(TEST_KEY_VALUE_TWO);
   az_iot_hub_client_properties props;
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   az_pair pair_out;
 
   assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_OK);
   assert_memory_equal(
-      az_span_ptr(pair_out.key), az_span_ptr(test_key_one), (size_t)az_span_length(test_key_one));
+      az_span_ptr(pair_out.key), az_span_ptr(test_key_one), (size_t)az_span_size(test_key_one));
   assert_memory_equal(
       az_span_ptr(pair_out.value),
       az_span_ptr(test_value_one),
-      (size_t)az_span_length(test_value_one));
+      (size_t)az_span_size(test_value_one));
 
   assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_OK);
   assert_memory_equal(
-      az_span_ptr(pair_out.key), az_span_ptr(test_key_two), (size_t)az_span_length(test_key_two));
+      az_span_ptr(pair_out.key), az_span_ptr(test_key_two), (size_t)az_span_size(test_key_two));
   assert_memory_equal(
       az_span_ptr(pair_out.value),
       az_span_ptr(test_value_two),
-      (size_t)az_span_length(test_value_two));
+      (size_t)az_span_size(test_value_two));
 
   assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_ERROR_EOF);
 
-  //Reset to beginning of span
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  // Reset to beginning of span
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_OK);
   assert_memory_equal(
-      az_span_ptr(pair_out.key), az_span_ptr(test_key_one), (size_t)az_span_length(test_key_one));
+      az_span_ptr(pair_out.key), az_span_ptr(test_key_one), (size_t)az_span_size(test_key_one));
   assert_memory_equal(
       az_span_ptr(pair_out.value),
       az_span_ptr(test_value_one),
-      (size_t)az_span_length(test_value_one));
+      (size_t)az_span_size(test_value_one));
 
   assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_OK);
   assert_memory_equal(
-      az_span_ptr(pair_out.key), az_span_ptr(test_key_two), (size_t)az_span_length(test_key_two));
+      az_span_ptr(pair_out.key), az_span_ptr(test_key_two), (size_t)az_span_size(test_key_two));
   assert_memory_equal(
       az_span_ptr(pair_out.value),
       az_span_ptr(test_value_two),
-      (size_t)az_span_length(test_value_two));
+      (size_t)az_span_size(test_value_two));
 
   assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_ERROR_EOF);
 }
@@ -853,9 +860,9 @@ static void test_az_iot_hub_client_properties_next_empty_succeed(void** state)
   (void)state;
 
   uint8_t empty_prop_buf[8] = { 0 };
-  az_span test_span = az_span_init(empty_prop_buf, 0, _az_COUNTOF(empty_prop_buf));
+  az_span test_span = az_span_init(empty_prop_buf, _az_COUNTOF(empty_prop_buf));
   az_iot_hub_client_properties props;
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span, 0), AZ_OK);
 
   az_pair pair_out;
 

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
@@ -61,7 +61,7 @@ static const char test_correct_one_key_value[] = "key_one=value_one";
 static const char test_correct_two_key_value[] = "key_one=value_one&key_two=value_two";
 
 #ifndef NO_PRECONDITION_CHECKING
-enable_precondition_check_tests();
+enable_precondition_check_tests()
 
 static void test_az_iot_hub_client_init_NULL_client_fails(void** state)
 {

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
@@ -61,10 +61,9 @@ static const char test_correct_one_key_value[] = "key_one=value_one";
 static const char test_correct_two_key_value[] = "key_one=value_one&key_two=value_two";
 
 #ifndef NO_PRECONDITION_CHECKING
+enable_precondition_check_tests();
 
-enable_precondition_check_tests()
-
-    static void test_az_iot_hub_client_init_NULL_client_fails(void** state)
+static void test_az_iot_hub_client_init_NULL_client_fails(void** state)
 {
   (void)state;
 

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
@@ -522,7 +522,7 @@ static void test_az_iot_hub_client_properties_init_user_set_params_succeed(void*
       az_iot_hub_client_properties_init(&props, test_span, az_span_size(test_span)), AZ_OK);
 
   assert_memory_equal(
-      az_span_ptr(props._internal.properties),
+      az_span_ptr(props._internal.properties_buffer),
       test_correct_one_key_value,
       sizeof(test_correct_one_key_value) - 1);
 }
@@ -540,7 +540,7 @@ static void test_az_iot_hub_client_properties_append_succeed(void** state)
   assert_int_equal(
       az_iot_hub_client_properties_append(&props, test_key_one, test_value_one), AZ_OK);
   az_span_for_test_verify(
-      props._internal.properties,
+      az_span_slice(props._internal.properties_buffer, 0, props._internal.properties_written),
       test_correct_one_key_value,
       _az_COUNTOF(test_correct_one_key_value) - 1,
       az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
@@ -560,7 +560,7 @@ static void test_az_iot_hub_client_properties_append_small_buffer_fail(void** st
       az_iot_hub_client_properties_append(&props, test_key_one, test_value_one),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
   assert_int_equal(
-      az_span_size(props._internal.properties), sizeof(test_correct_one_key_value) - 2);
+      az_span_size(props._internal.properties_buffer), sizeof(test_correct_one_key_value) - 2);
 }
 
 static void test_az_iot_hub_client_properties_append_twice_succeed(void** state)
@@ -578,7 +578,7 @@ static void test_az_iot_hub_client_properties_append_twice_succeed(void** state)
   assert_int_equal(
       az_iot_hub_client_properties_append(&props, test_key_two, test_value_two), AZ_OK);
   az_span_for_test_verify(
-      props._internal.properties,
+      az_span_slice(props._internal.properties_buffer, 0, props._internal.properties_written),
       test_correct_two_key_value,
       _az_COUNTOF(test_correct_two_key_value) - 1,
       az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
@@ -599,9 +599,9 @@ static void test_az_iot_hub_client_properties_append_twice_small_buffer_fail(voi
   assert_int_equal(
       az_iot_hub_client_properties_append(&props, test_key_two, test_value_two),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-  assert_int_equal(props._internal.properties_length, sizeof(test_correct_one_key_value) - 1);
+  assert_int_equal(props._internal.properties_written, sizeof(test_correct_one_key_value) - 1);
   assert_int_equal(
-      az_span_size(props._internal.properties), sizeof(test_correct_two_key_value) - 2);
+      az_span_size(props._internal.properties_buffer), sizeof(test_correct_two_key_value) - 2);
 }
 
 static void test_az_iot_hub_client_properties_find_succeed(void** state)

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
@@ -6,16 +6,16 @@
 #include <az_span.h>
 #include <az_test_span.h>
 
-#include <az_precondition_internal.h>
 #include <az_precondition.h>
+#include <az_precondition_internal.h>
 
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 
-#include <cmocka.h>
 #include <az_test_precondition.h>
+#include <cmocka.h>
 
 #define TEST_SPAN_BUFFER_SIZE 128
 
@@ -26,42 +26,47 @@
 static const az_span test_device_hostname = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_HOSTNAME_STR);
 static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_ID_STR);
 static char g_test_correct_subscribe_topic[] = "devices/my_device/messages/devicebound/#";
-static const az_span test_URL_DECODED_topic = AZ_SPAN_LITERAL_FROM_STR("devices/useragent_c/messages/devicebound/$.mid=79eadb01-bd0d-472d-bd35-ccb76e70eab8&$.to=/devices/useragent_c/messages/deviceBound&abc=123");
-static const az_span test_URL_ENCODED_topic = AZ_SPAN_LITERAL_FROM_STR("devices/useragent_c/messages/devicebound/%24.to=%2Fdevices%2Fuseragent_c%2Fmessages%2FdeviceBound&abc=123&ghi=%2Fsome%2Fthing&jkl=%2Fsome%2Fthing%2F%3Fbla%3Dbla");
-
+static const az_span test_URL_DECODED_topic = AZ_SPAN_LITERAL_FROM_STR(
+    "devices/useragent_c/messages/devicebound/$.mid=79eadb01-bd0d-472d-bd35-ccb76e70eab8&$.to=/"
+    "devices/useragent_c/messages/deviceBound&abc=123");
+static const az_span test_URL_ENCODED_topic
+    = AZ_SPAN_LITERAL_FROM_STR("devices/useragent_c/messages/devicebound/"
+                               "%24.to=%2Fdevices%2Fuseragent_c%2Fmessages%2FdeviceBound&abc=123&"
+                               "ghi=%2Fsome%2Fthing&jkl=%2Fsome%2Fthing%2F%3Fbla%3Dbla");
 
 #ifndef NO_PRECONDITION_CHECKING
-
-enable_precondition_check_tests()
+enable_precondition_check_tests();
 
 static void test_az_iot_hub_client_c2d_received_topic_parse_NULL_client_fail(void** state)
 {
   (void)state;
 
-  az_span received_topic = AZ_SPAN_FROM_STR("devices/useragent_c/messages/devicebound/$.mid=79eadb01-bd0d-472d-bd35-ccb76e70eab8&$.to=/devices/useragent_c/messages/deviceBound&iothub-ack=full");
+  az_span received_topic = AZ_SPAN_FROM_STR(
+      "devices/useragent_c/messages/devicebound/$.mid=79eadb01-bd0d-472d-bd35-ccb76e70eab8&$.to=/"
+      "devices/useragent_c/messages/deviceBound&iothub-ack=full");
 
   az_iot_hub_client_c2d_request out_request;
 
   assert_precondition_checked(
-    az_iot_hub_client_c2d_received_topic_parse(NULL, received_topic, &out_request)
-  );
+      az_iot_hub_client_c2d_received_topic_parse(NULL, received_topic, &out_request));
 }
 
-static void test_az_iot_hub_client_c2d_received_topic_parse_AZ_SPAN_NULL_received_topic_fail(void** state)
+static void test_az_iot_hub_client_c2d_received_topic_parse_AZ_SPAN_NULL_received_topic_fail(
+    void** state)
 {
   (void)state;
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   az_span received_topic = AZ_SPAN_NULL;
 
   az_iot_hub_client_c2d_request out_request;
 
   assert_precondition_checked(
-    az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request)
-  );
+      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request));
 }
 
 static void test_az_iot_hub_client_c2d_received_topic_parse_NULL_out_request_fail(void** state)
@@ -70,13 +75,13 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_NULL_out_request_fai
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   az_span received_topic = test_URL_DECODED_topic;
 
   assert_precondition_checked(
-    az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, NULL)
-  );
+      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, NULL));
 }
 
 // Note: c2d messages ALWAYS contain propeties (at least $.to).
@@ -95,8 +100,7 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_no_properties_fail(v
   az_iot_hub_client_c2d_request out_request;
 
   assert_precondition_checked(
-    az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request)
-  );
+      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request));
 }
 
 static void test_az_iot_hub_client_c2d_received_topic_parse_MALFORMED_fail(void** state)
@@ -114,8 +118,7 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_MALFORMED_fail(void*
   az_iot_hub_client_c2d_request out_request;
 
   assert_precondition_checked(
-    az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request)
-  );
+      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request));
 }
 
 #endif // NO_PRECONDITION_CHECKING
@@ -125,7 +128,8 @@ static void test_az_iot_hub_client_c2d_subscribe_topic_filter_get_succeed(void**
   (void)state;
 
   uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_sub_topic = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+  az_span mqtt_sub_topic
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
@@ -140,6 +144,7 @@ static void test_az_iot_hub_client_c2d_subscribe_topic_filter_get_succeed(void**
       mqtt_sub_topic,
       g_test_correct_subscribe_topic,
       _az_COUNTOF(g_test_correct_subscribe_topic) - 1,
+      az_span_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -149,7 +154,7 @@ static void test_az_iot_hub_client_c2d_subscribe_topic_filter_get_twice_succeed(
 
   uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
   memset(mqtt_sub_topic_buf, 0xFF, _az_COUNTOF(mqtt_sub_topic_buf));
-  az_span mqtt_sub_topic = az_span_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+  az_span mqtt_sub_topic = az_span_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
@@ -162,10 +167,9 @@ static void test_az_iot_hub_client_c2d_subscribe_topic_filter_get_twice_succeed(
   assert_memory_equal(
       g_test_correct_subscribe_topic,
       az_span_ptr(mqtt_sub_topic),
-      (size_t)az_span_length(mqtt_sub_topic));
-  assert_int_equal(az_span_length(mqtt_sub_topic), _az_COUNTOF(g_test_correct_subscribe_topic) - 1);
-  assert_int_equal(az_span_capacity(mqtt_sub_topic), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(mqtt_sub_topic_buf[az_span_length(mqtt_sub_topic)], 0xFF);
+      (size_t)az_span_size(mqtt_sub_topic));
+  assert_int_equal(az_span_size(mqtt_sub_topic), _az_COUNTOF(g_test_correct_subscribe_topic) - 1);
+  assert_int_equal(mqtt_sub_topic_buf[az_span_size(mqtt_sub_topic)], 0xFF);
 
   assert_true(
       az_iot_hub_client_c2d_subscribe_topic_filter_get(&client, mqtt_sub_topic, &mqtt_sub_topic)
@@ -173,10 +177,9 @@ static void test_az_iot_hub_client_c2d_subscribe_topic_filter_get_twice_succeed(
   assert_memory_equal(
       g_test_correct_subscribe_topic,
       az_span_ptr(mqtt_sub_topic),
-      (size_t)az_span_length(mqtt_sub_topic));
-  assert_int_equal(az_span_length(mqtt_sub_topic), _az_COUNTOF(g_test_correct_subscribe_topic) - 1);
-  assert_int_equal(az_span_capacity(mqtt_sub_topic), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(mqtt_sub_topic_buf[az_span_length(mqtt_sub_topic)], 0xFF);
+      (size_t)az_span_size(mqtt_sub_topic));
+  assert_int_equal(az_span_size(mqtt_sub_topic), _az_COUNTOF(g_test_correct_subscribe_topic) - 1);
+  assert_int_equal(mqtt_sub_topic_buf[az_span_size(mqtt_sub_topic)], 0xFF);
 }
 
 static void test_az_iot_hub_client_c2d_subscribe_topic_filter_get_small_buffer_fail(void** state)
@@ -184,7 +187,7 @@ static void test_az_iot_hub_client_c2d_subscribe_topic_filter_get_small_buffer_f
   (void)state;
 
   uint8_t mqtt_sub_topic_buf[_az_COUNTOF(g_test_correct_subscribe_topic) - 2];
-  az_span mqtt_sub_topic = az_span_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+  az_span mqtt_sub_topic = az_span_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
@@ -193,9 +196,8 @@ static void test_az_iot_hub_client_c2d_subscribe_topic_filter_get_small_buffer_f
 
   assert_true(
       az_iot_hub_client_c2d_subscribe_topic_filter_get(&client, mqtt_sub_topic, &mqtt_sub_topic)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
-  assert_int_equal(az_span_length(mqtt_sub_topic), 0);
-  assert_int_equal(az_span_capacity(mqtt_sub_topic), _az_COUNTOF(g_test_correct_subscribe_topic) - 2);
+      == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+  assert_int_equal(az_span_size(mqtt_sub_topic), _az_COUNTOF(g_test_correct_subscribe_topic) - 2);
 }
 
 static void test_az_iot_hub_client_c2d_received_topic_parse_URL_DECODED_succeed(void** state)
@@ -212,16 +214,19 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_URL_DECODED_succeed(
 
   az_iot_hub_client_c2d_request out_request;
 
-  assert_return_code(az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request), AZ_OK);
+  assert_return_code(
+      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request), AZ_OK);
 
   // TODO: enable after az_iot_hub_client_properties_next() is implemented.
   // assert_return_code(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   // assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("$.mid")));
-  // assert_true(az_span_is_content_equal(pair.value, AZ_SPAN_FROM_STR("79eadb01-bd0d-472d-bd35-ccb76e70eab8")));
+  // assert_true(az_span_is_content_equal(pair.value,
+  // AZ_SPAN_FROM_STR("79eadb01-bd0d-472d-bd35-ccb76e70eab8")));
 
   // assert_return_code(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   // assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("$.to")));
-  // assert_true(az_span_is_content_equal(pair.value, AZ_SPAN_FROM_STR("/devices/useragent_c/messages/deviceBound")));
+  // assert_true(az_span_is_content_equal(pair.value,
+  // AZ_SPAN_FROM_STR("/devices/useragent_c/messages/deviceBound")));
 
   // assert_return_code(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   // assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("abc")));
@@ -242,13 +247,15 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_URL_ENCODED_succeed(
 
   az_iot_hub_client_c2d_request out_request;
 
-  assert_return_code(az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request), AZ_OK);
+  assert_return_code(
+      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request), AZ_OK);
 
   // TODO: enable after az_iot_hub_client_properties_next() is implemented.
   // assert_return_code(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   // assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("%24.to")));
-  // assert_true(az_span_is_content_equal(pair.value, AZ_SPAN_FROM_STR("%2Fdevices%2Fuseragent_c%2Fmessages%2FdeviceBound")));
-  // 
+  // assert_true(az_span_is_content_equal(pair.value,
+  // AZ_SPAN_FROM_STR("%2Fdevices%2Fuseragent_c%2Fmessages%2FdeviceBound")));
+  //
   // assert_return_code(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   // assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("abc")));
   // assert_true(az_span_is_content_equal(pair.value, AZ_SPAN_FROM_STR("123")));
@@ -259,7 +266,8 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_URL_ENCODED_succeed(
 
   // assert_return_code(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   // assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("jkl")));
-  // assert_true(az_span_is_content_equal(pair.value, AZ_SPAN_FROM_STR("%2Fsome%2Fthing%2F%3Fbla%3Dbla")));
+  // assert_true(az_span_is_content_equal(pair.value,
+  // AZ_SPAN_FROM_STR("%2Fsome%2Fthing%2F%3Fbla%3Dbla")));
 }
 
 int test_iot_hub_c2d()
@@ -271,7 +279,8 @@ int test_iot_hub_c2d()
   const struct CMUnitTest tests[] = {
 #ifndef NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_NULL_client_fail),
-    cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_AZ_SPAN_NULL_received_topic_fail),
+    cmocka_unit_test(
+        test_az_iot_hub_client_c2d_received_topic_parse_AZ_SPAN_NULL_received_topic_fail),
     cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_NULL_out_request_fail),
     cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_no_properties_fail),
     cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_MALFORMED_fail),

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
@@ -35,7 +35,7 @@ static const az_span test_URL_ENCODED_topic
                                "ghi=%2Fsome%2Fthing&jkl=%2Fsome%2Fthing%2F%3Fbla%3Dbla");
 
 #ifndef NO_PRECONDITION_CHECKING
-enable_precondition_check_tests();
+enable_precondition_check_tests()
 
 static void test_az_iot_hub_client_c2d_received_topic_parse_NULL_client_fail(void** state)
 {

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
@@ -3,8 +3,8 @@
 
 #include "test_az_iot_hub_client.h"
 #include <az_iot_hub_client.h>
-#include <az_span.h>
 #include <az_result.h>
+#include <az_span.h>
 
 #include <az_precondition.h>
 #include <az_precondition_internal.h>
@@ -38,7 +38,7 @@ enable_precondition_check_tests()
 
   uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
   az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   assert_precondition_checked(
       az_iot_hub_client_methods_subscribe_topic_filter_get(NULL, mqtt_sub_topic, &mqtt_sub_topic));
@@ -51,7 +51,7 @@ static void test_az_iot_hub_client_methods_subscribe_topic_filter_get_NULL_out_t
 
   uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
   az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -66,7 +66,7 @@ static void test_az_iot_hub_client_methods_subscribe_topic_filter_get_empty_topi
 
   uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
   az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -81,7 +81,7 @@ static void test_az_iot_hub_client_methods_response_publish_topic_get_NULL_clien
 
   uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
   az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_span request_id = AZ_SPAN_LITERAL_FROM_STR("2");
   uint16_t status = 202;
@@ -97,7 +97,7 @@ static void test_az_iot_hub_client_methods_response_publish_topic_get_NULL_out_t
 
   uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
   az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -116,7 +116,7 @@ static void test_az_iot_hub_client_methods_response_publish_topic_get_AZ_SPAN_NU
 
   uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
   az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -135,7 +135,7 @@ static void test_az_iot_hub_client_methods_response_publish_topic_get_EMPTY_requ
 
   uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
   az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -154,7 +154,7 @@ static void test_az_iot_hub_client_methods_response_publish_topic_get_AZ_SPAN_NU
 
   uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
   az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -231,7 +231,7 @@ static void test_az_iot_hub_client_methods_subscribe_topic_filter_get_succeed(vo
 
   uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
   az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -244,6 +244,7 @@ static void test_az_iot_hub_client_methods_subscribe_topic_filter_get_succeed(vo
       mqtt_sub_topic,
       g_expected_methods_subscribe_topic,
       _az_COUNTOF(g_expected_methods_subscribe_topic) - 1,
+      az_span_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -254,14 +255,14 @@ static void test_az_iot_hub_client_methods_subscribe_topic_filter_get_INSUFFICIE
 
   uint8_t mqtt_sub_topic_buf[5];
   az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
   assert_true(
       az_iot_hub_client_methods_subscribe_topic_filter_get(&client, mqtt_sub_topic, &mqtt_sub_topic)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+      == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void test_az_iot_hub_client_methods_response_publish_topic_get_succeed(void** state)
@@ -270,7 +271,7 @@ static void test_az_iot_hub_client_methods_response_publish_topic_get_succeed(vo
 
   uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
   az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -285,7 +286,11 @@ static void test_az_iot_hub_client_methods_response_publish_topic_get_succeed(vo
       == AZ_OK);
 
   az_span_for_test_verify(
-      mqtt_sub_topic, expected_topic, _az_COUNTOF(expected_topic) - 1, TEST_SPAN_BUFFER_SIZE);
+      mqtt_sub_topic,
+      expected_topic,
+      _az_COUNTOF(expected_topic) - 1,
+      az_span_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf)),
+      TEST_SPAN_BUFFER_SIZE);
 }
 
 static void
@@ -296,7 +301,7 @@ test_az_iot_hub_client_methods_response_publish_topic_get_INSUFFICIENT_BUFFER_fo
 
   uint8_t mqtt_sub_topic_buf[10];
   az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -307,7 +312,7 @@ test_az_iot_hub_client_methods_response_publish_topic_get_INSUFFICIENT_BUFFER_fo
   assert_true(
       az_iot_hub_client_methods_response_publish_topic_get(
           &client, request_id, status, mqtt_sub_topic, &mqtt_sub_topic)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+      == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void
@@ -318,7 +323,7 @@ test_az_iot_hub_client_methods_response_publish_topic_get_INSUFFICIENT_BUFFER_fo
 
   uint8_t mqtt_sub_topic_buf[21]; // Enough for "$iothub/methods/res/2"
   az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -329,7 +334,7 @@ test_az_iot_hub_client_methods_response_publish_topic_get_INSUFFICIENT_BUFFER_fo
   assert_true(
       az_iot_hub_client_methods_response_publish_topic_get(
           &client, request_id, status, mqtt_sub_topic, &mqtt_sub_topic)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+      == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void
@@ -340,7 +345,7 @@ test_az_iot_hub_client_methods_response_publish_topic_get_INSUFFICIENT_BUFFER_fo
 
   uint8_t mqtt_sub_topic_buf[24]; // Enough for "$iothub/methods/res/202/"
   az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -351,7 +356,7 @@ test_az_iot_hub_client_methods_response_publish_topic_get_INSUFFICIENT_BUFFER_fo
   assert_true(
       az_iot_hub_client_methods_response_publish_topic_get(
           &client, request_id, status, mqtt_sub_topic, &mqtt_sub_topic)
-      == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+      == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void test_az_iot_hub_client_methods_received_topic_parse_succeed(void** state)
@@ -370,9 +375,9 @@ static void test_az_iot_hub_client_methods_received_topic_parse_succeed(void** s
   assert_true(
       az_iot_hub_client_methods_received_topic_parse(&client, received_topic, &out_request)
       == AZ_OK);
-  assert_int_equal(az_span_length(out_request.name), _az_COUNTOF(expected_name) - 1);
+  assert_int_equal(az_span_size(out_request.name), _az_COUNTOF(expected_name) - 1);
   assert_memory_equal(az_span_ptr(out_request.name), expected_name, _az_COUNTOF(expected_name) - 1);
-  assert_int_equal(az_span_length(out_request.request_id), _az_COUNTOF(expected_request_id) - 1);
+  assert_int_equal(az_span_size(out_request.request_id), _az_COUNTOF(expected_request_id) - 1);
   assert_memory_equal(
       az_span_ptr(out_request.request_id),
       expected_request_id,
@@ -438,9 +443,7 @@ static void test_az_iot_hub_client_methods_received_topic_parse_topic_filter_fai
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
   az_span received_topic = az_span_init(
-      g_expected_methods_subscribe_topic,
-      _az_COUNTOF(g_expected_methods_subscribe_topic),
-      _az_COUNTOF(g_expected_methods_subscribe_topic));
+      g_expected_methods_subscribe_topic, _az_COUNTOF(g_expected_methods_subscribe_topic));
 
   az_iot_hub_client_method_request out_request;
 

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
@@ -28,11 +28,9 @@ static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_ID_ST
 static uint8_t g_expected_methods_subscribe_topic[] = "$iothub/methods/POST/#";
 
 #ifndef NO_PRECONDITION_CHECKING
+enable_precondition_check_tests();
 
-enable_precondition_check_tests()
-
-    static void test_az_iot_hub_client_methods_subscribe_topic_filter_get_NULL_client_fail(
-        void** state)
+static void test_az_iot_hub_client_methods_subscribe_topic_filter_get_NULL_client_fail(void** state)
 {
   (void)state;
 

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
@@ -28,7 +28,7 @@ static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_ID_ST
 static uint8_t g_expected_methods_subscribe_topic[] = "$iothub/methods/POST/#";
 
 #ifndef NO_PRECONDITION_CHECKING
-enable_precondition_check_tests();
+enable_precondition_check_tests()
 
 static void test_az_iot_hub_client_methods_subscribe_topic_filter_get_NULL_client_fail(void** state)
 {

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_sas.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_sas.c
@@ -6,16 +6,16 @@
 #include <az_span.h>
 #include <az_test_span.h>
 
-#include <az_precondition_internal.h>
 #include <az_precondition.h>
+#include <az_precondition_internal.h>
 
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 
-#include <cmocka.h>
 #include <az_test_precondition.h>
+#include <cmocka.h>
 
 #define TEST_SPAN_BUFFER_SIZE 256
 
@@ -30,9 +30,9 @@
 
 enable_precondition_check_tests()
 
-// Tests
+    // Tests
 
-static void az_iot_sas_token_get_document_NULL_document_fails(void** state)
+    static void az_iot_sas_token_get_document_NULL_document_fails(void** state)
 {
   (void)state;
   az_span iothub_fqdn = AZ_SPAN_FROM_STR(TEST_FQDN);
@@ -41,8 +41,7 @@ static void az_iot_sas_token_get_document_NULL_document_fails(void** state)
   az_span document = AZ_SPAN_NULL;
 
   assert_precondition_checked(
-    az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, NULL)
-  );
+      az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, NULL));
 }
 
 static void az_iot_sas_token_get_document_NULL_document_span_fails(void** state)
@@ -55,8 +54,7 @@ static void az_iot_sas_token_get_document_NULL_document_span_fails(void** state)
   az_span document = AZ_SPAN_NULL;
 
   assert_precondition_checked(
-    az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document)
-  );
+      az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document));
 }
 
 static void az_iot_sas_token_get_document_empty_device_id_fails(void** state)
@@ -67,11 +65,10 @@ static void az_iot_sas_token_get_document_empty_device_id_fails(void** state)
   int32_t expiry_time_secs = TEST_EXPIRATION;
 
   uint8_t raw_document[TEST_SPAN_BUFFER_SIZE];
-  az_span document = az_span_init(raw_document, 0, _az_COUNTOF(raw_document));
+  az_span document = az_span_init(raw_document, _az_COUNTOF(raw_document));
 
   assert_precondition_checked(
-    az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document)
-  );
+      az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document));
 }
 
 static void az_iot_sas_token_get_document_empty_iothub_fqdn_fails(void** state)
@@ -82,11 +79,10 @@ static void az_iot_sas_token_get_document_empty_iothub_fqdn_fails(void** state)
   int32_t expiry_time_secs = TEST_EXPIRATION;
 
   uint8_t raw_document[TEST_SPAN_BUFFER_SIZE];
-  az_span document = az_span_init(raw_document, 0, _az_COUNTOF(raw_document));
+  az_span document = az_span_init(raw_document, _az_COUNTOF(raw_document));
 
   assert_precondition_checked(
-    az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document)
-  );
+      az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document));
 }
 
 static void az_iot_sas_token_generate_empty_device_id_fails(void** state)
@@ -99,11 +95,10 @@ static void az_iot_sas_token_generate_empty_device_id_fails(void** state)
   az_span signature = AZ_SPAN_FROM_STR(TEST_SIG);
 
   uint8_t raw_sas_token[TEST_SPAN_BUFFER_SIZE];
-  az_span sas_token = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
+  az_span sas_token = az_span_init(raw_sas_token, _az_COUNTOF(raw_sas_token));
 
-  assert_precondition_checked(
-    az_iot_sas_token_generate(iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)
-  );
+  assert_precondition_checked(az_iot_sas_token_generate(
+      iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token));
 }
 
 static void az_iot_sas_token_generate_empty_iothub_fqdn_fails(void** state)
@@ -116,11 +111,10 @@ static void az_iot_sas_token_generate_empty_iothub_fqdn_fails(void** state)
   az_span signature = AZ_SPAN_FROM_STR(TEST_SIG);
 
   uint8_t raw_sas_token[TEST_SPAN_BUFFER_SIZE];
-  az_span sas_token = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
+  az_span sas_token = az_span_init(raw_sas_token, _az_COUNTOF(raw_sas_token));
 
-  assert_precondition_checked(
-    az_iot_sas_token_generate(iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)
-  );
+  assert_precondition_checked(az_iot_sas_token_generate(
+      iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token));
 }
 
 static void az_iot_sas_token_generate_EMPTY_signature_fails(void** state)
@@ -133,11 +127,10 @@ static void az_iot_sas_token_generate_EMPTY_signature_fails(void** state)
   az_span signature = AZ_SPAN_NULL;
 
   uint8_t raw_sas_token[TEST_SPAN_BUFFER_SIZE];
-  az_span sas_token = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
+  az_span sas_token = az_span_init(raw_sas_token, _az_COUNTOF(raw_sas_token));
 
-  assert_precondition_checked(
-    az_iot_sas_token_generate(iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)
-  );
+  assert_precondition_checked(az_iot_sas_token_generate(
+      iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token));
 }
 
 static void az_iot_sas_token_generate_NULL_sas_token_span_fails(void** state)
@@ -151,9 +144,8 @@ static void az_iot_sas_token_generate_NULL_sas_token_span_fails(void** state)
 
   az_span sas_token = AZ_SPAN_NULL;
 
-  assert_precondition_checked(
-    az_iot_sas_token_generate(iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)
-  );
+  assert_precondition_checked(az_iot_sas_token_generate(
+      iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token));
 }
 
 static void az_iot_sas_token_generate_NULL_out_sas_token_fails(void** state)
@@ -166,11 +158,10 @@ static void az_iot_sas_token_generate_NULL_out_sas_token_fails(void** state)
   az_span signature = AZ_SPAN_FROM_STR(TEST_SIG);
 
   uint8_t raw_sas_token[TEST_SPAN_BUFFER_SIZE];
-  az_span sas_token = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
+  az_span sas_token = az_span_init(raw_sas_token, _az_COUNTOF(raw_sas_token));
 
-  assert_precondition_checked(
-       az_iot_sas_token_generate(iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, NULL)
-  );
+  assert_precondition_checked(az_iot_sas_token_generate(
+      iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, NULL));
 }
 
 #endif // NO_PRECONDITION_CHECKING
@@ -185,12 +176,16 @@ static void az_iot_sas_token_get_document_succeeds(void** state)
   int32_t expiry_time_secs = TEST_EXPIRATION;
 
   uint8_t raw_document[TEST_SPAN_BUFFER_SIZE];
-  az_span document = az_span_for_test_init(raw_document, 0, _az_COUNTOF(raw_document));
+  az_span document = az_span_for_test_init(raw_document, _az_COUNTOF(raw_document));
 
   assert_true(az_succeeded(az_iot_sas_token_get_document(
       iothub_fqdn, device_id, expiry_time_secs, document, &document)));
   az_span_for_test_verify(
-      document, expected_document,(int32_t)strlen(expected_document), TEST_SPAN_BUFFER_SIZE);
+      document,
+      expected_document,
+      (int32_t)strlen(expected_document),
+      az_span_init(raw_document, _az_COUNTOF(raw_document)),
+      TEST_SPAN_BUFFER_SIZE);
 }
 
 static void az_iot_sas_token_generate_succeeds(void** state)
@@ -206,12 +201,16 @@ static void az_iot_sas_token_generate_succeeds(void** state)
   az_span signature = AZ_SPAN_FROM_STR(TEST_SIG);
 
   uint8_t raw_sas_token[TEST_SPAN_BUFFER_SIZE];
-  az_span sas_token = az_span_for_test_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
+  az_span sas_token = az_span_for_test_init(raw_sas_token, _az_COUNTOF(raw_sas_token));
 
   assert_true(az_succeeded(az_iot_sas_token_generate(
       iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)));
   az_span_for_test_verify(
-      sas_token, expected_sas_token, (int32_t)strlen(expected_sas_token), TEST_SPAN_BUFFER_SIZE);
+      sas_token,
+      expected_sas_token,
+      (int32_t)strlen(expected_sas_token),
+      az_span_init(raw_sas_token, _az_COUNTOF(raw_sas_token)),
+      TEST_SPAN_BUFFER_SIZE);
 }
 
 static void az_iot_sas_token_generate_with_keyname_succeeds(void** state)
@@ -228,15 +227,20 @@ static void az_iot_sas_token_generate_with_keyname_succeeds(void** state)
   az_span signature = AZ_SPAN_FROM_STR(TEST_SIG);
 
   uint8_t raw_sas_token[TEST_SPAN_BUFFER_SIZE];
-  az_span sas_token = az_span_for_test_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
+  az_span sas_token = az_span_for_test_init(raw_sas_token, _az_COUNTOF(raw_sas_token));
 
   assert_true(az_succeeded(az_iot_sas_token_generate(
       iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)));
   az_span_for_test_verify(
-      sas_token, expected_sas_token, (int32_t)strlen(expected_sas_token), TEST_SPAN_BUFFER_SIZE);
+      sas_token,
+      expected_sas_token,
+      (int32_t)strlen(expected_sas_token),
+      az_span_init(raw_sas_token, _az_COUNTOF(raw_sas_token)),
+      TEST_SPAN_BUFFER_SIZE);
 }
 
-// Conditions like buffer (i.e., az_span) capacity are not covered by pre-conditions, so these tests are always mandatory.
+// Conditions like buffer (i.e., az_span) capacity are not covered by pre-conditions, so these tests
+// are always mandatory.
 static void az_iot_sas_token_generate_sas_token_overflow_fails(void** state)
 {
   (void)state;
@@ -247,15 +251,16 @@ static void az_iot_sas_token_generate_sas_token_overflow_fails(void** state)
   az_span signature = AZ_SPAN_FROM_STR(TEST_SIG);
 
   uint8_t raw_sas_token[32];
-  az_span sas_token = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
+  az_span sas_token = az_span_init(raw_sas_token, _az_COUNTOF(raw_sas_token));
 
   assert_int_equal(
       az_iot_sas_token_generate(
           iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-// Conditions like buffer (i.e., az_span) capacity are not covered by pre-conditions, so these tests are always mandatory.
+// Conditions like buffer (i.e., az_span) capacity are not covered by pre-conditions, so these tests
+// are always mandatory.
 static void az_iot_sas_token_get_document_document_overflow_fails(void** state)
 {
   (void)state;
@@ -264,11 +269,11 @@ static void az_iot_sas_token_get_document_document_overflow_fails(void** state)
   int32_t expiry_time_secs = TEST_EXPIRATION;
 
   uint8_t raw_document[32];
-  az_span document = az_span_init(raw_document, 0, _az_COUNTOF(raw_document));
+  az_span document = az_span_init(raw_document, _az_COUNTOF(raw_document));
 
   assert_int_equal(
       az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 int test_iot_sas_token()

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_sas.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_sas.c
@@ -27,12 +27,11 @@
 #define TEST_KEY_NAME "iothubowner"
 
 #ifndef NO_PRECONDITION_CHECKING
+enable_precondition_check_tests();
 
-enable_precondition_check_tests()
+// Tests
 
-    // Tests
-
-    static void az_iot_sas_token_get_document_NULL_document_fails(void** state)
+static void az_iot_sas_token_get_document_NULL_document_fails(void** state)
 {
   (void)state;
   az_span iothub_fqdn = AZ_SPAN_FROM_STR(TEST_FQDN);

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_sas.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_sas.c
@@ -27,7 +27,7 @@
 #define TEST_KEY_NAME "iothubowner"
 
 #ifndef NO_PRECONDITION_CHECKING
-enable_precondition_check_tests();
+enable_precondition_check_tests()
 
 // Tests
 

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -36,10 +36,9 @@ static const char g_test_correct_topic_with_options_module_id_with_props[]
     = "devices/my_device/modules/my_module_id/messages/events/key=value&key_two=value2";
 
 #ifndef NO_PRECONDITION_CHECKING
+enable_precondition_check_tests();
 
-enable_precondition_check_tests()
-
-    static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_client_fails(void** state)
+static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_client_fails(void** state)
 {
   (void)state;
 

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -45,7 +45,7 @@ enable_precondition_check_tests()
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
 
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_precondition_checked(
       az_iot_hub_client_telemetry_publish_topic_get(NULL, NULL, mqtt_topic, &mqtt_topic));
@@ -60,7 +60,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_mqtt_topic_f
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_buf[1];
-  az_span bad_mqtt_topic = az_span_init(test_buf, 0, _az_COUNTOF(test_buf));
+  az_span bad_mqtt_topic = az_span_init(test_buf, _az_COUNTOF(test_buf));
   bad_mqtt_topic._internal.ptr = NULL;
 
   assert_precondition_checked(az_iot_hub_client_telemetry_publish_topic_get(
@@ -77,7 +77,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_out_mqtt_top
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_precondition_checked(
       az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, NULL));
@@ -85,8 +85,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_out_mqtt_top
 
 #endif // NO_PRECONDITION_CHECKING
 
-static void
-test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_succeed(
+static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_succeed(
     void** state)
 {
   (void)state;
@@ -97,7 +96,7 @@ test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_succeed(
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
   memset(mqtt_topic_buf, 0xFF, _az_COUNTOF(mqtt_topic_buf));
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_true(
       az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, &mqtt_topic)
@@ -107,9 +106,8 @@ test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_succeed(
       (char*)az_span_ptr(mqtt_topic),
       _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1);
   assert_int_equal(
-      az_span_length(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1);
-  assert_int_equal(az_span_capacity(mqtt_topic), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(mqtt_topic_buf[az_span_length(mqtt_topic)], 0xFF);
+      az_span_size(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1);
+  assert_int_equal(mqtt_topic_buf[az_span_size(mqtt_topic)], 0xFF);
 }
 
 static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_twice_succeed(
@@ -122,7 +120,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_pro
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, &mqtt_topic), AZ_OK);
@@ -130,6 +128,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_pro
       mqtt_topic,
       g_test_correct_topic_no_options_no_props,
       _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1,
+      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
       TEST_SPAN_BUFFER_SIZE);
 
   assert_int_equal(
@@ -138,6 +137,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_pro
       mqtt_topic,
       g_test_correct_topic_no_options_no_props,
       _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1,
+      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -154,7 +154,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_p
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, &mqtt_topic), AZ_OK);
@@ -163,6 +163,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_p
       mqtt_topic,
       g_test_correct_topic_with_options_no_props,
       _az_COUNTOF(g_test_correct_topic_with_options_no_props) - 1,
+      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -179,10 +180,11 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
   az_iot_hub_client_properties props;
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
@@ -192,6 +194,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with
       mqtt_topic,
       g_test_correct_topic_with_options_with_props,
       _az_COUNTOF(g_test_correct_topic_with_options_with_props) - 1,
+      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -209,17 +212,17 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_props_small
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
   az_iot_hub_client_properties props;
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
   uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_with_options_with_props) - 2];
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
-  assert_int_equal(az_span_length(mqtt_topic), 0);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
   assert_int_equal(
-      az_span_capacity(mqtt_topic), _az_COUNTOF(g_test_correct_topic_with_options_with_props) - 2);
+      az_span_size(mqtt_topic), _az_COUNTOF(g_test_correct_topic_with_options_with_props) - 2);
 }
 
 static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_props_succeed(
@@ -232,10 +235,11 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_p
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   az_iot_hub_client_properties props;
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
@@ -245,6 +249,7 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_p
       mqtt_topic,
       g_test_correct_topic_no_options_with_props,
       _az_COUNTOF(g_test_correct_topic_no_options_with_props) - 1,
+      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -259,17 +264,17 @@ test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_props_small_b
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   az_iot_hub_client_properties props;
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
   uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_no_options_with_props) - 2];
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
-  assert_int_equal(az_span_length(mqtt_topic), 0);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
   assert_int_equal(
-      az_span_capacity(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_with_props) - 2);
+      az_span_size(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_with_props) - 2);
 }
 
 static void
@@ -286,10 +291,11 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_p
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
   az_iot_hub_client_properties props;
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
@@ -299,6 +305,7 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_p
       mqtt_topic,
       g_test_correct_topic_with_options_module_id_with_props,
       _az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 1,
+      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -316,17 +323,17 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_p
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
   az_iot_hub_client_properties props;
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_props), AZ_OK);
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
   uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 2];
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
-  assert_int_equal(az_span_length(mqtt_topic), 0);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
   assert_int_equal(
-      az_span_capacity(mqtt_topic),
+      az_span_size(mqtt_topic),
       _az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 2);
 }
 
@@ -344,7 +351,8 @@ int test_iot_hub_telemetry()
 #endif // NO_PRECONDITION_CHECKING
     cmocka_unit_test(
         test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_twice_succeed),
+    cmocka_unit_test(
+        test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_twice_succeed),
     cmocka_unit_test(
         test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_props_succeed),
     cmocka_unit_test(

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -36,7 +36,7 @@ static const char g_test_correct_topic_with_options_module_id_with_props[]
     = "devices/my_device/modules/my_module_id/messages/events/key=value&key_two=value2";
 
 #ifndef NO_PRECONDITION_CHECKING
-enable_precondition_check_tests();
+enable_precondition_check_tests()
 
 static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_client_fails(void** state)
 {

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
@@ -33,13 +33,13 @@ static const char test_correct_twin_patch_pub_topic[]
 #ifndef NO_PRECONDITION_CHECKING
 enable_precondition_check_tests()
 
-static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_null_client_fails(
-    void** state)
+    static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_null_client_fails(
+        void** state)
 {
   (void)state;
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(
       az_iot_hub_client_twin_response_subscribe_topic_filter_get(NULL, test_span, &test_span));
@@ -55,7 +55,7 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_NULL
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
   test_span._internal.ptr = NULL;
 
   assert_precondition_checked(
@@ -72,7 +72,7 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_NULL
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(
       az_iot_hub_client_twin_response_subscribe_topic_filter_get(&client, test_span, NULL));
@@ -84,7 +84,7 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_NULL_cl
   (void)state;
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(
       az_iot_hub_client_twin_patch_subscribe_topic_filter_get(NULL, test_span, &test_span));
@@ -100,7 +100,7 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_NULL_sp
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
   test_span._internal.ptr = NULL;
 
   assert_precondition_checked(
@@ -117,7 +117,7 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_NULL_ou
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(
       az_iot_hub_client_twin_patch_subscribe_topic_filter_get(&client, test_span, NULL));
@@ -128,7 +128,7 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_client_fails(
   (void)state;
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(az_iot_hub_client_twin_get_publish_topic_get(
       NULL, test_device_request_id, test_span, &test_span));
@@ -143,11 +143,11 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_request_id_fa
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_get_request_topic) - 1];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   uint8_t test_bad_request_id_buf[1];
   az_span test_bad_request_id
-      = az_span_init(test_bad_request_id_buf, 0, _az_COUNTOF(test_bad_request_id_buf));
+      = az_span_init(test_bad_request_id_buf, _az_COUNTOF(test_bad_request_id_buf));
   test_bad_request_id._internal.ptr = NULL;
 
   assert_precondition_checked(az_iot_hub_client_twin_get_publish_topic_get(
@@ -163,7 +163,7 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_span_fails(vo
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_get_request_topic) - 1];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
   test_span._internal.ptr = NULL;
 
   assert_precondition_checked(az_iot_hub_client_twin_get_publish_topic_get(
@@ -179,7 +179,7 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_out_span_fail
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_get_request_topic) - 1];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(az_iot_hub_client_twin_get_publish_topic_get(
       &client, test_device_request_id, test_span, NULL));
@@ -190,7 +190,7 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_NULL_client_fail
   (void)state;
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(az_iot_hub_client_twin_patch_publish_topic_get(
       NULL, test_device_request_id, test_span, &test_span));
@@ -206,11 +206,11 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_invalid_request_
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   uint8_t test_bad_request_id_buf[1];
   az_span test_bad_request_id
-      = az_span_init(test_bad_request_id_buf, 0, _az_COUNTOF(test_bad_request_id_buf));
+      = az_span_init(test_bad_request_id_buf, _az_COUNTOF(test_bad_request_id_buf));
   test_bad_request_id._internal.ptr = NULL;
 
   assert_precondition_checked(az_iot_hub_client_twin_patch_publish_topic_get(
@@ -226,7 +226,7 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_NULL_span_fails(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
   test_span._internal.ptr = NULL;
 
   assert_precondition_checked(az_iot_hub_client_twin_patch_publish_topic_get(
@@ -242,7 +242,7 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_NULL_out_span_fa
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_precondition_checked(az_iot_hub_client_twin_patch_publish_topic_get(
       &client, test_device_request_id, test_span, NULL));
@@ -259,7 +259,7 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_succ
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_response_subscribe_topic_filter_get(&client, test_span, &test_span),
@@ -268,10 +268,12 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_succ
       test_span,
       test_correct_twin_response_topic_filter,
       _az_COUNTOF(test_correct_twin_response_topic_filter) - 1,
+      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
-static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_twice_succeed(void** state)
+static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_twice_succeed(
+    void** state)
 {
   (void)state;
 
@@ -281,7 +283,7 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_twic
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
   memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_response_subscribe_topic_filter_get(&client, test_span, &test_span),
@@ -290,9 +292,8 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_twic
       az_span_ptr(test_span),
       test_correct_twin_response_topic_filter,
       _az_COUNTOF(test_correct_twin_response_topic_filter) - 1);
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_twin_response_topic_filter) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
+  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_response_topic_filter) - 1);
+  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
 
   assert_int_equal(
       az_iot_hub_client_twin_response_subscribe_topic_filter_get(&client, test_span, &test_span),
@@ -301,12 +302,12 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_twic
       az_span_ptr(test_span),
       test_correct_twin_response_topic_filter,
       _az_COUNTOF(test_correct_twin_response_topic_filter) - 1);
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_twin_response_topic_filter) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
+  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_response_topic_filter) - 1);
+  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
 }
 
-static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_small_buffer_fails(void** state)
+static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_small_buffer_fails(
+    void** state)
 {
   (void)state;
 
@@ -315,14 +316,13 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_smal
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 2];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_response_subscribe_topic_filter_get(&client, test_span, &test_span),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
-  assert_int_equal(az_span_length(test_span), 0);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
   assert_int_equal(
-      az_span_capacity(test_span), _az_COUNTOF(test_correct_twin_response_topic_filter) - 2);
+      az_span_size(test_span), _az_COUNTOF(test_correct_twin_response_topic_filter) - 2);
 }
 
 static void test_az_iot_hub_client_twin_get_publish_topic_get_succeed(void** state)
@@ -334,7 +334,7 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_succeed(void** sta
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_get_publish_topic_get(
@@ -344,6 +344,7 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_succeed(void** sta
       test_span,
       test_correct_twin_get_request_topic,
       _az_COUNTOF(test_correct_twin_get_request_topic) - 1,
+      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -357,7 +358,7 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_twice_succeed(void
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
   memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_get_publish_topic_get(
@@ -367,9 +368,8 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_twice_succeed(void
       az_span_ptr(test_span),
       test_correct_twin_get_request_topic,
       _az_COUNTOF(test_correct_twin_get_request_topic) - 1);
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_twin_get_request_topic) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
+  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_get_request_topic) - 1);
+  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
 
   assert_int_equal(
       az_iot_hub_client_twin_get_publish_topic_get(
@@ -379,9 +379,8 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_twice_succeed(void
       az_span_ptr(test_span),
       test_correct_twin_get_request_topic,
       _az_COUNTOF(test_correct_twin_get_request_topic) - 1);
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_twin_get_request_topic) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
+  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_get_request_topic) - 1);
+  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
 }
 
 static void test_az_iot_hub_client_twin_get_publish_topic_get_small_buffer_fails(void** state)
@@ -393,15 +392,13 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_small_buffer_fails
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_get_request_topic) - 2];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_get_publish_topic_get(
           &client, test_device_request_id, test_span, &test_span),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
-  assert_int_equal(az_span_length(test_span), 0);
-  assert_int_equal(
-      az_span_capacity(test_span), _az_COUNTOF(test_correct_twin_get_request_topic) - 2);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+  assert_int_equal(az_span_size(test_span), _az_COUNTOF(test_correct_twin_get_request_topic) - 2);
 }
 
 static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_succeed(void** state)
@@ -413,7 +410,7 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_succeed
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_patch_subscribe_topic_filter_get(&client, test_span, &test_span),
@@ -422,6 +419,7 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_succeed
       test_span,
       test_correct_twin_path_subscribe_topic,
       _az_COUNTOF(test_correct_twin_path_subscribe_topic) - 1,
+      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -435,7 +433,7 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_twice_s
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
   memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_patch_subscribe_topic_filter_get(&client, test_span, &test_span),
@@ -444,9 +442,8 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_twice_s
       az_span_ptr(test_span),
       test_correct_twin_path_subscribe_topic,
       _az_COUNTOF(test_correct_twin_path_subscribe_topic) - 1);
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_twin_path_subscribe_topic) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
+  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_path_subscribe_topic) - 1);
+  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
 
   assert_int_equal(
       az_iot_hub_client_twin_patch_subscribe_topic_filter_get(&client, test_span, &test_span),
@@ -455,12 +452,12 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_twice_s
       az_span_ptr(test_span),
       test_correct_twin_path_subscribe_topic,
       _az_COUNTOF(test_correct_twin_path_subscribe_topic) - 1);
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_twin_path_subscribe_topic) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
+  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_path_subscribe_topic) - 1);
+  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
 }
 
-static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_small_buffer_fails(void** state)
+static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_small_buffer_fails(
+    void** state)
 {
   (void)state;
 
@@ -469,14 +466,13 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_small_b
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_path_subscribe_topic) - 2];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_patch_subscribe_topic_filter_get(&client, test_span, &test_span),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
-  assert_int_equal(az_span_length(test_span), 0);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
   assert_int_equal(
-      az_span_capacity(test_span), _az_COUNTOF(test_correct_twin_path_subscribe_topic) - 2);
+      az_span_size(test_span), _az_COUNTOF(test_correct_twin_path_subscribe_topic) - 2);
 }
 
 static void test_az_iot_hub_client_twin_patch_publish_topic_get_succeed(void** state)
@@ -488,7 +484,7 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_succeed(void** s
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_patch_publish_topic_get(
@@ -498,6 +494,7 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_succeed(void** s
       test_span,
       test_correct_twin_patch_pub_topic,
       _az_COUNTOF(test_correct_twin_patch_pub_topic) - 1,
+      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -511,7 +508,7 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_twice_succeed(vo
 
   uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
   memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_patch_publish_topic_get(
@@ -521,9 +518,8 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_twice_succeed(vo
       az_span_ptr(test_span),
       test_correct_twin_patch_pub_topic,
       _az_COUNTOF(test_correct_twin_patch_pub_topic) - 1);
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_twin_patch_pub_topic) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
+  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_patch_pub_topic) - 1);
+  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
 
   assert_int_equal(
       az_iot_hub_client_twin_patch_publish_topic_get(
@@ -533,9 +529,8 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_twice_succeed(vo
       az_span_ptr(test_span),
       test_correct_twin_patch_pub_topic,
       _az_COUNTOF(test_correct_twin_patch_pub_topic) - 1);
-  assert_int_equal(az_span_length(test_span), sizeof(test_correct_twin_patch_pub_topic) - 1);
-  assert_int_equal(az_span_capacity(test_span), TEST_SPAN_BUFFER_SIZE);
-  assert_int_equal(test_span_buf[az_span_length(test_span)], 0xFF);
+  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_patch_pub_topic) - 1);
+  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
 }
 
 static void test_az_iot_hub_client_twin_patch_publish_topic_get_small_buffer_fails(void** state)
@@ -547,15 +542,13 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_small_buffer_fai
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 2];
-  az_span test_span = az_span_init(test_span_buf, 0, _az_COUNTOF(test_span_buf));
+  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
   assert_int_equal(
       az_iot_hub_client_twin_patch_publish_topic_get(
           &client, test_device_request_id, test_span, &test_span),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
-  assert_int_equal(az_span_length(test_span), 0);
-  assert_int_equal(
-      az_span_capacity(test_span), _az_COUNTOF(test_correct_twin_patch_pub_topic) - 2);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+  assert_int_equal(az_span_size(test_span), _az_COUNTOF(test_correct_twin_patch_pub_topic) - 2);
 }
 
 int test_az_iot_hub_client_twin()
@@ -588,13 +581,15 @@ int test_az_iot_hub_client_twin()
 #endif // NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_twice_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_small_buffer_fails),
+    cmocka_unit_test(
+        test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_small_buffer_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_get_publish_topic_get_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_get_publish_topic_get_twice_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_get_publish_topic_get_small_buffer_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_twice_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_small_buffer_fails),
+    cmocka_unit_test(
+        test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_small_buffer_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_patch_publish_topic_get_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_patch_publish_topic_get_twice_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_patch_publish_topic_get_small_buffer_fails),

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
@@ -31,10 +31,10 @@ static const char test_correct_twin_patch_pub_topic[]
     = "$iothub/twin/PATCH/properties/reported/?$rid=id_one";
 
 #ifndef NO_PRECONDITION_CHECKING
-enable_precondition_check_tests()
+enable_precondition_check_tests();
 
-    static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_null_client_fails(
-        void** state)
+static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_null_client_fails(
+    void** state)
 {
   (void)state;
 

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
@@ -31,7 +31,7 @@ static const char test_correct_twin_patch_pub_topic[]
     = "$iothub/twin/PATCH/properties/reported/?$rid=id_one";
 
 #ifndef NO_PRECONDITION_CHECKING
-enable_precondition_check_tests();
+enable_precondition_check_tests()
 
 static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_null_client_fails(
     void** state)

--- a/sdk/iot/pnp/src/az_iot_pnp_client.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client.c
@@ -66,7 +66,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
       az_iot_hub_client_user_name_get(&client->_internal.iot_hub_client, remainder, &user_name));
 
   int32_t written = az_span_size(user_name);
-  remainder = az_span_slice(remainder, written, -1);
+  remainder = az_span_slice_to_end(remainder, written);
 
   int32_t required_length
       = az_span_size(pnp_model_id) + az_span_size(client->_internal.root_interface_name) + 2;

--- a/sdk/iot/pnp/src/az_iot_pnp_client.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client.c
@@ -73,9 +73,9 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, required_length);
 
-  remainder = az_span_copy_uint8(remainder, pnp_client_param_separator);
+  remainder = az_span_copy_u8(remainder, pnp_client_param_separator);
   remainder = az_span_copy(remainder, pnp_model_id);
-  remainder = az_span_copy_uint8(remainder, pnp_client_param_equals);
+  remainder = az_span_copy_u8(remainder, pnp_client_param_equals);
   az_span_copy(remainder, client->_internal.root_interface_name);
 
   *out_mqtt_user_name = az_span_slice(mqtt_user_name, 0, written + required_length);

--- a/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
@@ -25,23 +25,24 @@ static az_result _az_add_telemetry_property(
     bool add_separator,
     az_span* out_mqtt_topic)
 {
-  int32_t required_length = az_span_length(property_name) + az_span_length(property_value) + 1;
+  int32_t required_length = az_span_size(property_name) + az_span_size(property_value) + 1;
   if (add_separator)
   {
     required_length++;
   }
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_topic, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic, required_length);
 
+  az_span remainder = mqtt_topic;
   if (add_separator)
   {
-    mqtt_topic = az_span_append_uint8(mqtt_topic, pnp_telemetry_param_separator);
+    remainder = az_span_copy_uint8(remainder, pnp_telemetry_param_separator);
   }
-  mqtt_topic = az_span_append(mqtt_topic, property_name);
-  mqtt_topic = az_span_append_uint8(mqtt_topic, pnp_telemetry_param_equals);
-  mqtt_topic = az_span_append(mqtt_topic, property_value);
+  remainder = az_span_copy(remainder, property_name);
+  remainder = az_span_copy_uint8(remainder, pnp_telemetry_param_equals);
+  az_span_copy(remainder, property_value);
 
-  *out_mqtt_topic = mqtt_topic;
+  *out_mqtt_topic = az_span_slice(mqtt_topic, 0, required_length);
 
   return AZ_OK;
 }
@@ -59,33 +60,51 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
   AZ_PRECONDITION_IS_NULL(reserved);
   AZ_PRECONDITION_NOT_NULL(out_mqtt_topic);
 
+  az_span written_span;
+  int32_t written = 0;
+
   AZ_RETURN_IF_FAILED(az_iot_hub_client_telemetry_publish_topic_get(
-      &client->_internal.iot_hub_client, NULL, mqtt_topic, &mqtt_topic));
+      &client->_internal.iot_hub_client,
+      NULL,
+      az_span_slice(mqtt_topic, written, -1),
+      &written_span));
+
+  written += az_span_size(written_span);
 
   AZ_RETURN_IF_FAILED(_az_add_telemetry_property(
-      mqtt_topic, pnp_telemetry_component_name_param, component_name, false, &mqtt_topic));
+      az_span_slice(mqtt_topic, written, -1),
+      pnp_telemetry_component_name_param,
+      component_name,
+      false,
+      &written_span));
+
+  written += az_span_size(written_span);
 
   if (az_span_ptr(client->_internal.options.content_type) != NULL)
   {
     AZ_RETURN_IF_FAILED(_az_add_telemetry_property(
-        mqtt_topic,
+        az_span_slice(mqtt_topic, written, -1),
         pnp_telemetry_content_type_param,
         client->_internal.options.content_type,
         true,
-        &mqtt_topic));
+        &written_span));
+
+    written += az_span_size(written_span);
   }
 
   if (az_span_ptr(client->_internal.options.content_encoding) != NULL)
   {
     AZ_RETURN_IF_FAILED(_az_add_telemetry_property(
-        mqtt_topic,
+        az_span_slice(mqtt_topic, written, -1),
         pnp_telemetry_content_encoding_param,
         client->_internal.options.content_encoding,
         true,
-        &mqtt_topic));
+        &written_span));
+
+    written += az_span_size(written_span);
   }
 
-  *out_mqtt_topic = mqtt_topic;
+  *out_mqtt_topic = az_span_slice(mqtt_topic, 0, written);
 
   return AZ_OK;
 }

--- a/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
@@ -66,13 +66,13 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
   AZ_RETURN_IF_FAILED(az_iot_hub_client_telemetry_publish_topic_get(
       &client->_internal.iot_hub_client,
       NULL,
-      az_span_slice(mqtt_topic, written, -1),
+      az_span_slice_to_end(mqtt_topic, written),
       &written_span));
 
   written += az_span_size(written_span);
 
   AZ_RETURN_IF_FAILED(_az_add_telemetry_property(
-      az_span_slice(mqtt_topic, written, -1),
+      az_span_slice_to_end(mqtt_topic, written),
       pnp_telemetry_component_name_param,
       component_name,
       false,
@@ -83,7 +83,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
   if (az_span_ptr(client->_internal.options.content_type) != NULL)
   {
     AZ_RETURN_IF_FAILED(_az_add_telemetry_property(
-        az_span_slice(mqtt_topic, written, -1),
+        az_span_slice_to_end(mqtt_topic, written),
         pnp_telemetry_content_type_param,
         client->_internal.options.content_type,
         true,
@@ -95,7 +95,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
   if (az_span_ptr(client->_internal.options.content_encoding) != NULL)
   {
     AZ_RETURN_IF_FAILED(_az_add_telemetry_property(
-        az_span_slice(mqtt_topic, written, -1),
+        az_span_slice_to_end(mqtt_topic, written),
         pnp_telemetry_content_encoding_param,
         client->_internal.options.content_encoding,
         true,

--- a/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
@@ -36,10 +36,10 @@ static az_result _az_add_telemetry_property(
   az_span remainder = mqtt_topic;
   if (add_separator)
   {
-    remainder = az_span_copy_uint8(remainder, pnp_telemetry_param_separator);
+    remainder = az_span_copy_u8(remainder, pnp_telemetry_param_separator);
   }
   remainder = az_span_copy(remainder, property_name);
-  remainder = az_span_copy_uint8(remainder, pnp_telemetry_param_equals);
+  remainder = az_span_copy_u8(remainder, pnp_telemetry_param_equals);
   az_span_copy(remainder, property_value);
 
   *out_mqtt_topic = az_span_slice(mqtt_topic, 0, required_length);

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
@@ -40,7 +40,7 @@ static const char test_correct_pnp_user_name_with_user_agent[]
       "&digital-twin-model-id=" TEST_ROOT_INTERFACE_NAME;
 
 #ifndef NO_PRECONDITION_CHECKING
-enable_precondition_check_tests();
+enable_precondition_check_tests()
 
 static void test_az_iot_pnp_client_init_NULL_client_fails(void** state)
 {

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
@@ -139,12 +139,14 @@ static void test_az_iot_pnp_client_get_user_name_succeed(void** state)
       AZ_OK);
 
   uint8_t test_span_buffer[_az_COUNTOF(test_correct_pnp_user_name) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  az_span test_span = az_span_init(test_span_buffer, _az_COUNTOF(test_span_buffer));
   assert_int_equal(az_iot_pnp_client_get_user_name(&client, test_span, &test_span), AZ_OK);
 
-  assert_int_equal(az_span_length(test_span), _az_COUNTOF(test_correct_pnp_user_name) - 1);
+  assert_int_equal(az_span_size(test_span), _az_COUNTOF(test_correct_pnp_user_name) - 1);
   assert_memory_equal(
-      test_correct_pnp_user_name, az_span_ptr(test_span), _az_COUNTOF(test_correct_pnp_user_name) - 1);
+      test_correct_pnp_user_name,
+      az_span_ptr(test_span),
+      _az_COUNTOF(test_correct_pnp_user_name) - 1);
 }
 
 static void test_az_iot_pnp_client_get_user_name_small_buffer_fail(void** state)
@@ -158,10 +160,10 @@ static void test_az_iot_pnp_client_get_user_name_small_buffer_fail(void** state)
       AZ_OK);
 
   uint8_t test_span_buffer[_az_COUNTOF(test_correct_pnp_user_name) - 2];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  az_span test_span = az_span_init(test_span_buffer, _az_COUNTOF(test_span_buffer));
   assert_int_equal(
       az_iot_pnp_client_get_user_name(&client, test_span, &test_span),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void test_az_iot_pnp_client_get_user_name_user_options_succeed(void** state)
@@ -180,11 +182,11 @@ static void test_az_iot_pnp_client_get_user_name_user_options_succeed(void** sta
       AZ_OK);
 
   uint8_t test_span_buffer[_az_COUNTOF(test_correct_pnp_user_name_with_user_agent) - 1];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  az_span test_span = az_span_init(test_span_buffer, _az_COUNTOF(test_span_buffer));
   assert_int_equal(az_iot_pnp_client_get_user_name(&client, test_span, &test_span), AZ_OK);
 
   assert_int_equal(
-      az_span_length(test_span), _az_COUNTOF(test_correct_pnp_user_name_with_user_agent) - 1);
+      az_span_size(test_span), _az_COUNTOF(test_correct_pnp_user_name_with_user_agent) - 1);
   assert_memory_equal(
       test_correct_pnp_user_name_with_user_agent,
       az_span_ptr(test_span),
@@ -207,10 +209,10 @@ static void test_az_iot_pnp_client_get_user_name_user_options_small_buffer_fail(
       AZ_OK);
 
   uint8_t test_span_buffer[_az_COUNTOF(test_correct_pnp_user_name_with_user_agent) - 2];
-  az_span test_span = az_span_init(test_span_buffer, 0, _az_COUNTOF(test_span_buffer));
+  az_span test_span = az_span_init(test_span_buffer, _az_COUNTOF(test_span_buffer));
   assert_int_equal(
       az_iot_pnp_client_get_user_name(&client, test_span, &test_span),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 // TODO: Add tests for inline functions (e.g. az_iot_pnp_client_get_id).  Will add them prior to
@@ -240,4 +242,3 @@ int test_iot_pnp_client()
   };
   return cmocka_run_group_tests_name("az_iot_pnp_client", tests, NULL, NULL);
 }
-

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
@@ -40,10 +40,9 @@ static const char test_correct_pnp_user_name_with_user_agent[]
       "&digital-twin-model-id=" TEST_ROOT_INTERFACE_NAME;
 
 #ifndef NO_PRECONDITION_CHECKING
+enable_precondition_check_tests();
 
-enable_precondition_check_tests()
-
-    static void test_az_iot_pnp_client_init_NULL_client_fails(void** state)
+static void test_az_iot_pnp_client_init_NULL_client_fails(void** state)
 {
   (void)state;
 

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
@@ -45,10 +45,9 @@ static const char g_test_correct_pnp_topic_content_type_and_encoding[]
       "&%24.ct=" TEST_CONTENT_TYPE "&%24.ce=" TEST_CONTENT_ENCODING;
 
 #ifndef NO_PRECONDITION_CHECKING
+enable_precondition_check_tests();
 
-enable_precondition_check_tests()
-
-    static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_client_fails(void** state)
+static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_client_fails(void** state)
 {
   (void)state;
 

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
@@ -45,7 +45,7 @@ static const char g_test_correct_pnp_topic_content_type_and_encoding[]
       "&%24.ct=" TEST_CONTENT_TYPE "&%24.ce=" TEST_CONTENT_ENCODING;
 
 #ifndef NO_PRECONDITION_CHECKING
-enable_precondition_check_tests();
+enable_precondition_check_tests()
 
 static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_client_fails(void** state)
 {

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
@@ -54,7 +54,7 @@ enable_precondition_check_tests()
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
 
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
       NULL, test_component_name, mqtt_topic, NULL, &mqtt_topic));
@@ -71,7 +71,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_mqtt_topic_f
       AZ_OK);
 
   uint8_t test_buf[1];
-  az_span bad_mqtt_topic = az_span_init(test_buf, 0, _az_COUNTOF(test_buf));
+  az_span bad_mqtt_topic = az_span_init(test_buf, _az_COUNTOF(test_buf));
   bad_mqtt_topic._internal.ptr = NULL;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
@@ -90,7 +90,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_out_mqtt_top
       AZ_OK);
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
       &client, test_component_name, mqtt_topic, NULL, NULL));
@@ -108,7 +108,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_component_na
       AZ_OK);
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
       &client, AZ_SPAN_NULL, mqtt_topic, NULL, &mqtt_topic));
@@ -125,7 +125,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_non_NULL_reserved
       AZ_OK);
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
       &client, test_component_name, AZ_SPAN_NULL, (void*)0x1, &mqtt_topic));
@@ -144,7 +144,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_no_options_succee
       AZ_OK);
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
@@ -155,6 +155,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_no_options_succee
       mqtt_topic,
       g_test_correct_pnp_topic_no_options,
       _az_COUNTOF(g_test_correct_pnp_topic_no_options) - 1,
+      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -172,7 +173,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_succ
       AZ_OK);
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
@@ -183,6 +184,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_succ
       mqtt_topic,
       g_test_correct_pnp_topic_content_type,
       _az_COUNTOF(g_test_correct_pnp_topic_content_type) - 1,
+      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -201,7 +203,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_encoding_
       AZ_OK);
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
@@ -212,6 +214,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_encoding_
       mqtt_topic,
       g_test_correct_pnp_topic_content_encoding,
       _az_COUNTOF(g_test_correct_pnp_topic_content_encoding) - 1,
+      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -231,7 +234,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_and_
       AZ_OK);
 
   uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
@@ -242,6 +245,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_and_
       mqtt_topic,
       g_test_correct_pnp_topic_content_type_and_encoding,
       _az_COUNTOF(g_test_correct_pnp_topic_content_type_and_encoding) - 1,
+      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
       TEST_SPAN_BUFFER_SIZE);
 }
 
@@ -256,12 +260,12 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_with_small_buffer
       AZ_OK);
 
   uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_no_options) - 2];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
           &client, test_component_name, mqtt_topic, NULL, &mqtt_topic),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_with_small_buffer_fails(
@@ -279,12 +283,12 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_with
       AZ_OK);
 
   uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_content_type) - 2];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
           &client, test_component_name, mqtt_topic, NULL, &mqtt_topic),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void
@@ -303,12 +307,12 @@ test_az_iot_pnp_client_telemetry_publish_topic_get_content_encoding_with_small_b
       AZ_OK);
 
   uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_content_type) - 2];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
           &client, test_component_name, mqtt_topic, NULL, &mqtt_topic),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void
@@ -328,12 +332,12 @@ test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_and_encoding_wit
       AZ_OK);
 
   uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_content_type_and_encoding) - 2];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, 0, _az_COUNTOF(mqtt_topic_buf));
+  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
           &client, test_component_name, mqtt_topic, NULL, &mqtt_topic),
-      AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 int test_iot_pnp_telemetry()

--- a/sdk/iot/provisioning/samples/src/paho_iot_provisioning_example.c
+++ b/sdk/iot/provisioning/samples/src/paho_iot_provisioning_example.c
@@ -62,15 +62,17 @@ static az_result read_configuration_entry(
   {
     printf("%s\n", hide_value ? "***" : env);
     az_span env_span = az_span_from_str(env);
-    AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(buffer, az_span_length(env_span));
-    *out_value = az_span_copy(buffer, env_span);
+    AZ_RETURN_IF_NOT_ENOUGH_SIZE(buffer, az_span_size(env_span));
+    az_span_copy(buffer, env_span);
+    *out_value = az_span_slice(buffer, 0, az_span_size(env_span));
   }
   else if (default_value != NULL)
   {
     printf("%s\n", default_value);
     az_span default_span = az_span_from_str(default_value);
-    AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(buffer, az_span_length(default_span));
-    *out_value = az_span_copy(buffer, default_span);
+    AZ_RETURN_IF_NOT_ENOUGH_SIZE(buffer, az_span_size(default_span));
+    az_span_copy(buffer, default_span);
+    *out_value = az_span_slice(buffer, 0, az_span_size(default_span));
   }
   else
   {
@@ -142,7 +144,7 @@ static int on_received(void* context, char* topicName, int topicLen, MQTTClient_
   {
     putchar(*payloadptr++);
   }
-  
+
   putchar('\n');
   MQTTClient_freeMessage(&message);
   MQTTClient_free(topicName);
@@ -167,7 +169,7 @@ static int connect()
     return rc;
   }
 
-  if ((rc = az_span_append_uint8(username_span, '\0', &username_span)) != AZ_OK)
+  if ((rc = az_span_copy_uint8(username_span, '\0', &username_span)) != AZ_OK)
   {
     printf("Failed to get MQTT username, return code %d\n", rc);
     return rc;
@@ -181,7 +183,7 @@ static int connect()
   {
     mqtt_ssl_options.trustStore = (char*)x509_trust_pem_file;
   }
-  
+
   mqtt_connect_options.ssl = &mqtt_ssl_options;
 
   if ((rc = MQTTClient_connect(mqtt_client, &mqtt_connect_options)) != MQTTCLIENT_SUCCESS)
@@ -208,7 +210,7 @@ static int subscribe()
     return rc;
   }
 
-  if ((rc = az_span_append_uint8(topic_filter_span, '\0', &topic_filter_span)) != AZ_OK)
+  if ((rc = az_span_copy_uint8(topic_filter_span, '\0', &topic_filter_span)) != AZ_OK)
   {
     printf("Failed to get MQTT SUB topic filter, return code %d\n", rc);
     return rc;
@@ -240,7 +242,7 @@ static int register_device()
     return rc;
   }
 
-  if ((rc = az_span_append_uint8(topic_span, '\0', &topic_span)) != AZ_OK)
+  if ((rc = az_span_copy_uint8(topic_span, '\0', &topic_span)) != AZ_OK)
   {
     printf("Failed to get MQTT PUB register topic, return code %d\n", rc);
     return rc;
@@ -281,7 +283,7 @@ int main()
     return rc;
   }
 
-  if ((rc = az_span_append_uint8(client_id_span, '\0', &client_id_span)) != AZ_OK)
+  if ((rc = az_span_copy_uint8(client_id_span, '\0', &client_id_span)) != AZ_OK)
   {
     printf("Failed to get MQTT username, return code %d\n", rc);
     return rc;

--- a/sdk/iot/provisioning/samples/src/paho_iot_provisioning_example.c
+++ b/sdk/iot/provisioning/samples/src/paho_iot_provisioning_example.c
@@ -169,7 +169,7 @@ static int connect()
     return rc;
   }
 
-  if ((rc = az_span_copy_uint8(username_span, '\0', &username_span)) != AZ_OK)
+  if ((rc = az_span_copy_u8(username_span, '\0', &username_span)) != AZ_OK)
   {
     printf("Failed to get MQTT username, return code %d\n", rc);
     return rc;
@@ -210,7 +210,7 @@ static int subscribe()
     return rc;
   }
 
-  if ((rc = az_span_copy_uint8(topic_filter_span, '\0', &topic_filter_span)) != AZ_OK)
+  if ((rc = az_span_copy_u8(topic_filter_span, '\0', &topic_filter_span)) != AZ_OK)
   {
     printf("Failed to get MQTT SUB topic filter, return code %d\n", rc);
     return rc;
@@ -242,7 +242,7 @@ static int register_device()
     return rc;
   }
 
-  if ((rc = az_span_copy_uint8(topic_span, '\0', &topic_span)) != AZ_OK)
+  if ((rc = az_span_copy_u8(topic_span, '\0', &topic_span)) != AZ_OK)
   {
     printf("Failed to get MQTT PUB register topic, return code %d\n", rc);
     return rc;
@@ -283,7 +283,7 @@ int main()
     return rc;
   }
 
-  if ((rc = az_span_copy_uint8(client_id_span, '\0', &client_id_span)) != AZ_OK)
+  if ((rc = az_span_copy_u8(client_id_span, '\0', &client_id_span)) != AZ_OK)
   {
     printf("Failed to get MQTT username, return code %d\n", rc);
     return rc;

--- a/sdk/iot/provisioning/src/az_iot_provisioning_client.c
+++ b/sdk/iot/provisioning/src/az_iot_provisioning_client.c
@@ -75,7 +75,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_user_name_get(
 
   if (az_span_size(*user_agent) > 0)
   {
-    remainder = az_span_copy_uint8(remainder, '&');
+    remainder = az_span_copy_u8(remainder, '&');
     az_span_copy(remainder, *user_agent);
   }
 
@@ -125,7 +125,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_subscribe_topic_filte
   az_span remainder = az_span_copy(mqtt_topic_filter, str_dps);
   remainder = az_span_copy(remainder, str_registrations);
   remainder = az_span_copy(remainder, str_res);
-  az_span_copy_uint8(remainder, '#');
+  az_span_copy_u8(remainder, '#');
 
   *out_mqtt_topic_filter = az_span_slice(mqtt_topic_filter, 0, required_length);
 

--- a/sdk/iot/provisioning/src/az_iot_provisioning_client.c
+++ b/sdk/iot/provisioning/src/az_iot_provisioning_client.c
@@ -58,28 +58,28 @@ AZ_NODISCARD az_result az_iot_provisioning_client_user_name_get(
 
   const az_span* const user_agent = &(client->_internal.options.user_agent);
 
-  int32_t required_length = az_span_length(client->_internal.id_scope)
-      + az_span_length(str_registrations) + az_span_length(client->_internal.registration_id)
-      + az_span_length(provisioning_service_api_version);
-  if (az_span_length(*user_agent) > 0)
+  int32_t required_length = az_span_size(client->_internal.id_scope)
+      + az_span_size(str_registrations) + az_span_size(client->_internal.registration_id)
+      + az_span_size(provisioning_service_api_version);
+  if (az_span_size(*user_agent) > 0)
   {
-    required_length += az_span_length(*user_agent) + 1;
+    required_length += az_span_size(*user_agent) + 1;
   }
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_user_name, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_user_name, required_length);
 
-  mqtt_user_name = az_span_copy(mqtt_user_name, client->_internal.id_scope);
-  mqtt_user_name = az_span_append(mqtt_user_name, str_registrations);
-  mqtt_user_name = az_span_append(mqtt_user_name, client->_internal.registration_id);
-  mqtt_user_name = az_span_append(mqtt_user_name, provisioning_service_api_version);
+  az_span remainder = az_span_copy(mqtt_user_name, client->_internal.id_scope);
+  remainder = az_span_copy(remainder, str_registrations);
+  remainder = az_span_copy(remainder, client->_internal.registration_id);
+  remainder = az_span_copy(remainder, provisioning_service_api_version);
 
-  if (az_span_length(*user_agent) > 0)
+  if (az_span_size(*user_agent) > 0)
   {
-    mqtt_user_name = az_span_append_uint8(mqtt_user_name, '&');
-    mqtt_user_name = az_span_append(mqtt_user_name, *user_agent);
+    remainder = az_span_copy_uint8(remainder, '&');
+    az_span_copy(remainder, *user_agent);
   }
 
-  *out_mqtt_user_name = mqtt_user_name;
+  *out_mqtt_user_name = az_span_slice(mqtt_user_name, 0, required_length);
 
   return AZ_OK;
 }
@@ -94,13 +94,13 @@ AZ_NODISCARD az_result az_iot_provisioning_client_id_get(
   AZ_PRECONDITION_VALID_SPAN(mqtt_client_id, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_mqtt_client_id);
 
-  int required_length = az_span_length(client->_internal.registration_id);
+  int required_length = az_span_size(client->_internal.registration_id);
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_client_id, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_client_id, required_length);
 
-  mqtt_client_id = az_span_copy(mqtt_client_id, client->_internal.registration_id);
+  az_span_copy(mqtt_client_id, client->_internal.registration_id);
 
-  *out_mqtt_client_id = mqtt_client_id;
+  *out_mqtt_client_id = az_span_slice(mqtt_client_id, 0, required_length);
 
   return AZ_OK;
 }
@@ -118,16 +118,16 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_subscribe_topic_filte
   AZ_PRECONDITION_NOT_NULL(out_mqtt_topic_filter);
 
   int32_t required_length
-      = az_span_length(str_dps) + az_span_length(str_registrations) + az_span_length(str_res) + 1;
+      = az_span_size(str_dps) + az_span_size(str_registrations) + az_span_size(str_res) + 1;
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_topic_filter, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_filter, required_length);
 
-  mqtt_topic_filter = az_span_copy(mqtt_topic_filter, str_dps);
-  mqtt_topic_filter = az_span_append(mqtt_topic_filter, str_registrations);
-  mqtt_topic_filter = az_span_append(mqtt_topic_filter, str_res);
-  mqtt_topic_filter = az_span_append_uint8(mqtt_topic_filter, '#');
+  az_span remainder = az_span_copy(mqtt_topic_filter, str_dps);
+  remainder = az_span_copy(remainder, str_registrations);
+  remainder = az_span_copy(remainder, str_res);
+  az_span_copy_uint8(remainder, '#');
 
-  *out_mqtt_topic_filter = mqtt_topic_filter;
+  *out_mqtt_topic_filter = az_span_slice(mqtt_topic_filter, 0, required_length);
 
   return AZ_OK;
 }
@@ -161,16 +161,16 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_publish_topic_get(
   AZ_PRECONDITION_VALID_SPAN(mqtt_topic, 0, false);
   AZ_PRECONDITION_NOT_NULL(out_mqtt_topic);
 
-  int32_t required_length = az_span_length(str_dps) + az_span_length(str_registrations)
-      + az_span_length(str_put_iotdps_register);
+  int32_t required_length = az_span_size(str_dps) + az_span_size(str_registrations)
+      + az_span_size(str_put_iotdps_register);
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_topic, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic, required_length);
 
-  mqtt_topic = az_span_copy(mqtt_topic, str_dps);
-  mqtt_topic = az_span_append(mqtt_topic, str_registrations);
-  mqtt_topic = az_span_append(mqtt_topic, str_put_iotdps_register);
+  az_span remainder = az_span_copy(mqtt_topic, str_dps);
+  remainder = az_span_copy(remainder, str_registrations);
+  az_span_copy(remainder, str_put_iotdps_register);
 
-  *out_mqtt_topic = mqtt_topic;
+  *out_mqtt_topic = az_span_slice(mqtt_topic, 0, required_length);
 
   return AZ_OK;
 }
@@ -190,18 +190,18 @@ AZ_NODISCARD az_result az_iot_provisioning_client_get_operation_status_publish_t
   AZ_PRECONDITION_NOT_NULL(register_response);
   AZ_PRECONDITION_VALID_SPAN(register_response->operation_id, 1, false);
 
-  int32_t required_length = az_span_length(str_dps) + az_span_length(str_registrations)
-      + az_span_length(str_get_iotdps_get_operationstatus)
-      + az_span_length(register_response->operation_id);
+  int32_t required_length = az_span_size(str_dps) + az_span_size(str_registrations)
+      + az_span_size(str_get_iotdps_get_operationstatus)
+      + az_span_size(register_response->operation_id);
 
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(mqtt_topic, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic, required_length);
 
-  mqtt_topic = az_span_copy(mqtt_topic, str_dps);
-  mqtt_topic = az_span_append(mqtt_topic, str_registrations);
-  mqtt_topic = az_span_append(mqtt_topic, str_get_iotdps_get_operationstatus);
-  mqtt_topic = az_span_append(mqtt_topic, register_response->operation_id);
+  az_span remainder = az_span_copy(mqtt_topic, str_dps);
+  remainder = az_span_copy(remainder, str_registrations);
+  remainder = az_span_copy(remainder, str_get_iotdps_get_operationstatus);
+  az_span_copy(remainder, register_response->operation_id);
 
-  *out_mqtt_topic = mqtt_topic;
+  *out_mqtt_topic = az_span_slice(mqtt_topic, 0, required_length);
 
   return AZ_OK;
 }

--- a/sdk/iot/provisioning/tests/cmocka/test_az_iot_provisioning_client.c
+++ b/sdk/iot/provisioning/tests/cmocka/test_az_iot_provisioning_client.c
@@ -40,7 +40,7 @@ static void test_az_iot_provisioning_client_default_options_get_connect_info_suc
   assert_int_equal(AZ_OK, ret);
 
   uint8_t client_id_buffer[128];
-  az_span client_id = AZ_SPAN_LITERAL_FROM_BUFFER(client_id_buffer);
+  az_span client_id = AZ_SPAN_FROM_BUFFER(client_id_buffer);
   az_span_fill(client_id, 0xCC);
 
   ret = az_iot_provisioning_client_id_get(&client, client_id, &client_id);
@@ -50,7 +50,7 @@ static void test_az_iot_provisioning_client_default_options_get_connect_info_suc
   assert_int_equal(0xCC, client_id_buffer[az_span_size(client_id)]);
 
   uint8_t username_buffer[128];
-  az_span username = AZ_SPAN_LITERAL_FROM_BUFFER(username_buffer);
+  az_span username = AZ_SPAN_FROM_BUFFER(username_buffer);
   az_span_fill(username, 0xCC);
 
   az_span expected_username
@@ -75,7 +75,7 @@ static void test_az_iot_provisioning_client_custom_options_get_username_succeed(
   assert_int_equal(AZ_OK, ret);
 
   uint8_t username_buffer[128];
-  az_span username = AZ_SPAN_LITERAL_FROM_BUFFER(username_buffer);
+  az_span username = AZ_SPAN_FROM_BUFFER(username_buffer);
   az_span_fill(username, 0xCC);
 
   az_span expected_username = AZ_SPAN_LITERAL_FROM_STR(
@@ -93,7 +93,7 @@ static void test_az_iot_provisioning_client_get_subscribe_topic_filter_succeed()
 {
   az_iot_provisioning_client client;
   uint8_t topic_buffer[128];
-  az_span topic = AZ_SPAN_LITERAL_FROM_BUFFER(topic_buffer);
+  az_span topic = AZ_SPAN_FROM_BUFFER(topic_buffer);
   az_span_fill(topic, 0xCC);
 
   az_span expected_topic = AZ_SPAN_LITERAL_FROM_STR("$dps/registrations/res/#");
@@ -109,7 +109,7 @@ static void test_az_iot_provisioning_client_get_register_publish_topic_filter_su
 {
   az_iot_provisioning_client client;
   uint8_t topic_buffer[128];
-  az_span topic = AZ_SPAN_LITERAL_FROM_BUFFER(topic_buffer);
+  az_span topic = AZ_SPAN_FROM_BUFFER(topic_buffer);
   az_span_fill(topic, 0xCC);
 
   az_span expected_topic
@@ -125,7 +125,7 @@ static void test_az_iot_provisioning_client_get_operation_status_publish_topic_f
 {
   az_iot_provisioning_client client;
   uint8_t topic_buffer[128];
-  az_span topic = AZ_SPAN_LITERAL_FROM_BUFFER(topic_buffer);
+  az_span topic = AZ_SPAN_FROM_BUFFER(topic_buffer);
   az_span_fill(topic, 0xCC);
 
   az_span expected_topic

--- a/sdk/iot/provisioning/tests/cmocka/test_az_iot_provisioning_client.c
+++ b/sdk/iot/provisioning/tests/cmocka/test_az_iot_provisioning_client.c
@@ -41,17 +41,17 @@ static void test_az_iot_provisioning_client_default_options_get_connect_info_suc
 
   uint8_t client_id_buffer[128];
   az_span client_id = AZ_SPAN_LITERAL_FROM_BUFFER(client_id_buffer);
-  az_span_set(client_id, 0xCC);
+  az_span_fill(client_id, 0xCC);
 
   ret = az_iot_provisioning_client_id_get(&client, client_id, &client_id);
   assert_int_equal(AZ_OK, ret);
   assert_memory_equal(
-      az_span_ptr(test_registration_id), az_span_ptr(client_id), (size_t)az_span_length(client_id));
-  assert_int_equal(0xCC, client_id_buffer[az_span_length(client_id)]);
+      az_span_ptr(test_registration_id), az_span_ptr(client_id), (size_t)az_span_size(client_id));
+  assert_int_equal(0xCC, client_id_buffer[az_span_size(client_id)]);
 
   uint8_t username_buffer[128];
   az_span username = AZ_SPAN_LITERAL_FROM_BUFFER(username_buffer);
-  az_span_set(username, 0xCC);
+  az_span_fill(username, 0xCC);
 
   az_span expected_username
       = AZ_SPAN_LITERAL_FROM_STR(TEST_ID_SCOPE "/registrations/" TEST_REGISTRATION_ID
@@ -60,8 +60,8 @@ static void test_az_iot_provisioning_client_default_options_get_connect_info_suc
   ret = az_iot_provisioning_client_user_name_get(&client, username, &username);
   assert_int_equal(AZ_OK, ret);
   assert_memory_equal(
-      az_span_ptr(expected_username), az_span_ptr(username), (size_t)az_span_length(username));
-  assert_int_equal(0xCC, username_buffer[az_span_length(username)]);
+      az_span_ptr(expected_username), az_span_ptr(username), (size_t)az_span_size(username));
+  assert_int_equal(0xCC, username_buffer[az_span_size(username)]);
 }
 
 static void test_az_iot_provisioning_client_custom_options_get_username_succeed()
@@ -76,7 +76,7 @@ static void test_az_iot_provisioning_client_custom_options_get_username_succeed(
 
   uint8_t username_buffer[128];
   az_span username = AZ_SPAN_LITERAL_FROM_BUFFER(username_buffer);
-  az_span_set(username, 0xCC);
+  az_span_fill(username, 0xCC);
 
   az_span expected_username = AZ_SPAN_LITERAL_FROM_STR(
       TEST_ID_SCOPE "/registrations/" TEST_REGISTRATION_ID
@@ -85,8 +85,8 @@ static void test_az_iot_provisioning_client_custom_options_get_username_succeed(
   ret = az_iot_provisioning_client_user_name_get(&client, username, &username);
   assert_int_equal(AZ_OK, ret);
   assert_memory_equal(
-      az_span_ptr(expected_username), az_span_ptr(username), (size_t)az_span_length(username));
-  assert_int_equal(0xCC, username_buffer[az_span_length(username)]);
+      az_span_ptr(expected_username), az_span_ptr(username), (size_t)az_span_size(username));
+  assert_int_equal(0xCC, username_buffer[az_span_size(username)]);
 }
 
 static void test_az_iot_provisioning_client_get_subscribe_topic_filter_succeed()
@@ -94,17 +94,15 @@ static void test_az_iot_provisioning_client_get_subscribe_topic_filter_succeed()
   az_iot_provisioning_client client;
   uint8_t topic_buffer[128];
   az_span topic = AZ_SPAN_LITERAL_FROM_BUFFER(topic_buffer);
-  az_span_set(topic, 0xCC);
+  az_span_fill(topic, 0xCC);
 
   az_span expected_topic = AZ_SPAN_LITERAL_FROM_STR("$dps/registrations/res/#");
 
   az_result ret
       = az_iot_provisioning_client_register_subscribe_topic_filter_get(&client, topic, &topic);
   assert_int_equal(AZ_OK, ret);
-  assert_memory_equal(
-      az_span_ptr(expected_topic), az_span_ptr(topic), (size_t)az_span_length(topic));
-
-  assert_int_equal(0xCC, topic_buffer[az_span_length(topic)]);
+  assert_memory_equal(az_span_ptr(expected_topic), az_span_ptr(topic), (size_t)az_span_size(topic));
+  assert_int_equal(0xCC, topic_buffer[az_span_size(topic)]);
 }
 
 static void test_az_iot_provisioning_client_get_register_publish_topic_filter_succeed()
@@ -112,16 +110,15 @@ static void test_az_iot_provisioning_client_get_register_publish_topic_filter_su
   az_iot_provisioning_client client;
   uint8_t topic_buffer[128];
   az_span topic = AZ_SPAN_LITERAL_FROM_BUFFER(topic_buffer);
-  az_span_set(topic, 0xCC);
+  az_span_fill(topic, 0xCC);
 
   az_span expected_topic
       = AZ_SPAN_LITERAL_FROM_STR("$dps/registrations/PUT/iotdps-register/?$rid=1");
 
   az_result ret = az_iot_provisioning_client_register_publish_topic_get(&client, topic, &topic);
   assert_int_equal(AZ_OK, ret);
-  assert_memory_equal(
-      az_span_ptr(expected_topic), az_span_ptr(topic), (size_t)az_span_length(topic));
-  assert_int_equal(0xCC, topic_buffer[az_span_length(topic)]);
+  assert_memory_equal(az_span_ptr(expected_topic), az_span_ptr(topic), (size_t)az_span_size(topic));
+  assert_int_equal(0xCC, topic_buffer[az_span_size(topic)]);
 }
 
 static void test_az_iot_provisioning_client_get_operation_status_publish_topic_filter_succeed()
@@ -129,7 +126,7 @@ static void test_az_iot_provisioning_client_get_operation_status_publish_topic_f
   az_iot_provisioning_client client;
   uint8_t topic_buffer[128];
   az_span topic = AZ_SPAN_LITERAL_FROM_BUFFER(topic_buffer);
-  az_span_set(topic, 0xCC);
+  az_span_fill(topic, 0xCC);
 
   az_span expected_topic
       = AZ_SPAN_LITERAL_FROM_STR("$dps/registrations/GET/iotdps-get-operationstatus/"
@@ -145,9 +142,8 @@ static void test_az_iot_provisioning_client_get_operation_status_publish_topic_f
       &client, &response, topic, &topic);
 
   assert_int_equal(AZ_OK, ret);
-  assert_memory_equal(
-      az_span_ptr(expected_topic), az_span_ptr(topic), (size_t)az_span_length(topic));
-  assert_int_equal(0xCC, topic_buffer[az_span_length(topic)]);
+  assert_memory_equal(az_span_ptr(expected_topic), az_span_ptr(topic), (size_t)az_span_size(topic));
+  assert_int_equal(0xCC, topic_buffer[az_span_size(topic)]);
 }
 
 #ifdef _MSC_VER

--- a/sdk/platform/http_client/curl/src/az_curl.c
+++ b/sdk/platform/http_client/curl/src/az_curl.c
@@ -296,7 +296,8 @@ _az_http_client_curl_send_post_request(CURL* p_curl, _az_http_request const* p_r
   char* b = (char*)az_span_ptr(body);
   az_span_to_str(b, required_length, p_request->_internal.body);
 
-  az_result res_code = _az_http_client_curl_code_to_result(curl_easy_setopt(p_curl, CURLOPT_POSTFIELDS, b));
+  az_result res_code
+      = _az_http_client_curl_code_to_result(curl_easy_setopt(p_curl, CURLOPT_POSTFIELDS, b));
   if (az_succeeded(res_code))
   {
     res_code = _az_http_client_curl_code_to_result(curl_easy_perform(p_curl));
@@ -354,7 +355,7 @@ static int32_t _az_http_client_curl_upload_read_callback(
 
   // Update the userdata span. If we already copied all content, slice will set upload_content with
   // 0 length
-  *upload_content = az_span_slice(*upload_content, size_of_copy, -1);
+  *upload_content = az_span_slice_to_end(*upload_content, size_of_copy);
 
   return size_of_copy;
 }

--- a/sdk/platform/http_client/curl/src/az_curl.c
+++ b/sdk/platform/http_client/curl/src/az_curl.c
@@ -512,7 +512,7 @@ static AZ_NODISCARD az_result _az_http_client_curl_send_request_impl_process(
 
   AZ_RETURN_IF_FAILED(_az_http_client_curl_setup_url(p_curl, p_request));
 
-  AZ_RETURN_IF_FAILED(_az_http_client_curl_setup_response_redirect(p_curl, &response));
+  AZ_RETURN_IF_FAILED(_az_http_client_curl_setup_response_redirect(p_curl, response));
 
   if (az_span_is_content_equal(p_request->_internal.method, az_http_method_get()))
   {

--- a/sdk/platform/http_client/curl/src/az_curl.c
+++ b/sdk/platform/http_client/curl/src/az_curl.c
@@ -109,7 +109,7 @@ _az_span_append_header_to_buffer(az_span writable_buffer, az_pair header, az_spa
   writable_buffer = az_span_copy(writable_buffer, header.key);
   writable_buffer = az_span_copy(writable_buffer, separator);
   writable_buffer = az_span_copy(writable_buffer, header.value);
-  az_span_copy_uint8(writable_buffer, 0);
+  az_span_copy_u8(writable_buffer, 0);
 
   return AZ_OK;
 }
@@ -209,7 +209,7 @@ _az_http_client_curl_append_url(az_span writable_buffer, az_span url_from_reques
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(writable_buffer, required_length);
 
   writable_buffer = az_span_copy(writable_buffer, url_from_request);
-  az_span_copy_uint8(writable_buffer, 0);
+  az_span_copy_u8(writable_buffer, 0);
 
   return AZ_OK;
 }
@@ -294,15 +294,12 @@ _az_http_client_curl_send_post_request(CURL* p_curl, _az_http_request const* p_r
   AZ_RETURN_IF_FAILED(_az_span_malloc(required_length, &body));
 
   char* b = (char*)az_span_ptr(body);
-  az_result res_code = az_span_to_str(b, required_length, p_request->_internal.body);
+  az_span_to_str(b, required_length, p_request->_internal.body);
 
+  az_result res_code = _az_http_client_curl_code_to_result(curl_easy_setopt(p_curl, CURLOPT_POSTFIELDS, b));
   if (az_succeeded(res_code))
   {
-    res_code = _az_http_client_curl_code_to_result(curl_easy_setopt(p_curl, CURLOPT_POSTFIELDS, b));
-    if (az_succeeded(res_code))
-    {
-      res_code = _az_http_client_curl_code_to_result(curl_easy_perform(p_curl));
-    }
+    res_code = _az_http_client_curl_code_to_result(curl_easy_perform(p_curl));
   }
 
   _az_span_free(&body);
@@ -541,7 +538,7 @@ static AZ_NODISCARD az_result _az_http_client_curl_send_request_impl_process(
   {
     AZ_RETURN_IF_NOT_ENOUGH_SIZE(response->_internal.http_response, 1);
 
-    az_span_copy_uint8(response->_internal.http_response, 0);
+    az_span_copy_u8(response->_internal.http_response, 0);
   }
   return result;
 }

--- a/sdk/platform/http_client/curl/src/az_curl.c
+++ b/sdk/platform/http_client/curl/src/az_curl.c
@@ -463,11 +463,12 @@ _az_http_client_curl_setup_url(CURL* p_curl, _az_http_request const* p_request)
   return result;
 }
 
+// TODO: Fix up the documentation here.
 /**
  * @brief set url the response redirection to user buffer
  *
- * @param p_curl specif curl structure used to send http request
- * @param response_builder an http request builder holding all http request data
+ * @param p_curl specific curl structure used to send http request
+ * @param response an http response object which will hold all the HTTP response
  * @return az_result
  */
 static AZ_NODISCARD az_result

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -105,7 +105,7 @@ int main()
     printf("Failed to reset http response (1)");
   }
 
-  az_span_set(http_response._internal.http_response, '.');
+  az_span_fill(http_response._internal.http_response, '.');
 
   /******************  GET KEY latest ver ******************************/
   az_result get_key_result = az_keyvault_keys_key_get(
@@ -123,15 +123,14 @@ int main()
   // version is still at http_response. Let's copy it to a new buffer
   uint8_t version_buf[40];
   az_span version_builder = AZ_SPAN_FROM_BUFFER(version_buf);
-  if ((az_span_capacity(version_builder) - az_span_length(version_builder))
-      < az_span_length(version))
+  if (az_span_size(version_builder) < az_span_size(version))
   {
     printf("Failed to append key version");
   }
   else
   {
-    version_builder = az_span_append(version_builder, version);
-    version = az_span_slice(version_builder, 0, az_span_length(version_builder));
+    az_span_copy(version_builder, version);
+    version = az_span_slice(version_builder, 0, az_span_size(version));
   }
 
   // Reuse response buffer for delete Key by creating a new span from response_buffer
@@ -141,7 +140,7 @@ int main()
     printf("Failed to reset http response (2)");
   }
 
-  az_span_set(response_span, '.');
+  az_span_fill(response_span, '.');
 
   /*********************  Create a new key version (use default options) *************/
   az_result const create_version_result = az_keyvault_keys_key_create(
@@ -168,7 +167,7 @@ int main()
     printf("Failed to reset http response (3)");
   }
 
-  az_span_set(response_span, '.');
+  az_span_fill(response_span, '.');
 
   /******************  GET KEY previous ver ******************************/
   az_result const get_key_prev_ver_result = az_keyvault_keys_key_get(
@@ -199,7 +198,7 @@ int main()
     printf("Failed to reset http response (4)");
   }
 
-  az_span_set(response_span, '.');
+  az_span_fill(response_span, '.');
 
   /******************  GET KEY (should return failed response ) ******************************/
   az_result get_key_again_result = az_keyvault_keys_key_get(
@@ -248,7 +247,7 @@ az_span get_key_version(az_http_response* response)
     return AZ_SPAN_NULL;
   }
   // calculate version
-  int32_t kid_length = az_span_length(k);
+  int32_t kid_length = az_span_size(k);
   az_span version = { 0 };
 
   for (int32_t index = kid_length; index > 0; --index)

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -255,7 +255,7 @@ az_span get_key_version(az_http_response* response)
 
     if (az_span_ptr(k)[index] == '/')
     {
-      version = az_span_slice(k, index + 1, -1);
+      version = az_span_slice_to_end(k, index + 1);
       break;
     }
   }

--- a/sdk/samples/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/samples/keyvault/keyvault/src/az_keyvault_client.c
@@ -143,8 +143,10 @@ AZ_NODISCARD az_result az_keyvault_keys_client_init(
   };
 
   // Copy url to client buffer so customer can re-use buffer on his/her side
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(self->_internal.uri, az_span_length(uri));
-  self->_internal.uri = az_span_copy(self->_internal.uri, uri);
+  int32_t uri_size = az_span_size(uri);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(self->_internal.uri, uri_size);
+  az_span_copy(self->_internal.uri, uri);
+  self->_internal.uri = az_span_slice(self->_internal.uri, 0, uri_size);
 
   AZ_RETURN_IF_FAILED(
       _az_credential_set_scopes(cred, AZ_SPAN_FROM_STR("https://vault.azure.net/.default")));
@@ -227,7 +229,7 @@ AZ_NODISCARD az_result _az_keyvault_keys_key_create_build_json_body(
   }
 
   AZ_RETURN_IF_FAILED(az_json_builder_append_token(&builder, az_json_token_object_end()));
-  *http_body = builder._internal.json;
+  *http_body = az_json_builder_span_get(&builder);
 
   return AZ_OK;
 }
@@ -245,8 +247,9 @@ AZ_NODISCARD az_result az_keyvault_keys_key_create(
   uint8_t url_buffer[AZ_HTTP_REQUEST_URL_BUF_SIZE];
   az_span request_url_span = AZ_SPAN_FROM_BUFFER(url_buffer);
   // copy url from client
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(request_url_span, az_span_length(client->_internal.uri));
-  request_url_span = az_span_copy(request_url_span, client->_internal.uri);
+  int32_t uri_size = az_span_size(client->_internal.uri);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(request_url_span, uri_size);
+  az_span_copy(request_url_span, client->_internal.uri);
 
   // Headers buffer
   uint8_t headers_buffer[_az_KEYVAULT_HTTP_REQUEST_HEADER_BUF_SIZE];
@@ -262,7 +265,13 @@ AZ_NODISCARD az_result az_keyvault_keys_key_create(
   // create request
   _az_http_request hrb;
   AZ_RETURN_IF_FAILED(az_http_request_init(
-      &hrb, context, az_http_method_post(), request_url_span, request_headers_span, created_body));
+      &hrb,
+      context,
+      az_http_method_post(),
+      request_url_span,
+      uri_size,
+      request_headers_span,
+      created_body));
 
   // add path to request
   AZ_RETURN_IF_FAILED(az_http_request_append_path(&hrb, az_keyvault_client_constant_for_keys()));
@@ -305,13 +314,20 @@ AZ_NODISCARD az_result az_keyvault_keys_key_get(
   uint8_t url_buffer[AZ_HTTP_REQUEST_URL_BUF_SIZE];
   az_span request_url_span = AZ_SPAN_FROM_BUFFER(url_buffer);
   // copy url from client
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(request_url_span, az_span_length(client->_internal.uri));
-  request_url_span = az_span_copy(request_url_span, client->_internal.uri);
+  int32_t uri_size = az_span_size(client->_internal.uri);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(request_url_span, uri_size);
+  az_span_copy(request_url_span, client->_internal.uri);
 
   // create request
   _az_http_request hrb;
   AZ_RETURN_IF_FAILED(az_http_request_init(
-      &hrb, context, az_http_method_get(), request_url_span, request_headers_span, AZ_SPAN_NULL));
+      &hrb,
+      context,
+      az_http_method_get(),
+      request_url_span,
+      uri_size,
+      request_headers_span,
+      AZ_SPAN_NULL));
 
   // Add path to request
   AZ_RETURN_IF_FAILED(az_http_request_append_path(&hrb, az_keyvault_client_constant_for_keys()));
@@ -320,7 +336,7 @@ AZ_NODISCARD az_result az_keyvault_keys_key_get(
   AZ_RETURN_IF_FAILED(az_http_request_append_path(&hrb, key_name));
 
   // Add key_version if requested
-  if (az_span_length(key_version) > 0)
+  if (az_span_size(key_version) > 0)
   {
     AZ_RETURN_IF_FAILED(az_http_request_append_path(&hrb, key_version));
   }
@@ -340,8 +356,9 @@ AZ_NODISCARD az_result az_keyvault_keys_key_delete(
   uint8_t url_buffer[AZ_HTTP_REQUEST_URL_BUF_SIZE];
   az_span request_url_span = AZ_SPAN_FROM_BUFFER(url_buffer);
   // copy url from client
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(request_url_span, az_span_length(client->_internal.uri));
-  request_url_span = az_span_copy(request_url_span, client->_internal.uri);
+  int32_t uri_size = az_span_size(client->_internal.uri);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(request_url_span, uri_size);
+  az_span_copy(request_url_span, client->_internal.uri);
 
   uint8_t headers_buffer[_az_KEYVAULT_HTTP_REQUEST_HEADER_BUF_SIZE];
   az_span request_headers_span = AZ_SPAN_FROM_BUFFER(headers_buffer);
@@ -354,6 +371,7 @@ AZ_NODISCARD az_result az_keyvault_keys_key_delete(
       context,
       az_http_method_delete(),
       request_url_span,
+      uri_size,
       request_headers_span,
       AZ_SPAN_NULL));
 

--- a/sdk/storage/blobs/samples/src/blobs_client_example.c
+++ b/sdk/storage/blobs/samples/src/blobs_client_example.c
@@ -34,8 +34,9 @@ az_storage_blobs_blob_download(az_storage_blobs_blob_client* client, az_http_res
   // create request buffer TODO: define size for a getKey Request
   uint8_t url_buffer[1024 * 4];
   az_span request_url_span = AZ_SPAN_FROM_BUFFER(url_buffer);
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(request_url_span, az_span_length(client->_internal.uri));
-  request_url_span = az_span_append(request_url_span, client->_internal.uri);
+  int32_t uri_size = az_span_size(client->_internal.uri);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(request_url_span, uri_size);
+  az_span_copy(request_url_span, client->_internal.uri);
 
   uint8_t headers_buffer[4 * sizeof(az_pair)];
   az_span request_headers_span = AZ_SPAN_FROM_BUFFER(headers_buffer);
@@ -48,6 +49,7 @@ az_storage_blobs_blob_download(az_storage_blobs_blob_client* client, az_http_res
       &az_context_app,
       az_http_method_get(),
       request_url_span,
+      uri_size,
       request_headers_span,
       AZ_SPAN_NULL));
 
@@ -63,8 +65,9 @@ az_storage_blobs_blob_delete(az_storage_blobs_blob_client* client, az_http_respo
   // create request buffer TODO: define size for blob delete
   uint8_t url_buffer[1024 * 4];
   az_span request_url_span = AZ_SPAN_FROM_BUFFER(url_buffer);
-  AZ_RETURN_IF_NOT_ENOUGH_CAPACITY(request_url_span, az_span_length(client->_internal.uri));
-  request_url_span = az_span_append(request_url_span, client->_internal.uri);
+  int32_t uri_size = az_span_size(client->_internal.uri);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(request_url_span, uri_size);
+  az_span_copy(request_url_span, client->_internal.uri);
 
   uint8_t headers_buffer[4 * sizeof(az_pair)];
   az_span request_headers_span = AZ_SPAN_FROM_BUFFER(headers_buffer);
@@ -77,6 +80,7 @@ az_storage_blobs_blob_delete(az_storage_blobs_blob_client* client, az_http_respo
       &az_context_app,
       az_http_method_delete(),
       request_url_span,
+      uri_size,
       request_headers_span,
       AZ_SPAN_NULL));
 

--- a/sdk/storage/blobs/src/az_storage_blobs_blob_client.c
+++ b/sdk/storage/blobs/src/az_storage_blobs_blob_client.c
@@ -9,6 +9,7 @@
 #include <az_json.h>
 #include <az_precondition.h>
 #include <az_precondition_internal.h>
+#include <az_span_internal.h>
 #include <az_storage_blobs.h>
 
 #include <stddef.h>
@@ -129,13 +130,6 @@ AZ_NODISCARD az_result az_storage_blobs_blob_client_init(
       _az_credential_set_scopes(cred, AZ_SPAN_FROM_STR("https://storage.azure.com/.default")));
 
   return AZ_OK;
-}
-
-static AZ_NODISCARD int32_t _az_span_diff(az_span new_span, az_span old_span)
-{
-  int32_t answer = az_span_size(old_span) - az_span_size(new_span);
-  AZ_PRECONDITION(answer == (int32_t)(az_span_ptr(new_span) - az_span_ptr(old_span)));
-  return answer;
 }
 
 AZ_NODISCARD az_result az_storage_blobs_blob_upload(

--- a/sdk/storage/blobs/src/az_storage_blobs_blob_client.c
+++ b/sdk/storage/blobs/src/az_storage_blobs_blob_client.c
@@ -183,7 +183,7 @@ AZ_NODISCARD az_result az_storage_blobs_blob_upload(
   az_span content_length_builder = AZ_SPAN_FROM_BUFFER(content_length);
   az_span remainder;
   AZ_RETURN_IF_FAILED(
-      az_span_copy_i64toa(content_length_builder, az_span_size(content), &remainder));
+      az_span_i64toa(content_length_builder, az_span_size(content), &remainder));
   content_length_builder
       = az_span_slice(content_length_builder, 0, _az_span_diff(remainder, content_length_builder));
 


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-for-c/pull/549

The az_span struct now matches [C++ std::span](https://en.cppreference.com/w/cpp/container/span) and [.NET’s `Span<T>`](https://docs.microsoft.com/en-us/dotnet/api/system.span-1?view=netcore-3.1).

**What changed:**
- `az_span` is now a 2-field struct (ptr, size) instead of a 3-field struct (ptr, length, capacity)
   - For the places that still needed a "builder" pattern, a length field (or parameter) got added to keep track of how much data was written into the az_span.
- `az_span_append` is gone and the remaining `az_span_append_*` functions got renamed. These now return the remainder of the destination span.
- `az_span_copy` now returns the **remainder** of the destination span (i.e. leftover empty space).
- Some `az_span` creation macros that were not useful (or were causing confusion) got removed.
- Conditionally inlining `az_span_init` when preconditions are off. Fixes https://github.com/Azure/azure-sdk-for-c/issues/557
- Rename parsing/formatting apis to be of the form `az_span_atoi32`, `az_span_atou32`, `az-span_i64toa`, etc.
- Changed `az_span_to_str` to be void returning and moved the size checks into a precondition.
- Ctrl+K/Ctrl+D clang formatting in Visual Studio on the files that I was already modifying.

**Benefits:**
1. Remove confusion between length and capacity within `az_span` APIs and in how it's used.
2. Simpler programming and mental model (common pattern is to slice the `az_span`).
3. Smaller code size to avoid bloat for use cases that don't need a `builder`.

**Questions left to consider and resolve (in subsequent PR):**
- [ ] Should we change the parse and format APIs (atoi, itoa, etc.) to require large enough destination and potentially return the bytes written/consumed?
- [x] **[done in this PR]** Remove `az_span_slice` support for -1 and add `az_span_slice_to_end` overload instead.
- [ ] Consider making the span fields public, constant, and remove the getters, if feasible.
- [ ] Consider using regular inline rather than static/force inline.
- [x] **[done in this PR]** Consider moving url_encode API to an internal where it is needed, if it is not useful across several components.
- [ ] Add more unit tests, especially around preconditions - https://github.com/Azure/azure-sdk-for-c/issues/555 / https://github.com/Azure/azure-sdk-for-c/pull/562
