### PR TITLE
pass az_span lenght to scan until function

### DIFF
--- a/sdk/core/core/src/az_http_request.c
+++ b/sdk/core/core/src/az_http_request.c
@@ -34,7 +34,7 @@ AZ_NODISCARD az_result az_http_request_init(
   AZ_PRECONDITION_VALID_SPAN(headers_buffer, 0, false);
 
   int32_t query_start = 0;
-  az_result url_with_query = _az_scan_until(url, _az_is_question_mark, &query_start);
+  az_result url_with_query = _az_scan_until(url, url_length, _az_is_question_mark, &query_start);
 
   *p_request
       = (_az_http_request){ ._internal = {

--- a/sdk/core/core/src/az_http_request.c
+++ b/sdk/core/core/src/az_http_request.c
@@ -34,7 +34,8 @@ AZ_NODISCARD az_result az_http_request_init(
   AZ_PRECONDITION_VALID_SPAN(headers_buffer, 0, false);
 
   int32_t query_start = 0;
-  az_result url_with_query = _az_scan_until(url, url_length, _az_is_question_mark, &query_start);
+  az_result url_with_query = _az_span_scan_until(
+      az_span_init(az_span_ptr(url), url_length), _az_is_question_mark, &query_start);
 
   *p_request
       = (_az_http_request){ ._internal = {

--- a/sdk/core/core/src/az_http_response.c
+++ b/sdk/core/core/src/az_http_response.c
@@ -95,7 +95,7 @@ _az_get_http_status_line(az_span* self, az_http_response_status_line* out_status
   // HTAB = "\t"
   // VCHAR or obs-text is %x21-FF,
   int32_t offset = 0;
-  AZ_RETURN_IF_FAILED(_az_scan_until(*self, _az_is_new_line, &offset));
+  AZ_RETURN_IF_FAILED(_az_scan_until(*self, az_span_size(*self), _az_is_new_line, &offset));
 
   // save reason-phrase in status line now that we got the offset. Remove 1 last chars(\r)
   out_status_line->reason_phrase = az_span_slice(*self, 0, offset - 1);
@@ -170,7 +170,8 @@ az_http_response_get_next_header(az_http_response* response, az_pair* out_header
     //         "_" / "`" / "|" / "~" / DIGIT / ALPHA;
     // any VCHAR,
     //    except delimiters
-    AZ_RETURN_IF_FAILED(_az_scan_until(*reader, _az_is_a_colon, &field_name_length));
+    AZ_RETURN_IF_FAILED(
+        _az_scan_until(*reader, az_span_size(*reader), _az_is_a_colon, &field_name_length));
 
     // form a header name. Reader is currently at char ':'
     out_header->key = az_span_slice(*reader, 0, field_name_length);
@@ -179,7 +180,8 @@ az_http_response_get_next_header(az_http_response* response, az_pair* out_header
 
     // OWS
     int32_t ows_len = 0;
-    AZ_RETURN_IF_FAILED(_az_scan_until(*reader, _az_slice_is_not_http_whitespace, &ows_len));
+    AZ_RETURN_IF_FAILED(
+        _az_scan_until(*reader, az_span_size(*reader), _az_slice_is_not_http_whitespace, &ows_len));
     *reader = az_span_slice_to_end(*reader, ows_len);
   }
   // field-value    = *( field-content / obs-fold )

--- a/sdk/core/core/src/az_http_response.c
+++ b/sdk/core/core/src/az_http_response.c
@@ -95,7 +95,7 @@ _az_get_http_status_line(az_span* self, az_http_response_status_line* out_status
   // HTAB = "\t"
   // VCHAR or obs-text is %x21-FF,
   int32_t offset = 0;
-  AZ_RETURN_IF_FAILED(_az_scan_until(*self, az_span_size(*self), _az_is_new_line, &offset));
+  AZ_RETURN_IF_FAILED(_az_span_scan_until(*self, _az_is_new_line, &offset));
 
   // save reason-phrase in status line now that we got the offset. Remove 1 last chars(\r)
   out_status_line->reason_phrase = az_span_slice(*self, 0, offset - 1);
@@ -170,8 +170,7 @@ az_http_response_get_next_header(az_http_response* response, az_pair* out_header
     //         "_" / "`" / "|" / "~" / DIGIT / ALPHA;
     // any VCHAR,
     //    except delimiters
-    AZ_RETURN_IF_FAILED(
-        _az_scan_until(*reader, az_span_size(*reader), _az_is_a_colon, &field_name_length));
+    AZ_RETURN_IF_FAILED(_az_span_scan_until(*reader, _az_is_a_colon, &field_name_length));
 
     // form a header name. Reader is currently at char ':'
     out_header->key = az_span_slice(*reader, 0, field_name_length);
@@ -180,8 +179,7 @@ az_http_response_get_next_header(az_http_response* response, az_pair* out_header
 
     // OWS
     int32_t ows_len = 0;
-    AZ_RETURN_IF_FAILED(
-        _az_scan_until(*reader, az_span_size(*reader), _az_slice_is_not_http_whitespace, &ows_len));
+    AZ_RETURN_IF_FAILED(_az_span_scan_until(*reader, _az_slice_is_not_http_whitespace, &ows_len));
     *reader = az_span_slice_to_end(*reader, ows_len);
   }
   // field-value    = *( field-content / obs-fold )

--- a/sdk/core/core/src/az_span.c
+++ b/sdk/core/core/src/az_span.c
@@ -649,9 +649,10 @@ AZ_NODISCARD az_result _az_is_expected_span(az_span* self, az_span expected)
 
 // PRIVATE. read until condition is true on character.
 // Then return number of positions read with output parameter
-AZ_NODISCARD az_result _az_scan_until(az_span self, _az_predicate predicate, int32_t* out_index)
+AZ_NODISCARD az_result
+_az_scan_until(az_span self, int32_t current_size, _az_predicate predicate, int32_t* out_index)
 {
-  for (int32_t index = 0; index < az_span_size(self); ++index)
+  for (int32_t index = 0; index < current_size; ++index)
   {
     az_span s = az_span_slice_to_end(self, index);
     az_result predicate_result = predicate(s);

--- a/sdk/core/core/src/az_span.c
+++ b/sdk/core/core/src/az_span.c
@@ -650,9 +650,9 @@ AZ_NODISCARD az_result _az_is_expected_span(az_span* self, az_span expected)
 // PRIVATE. read until condition is true on character.
 // Then return number of positions read with output parameter
 AZ_NODISCARD az_result
-_az_scan_until(az_span self, int32_t current_size, _az_predicate predicate, int32_t* out_index)
+_az_span_scan_until(az_span self, _az_predicate predicate, int32_t* out_index)
 {
-  for (int32_t index = 0; index < current_size; ++index)
+  for (int32_t index = 0; index < az_span_size(self); ++index)
   {
     az_span s = az_span_slice_to_end(self, index);
     az_result predicate_result = predicate(s);

--- a/sdk/core/core/src/az_span_private.h
+++ b/sdk/core/core/src/az_span_private.h
@@ -46,7 +46,8 @@ typedef az_result (*_az_predicate)(az_span slice);
 
 // PRIVATE. read until condition is true on character.
 // Then return number of positions read with output parameter
-AZ_NODISCARD az_result _az_scan_until(az_span self, _az_predicate predicate, int32_t* out_index);
+AZ_NODISCARD az_result
+_az_scan_until(az_span self, int32_t current_size, _az_predicate predicate, int32_t* out_index);
 
 AZ_NODISCARD az_result _az_is_expected_span(az_span* self, az_span expected);
 

--- a/sdk/core/core/src/az_span_private.h
+++ b/sdk/core/core/src/az_span_private.h
@@ -47,7 +47,7 @@ typedef az_result (*_az_predicate)(az_span slice);
 // PRIVATE. read until condition is true on character.
 // Then return number of positions read with output parameter
 AZ_NODISCARD az_result
-_az_scan_until(az_span self, int32_t current_size, _az_predicate predicate, int32_t* out_index);
+_az_span_scan_until(az_span self, _az_predicate predicate, int32_t* out_index);
 
 AZ_NODISCARD az_result _az_is_expected_span(az_span* self, az_span expected);
 


### PR DESCRIPTION
fixes: https://github.com/Azure/azure-sdk-for-c/issues/594

make _az_scan_until(..) have an extra parameter with the lenght of the az_span (just like it is done on az_span_replace(....)