### PR TITLE
Assign test set name as parameter

### DIFF
--- a/sdk/iot/core/tests/cmocka/main.c
+++ b/sdk/iot/core/tests/cmocka/main.c
@@ -14,8 +14,8 @@
 int main()
 {
   int result = 0;
-  
-  result += test_az_iot_core();
-  
+
+  result += test_az_iot_core("az_iot_core");
+
   return result;
 }

--- a/sdk/iot/core/tests/cmocka/test_az_iot_core.c
+++ b/sdk/iot/core/tests/cmocka/test_az_iot_core.c
@@ -136,11 +136,11 @@ static void test_az_iot_get_status_from_uint32(void** state)
 
 }
 
-int test_az_iot_core()
+int test_az_iot_core(char const* const test_set_name)
 {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(az_span_token_success),
     cmocka_unit_test(test_az_iot_get_status_from_uint32),
   };
-  return cmocka_run_group_tests_name("az_iot_core", tests, NULL, NULL);
+  return cmocka_run_group_tests_name(test_set_name, tests, NULL, NULL);
 }

--- a/sdk/iot/core/tests/cmocka/test_az_iot_core.h
+++ b/sdk/iot/core/tests/cmocka/test_az_iot_core.h
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-int test_az_iot_core();
+int test_az_iot_core(char const* const test_set_name);

--- a/sdk/iot/hub/tests/cmocka/main.c
+++ b/sdk/iot/hub/tests/cmocka/main.c
@@ -15,12 +15,12 @@ int main()
 {
   int result = 0;
 
-  result += test_iot_hub_c2d();
-  result += test_iot_hub_client();
-  result += test_iot_sas_token();
-  result += test_iot_hub_telemetry();
-  result += test_az_iot_hub_client_twin();
-  result += test_iot_hub_methods();
+  result += test_iot_hub_c2d("az_iot_hub_c2d");
+  result += test_iot_hub_client("az_iot_hub_client");
+  result += test_iot_sas_token("az_iot_hub_client_sas");
+  result += test_iot_hub_telemetry("az_iot_hub_client_telemetry");
+  result += test_az_iot_hub_client_twin("az_iot_hub_client_twin");
+  result += test_iot_hub_methods("az_iot_hub_methods");
 
   return result;
 }

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
@@ -862,7 +862,7 @@ static void test_az_iot_hub_client_properties_next_empty_succeed(void** state)
   assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_ERROR_EOF);
 }
 
-int test_iot_hub_client()
+int test_iot_hub_client(char const* const test_set_name)
 {
 #ifndef NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
@@ -923,5 +923,5 @@ int test_iot_hub_client()
     cmocka_unit_test(test_az_iot_hub_client_properties_next_twice_succeed),
     cmocka_unit_test(test_az_iot_hub_client_properties_next_empty_succeed),
   };
-  return cmocka_run_group_tests_name("az_iot_hub_client", tests, NULL, NULL);
+  return cmocka_run_group_tests_name(test_set_name, tests, NULL, NULL);
 }

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.h
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.h
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-int test_iot_hub_c2d();
-int test_iot_sas_token();
-int test_iot_hub_telemetry();
-int test_iot_hub_client();
-int test_az_iot_hub_client_twin();
-int test_iot_hub_methods();
+int test_iot_hub_c2d(char const* const test_set_name);
+int test_iot_sas_token(char const* const test_set_name);
+int test_iot_hub_telemetry(char const* const test_set_name);
+int test_iot_hub_client(char const* const test_set_name);
+int test_az_iot_hub_client_twin(char const* const test_set_name);
+int test_iot_hub_methods(char const* const test_set_name);

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
@@ -6,16 +6,16 @@
 #include <az_span.h>
 #include <az_test_span.h>
 
-#include <az_precondition_internal.h>
 #include <az_precondition.h>
+#include <az_precondition_internal.h>
 
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 
-#include <cmocka.h>
 #include <az_test_precondition.h>
+#include <cmocka.h>
 
 #define TEST_SPAN_BUFFER_SIZE 128
 
@@ -26,42 +26,48 @@
 static const az_span test_device_hostname = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_HOSTNAME_STR);
 static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_ID_STR);
 static char g_test_correct_subscribe_topic[] = "devices/my_device/messages/devicebound/#";
