### PR TITLE
Documentation generation ignores az_ prefix

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1152,7 +1152,7 @@ COLS_IN_ALPHA_INDEX    = 5
 # while generating the index headers.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
-IGNORE_PREFIX          =
+IGNORE_PREFIX          = az_
 
 #---------------------------------------------------------------------------
 # Configuration options related to the HTML output

--- a/Doxyfile
+++ b/Doxyfile
@@ -1152,7 +1152,7 @@ COLS_IN_ALPHA_INDEX    = 5
 # while generating the index headers.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
-IGNORE_PREFIX          = az_
+IGNORE_PREFIX          = az_ AZ_
 
 #---------------------------------------------------------------------------
 # Configuration options related to the HTML output

--- a/eng/docs/api/Doxyfile.template
+++ b/eng/docs/api/Doxyfile.template
@@ -1168,7 +1168,7 @@ COLS_IN_ALPHA_INDEX    = 5
 # while generating the index headers.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
-IGNORE_PREFIX          = az_
+IGNORE_PREFIX          = az_ AZ_
 
 #---------------------------------------------------------------------------
 # Configuration options related to the HTML output

--- a/eng/docs/api/Doxyfile.template
+++ b/eng/docs/api/Doxyfile.template
@@ -1168,7 +1168,7 @@ COLS_IN_ALPHA_INDEX    = 5
 # while generating the index headers.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
-IGNORE_PREFIX          =
+IGNORE_PREFIX          = az_
 
 #---------------------------------------------------------------------------
 # Configuration options related to the HTML output


### PR DESCRIPTION
Currently: everything is sorted under "a" because our public items mostly have az_ as the prefix. 

With this change: documentation generation ignores the az_ prefix so we get better sorting
![image](https://user-images.githubusercontent.com/2158838/79807923-20763a80-8321-11ea-99b0-9862b18696d0.png)