-static const az_span test_URL_DECODED_topic = AZ_SPAN_LITERAL_FROM_STR("devices/useragent_c/messages/devicebound/$.mid=79eadb01-bd0d-472d-bd35-ccb76e70eab8&$.to=/devices/useragent_c/messages/deviceBound&abc=123");
-static const az_span test_URL_ENCODED_topic = AZ_SPAN_LITERAL_FROM_STR("devices/useragent_c/messages/devicebound/%24.to=%2Fdevices%2Fuseragent_c%2Fmessages%2FdeviceBound&abc=123&ghi=%2Fsome%2Fthing&jkl=%2Fsome%2Fthing%2F%3Fbla%3Dbla");
-
+static const az_span test_URL_DECODED_topic = AZ_SPAN_LITERAL_FROM_STR(
+    "devices/useragent_c/messages/devicebound/$.mid=79eadb01-bd0d-472d-bd35-ccb76e70eab8&$.to=/"
+    "devices/useragent_c/messages/deviceBound&abc=123");
+static const az_span test_URL_ENCODED_topic
+    = AZ_SPAN_LITERAL_FROM_STR("devices/useragent_c/messages/devicebound/"
+                               "%24.to=%2Fdevices%2Fuseragent_c%2Fmessages%2FdeviceBound&abc=123&"
+                               "ghi=%2Fsome%2Fthing&jkl=%2Fsome%2Fthing%2F%3Fbla%3Dbla");
 
 #ifndef NO_PRECONDITION_CHECKING
 
 enable_precondition_check_tests()
 
-static void test_az_iot_hub_client_c2d_received_topic_parse_NULL_client_fail(void** state)
+    static void test_az_iot_hub_client_c2d_received_topic_parse_NULL_client_fail(void** state)
 {
   (void)state;
 
-  az_span received_topic = AZ_SPAN_FROM_STR("devices/useragent_c/messages/devicebound/$.mid=79eadb01-bd0d-472d-bd35-ccb76e70eab8&$.to=/devices/useragent_c/messages/deviceBound&iothub-ack=full");
+  az_span received_topic = AZ_SPAN_FROM_STR(
+      "devices/useragent_c/messages/devicebound/$.mid=79eadb01-bd0d-472d-bd35-ccb76e70eab8&$.to=/"
+      "devices/useragent_c/messages/deviceBound&iothub-ack=full");
 
   az_iot_hub_client_c2d_request out_request;
 
   assert_precondition_checked(
-    az_iot_hub_client_c2d_received_topic_parse(NULL, received_topic, &out_request)
-  );
+      az_iot_hub_client_c2d_received_topic_parse(NULL, received_topic, &out_request));
 }
 
-static void test_az_iot_hub_client_c2d_received_topic_parse_AZ_SPAN_NULL_received_topic_fail(void** state)
+static void test_az_iot_hub_client_c2d_received_topic_parse_AZ_SPAN_NULL_received_topic_fail(
+    void** state)
 {
   (void)state;
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   az_span received_topic = AZ_SPAN_NULL;
 
   az_iot_hub_client_c2d_request out_request;
 
   assert_precondition_checked(
-    az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request)
-  );
+      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request));
 }
 
 static void test_az_iot_hub_client_c2d_received_topic_parse_NULL_out_request_fail(void** state)
@@ -70,13 +76,13 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_NULL_out_request_fai
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   az_span received_topic = test_URL_DECODED_topic;
 
   assert_precondition_checked(
-    az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, NULL)
-  );
+      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, NULL));
 }
 
 // Note: c2d messages ALWAYS contain propeties (at least $.to).
@@ -95,8 +101,7 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_no_properties_fail(v
   az_iot_hub_client_c2d_request out_request;
 
   assert_precondition_checked(
-    az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request)
-  );
+      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request));
 }
 
 static void test_az_iot_hub_client_c2d_received_topic_parse_MALFORMED_fail(void** state)
@@ -114,8 +119,7 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_MALFORMED_fail(void*
   az_iot_hub_client_c2d_request out_request;
 
   assert_precondition_checked(
-    az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request)
-  );
+      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request));
 }
 
 #endif // NO_PRECONDITION_CHECKING
@@ -125,7 +129,8 @@ static void test_az_iot_hub_client_c2d_subscribe_topic_filter_get_succeed(void**
   (void)state;
 
   uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_sub_topic = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
+  az_span mqtt_sub_topic
+      = az_span_for_test_init(mqtt_sub_topic_buf, 0, _az_COUNTOF(mqtt_sub_topic_buf));
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
@@ -195,7 +200,8 @@ static void test_az_iot_hub_client_c2d_subscribe_topic_filter_get_small_buffer_f
       az_iot_hub_client_c2d_subscribe_topic_filter_get(&client, mqtt_sub_topic, &mqtt_sub_topic)
       == AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
   assert_int_equal(az_span_length(mqtt_sub_topic), 0);
-  assert_int_equal(az_span_capacity(mqtt_sub_topic), _az_COUNTOF(g_test_correct_subscribe_topic) - 2);
+  assert_int_equal(
+      az_span_capacity(mqtt_sub_topic), _az_COUNTOF(g_test_correct_subscribe_topic) - 2);
 }
 
 static void test_az_iot_hub_client_c2d_received_topic_parse_URL_DECODED_succeed(void** state)
@@ -212,16 +218,19 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_URL_DECODED_succeed(
 
   az_iot_hub_client_c2d_request out_request;
 
-  assert_return_code(az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request), AZ_OK);
+  assert_return_code(
+      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request), AZ_OK);
 
   // TODO: enable after az_iot_hub_client_properties_next() is implemented.
   // assert_return_code(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   // assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("$.mid")));
-  // assert_true(az_span_is_content_equal(pair.value, AZ_SPAN_FROM_STR("79eadb01-bd0d-472d-bd35-ccb76e70eab8")));
+  // assert_true(az_span_is_content_equal(pair.value,
+  // AZ_SPAN_FROM_STR("79eadb01-bd0d-472d-bd35-ccb76e70eab8")));
 
   // assert_return_code(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   // assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("$.to")));
-  // assert_true(az_span_is_content_equal(pair.value, AZ_SPAN_FROM_STR("/devices/useragent_c/messages/deviceBound")));
+  // assert_true(az_span_is_content_equal(pair.value,
+  // AZ_SPAN_FROM_STR("/devices/useragent_c/messages/deviceBound")));
 
   // assert_return_code(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   // assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("abc")));
@@ -242,13 +251,15 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_URL_ENCODED_succeed(
 
   az_iot_hub_client_c2d_request out_request;
 
-  assert_return_code(az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request), AZ_OK);
+  assert_return_code(
+      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request), AZ_OK);
 
   // TODO: enable after az_iot_hub_client_properties_next() is implemented.
   // assert_return_code(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   // assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("%24.to")));
-  // assert_true(az_span_is_content_equal(pair.value, AZ_SPAN_FROM_STR("%2Fdevices%2Fuseragent_c%2Fmessages%2FdeviceBound")));
-  // 
+  // assert_true(az_span_is_content_equal(pair.value,
+  // AZ_SPAN_FROM_STR("%2Fdevices%2Fuseragent_c%2Fmessages%2FdeviceBound")));
+  //
   // assert_return_code(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   // assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("abc")));
   // assert_true(az_span_is_content_equal(pair.value, AZ_SPAN_FROM_STR("123")));
@@ -259,10 +270,11 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_URL_ENCODED_succeed(
 
   // assert_return_code(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   // assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("jkl")));
-  // assert_true(az_span_is_content_equal(pair.value, AZ_SPAN_FROM_STR("%2Fsome%2Fthing%2F%3Fbla%3Dbla")));
+  // assert_true(az_span_is_content_equal(pair.value,
+  // AZ_SPAN_FROM_STR("%2Fsome%2Fthing%2F%3Fbla%3Dbla")));
 }
 
-int test_iot_hub_c2d()
+int test_iot_hub_c2d(char const* const test_set_name)
 {
 #ifndef NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
@@ -271,7 +283,8 @@ int test_iot_hub_c2d()
   const struct CMUnitTest tests[] = {
 #ifndef NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_NULL_client_fail),
-    cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_AZ_SPAN_NULL_received_topic_fail),
+    cmocka_unit_test(
+        test_az_iot_hub_client_c2d_received_topic_parse_AZ_SPAN_NULL_received_topic_fail),
     cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_NULL_out_request_fail),
     cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_no_properties_fail),
     cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_MALFORMED_fail),
@@ -282,5 +295,5 @@ int test_iot_hub_c2d()
     cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_URL_DECODED_succeed),
     cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_URL_ENCODED_succeed)
   };
-  return cmocka_run_group_tests_name("az_iot_hub_c2d", tests, NULL, NULL);
+  return cmocka_run_group_tests_name(test_set_name, tests, NULL, NULL);
 }

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
@@ -3,8 +3,8 @@
 
 #include "test_az_iot_hub_client.h"
 #include <az_iot_hub_client.h>
-#include <az_span.h>
 #include <az_result.h>
+#include <az_span.h>
 
 #include <az_precondition.h>
 #include <az_precondition_internal.h>
@@ -465,7 +465,7 @@ static void test_az_iot_hub_client_methods_received_topic_parse_response_topic_f
       == AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
-int test_iot_hub_methods()
+int test_iot_hub_methods(char const* const test_set_name)
 {
 #ifndef NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
@@ -508,5 +508,5 @@ int test_iot_hub_methods()
     cmocka_unit_test(test_az_iot_hub_client_methods_received_topic_parse_response_topic_fail)
   };
 
-  return cmocka_run_group_tests_name("az_iot_hub_methods", tests, NULL, NULL);
+  return cmocka_run_group_tests_name(test_set_name, tests, NULL, NULL);
 }

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_sas.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_sas.c
@@ -6,16 +6,16 @@
 #include <az_span.h>
 #include <az_test_span.h>
 
-#include <az_precondition_internal.h>
 #include <az_precondition.h>
+#include <az_precondition_internal.h>
 
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
 
-#include <cmocka.h>
 #include <az_test_precondition.h>
+#include <cmocka.h>
 
 #define TEST_SPAN_BUFFER_SIZE 256
 
@@ -30,9 +30,9 @@
 
 enable_precondition_check_tests()
 
-// Tests
+    // Tests
 
-static void az_iot_sas_token_get_document_NULL_document_fails(void** state)
+    static void az_iot_sas_token_get_document_NULL_document_fails(void** state)
 {
   (void)state;
   az_span iothub_fqdn = AZ_SPAN_FROM_STR(TEST_FQDN);
@@ -41,8 +41,7 @@ static void az_iot_sas_token_get_document_NULL_document_fails(void** state)
   az_span document = AZ_SPAN_NULL;
 
   assert_precondition_checked(
-    az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, NULL)
-  );
+      az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, NULL));
 }
 
 static void az_iot_sas_token_get_document_NULL_document_span_fails(void** state)
@@ -55,8 +54,7 @@ static void az_iot_sas_token_get_document_NULL_document_span_fails(void** state)
   az_span document = AZ_SPAN_NULL;
 
   assert_precondition_checked(
-    az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document)
-  );
+      az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document));
 }
 
 static void az_iot_sas_token_get_document_empty_device_id_fails(void** state)
@@ -70,8 +68,7 @@ static void az_iot_sas_token_get_document_empty_device_id_fails(void** state)
   az_span document = az_span_init(raw_document, 0, _az_COUNTOF(raw_document));
 
   assert_precondition_checked(
-    az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document)
-  );
+      az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document));
 }
 
 static void az_iot_sas_token_get_document_empty_iothub_fqdn_fails(void** state)
@@ -85,8 +82,7 @@ static void az_iot_sas_token_get_document_empty_iothub_fqdn_fails(void** state)
   az_span document = az_span_init(raw_document, 0, _az_COUNTOF(raw_document));
 
   assert_precondition_checked(
-    az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document)
-  );
+      az_iot_sas_token_get_document(iothub_fqdn, device_id, expiry_time_secs, document, &document));
 }
 
 static void az_iot_sas_token_generate_empty_device_id_fails(void** state)
@@ -101,9 +97,8 @@ static void az_iot_sas_token_generate_empty_device_id_fails(void** state)
   uint8_t raw_sas_token[TEST_SPAN_BUFFER_SIZE];
   az_span sas_token = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
 
-  assert_precondition_checked(
-    az_iot_sas_token_generate(iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)
-  );
+  assert_precondition_checked(az_iot_sas_token_generate(
+      iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token));
 }
 
 static void az_iot_sas_token_generate_empty_iothub_fqdn_fails(void** state)
@@ -118,9 +113,8 @@ static void az_iot_sas_token_generate_empty_iothub_fqdn_fails(void** state)
   uint8_t raw_sas_token[TEST_SPAN_BUFFER_SIZE];
   az_span sas_token = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
 
-  assert_precondition_checked(
-    az_iot_sas_token_generate(iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)
-  );
+  assert_precondition_checked(az_iot_sas_token_generate(
+      iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token));
 }
 
 static void az_iot_sas_token_generate_EMPTY_signature_fails(void** state)
@@ -135,9 +129,8 @@ static void az_iot_sas_token_generate_EMPTY_signature_fails(void** state)
   uint8_t raw_sas_token[TEST_SPAN_BUFFER_SIZE];
   az_span sas_token = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
 
-  assert_precondition_checked(
-    az_iot_sas_token_generate(iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)
-  );
+  assert_precondition_checked(az_iot_sas_token_generate(
+      iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token));
 }
 
 static void az_iot_sas_token_generate_NULL_sas_token_span_fails(void** state)
@@ -151,9 +144,8 @@ static void az_iot_sas_token_generate_NULL_sas_token_span_fails(void** state)
 
   az_span sas_token = AZ_SPAN_NULL;
 
-  assert_precondition_checked(
-    az_iot_sas_token_generate(iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token)
-  );
+  assert_precondition_checked(az_iot_sas_token_generate(
+      iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, &sas_token));
 }
 
 static void az_iot_sas_token_generate_NULL_out_sas_token_fails(void** state)
@@ -168,9 +160,8 @@ static void az_iot_sas_token_generate_NULL_out_sas_token_fails(void** state)
   uint8_t raw_sas_token[TEST_SPAN_BUFFER_SIZE];
   az_span sas_token = az_span_init(raw_sas_token, 0, _az_COUNTOF(raw_sas_token));
 
-  assert_precondition_checked(
-       az_iot_sas_token_generate(iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, NULL)
-  );
+  assert_precondition_checked(az_iot_sas_token_generate(
+      iothub_fqdn, device_id, signature, expiry_time_secs, key_name, sas_token, NULL));
 }
 
 #endif // NO_PRECONDITION_CHECKING
@@ -190,7 +181,7 @@ static void az_iot_sas_token_get_document_succeeds(void** state)
   assert_true(az_succeeded(az_iot_sas_token_get_document(
       iothub_fqdn, device_id, expiry_time_secs, document, &document)));
   az_span_for_test_verify(
-      document, expected_document,(int32_t)strlen(expected_document), TEST_SPAN_BUFFER_SIZE);
+      document, expected_document, (int32_t)strlen(expected_document), TEST_SPAN_BUFFER_SIZE);
 }
 
 static void az_iot_sas_token_generate_succeeds(void** state)
@@ -236,7 +227,8 @@ static void az_iot_sas_token_generate_with_keyname_succeeds(void** state)
       sas_token, expected_sas_token, (int32_t)strlen(expected_sas_token), TEST_SPAN_BUFFER_SIZE);
 }
 
-// Conditions like buffer (i.e., az_span) capacity are not covered by pre-conditions, so these tests are always mandatory.
+// Conditions like buffer (i.e., az_span) capacity are not covered by pre-conditions, so these tests
+// are always mandatory.
 static void az_iot_sas_token_generate_sas_token_overflow_fails(void** state)
 {
   (void)state;
@@ -255,7 +247,8 @@ static void az_iot_sas_token_generate_sas_token_overflow_fails(void** state)
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
-// Conditions like buffer (i.e., az_span) capacity are not covered by pre-conditions, so these tests are always mandatory.
+// Conditions like buffer (i.e., az_span) capacity are not covered by pre-conditions, so these tests
+// are always mandatory.
 static void az_iot_sas_token_get_document_document_overflow_fails(void** state)
 {
   (void)state;
@@ -271,7 +264,7 @@ static void az_iot_sas_token_get_document_document_overflow_fails(void** state)
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
-int test_iot_sas_token()
+int test_iot_sas_token(char const* const test_set_name)
 {
 #ifndef NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
@@ -295,5 +288,5 @@ int test_iot_sas_token()
     cmocka_unit_test(az_iot_sas_token_generate_sas_token_overflow_fails),
     cmocka_unit_test(az_iot_sas_token_get_document_document_overflow_fails)
   };
-  return cmocka_run_group_tests_name("az_iot_hub_client_sas", tests, NULL, NULL);
+  return cmocka_run_group_tests_name(test_set_name, tests, NULL, NULL);
 }

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -330,7 +330,7 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_p
       _az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 2);
 }
 
-int test_iot_hub_telemetry()
+int test_iot_hub_telemetry(char const* const test_set_name)
 {
 #ifndef NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
@@ -361,5 +361,5 @@ int test_iot_hub_telemetry()
         test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_props_small_buffer_fails),
   };
 
-  return cmocka_run_group_tests_name("az_iot_hub_client_telemetry", tests, NULL, NULL);
+  return cmocka_run_group_tests_name(test_set_name, tests, NULL, NULL);
 }

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
@@ -558,7 +558,7 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_small_buffer_fai
       az_span_capacity(test_span), _az_COUNTOF(test_correct_twin_patch_pub_topic) - 2);
 }
 
-int test_az_iot_hub_client_twin()
+int test_az_iot_hub_client_twin(char const* const test_set_name)
 {
 #ifndef NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
@@ -600,5 +600,5 @@ int test_az_iot_hub_client_twin()
     cmocka_unit_test(test_az_iot_hub_client_twin_patch_publish_topic_get_small_buffer_fails),
   };
 
-  return cmocka_run_group_tests_name("az_iot_hub_client_twin", tests, NULL, NULL);
+  return cmocka_run_group_tests_name(test_set_name, tests, NULL, NULL);
 }

--- a/sdk/iot/pnp/tests/cmocka/main.c
+++ b/sdk/iot/pnp/tests/cmocka/main.c
@@ -15,8 +15,8 @@ int main()
 {
   int result = 0;
 
-  result += test_iot_pnp_client();
-  result += test_iot_pnp_telemetry();
+  result += test_iot_pnp_client("az_iot_pnp_client");
+  result += test_iot_pnp_telemetry("az_iot_pnp_client_telemetry");
 
   return result;
 }

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
@@ -144,7 +144,9 @@ static void test_az_iot_pnp_client_get_user_name_succeed(void** state)
 
   assert_int_equal(az_span_length(test_span), _az_COUNTOF(test_correct_pnp_user_name) - 1);
   assert_memory_equal(
-      test_correct_pnp_user_name, az_span_ptr(test_span), _az_COUNTOF(test_correct_pnp_user_name) - 1);
+      test_correct_pnp_user_name,
+      az_span_ptr(test_span),
+      _az_COUNTOF(test_correct_pnp_user_name) - 1);
 }
 
 static void test_az_iot_pnp_client_get_user_name_small_buffer_fail(void** state)
@@ -217,7 +219,7 @@ static void test_az_iot_pnp_client_get_user_name_user_options_small_buffer_fail(
 // merge if guidance is available.  Otherwise will open separate GitHub bug to not block merge
 // and record number here.
 
-int test_iot_pnp_client()
+int test_iot_pnp_client(char const* const test_set_name)
 {
 #ifndef NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
@@ -238,6 +240,5 @@ int test_iot_pnp_client()
     cmocka_unit_test(test_az_iot_pnp_client_get_user_name_user_options_succeed),
     cmocka_unit_test(test_az_iot_pnp_client_get_user_name_user_options_small_buffer_fail),
   };
-  return cmocka_run_group_tests_name("az_iot_pnp_client", tests, NULL, NULL);
+  return cmocka_run_group_tests_name(test_set_name, tests, NULL, NULL);
 }
-

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.h
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.h
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-int test_iot_pnp_client();
-int test_iot_pnp_telemetry();
+int test_iot_pnp_client(char const* const test_set_name);
+int test_iot_pnp_telemetry(char const* const test_set_name);

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
@@ -336,7 +336,7 @@ test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_and_encoding_wit
       AZ_ERROR_INSUFFICIENT_SPAN_CAPACITY);
 }
 
-int test_iot_pnp_telemetry()
+int test_iot_pnp_telemetry(char const* const test_set_name)
 {
 #ifndef NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
@@ -363,5 +363,5 @@ int test_iot_pnp_telemetry()
     cmocka_unit_test(
         test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_and_encoding_with_small_buffer_fails),
   };
-  return cmocka_run_group_tests_name("az_iot_pnp_client", tests, NULL, NULL);
+  return cmocka_run_group_tests_name(test_set_name, tests, NULL, NULL);
 }

--- a/sdk/iot/provisioning/tests/cmocka/main.c
+++ b/sdk/iot/provisioning/tests/cmocka/main.c
@@ -14,9 +14,9 @@
 int main()
 {
   int result = 0;
-  
-  result += test_az_iot_provisioning_client();
-  result += test_az_iot_provisioning_client_register();
+
+  result += test_az_iot_provisioning_client("az_iot_provisioning_client");
+  result += test_az_iot_provisioning_client_register("az_iot_provisioning_client_register");
 
   return result;
 }

--- a/sdk/iot/provisioning/tests/cmocka/test_az_iot_provisioning_client.c
+++ b/sdk/iot/provisioning/tests/cmocka/test_az_iot_provisioning_client.c
@@ -155,7 +155,7 @@ static void test_az_iot_provisioning_client_get_operation_status_publish_topic_f
 #pragma warning(disable : 4113)
 #endif
 
-int test_az_iot_provisioning_client()
+int test_az_iot_provisioning_client(char const* const test_set_name)
 {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_az_iot_provisioning_client_options_default_succeed),
@@ -167,5 +167,5 @@ int test_az_iot_provisioning_client()
         test_az_iot_provisioning_client_get_operation_status_publish_topic_filter_succeed),
   };
 
-  return cmocka_run_group_tests_name("az_iot_provisioning_client", tests, NULL, NULL);
+  return cmocka_run_group_tests_name(test_set_name, tests, NULL, NULL);
 }

--- a/sdk/iot/provisioning/tests/cmocka/test_az_iot_provisioning_client.h
+++ b/sdk/iot/provisioning/tests/cmocka/test_az_iot_provisioning_client.h
@@ -3,5 +3,5 @@
 
 // Placeholder for int test_iot_provisioning_(); declarations
 
-int test_az_iot_provisioning_client();
-int test_az_iot_provisioning_client_register();
+int test_az_iot_provisioning_client(char const* const test_set_name);
+int test_az_iot_provisioning_client_register(char const* const test_set_name);

--- a/sdk/iot/provisioning/tests/cmocka/test_az_iot_provisioning_client_register.c
+++ b/sdk/iot/provisioning/tests/cmocka/test_az_iot_provisioning_client_register.c
@@ -12,17 +12,16 @@
 
 #include <cmocka.h>
 
-
 static void test_az_iot_provisioning_client_register_publish_topic_get_succeed(void** state)
 {
   (void)state;
 }
 
-int test_az_iot_provisioning_client_register()
+int test_az_iot_provisioning_client_register(char const* const test_set_name)
 {
   const struct CMUnitTest tests[] = {
-       cmocka_unit_test(test_az_iot_provisioning_client_register_publish_topic_get_succeed),
+    cmocka_unit_test(test_az_iot_provisioning_client_register_publish_topic_get_succeed),
   };
 
-  return cmocka_run_group_tests_name("az_iot_provisioning_client_register", tests, NULL, NULL);
+  return cmocka_run_group_tests_name(test_set_name, tests, NULL, NULL);
 }


### PR DESCRIPTION
created issue: https://github.com/Azure/azure-sdk-for-c/issues/586

Instead of just changing the name, I am suggesting to use test set name as parameter so we can easily detect a duplicated test set name is used, since currently it can get hidden.