### PR TITLE
Change IoT API's to use char* and int instead of span

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ if(NOT DEFINED ENV{AZ_SDK_C_NO_SAMPLES})
   add_subdirectory(sdk/samples/keyvault/keyvault/samples)
   add_subdirectory(sdk/storage/blobs/samples)
   if(BUILD_PAHO_TRANSPORT)
-    add_subdirectory(sdk/iot/provisioning/samples)
+    # add_subdirectory(sdk/iot/provisioning/samples)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ if(NOT DEFINED ENV{AZ_SDK_C_NO_SAMPLES})
   add_subdirectory(sdk/samples/keyvault/keyvault/samples)
   add_subdirectory(sdk/storage/blobs/samples)
   if(BUILD_PAHO_TRANSPORT)
-    # add_subdirectory(sdk/iot/provisioning/samples)
+    add_subdirectory(sdk/iot/provisioning/samples)
   endif()
 endif()
 

--- a/sdk/iot/README.md
+++ b/sdk/iot/README.md
@@ -16,7 +16,7 @@ TBD
 
 To use IoT Hub connectivity, the first action by a developer should be to initialize the
 client with the `az_iot_hub_client_init()` API. Once that is initialized, you may use the
-`az_iot_hub_client_user_name_get()` and `az_iot_hub_client_client_id_get()` to get the
+`az_iot_hub_client_get_user_name()` and `az_iot_hub_client_client_id_get()` to get the
 user name and client id to establish a connection with IoT Hub.
 
 An example use case is below.
@@ -45,7 +45,7 @@ int main()
   az_iot_hub_client_init(&my_client, my_iothub_hostname, my_device_id, &options);
 
   //Get the MQTT user name to connect
-  az_iot_hub_client_user_name_get(&my_client, my_mqtt_user_name, 
+  az_iot_hub_client_get_user_name(&my_client, my_mqtt_user_name, 
                 sizeof(my_mqtt_user_name), &my_mqtt_user_name_length);
 
   //Get the MQTT client id to connect

--- a/sdk/iot/README.md
+++ b/sdk/iot/README.md
@@ -16,7 +16,7 @@ TBD
 
 To use IoT Hub connectivity, the first action by a developer should be to initialize the
 client with the `az_iot_hub_client_init()` API. Once that is initialized, you may use the
-`az_iot_hub_client_get_user_name()` and `az_iot_hub_client_client_id_get()` to get the
+`az_iot_hub_client_get_user_name()` and `az_iot_hub_client_get_client_id()` to get the
 user name and client id to establish a connection with IoT Hub.
 
 An example use case is below.
@@ -49,7 +49,7 @@ int main()
                 sizeof(my_mqtt_user_name), &my_mqtt_user_name_length);
 
   //Get the MQTT client id to connect
-  az_iot_hub_client_client_id_get(&my_client, my_mqtt_client_id, 
+  az_iot_hub_client_get_client_id(&my_client, my_mqtt_client_id, 
                 sizeof(my_mqtt_client_id), &my_mqtt_client_id_length);
 
   //At this point you are free to use my_mqtt_client_id and my_mqtt_user_name to connect using

--- a/sdk/iot/README.md
+++ b/sdk/iot/README.md
@@ -29,12 +29,12 @@ static az_span my_iothub_hostname = AZ_SPAN_LITERAL_FROM_STR("constoso.azure-dev
 static az_span my_device_id = AZ_SPAN_LITERAL_FROM_STR("contoso_device");
 
 //Make sure to size the buffer to fit the user name (100 is an example)
-static uint8_t my_mqtt_user_name_buffer[100];
-static az_span my_mqtt_user_name = AZ_SPAN_LITERAL_FROM_BUFFER(my_mqtt_user_name_buffer);
+static char my_mqtt_user_name[100];
+static size_t my_mqtt_user_name_length;
 
 //Make sure to size the buffer to fit the client id (16 is an example)
-static uint8_t my_mqtt_client_id_buffer[16];
-static az_span my_mqtt_client_id = AZ_SPAN_LITERAL_FROM_BUFFER(my_mqtt_client_id_buffer);
+static char my_mqtt_client_id_buffer[16];
+static size_t my_mqtt_client_id_length;
 
 int main()
 {
@@ -45,10 +45,12 @@ int main()
   az_iot_hub_client_init(&my_client, my_iothub_hostname, my_device_id, &options);
 
   //Get the MQTT user name to connect
-  az_iot_hub_client_user_name_get(&my_client, my_mqtt_user_name, &my_mqtt_user_name)
+  az_iot_hub_client_user_name_get(&my_client, my_mqtt_user_name, 
+                sizeof(my_mqtt_user_name), &my_mqtt_user_name_length);
 
   //Get the MQTT client id to connect
-  az_iot_hub_client_client_id_get(&my_client, my_mqtt_client_id, &my_mqtt_client_id);
+  az_iot_hub_client_client_id_get(&my_client, my_mqtt_client_id, 
+                sizeof(my_mqtt_client_id), &my_mqtt_client_id_length);
 
   //At this point you are free to use my_mqtt_client_id and my_mqtt_user_name to connect using
   //your MQTT client.
@@ -108,15 +110,13 @@ void my_telemetry_func()
   //Initialize the client to then pass to the telemetry API
   az_iot_hub_client_init(&my_client, my_iothub_hostname, my_device_id, NULL);
 
-  //Allocate a span with capacity large enough to put the telemetry topic.
-  //Optionally, the size can include space for a null terminator.
-  //Here, the buffer is zero initialized to null terminate the topic.
-  uint8_t telemetry_topic_buffer[64] = { 0 };
-  az_span topic_span = az_span_init(telemetry_topic_buffer,
-                sizeof(telemetry_topic_buffer) / sizeof(telemetry_topic_buffer[0]));
+  //Allocate a char buffer with capacity large enough to put the telemetry topic.
+  char telemetry_topic[64];
+  size_t telemetry_topic_length;
 
-  //Get the NULL terminated topic and put in topic_span to send the telemetry
-  az_iot_hub_client_telemetry_get_publish_topic(&my_client, NULL, topic_span, &topic_span);
+  //Get the NULL terminated topic and put in telemetry_topic to send the telemetry
+  az_iot_hub_client_telemetry_get_publish_topic(&my_client, NULL, telemetry_topic, 
+                                    sizeof(telemetry_topic), &telemetry_topic_length);
 }
 ```
 

--- a/sdk/iot/README.md
+++ b/sdk/iot/README.md
@@ -94,7 +94,7 @@ void my_property_func()
 
 ### Telemetry
 
-Telemetry functionality can be achieved by sending a user payload to a specific topic. In order to get the appropriate topic to which to send, use the `az_iot_hub_client_telemetry_publish_topic_get()` API. An example use case is below.
+Telemetry functionality can be achieved by sending a user payload to a specific topic. In order to get the appropriate topic to which to send, use the `az_iot_hub_client_telemetry_get_publish_topic()` API. An example use case is below.
 
 ```C
 //FOR SIMPLICITY THIS DOES NOT HAVE ERROR CHECKING. IN PRODUCTION ENSURE PROPER ERROR CHECKING.
@@ -116,7 +116,7 @@ void my_telemetry_func()
                 sizeof(telemetry_topic_buffer) / sizeof(telemetry_topic_buffer[0]));
 
   //Get the NULL terminated topic and put in topic_span to send the telemetry
-  az_iot_hub_client_telemetry_publish_topic_get(&my_client, NULL, topic_span, &topic_span);
+  az_iot_hub_client_telemetry_get_publish_topic(&my_client, NULL, topic_span, &topic_span);
 }
 ```
 

--- a/sdk/iot/doc/mqtt_state_machine.md
+++ b/sdk/iot/doc/mqtt_state_machine.md
@@ -132,7 +132,7 @@ _Example:_
         switch (twin_response.response_type)
         {
             case AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_GET:
-                // This is a response to a az_iot_hub_client_twin_get_get_publish_topic.
+                // This is a response to a az_iot_hub_client_twin_document_get_publish_topic.
                 break;
             case AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES:
                 // This is received as the Twin desired properties were changed using the service client.

--- a/sdk/iot/doc/mqtt_state_machine.md
+++ b/sdk/iot/doc/mqtt_state_machine.md
@@ -124,7 +124,7 @@ _Example:_
     {
         // This is a Method request:
         //  method_request.name contains the method
-        //  method_request.request_id contains the request ID that must be used to submit the response using az_iot_hub_client_methods_get_response_publish_topic()
+        //  method_request.request_id contains the request ID that must be used to submit the response using az_iot_hub_client_methods_response_get_publish_topic()
     }
     else if (az_succeeded(ret = az_iot_hub_client_twin_parse_received_topic(client, received_topic, &twin_response)))
     {
@@ -138,7 +138,7 @@ _Example:_
                 // This is received as the Twin desired properties were changed using the service client.
                 break;
             case AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES:
-                // This is a response received after patching the reported properties using az_iot_hub_client_twin_get_patch_publish_topic().
+                // This is a response received after patching the reported properties using az_iot_hub_client_twin_patch_get_publish_topic().
                 break;
             default:
                 // error.

--- a/sdk/iot/doc/mqtt_state_machine.md
+++ b/sdk/iot/doc/mqtt_state_machine.md
@@ -93,7 +93,7 @@ The application is responsible for filling in the MQTT payload with the format e
 _Example:_
 
 ```C
-if(az_failed(az_iot_hub_client_telemetry_publish_topic_get(client, NULL, mqtt_topic, &mqtt_topic)))
+if(az_failed(az_iot_hub_client_telemetry_get_publish_topic(client, NULL, mqtt_topic, &mqtt_topic)))
 {
     // error.
 }
@@ -114,17 +114,17 @@ _Example:_
 
     //az_span received_topic is filled by the application.
 
-    if (az_succeeded(az_iot_hub_client_c2d_received_topic_parse(client, received_topic, &c2d_request)))
+    if (az_succeeded(az_iot_hub_client_c2d_parse_received_topic(client, received_topic, &c2d_request)))
     {
         // This is a C2D message: 
         //  c2d_request.properties contain the properties of the message.
         //  the MQTT message payload contains the data.
     }
-    else if (az_succeeded(ret = az_iot_hub_client_methods_received_topic_parse(client, received_topic, &method_request)))
+    else if (az_succeeded(ret = az_iot_hub_client_methods_parse_received_topic(client, received_topic, &method_request)))
     {
         // This is a Method request:
         //  method_request.name contains the method
-        //  method_request.request_id contains the request ID that must be used to submit the response using az_iot_hub_client_methods_response_publish_topic_get()
+        //  method_request.request_id contains the request ID that must be used to submit the response using az_iot_hub_client_methods_get_response_publish_topic()
     }
     else if (az_succeeded(ret = az_iot_hub_client_twin_parse_received_topic(client, received_topic, &twin_response)))
     {
@@ -132,13 +132,13 @@ _Example:_
         switch (twin_response.response_type)
         {
             case AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_GET:
-                // This is a response to a az_iot_hub_client_twin_get_publish_topic_get.
+                // This is a response to a az_iot_hub_client_twin_get_get_publish_topic.
                 break;
             case AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES:
                 // This is received as the Twin desired properties were changed using the service client.
                 break;
             case AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES:
-                // This is a response received after patching the reported properties using az_iot_hub_client_twin_patch_publish_topic_get().
+                // This is a response received after patching the reported properties using az_iot_hub_client_twin_get_patch_publish_topic().
                 break;
             default:
                 // error.

--- a/sdk/iot/doc/resources/iot_hub_flow.puml
+++ b/sdk/iot/doc/resources/iot_hub_flow.puml
@@ -13,13 +13,13 @@ state color_coding {
 
 ' Init
 [*] --> az_iot_hub_client_init: START
-az_iot_hub_client_init -> az_iot_hub_client_user_name_get
-az_iot_hub_client_user_name_get -> az_iot_hub_client_id_get
-az_iot_hub_client_id_get -> application_mqtt_connect: X509 Client Auth: password is empty
+az_iot_hub_client_init -> az_iot_hub_client_get_user_name
+az_iot_hub_client_get_user_name -> az_iot_hub_client_get_client_id
+az_iot_hub_client_get_client_id -> application_mqtt_connect: X509 Client Auth: password is empty
 state application_mqtt_connect <<APP>>
 
 ' Optional SAS token generation:
-az_iot_hub_client_id_get -> az_iot_hub_client_sas_get_signature : SAS auth
+az_iot_hub_client_get_client_id -> az_iot_hub_client_sas_get_signature : SAS auth
 az_iot_hub_client_sas_get_signature -> application_hmac256
 application_hmac256 -> az_iot_hub_client_sas_get_password
 az_iot_hub_client_sas_get_password --> application_mqtt_connect : password is a SAS token
@@ -37,21 +37,21 @@ az_iot_hub_client_c2d_get_subscribe_topic_filter --> application_mqtt_subscribe
 application_mqtt_connect --> az_iot_hub_client_methods_get_subscribe_topic_filter
 az_iot_hub_client_methods_get_subscribe_topic_filter --> application_mqtt_subscribe
 
-az_iot_hub_client_methods_get_response_publish_topic --> application_mqtt_publish
+az_iot_hub_client_methods_response_get_publish_topic --> application_mqtt_publish
 
 ' Twin
-application_mqtt_connect --> az_iot_hub_client_twin_get_response_subscribe_topic_filter
-az_iot_hub_client_twin_get_response_subscribe_topic_filter --> application_mqtt_subscribe
+application_mqtt_connect --> az_iot_hub_client_twin_response_get_subscribe_topic_filter
+az_iot_hub_client_twin_response_get_subscribe_topic_filter --> application_mqtt_subscribe
 
-application_mqtt_connect --> az_iot_hub_client_twin_get_patch_subscribe_topic_filter
-az_iot_hub_client_twin_get_patch_subscribe_topic_filter --> application_mqtt_subscribe
+application_mqtt_connect --> az_iot_hub_client_twin_patch_get_subscribe_topic_filter
+az_iot_hub_client_twin_patch_get_subscribe_topic_filter --> application_mqtt_subscribe
 
 
 application_mqtt_subscribe --> az_iot_hub_client_twin_document_get_publish_topic
 az_iot_hub_client_twin_document_get_publish_topic --> application_mqtt_publish
 
-application_mqtt_subscribe --> az_iot_hub_client_twin_get_patch_publish_topic
-az_iot_hub_client_twin_get_patch_publish_topic --> application_mqtt_publish
+application_mqtt_subscribe --> az_iot_hub_client_twin_patch_get_publish_topic
+az_iot_hub_client_twin_patch_get_publish_topic --> application_mqtt_publish
 
 ' Common subscribe
 state application_mqtt_subscribe <<APP>>
@@ -73,7 +73,7 @@ state application_mqtt_receive <<APP>> {
     az_iot_hub_client_methods_parse_received_topic -> az_iot_hub_client_method_request : method call received
     az_iot_hub_client_method_request -> application_method_handle
     state application_method_handle <<APP>>
-    application_method_handle -> az_iot_hub_client_methods_get_response_publish_topic
+    application_method_handle -> az_iot_hub_client_methods_response_get_publish_topic
     
 ' Twin
     az_iot_hub_client_twin_parse_received_topic -> az_iot_hub_client_twin_response : twin GET or PATCH received
@@ -83,7 +83,7 @@ state application_mqtt_receive <<APP>> {
 az_iot_hub_client_init : - iot_hub_hostname
 az_iot_hub_client_init : - device_id
 
-az_iot_hub_client_user_name_get : - iot_hub
+az_iot_hub_client_get_user_name : - iot_hub
 
 ' SAS Tokens
 az_iot_hub_client_sas_get_signature : - unix_time
@@ -95,16 +95,16 @@ state az_iot_hub_client_method_request <<STRUCT>>
 az_iot_hub_client_method_request: - request_id
 az_iot_hub_client_method_request: - name
 
-az_iot_hub_client_methods_get_response_publish_topic: - request_id
-az_iot_hub_client_methods_get_response_publish_topic: - status
+az_iot_hub_client_methods_response_get_publish_topic: - request_id
+az_iot_hub_client_methods_response_get_publish_topic: - status
 
 state az_iot_hub_client_c2d_request <<STRUCT>>
 az_iot_hub_client_c2d_request : - az_iot_hub_client_properties
 
 az_iot_hub_client_twin_document_get_publish_topic : - request_id
 
-az_iot_hub_client_twin_get_patch_publish_topic : - request_id
-az_iot_hub_client_twin_get_patch_publish_topic : - if_match_version
+az_iot_hub_client_twin_patch_get_publish_topic : - request_id
+az_iot_hub_client_twin_patch_get_publish_topic : - if_match_version
 
 state az_iot_hub_client_twin_response <<STRUCT>>
 az_iot_hub_client_twin_response : - response_type

--- a/sdk/iot/doc/resources/iot_hub_flow.puml
+++ b/sdk/iot/doc/resources/iot_hub_flow.puml
@@ -26,32 +26,32 @@ az_iot_hub_client_sas_get_password --> application_mqtt_connect : password is a 
 state application_hmac256 <<APP>>
 
 ' Telemetry
-application_mqtt_connect --> az_iot_hub_client_telemetry_publish_topic_get : Telemetry can be used w/o subscribing to any topic.
-az_iot_hub_client_telemetry_publish_topic_get --> application_mqtt_publish
+application_mqtt_connect --> az_iot_hub_client_telemetry_get_publish_topic : Telemetry can be used w/o subscribing to any topic.
+az_iot_hub_client_telemetry_get_publish_topic --> application_mqtt_publish
 
 ' C2D
 application_mqtt_connect --> az_iot_hub_client_c2d_get_subscribe_topic_filter
 az_iot_hub_client_c2d_get_subscribe_topic_filter --> application_mqtt_subscribe
 
 ' Methods
-application_mqtt_connect --> az_iot_hub_client_methods_subscribe_topic_filter_get
-az_iot_hub_client_methods_subscribe_topic_filter_get --> application_mqtt_subscribe
+application_mqtt_connect --> az_iot_hub_client_methods_get_subscribe_topic_filter
+az_iot_hub_client_methods_get_subscribe_topic_filter --> application_mqtt_subscribe
 
-az_iot_hub_client_methods_response_publish_topic_get --> application_mqtt_publish
+az_iot_hub_client_methods_get_response_publish_topic --> application_mqtt_publish
 
 ' Twin
-application_mqtt_connect --> az_iot_hub_client_twin_response_subscribe_topic_filter_get
-az_iot_hub_client_twin_response_subscribe_topic_filter_get --> application_mqtt_subscribe
+application_mqtt_connect --> az_iot_hub_client_twin_get_response_subscribe_topic_filter
+az_iot_hub_client_twin_get_response_subscribe_topic_filter --> application_mqtt_subscribe
 
-application_mqtt_connect --> az_iot_hub_client_twin_patch_subscribe_topic_filter_get
-az_iot_hub_client_twin_patch_subscribe_topic_filter_get --> application_mqtt_subscribe
+application_mqtt_connect --> az_iot_hub_client_twin_get_patch_subscribe_topic_filter
+az_iot_hub_client_twin_get_patch_subscribe_topic_filter --> application_mqtt_subscribe
 
 
-application_mqtt_subscribe --> az_iot_hub_client_twin_get_publish_topic_get
-az_iot_hub_client_twin_get_publish_topic_get --> application_mqtt_publish
+application_mqtt_subscribe --> az_iot_hub_client_twin_get_get_publish_topic
+az_iot_hub_client_twin_get_get_publish_topic --> application_mqtt_publish
 
-application_mqtt_subscribe --> az_iot_hub_client_twin_patch_publish_topic_get
-az_iot_hub_client_twin_patch_publish_topic_get --> application_mqtt_publish
+application_mqtt_subscribe --> az_iot_hub_client_twin_get_patch_publish_topic
+az_iot_hub_client_twin_get_patch_publish_topic --> application_mqtt_publish
 
 ' Common subscribe
 state application_mqtt_subscribe <<APP>>
@@ -61,19 +61,19 @@ state application_mqtt_publish <<APP>>
 
 state application_mqtt_receive <<APP>> { 
 ' Callback delegating handler:
-    [*] --> az_iot_hub_client_c2d_received_topic_parse : Received PUBLISH message
-    az_iot_hub_client_c2d_received_topic_parse --> az_iot_hub_client_methods_received_topic_parse : not c2d related
-    az_iot_hub_client_methods_received_topic_parse --> az_iot_hub_client_twin_parse_received_topic : not methods related
+    [*] --> az_iot_hub_client_c2d_parse_received_topic : Received PUBLISH message
+    az_iot_hub_client_c2d_parse_received_topic --> az_iot_hub_client_methods_parse_received_topic : not c2d related
+    az_iot_hub_client_methods_parse_received_topic --> az_iot_hub_client_twin_parse_received_topic : not methods related
     az_iot_hub_client_twin_parse_received_topic --> [*] : not twin related
 
 ' C2D
-    az_iot_hub_client_c2d_received_topic_parse -> az_iot_hub_client_c2d_request : c2d call received
+    az_iot_hub_client_c2d_parse_received_topic -> az_iot_hub_client_c2d_request : c2d call received
     
 ' Methods:
-    az_iot_hub_client_methods_received_topic_parse -> az_iot_hub_client_method_request : method call received
+    az_iot_hub_client_methods_parse_received_topic -> az_iot_hub_client_method_request : method call received
     az_iot_hub_client_method_request -> application_method_handle
     state application_method_handle <<APP>>
-    application_method_handle -> az_iot_hub_client_methods_response_publish_topic_get
+    application_method_handle -> az_iot_hub_client_methods_get_response_publish_topic
     
 ' Twin
     az_iot_hub_client_twin_parse_received_topic -> az_iot_hub_client_twin_response : twin GET or PATCH received
@@ -89,22 +89,22 @@ az_iot_hub_client_user_name_get : - iot_hub
 az_iot_hub_client_sas_get_signature : - unix_time
 az_iot_hub_client_sas_get_password: - Base64(HMAC-SHA256(signature, SharedAccessKey))
 
-az_iot_hub_client_telemetry_publish_topic_get : - az_iot_hub_client_properties
+az_iot_hub_client_telemetry_get_publish_topic : - az_iot_hub_client_properties
 
 state az_iot_hub_client_method_request <<STRUCT>>
 az_iot_hub_client_method_request: - request_id
 az_iot_hub_client_method_request: - name
 
-az_iot_hub_client_methods_response_publish_topic_get: - request_id
-az_iot_hub_client_methods_response_publish_topic_get: - status
+az_iot_hub_client_methods_get_response_publish_topic: - request_id
+az_iot_hub_client_methods_get_response_publish_topic: - status
 
 state az_iot_hub_client_c2d_request <<STRUCT>>
 az_iot_hub_client_c2d_request : - az_iot_hub_client_properties
 
-az_iot_hub_client_twin_get_publish_topic_get : - request_id
+az_iot_hub_client_twin_get_get_publish_topic : - request_id
 
-az_iot_hub_client_twin_patch_publish_topic_get : - request_id
-az_iot_hub_client_twin_patch_publish_topic_get : - if_match_version
+az_iot_hub_client_twin_get_patch_publish_topic : - request_id
+az_iot_hub_client_twin_get_patch_publish_topic : - if_match_version
 
 state az_iot_hub_client_twin_response <<STRUCT>>
 az_iot_hub_client_twin_response : - response_type

--- a/sdk/iot/doc/resources/iot_hub_flow.puml
+++ b/sdk/iot/doc/resources/iot_hub_flow.puml
@@ -47,8 +47,8 @@ application_mqtt_connect --> az_iot_hub_client_twin_get_patch_subscribe_topic_fi
 az_iot_hub_client_twin_get_patch_subscribe_topic_filter --> application_mqtt_subscribe
 
 
-application_mqtt_subscribe --> az_iot_hub_client_twin_get_get_publish_topic
-az_iot_hub_client_twin_get_get_publish_topic --> application_mqtt_publish
+application_mqtt_subscribe --> az_iot_hub_client_twin_document_get_publish_topic
+az_iot_hub_client_twin_document_get_publish_topic --> application_mqtt_publish
 
 application_mqtt_subscribe --> az_iot_hub_client_twin_get_patch_publish_topic
 az_iot_hub_client_twin_get_patch_publish_topic --> application_mqtt_publish
@@ -101,7 +101,7 @@ az_iot_hub_client_methods_get_response_publish_topic: - status
 state az_iot_hub_client_c2d_request <<STRUCT>>
 az_iot_hub_client_c2d_request : - az_iot_hub_client_properties
 
-az_iot_hub_client_twin_get_get_publish_topic : - request_id
+az_iot_hub_client_twin_document_get_publish_topic : - request_id
 
 az_iot_hub_client_twin_get_patch_publish_topic : - request_id
 az_iot_hub_client_twin_get_patch_publish_topic : - if_match_version

--- a/sdk/iot/hub/inc/az_iot_hub_client.h
+++ b/sdk/iot/hub/inc/az_iot_hub_client.h
@@ -99,7 +99,7 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
  *                                                      \p mqtt_user_name. Can be `NULL`.
  * @return #az_result.
  */
-AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
+AZ_NODISCARD az_result az_iot_hub_client_get_user_name(
     az_iot_hub_client const* client,
     char* mqtt_user_name,
     size_t mqtt_user_name_size,
@@ -121,7 +121,7 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
  *                                                      of \p mqtt_client_id. Can be `NULL`.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_id_get(
+AZ_NODISCARD az_result az_iot_hub_client_get_client_id(
     az_iot_hub_client const* client,
     char*  mqtt_client_id,
     size_t mqtt_client_id_size,
@@ -431,7 +431,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_parse_received_topic(
  *                                                  \p mqtt_topic. Can be `NULL`.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_methods_get_response_publish_topic(
+AZ_NODISCARD az_result az_iot_hub_client_methods_response_get_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
     uint16_t status,
@@ -457,7 +457,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_get_response_publish_topic(
  *                                                         \p mqtt_topic_filter. Can be `NULL`.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_twin_get_response_subscribe_topic_filter(
+AZ_NODISCARD az_result az_iot_hub_client_twin_response_get_subscribe_topic_filter(
     az_iot_hub_client const* client,
     char* mqtt_topic_filter,
     size_t mqtt_topic_filter_size,
@@ -476,7 +476,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_response_subscribe_topic_filte
  *                                                         \p mqtt_topic_filter. Can be `NULL`.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
+AZ_NODISCARD az_result az_iot_hub_client_twin_patch_get_subscribe_topic_filter(
     az_iot_hub_client const* client,
     char* mqtt_topic_filter,
     size_t mqtt_topic_filter_size,
@@ -560,7 +560,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_document_get_publish_topic(
  *                                                  \p mqtt_topic. Can be `NULL`.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_publish_topic(
+AZ_NODISCARD az_result az_iot_hub_client_twin_patch_get_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
     char* mqtt_topic,

--- a/sdk/iot/hub/inc/az_iot_hub_client.h
+++ b/sdk/iot/hub/inc/az_iot_hub_client.h
@@ -538,7 +538,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
  *                                                  \p mqtt_topic. Can be `NULL`.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_twin_get_get_publish_topic(
+AZ_NODISCARD az_result az_iot_hub_client_twin_document_get_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
     char* mqtt_topic,

--- a/sdk/iot/hub/inc/az_iot_hub_client.h
+++ b/sdk/iot/hub/inc/az_iot_hub_client.h
@@ -100,8 +100,8 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
 AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
     az_iot_hub_client const* client,
     char* mqtt_user_name,
-    int32_t mqtt_user_name_size,
-    int32_t* out_mqtt_user_name_length);
+    size_t mqtt_user_name_size,
+    size_t* out_mqtt_user_name_length);
 
 /**
  * @brief Gets the MQTT client id.
@@ -120,8 +120,8 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
 AZ_NODISCARD az_result az_iot_hub_client_id_get(
     az_iot_hub_client const* client,
     char*  mqtt_client_id,
-    int32_t mqtt_client_id_size,
-    int32_t* out_mqtt_client_id_length);
+    size_t mqtt_client_id_size,
+    size_t* out_mqtt_client_id_length);
 
 /**
  *
@@ -311,8 +311,8 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
     az_iot_hub_client const* client,
     az_iot_hub_client_properties const* properties,
     char* mqtt_topic,
-    int32_t mqtt_topic_size,
-    int32_t* out_mqtt_topic_length);
+    size_t mqtt_topic_size,
+    size_t* out_mqtt_topic_length);
 
 /**
  *
@@ -335,8 +335,8 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
 AZ_NODISCARD az_result az_iot_hub_client_c2d_get_subscribe_topic_filter(
     az_iot_hub_client const* client,
     char* mqtt_topic_filter,
-    int32_t mqtt_topic_filter_size,
-    int32_t* out_mqtt_topic_filter_length);
+    size_t mqtt_topic_filter_size,
+    size_t* out_mqtt_topic_filter_length);
 
 /**
  * @brief The Cloud To Device Request.
@@ -381,8 +381,8 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
 AZ_NODISCARD az_result az_iot_hub_client_methods_get_subscribe_topic_filter(
     az_iot_hub_client const* client,
     char* mqtt_topic_filter,
-    int32_t mqtt_topic_filter_size,
-    int32_t* out_mqtt_topic_filter_length);
+    size_t mqtt_topic_filter_size,
+    size_t* out_mqtt_topic_filter_length);
 
 /**
  * @brief A method request received from IoT Hub.
@@ -428,8 +428,8 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_get_response_publish_topic(
     az_span request_id,
     uint16_t status,
     char* mqtt_topic,
-    int32_t mqtt_topic_size,
-    int32_t* out_mqtt_topic_length);
+    size_t mqtt_topic_size,
+    size_t* out_mqtt_topic_length);
 
 /**
  *
@@ -451,8 +451,8 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_get_response_publish_topic(
 AZ_NODISCARD az_result az_iot_hub_client_twin_get_response_subscribe_topic_filter(
     az_iot_hub_client const* client,
     char* mqtt_topic_filter,
-    int32_t mqtt_topic_filter_size,
-    int32_t* out_mqtt_topic_filter_length);
+    size_t mqtt_topic_filter_size,
+    size_t* out_mqtt_topic_filter_length);
 
 /**
  * @brief Gets the MQTT topic filter to subscribe to twin desired property changes.
@@ -469,8 +469,8 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_response_subscribe_topic_filte
 AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
     az_iot_hub_client const* client,
     char* mqtt_topic_filter,
-    int32_t mqtt_topic_filter_size,
-    int32_t* out_mqtt_topic_filter_length);
+    size_t mqtt_topic_filter_size,
+    size_t* out_mqtt_topic_filter_length);
 
 /**
  * @brief Twin response type.
@@ -531,8 +531,8 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_get_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
     char* mqtt_topic,
-    int32_t mqtt_topic_size,
-    int32_t* out_mqtt_topic_length);
+    size_t mqtt_topic_size,
+    size_t* out_mqtt_topic_length);
 
 /**
  * @brief Gets the MQTT topic that must be used to submit a Twin PATCH request.
@@ -552,8 +552,8 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
     char* mqtt_topic,
-    int32_t mqtt_topic_size,
-    int32_t* out_mqtt_topic_length);
+    size_t mqtt_topic_size,
+    size_t* out_mqtt_topic_length);
 
 #include <_az_cfg_suffix.h>
 

--- a/sdk/iot/hub/inc/az_iot_hub_client.h
+++ b/sdk/iot/hub/inc/az_iot_hub_client.h
@@ -91,10 +91,12 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
  * {iothubhostname}/{device_id}/{module_id}/?api-version=2018-06-30&{user_agent}
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[out] mqtt_user_name A char buffer with sufficient capacity to hold the MQTT user name.
- * @param[in] mqtt_user_name_size The size of the passed buffer. Must be greater than 0.
- * @param[out] out_mqtt_user_name_length The optional output length of the mqtt user name. Can
- * be `NULL`.
+ * @param[out] mqtt_user_name A buffer with sufficient capacity to hold the MQTT user name.
+ *                            If successful, contains a null-terminated string with the user name
+ *                            that needs to be passed to the MQTT client.
+ * @param[in] mqtt_user_name_size The size, in bytes of \p mqtt_user_name.
+ * @param[out] out_mqtt_user_name_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                      \p mqtt_user_name. Can be `NULL`.
  * @return #az_result.
  */
 AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
@@ -111,10 +113,12 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
  * [Format with module id] {device_id}/{module_id}
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[out] mqtt_client_id A char buffer with sufficient capacity to hold the MQTT client id.
- * @param[in] mqtt_client_id_size The size of the passed buffer. Must be greater than 0.
- * @param[out] out_mqtt_client_id_length The optional output length of the mqtt client id. Can
- * be `NULL`.
+ * @param[out] mqtt_client_id A buffer with sufficient capacity to hold the MQTT client id.
+ *                            If successful, contains a null-terminated string with the client id
+ *                            that needs to be passed to the MQTT client.
+ * @param[in] mqtt_client_id_size The size, in bytes of \p mqtt_client_id.
+ * @param[out] out_mqtt_client_id_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                      of \p mqtt_client_id. Can be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_hub_client_id_get(
@@ -300,11 +304,12 @@ az_iot_hub_client_properties_next(az_iot_hub_client_properties* properties, az_p
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] properties An optional #az_iot_hub_client_properties object (can be NULL).
- * @param[out] mqtt_topic A char buffer with sufficient capacity to hold the MQTT topic
- * filter. On success, will be `NULL` terminated.
- * @param[in] mqtt_topic_size The size of the passed buffer. Must be greater than 0.
- * @param[out] out_mqtt_topic_length The optional output length of the mqtt topic filter. Can
- * be `NULL`.
+ * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If
+ *                        successful, contains a null-terminated string with the topic that
+ *                        needs to be passed to the MQTT client.
+ * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
+ * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                  \p mqtt_topic. Can be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
@@ -325,11 +330,12 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
  * @note C2D MQTT Publish messages will have QoS At Least Once (1).
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[out] mqtt_topic_filter A char buffer with sufficient capacity to hold the MQTT topic
- *                              filter. On success, will be `NULL` terminated.
- * @param[in] mqtt_topic_filter_size The size of the passed buffer. Must be greater than 0.
- * @param[out] out_mqtt_topic_filter_length The optional output length of the mqtt topic filter. Can
- * be `NULL`.
+ * @param[out] mqtt_topic_filter A buffer with sufficient capacity to hold the MQTT topic filter.
+ *                               If successful, contains a null-terminated string with the topic
+ *                               filter that needs to be passed to the MQTT client.
+ * @param[in] mqtt_topic_filter_size The size, in bytes of \p mqtt_topic_filter.
+ * @param[out] out_mqtt_topic_filter_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                         \p mqtt_topic_filter. Can be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_hub_client_c2d_get_subscribe_topic_filter(
@@ -371,11 +377,12 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
  * @brief Gets the MQTT topic filter to subscribe to method requests.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[out] mqtt_topic_filter A char buffer with sufficient capacity to hold the MQTT topic
- *                              filter. On success, will be `NULL` terminated.
- * @param[in] mqtt_topic_filter_size The size of the passed buffer. Must be greater than 0.
- * @param[out] out_mqtt_topic_filter_length The optional output length of the mqtt topic filter. Can
- * be `NULL`.
+ * @param[out] mqtt_topic_filter A buffer with sufficient capacity to hold the MQTT topic filter.
+ *                               If successful, contains a null-terminated string with the topic
+ *                               filter that needs to be passed to the MQTT client.
+ * @param[in] mqtt_topic_filter_size The size, in bytes of \p mqtt_topic_filter.
+ * @param[out] out_mqtt_topic_filter_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                         \p mqtt_topic_filter. Can be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_hub_client_methods_get_subscribe_topic_filter(
@@ -416,11 +423,12 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_parse_received_topic(
  * @param[in] request_id The request id. Must match a received #az_iot_hub_client_method_request
  *                       request_id.
  * @param[in] status The status. Must be 200 for "OK", 404 for "error", or 504 for "timeout"
- * @param[out] mqtt_topic A char buffer with sufficient capacity to hold the MQTT topic
- *                              filter. On success, will be `NULL` terminated.
- * @param[in] mqtt_topic_size The size of the passed buffer. Must be greater than 0.
- * @param[out] out_mqtt_topic_length The optional output length of the mqtt topic filter. Can
- * be `NULL`.
+ * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If
+ *                        successful, contains a null-terminated string with the topic that
+ *                        needs to be passed to the MQTT client.
+ * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
+ * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                  \p mqtt_topic. Can be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_hub_client_methods_get_response_publish_topic(
@@ -441,11 +449,12 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_get_response_publish_topic(
  * @brief Gets the MQTT topic filter to subscribe to twin operation responses.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[out] mqtt_topic_filter A char buffer with sufficient capacity to hold the MQTT topic
- *                              filter. On success, will be `NULL` terminated.
- * @param[in] mqtt_topic_filter_size The size of the passed buffer. Must be greater than 0.
- * @param[out] out_mqtt_topic_filter_length The optional output length of the mqtt topic filter. Can
- * be `NULL`.
+ * @param[out] mqtt_topic_filter A buffer with sufficient capacity to hold the MQTT topic filter.
+ *                               If successful, contains a null-terminated string with the topic
+ *                               filter that needs to be passed to the MQTT client.
+ * @param[in] mqtt_topic_filter_size The size, in bytes of \p mqtt_topic_filter.
+ * @param[out] out_mqtt_topic_filter_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                         \p mqtt_topic_filter. Can be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_hub_client_twin_get_response_subscribe_topic_filter(
@@ -459,11 +468,12 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_response_subscribe_topic_filte
  * @note The payload will contain only changes made to the desired properties.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[out] mqtt_topic_filter A char buffer with sufficient capacity to hold the MQTT topic
- *                              filter. On success, will be `NULL` terminated.
- * @param[in] mqtt_topic_filter_size The size of the passed buffer. Must be greater than 0.
- * @param[out] out_mqtt_topic_filter_length The optional output length of the mqtt topic filter. Can
- * be `NULL`.
+ * @param[out] mqtt_topic_filter A buffer with sufficient capacity to hold the MQTT topic filter.
+ *                               If successful, contains a null-terminated string with the topic
+ *                               filter that needs to be passed to the MQTT client.
+ * @param[in] mqtt_topic_filter_size The size, in bytes of \p mqtt_topic_filter.
+ * @param[out] out_mqtt_topic_filter_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                         \p mqtt_topic_filter. Can be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
@@ -520,11 +530,12 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] request_id The request id.
- * @param[out] mqtt_topic A char buffer with sufficient capacity to hold the MQTT topic
- *                              filter. On success, will be `NULL` terminated.
- * @param[in] mqtt_topic_size The size of the passed buffer. Must be greater than 0.
- * @param[out] out_mqtt_topic_length The optional output length of the mqtt topic filter. Can
- * be `NULL`.
+ * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If
+ *                        successful, contains a null-terminated string with the topic that
+ *                        needs to be passed to the MQTT client.
+ * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
+ * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                  \p mqtt_topic. Can be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_hub_client_twin_get_get_publish_topic(
@@ -541,11 +552,12 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_get_publish_topic(
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] request_id The request id.
- * @param[out] mqtt_topic A char buffer with sufficient capacity to hold the MQTT topic
- *                              filter. On success, will be `NULL` terminated.
- * @param[in] mqtt_topic_size The size of the passed buffer. Must be greater than 0.
- * @param[out] out_mqtt_topic_length The optional output length of the mqtt topic filter. Can
- * be `NULL`.
+ * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If
+ *                        successful, contains a null-terminated string with the topic that
+ *                        needs to be passed to the MQTT client.
+ * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
+ * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                  \p mqtt_topic. Can be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_publish_topic(

--- a/sdk/iot/hub/inc/az_iot_hub_client.h
+++ b/sdk/iot/hub/inc/az_iot_hub_client.h
@@ -91,14 +91,17 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
  * {iothubhostname}/{device_id}/{module_id}/?api-version=2018-06-30&{user_agent}
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[in] mqtt_user_name An empty #az_span with sufficient capacity to hold the MQTT user name.
- * @param[out] out_mqtt_user_name The output #az_span containing the MQTT user name.
+ * @param[out] mqtt_user_name A char buffer with sufficient capacity to hold the MQTT user name.
+ * @param[in] mqtt_user_name_size The size of the passed buffer. Must be greater than 0.
+ * @param[out] out_mqtt_user_name_length The optional output length of the mqtt user name. Can
+ * be `NULL`.
  * @return #az_result.
  */
 AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
     az_iot_hub_client const* client,
-    az_span mqtt_user_name,
-    az_span* out_mqtt_user_name);
+    char* mqtt_user_name,
+    int32_t mqtt_user_name_size,
+    int32_t* out_mqtt_user_name_length);
 
 /**
  * @brief Gets the MQTT client id.
@@ -108,14 +111,17 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
  * [Format with module id] {device_id}/{module_id}
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[in] mqtt_client_id An empty #az_span with sufficient capacity to hold the MQTT client id.
- * @param[out] out_mqtt_client_id The output #az_span containing the MQTT client id.
+ * @param[out] mqtt_client_id A char buffer with sufficient capacity to hold the MQTT client id.
+ * @param[in] mqtt_client_id_size The size of the passed buffer. Must be greater than 0.
+ * @param[out] out_mqtt_client_id_length The optional output length of the mqtt client id. Can
+ * be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_hub_client_id_get(
     az_iot_hub_client const* client,
-    az_span mqtt_client_id,
-    az_span* out_mqtt_client_id);
+    char*  mqtt_client_id,
+    int32_t mqtt_client_id_size,
+    int32_t* out_mqtt_client_id_length);
 
 /**
  *
@@ -294,15 +300,19 @@ az_iot_hub_client_properties_next(az_iot_hub_client_properties* properties, az_p
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] properties An optional #az_iot_hub_client_properties object (can be NULL).
- * @param[in] mqtt_topic An empty #az_span with sufficient capacity to hold the MQTT topic.
- * @param[out] out_mqtt_topic The output #az_span containing the MQTT topic.
+ * @param[out] mqtt_topic A char buffer with sufficient capacity to hold the MQTT topic
+ * filter. On success, will be `NULL` terminated.
+ * @param[in] mqtt_topic_size The size of the passed buffer. Must be greater than 0.
+ * @param[out] out_mqtt_topic_length The optional output length of the mqtt topic filter. Can
+ * be `NULL`.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
+AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
     az_iot_hub_client const* client,
     az_iot_hub_client_properties const* properties,
-    az_span mqtt_topic,
-    az_span* out_mqtt_topic);
+    char* mqtt_topic,
+    int32_t mqtt_topic_size,
+    int32_t* out_mqtt_topic_length);
 
 /**
  *
@@ -325,8 +335,8 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
 AZ_NODISCARD az_result az_iot_hub_client_c2d_get_subscribe_topic_filter(
     az_iot_hub_client const* client,
     char* mqtt_topic_filter,
-    size_t mqtt_topic_filter_size,
-    size_t* out_mqtt_topic_filter_length);
+    int32_t mqtt_topic_filter_size,
+    int32_t* out_mqtt_topic_filter_length);
 
 /**
  * @brief The Cloud To Device Request.
@@ -346,7 +356,7 @@ typedef struct az_iot_hub_client_c2d_request
  *                         #az_iot_hub_client_c2d_request
  * @return az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_c2d_received_topic_parse(
+AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
     az_iot_hub_client const* client,
     az_span received_topic,
     az_iot_hub_client_c2d_request* out_request);
@@ -361,15 +371,18 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_received_topic_parse(
  * @brief Gets the MQTT topic filter to subscribe to method requests.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[in] mqtt_topic_filter An empty #az_span with sufficient capacity to hold the MQTT topic
- *                              filter.
- * @param[out] out_mqtt_topic_filter The output #az_span containing the MQTT topic filter.
+ * @param[out] mqtt_topic_filter A char buffer with sufficient capacity to hold the MQTT topic
+ *                              filter. On success, will be `NULL` terminated.
+ * @param[in] mqtt_topic_filter_size The size of the passed buffer. Must be greater than 0.
+ * @param[out] out_mqtt_topic_filter_length The optional output length of the mqtt topic filter. Can
+ * be `NULL`.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_methods_subscribe_topic_filter_get(
+AZ_NODISCARD az_result az_iot_hub_client_methods_get_subscribe_topic_filter(
     az_iot_hub_client const* client,
-    az_span mqtt_topic_filter,
-    az_span* out_mqtt_topic_filter);
+    char* mqtt_topic_filter,
+    int32_t mqtt_topic_filter_size,
+    int32_t* out_mqtt_topic_filter_length);
 
 /**
  * @brief A method request received from IoT Hub.
@@ -391,7 +404,7 @@ typedef struct az_iot_hub_client_method_request
  *                         #az_iot_hub_client_method_request.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_methods_received_topic_parse(
+AZ_NODISCARD az_result az_iot_hub_client_methods_parse_received_topic(
     az_iot_hub_client const* client,
     az_span received_topic,
     az_iot_hub_client_method_request* out_request);
@@ -402,17 +415,21 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_received_topic_parse(
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] request_id The request id. Must match a received #az_iot_hub_client_method_request
  *                       request_id.
- * @param[in] status The status. (E.g. 200 for success.)
- * @param[in] mqtt_topic An empty #az_span with sufficient capacity to hold the MQTT topic.
- * @param[out] out_mqtt_topic The output #az_span containing the MQTT topic.
+ * @param[in] status The status. Must be 200 for "OK", 404 for "error", or 504 for "timeout"
+ * @param[out] mqtt_topic A char buffer with sufficient capacity to hold the MQTT topic
+ *                              filter. On success, will be `NULL` terminated.
+ * @param[in] mqtt_topic_size The size of the passed buffer. Must be greater than 0.
+ * @param[out] out_mqtt_topic_length The optional output length of the mqtt topic filter. Can
+ * be `NULL`.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_methods_response_publish_topic_get(
+AZ_NODISCARD az_result az_iot_hub_client_methods_get_response_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
     uint16_t status,
-    az_span mqtt_topic,
-    az_span* out_mqtt_topic);
+    char* mqtt_topic,
+    int32_t mqtt_topic_size,
+    int32_t* out_mqtt_topic_length);
 
 /**
  *
@@ -424,30 +441,36 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_response_publish_topic_get(
  * @brief Gets the MQTT topic filter to subscribe to twin operation responses.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[in] mqtt_topic_filter An empty #az_span with sufficient capacity to hold the MQTT topic
- *                              filter.
- * @param[out] out_mqtt_topic_filter The output #az_span containing the MQTT topic filter.
+ * @param[out] mqtt_topic_filter A char buffer with sufficient capacity to hold the MQTT topic
+ *                              filter. On success, will be `NULL` terminated.
+ * @param[in] mqtt_topic_filter_size The size of the passed buffer. Must be greater than 0.
+ * @param[out] out_mqtt_topic_filter_length The optional output length of the mqtt topic filter. Can
+ * be `NULL`.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_twin_response_subscribe_topic_filter_get(
+AZ_NODISCARD az_result az_iot_hub_client_twin_get_response_subscribe_topic_filter(
     az_iot_hub_client const* client,
-    az_span mqtt_topic_filter,
-    az_span* out_mqtt_topic_filter);
+    char* mqtt_topic_filter,
+    int32_t mqtt_topic_filter_size,
+    int32_t* out_mqtt_topic_filter_length);
 
 /**
  * @brief Gets the MQTT topic filter to subscribe to twin desired property changes.
  * @note The payload will contain only changes made to the desired properties.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[in] mqtt_topic_filter An empty #az_span with sufficient capacity to hold the MQTT topic
- *                              filter.
- * @param[out] out_mqtt_topic_filter The output #az_span containing the MQTT topic filter.
+ * @param[out] mqtt_topic_filter A char buffer with sufficient capacity to hold the MQTT topic
+ *                              filter. On success, will be `NULL` terminated.
+ * @param[in] mqtt_topic_filter_size The size of the passed buffer. Must be greater than 0.
+ * @param[out] out_mqtt_topic_filter_length The optional output length of the mqtt topic filter. Can
+ * be `NULL`.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_twin_patch_subscribe_topic_filter_get(
+AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
     az_iot_hub_client const* client,
-    az_span mqtt_topic_filter,
-    az_span* out_mqtt_topic_filter);
+    char* mqtt_topic_filter,
+    int32_t mqtt_topic_filter_size,
+    int32_t* out_mqtt_topic_filter_length);
 
 /**
  * @brief Twin response type.
@@ -497,15 +520,19 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] request_id The request id.
- * @param[in] mqtt_topic An empty #az_span with sufficient capacity to hold the MQTT topic.
- * @param[out] out_mqtt_topic The output #az_span containing the MQTT topic.
+ * @param[out] mqtt_topic A char buffer with sufficient capacity to hold the MQTT topic
+ *                              filter. On success, will be `NULL` terminated.
+ * @param[in] mqtt_topic_size The size of the passed buffer. Must be greater than 0.
+ * @param[out] out_mqtt_topic_length The optional output length of the mqtt topic filter. Can
+ * be `NULL`.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_twin_get_publish_topic_get(
+AZ_NODISCARD az_result az_iot_hub_client_twin_get_get_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
-    az_span mqtt_topic,
-    az_span* out_mqtt_topic);
+    char* mqtt_topic,
+    int32_t mqtt_topic_size,
+    int32_t* out_mqtt_topic_length);
 
 /**
  * @brief Gets the MQTT topic that must be used to submit a Twin PATCH request.
@@ -514,15 +541,19 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_publish_topic_get(
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] request_id The request id.
- * @param[in] mqtt_topic An empty #az_span with sufficient capacity to hold the MQTT topic.
- * @param[out] out_mqtt_topic The output #az_span containing the MQTT topic.
+ * @param[out] mqtt_topic A char buffer with sufficient capacity to hold the MQTT topic
+ *                              filter. On success, will be `NULL` terminated.
+ * @param[in] mqtt_topic_size The size of the passed buffer. Must be greater than 0.
+ * @param[out] out_mqtt_topic_length The optional output length of the mqtt topic filter. Can
+ * be `NULL`.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_hub_client_twin_patch_publish_topic_get(
+AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
-    az_span mqtt_topic,
-    az_span* out_mqtt_topic);
+    char* mqtt_topic,
+    int32_t mqtt_topic_size,
+    int32_t* out_mqtt_topic_length);
 
 #include <_az_cfg_suffix.h>
 

--- a/sdk/iot/hub/src/az_iot_hub_client.c
+++ b/sdk/iot/hub/src/az_iot_hub_client.c
@@ -45,8 +45,8 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
 AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
     az_iot_hub_client const* client,
     char* mqtt_user_name,
-    int32_t mqtt_user_name_size,
-    int32_t* out_mqtt_user_name_length)
+    size_t mqtt_user_name_size,
+    size_t* out_mqtt_user_name_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_NOT_NULL(mqtt_user_name);
@@ -55,7 +55,7 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
   const az_span* const module_id = &(client->_internal.options.module_id);
   const az_span* const user_agent = &(client->_internal.options.user_agent);
 
-  az_span mqtt_user_name_span = az_span_init((uint8_t*)mqtt_user_name, mqtt_user_name_size);
+  az_span mqtt_user_name_span = az_span_init((uint8_t*)mqtt_user_name, (int32_t)mqtt_user_name_size);
 
   int32_t required_length = az_span_size(client->_internal.iot_hub_hostname)
       + az_span_size(client->_internal.device_id) + az_span_size(hub_service_api_version)
@@ -94,7 +94,7 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
 
   if (out_mqtt_user_name_length)
   {
-    *out_mqtt_user_name_length = required_length;
+    *out_mqtt_user_name_length = (size_t)required_length;
   }
 
   return AZ_OK;
@@ -103,14 +103,14 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
 AZ_NODISCARD az_result az_iot_hub_client_id_get(
     az_iot_hub_client const* client,
     char* mqtt_client_id,
-    int32_t mqtt_client_id_size,
-    int32_t* out_mqtt_client_id_length)
+    size_t mqtt_client_id_size,
+    size_t* out_mqtt_client_id_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_NOT_NULL(mqtt_client_id);
   AZ_PRECONDITION(mqtt_client_id_size > 0);
 
-  az_span mqtt_client_id_span = az_span_init((uint8_t*)mqtt_client_id, mqtt_client_id_size);
+  az_span mqtt_client_id_span = az_span_init((uint8_t*)mqtt_client_id, (int32_t)mqtt_client_id_size);
   const az_span* const module_id = &(client->_internal.options.module_id);
 
   int32_t required_length = az_span_size(client->_internal.device_id);
@@ -134,7 +134,7 @@ AZ_NODISCARD az_result az_iot_hub_client_id_get(
 
   if (out_mqtt_client_id_length)
   {
-    *out_mqtt_client_id_length = required_length;
+    *out_mqtt_client_id_length = (size_t)required_length;
   }
 
   return AZ_OK;

--- a/sdk/iot/hub/src/az_iot_hub_client.c
+++ b/sdk/iot/hub/src/az_iot_hub_client.c
@@ -42,7 +42,7 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
+AZ_NODISCARD az_result az_iot_hub_client_get_user_name(
     az_iot_hub_client const* client,
     char* mqtt_user_name,
     size_t mqtt_user_name_size,
@@ -100,7 +100,7 @@ AZ_NODISCARD az_result az_iot_hub_client_user_name_get(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_id_get(
+AZ_NODISCARD az_result az_iot_hub_client_get_client_id(
     az_iot_hub_client const* client,
     char* mqtt_client_id,
     size_t mqtt_client_id_size,

--- a/sdk/iot/hub/src/az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_c2d.c
@@ -18,8 +18,8 @@ static const uint8_t hash_tag = '#';
 AZ_NODISCARD az_result az_iot_hub_client_c2d_get_subscribe_topic_filter(
     az_iot_hub_client const* client,
     char* mqtt_topic_filter,
-    int32_t mqtt_topic_filter_size,
-    int32_t* out_mqtt_topic_filter_length)
+    size_t mqtt_topic_filter_size,
+    size_t* out_mqtt_topic_filter_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_NOT_NULL(mqtt_topic_filter);
@@ -42,7 +42,7 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_get_subscribe_topic_filter(
 
   if (out_mqtt_topic_filter_length)
   {
-    *out_mqtt_topic_filter_length = required_length;
+    *out_mqtt_topic_filter_length = (size_t)required_length;
   }
 
   return AZ_OK;

--- a/sdk/iot/hub/src/az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_c2d.c
@@ -18,8 +18,8 @@ static const uint8_t hash_tag = '#';
 AZ_NODISCARD az_result az_iot_hub_client_c2d_get_subscribe_topic_filter(
     az_iot_hub_client const* client,
     char* mqtt_topic_filter,
-    size_t mqtt_topic_filter_size,
-    size_t* out_mqtt_topic_filter_length)
+    int32_t mqtt_topic_filter_size,
+    int32_t* out_mqtt_topic_filter_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_NOT_NULL(mqtt_topic_filter);
@@ -42,13 +42,13 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_get_subscribe_topic_filter(
 
   if (out_mqtt_topic_filter_length)
   {
-    *out_mqtt_topic_filter_length = (size_t)required_length;
+    *out_mqtt_topic_filter_length = required_length;
   }
 
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_c2d_received_topic_parse(
+AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
     az_iot_hub_client const* client,
     az_span received_topic,
     az_iot_hub_client_c2d_request* out_request)

--- a/sdk/iot/hub/src/az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_methods.c
@@ -23,8 +23,8 @@ static const az_span methods_response_topic_properties = AZ_SPAN_LITERAL_FROM_ST
 AZ_NODISCARD az_result az_iot_hub_client_methods_get_subscribe_topic_filter(
     az_iot_hub_client const* client,
     char* mqtt_topic_filter,
-    int32_t mqtt_topic_filter_size,
-    int32_t* out_mqtt_topic_filter_length)
+    size_t mqtt_topic_filter_size,
+    size_t* out_mqtt_topic_filter_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_NOT_NULL(mqtt_topic_filter);
@@ -33,7 +33,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_get_subscribe_topic_filter(
   (void)client;
 
   az_span mqtt_topic_filter_span
-      = az_span_init((uint8_t*)mqtt_topic_filter, mqtt_topic_filter_size);
+      = az_span_init((uint8_t*)mqtt_topic_filter, (int32_t)mqtt_topic_filter_size);
 
   int32_t required_length = az_span_size(methods_topic_prefix)
       + az_span_size(methods_topic_filter_suffix) + (int32_t)sizeof(hashtag);
@@ -49,7 +49,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_get_subscribe_topic_filter(
 
   if(out_mqtt_topic_filter_length)
   {
-    *out_mqtt_topic_filter_length = required_length;
+    *out_mqtt_topic_filter_length = (size_t)required_length;
   }
 
   return AZ_OK;
@@ -109,8 +109,8 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_get_response_publish_topic(
     az_span request_id,
     uint16_t status,
     char* mqtt_topic,
-    int32_t mqtt_topic_size,
-    int32_t* out_mqtt_topic_length)
+    size_t mqtt_topic_size,
+    size_t* out_mqtt_topic_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_VALID_SPAN(request_id, 1, false);
@@ -120,7 +120,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_get_response_publish_topic(
 
   (void)client;
 
-  az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, mqtt_topic_size);
+  az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   int32_t required_length = az_span_size(methods_topic_prefix)
       + az_span_size(methods_response_topic_result) + STATUS_TO_STR_SIZE
       + az_span_size(methods_response_topic_properties) + az_span_size(request_id);
@@ -138,7 +138,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_get_response_publish_topic(
 
   if(out_mqtt_topic_length)
   {
-    *out_mqtt_topic_length = required_length;
+    *out_mqtt_topic_length = (size_t)required_length;
   }
 
   return AZ_OK;

--- a/sdk/iot/hub/src/az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_methods.c
@@ -11,38 +11,51 @@
 
 #include <_az_cfg.h>
 
+#define STATUS_TO_STR_SIZE 3
+
+static const uint8_t hashtag = '#';
+static const uint8_t null_terminator = '\0';
 static const az_span methods_topic_prefix = AZ_SPAN_LITERAL_FROM_STR("$iothub/methods/");
 static const az_span methods_topic_filter_suffix = AZ_SPAN_LITERAL_FROM_STR("POST/");
 static const az_span methods_response_topic_result = AZ_SPAN_LITERAL_FROM_STR("res/");
 static const az_span methods_response_topic_properties = AZ_SPAN_LITERAL_FROM_STR("/?$rid=");
 
-AZ_NODISCARD az_result az_iot_hub_client_methods_subscribe_topic_filter_get(
+AZ_NODISCARD az_result az_iot_hub_client_methods_get_subscribe_topic_filter(
     az_iot_hub_client const* client,
-    az_span mqtt_topic_filter,
-    az_span* out_mqtt_topic_filter)
+    char* mqtt_topic_filter,
+    int32_t mqtt_topic_filter_size,
+    int32_t* out_mqtt_topic_filter_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(mqtt_topic_filter, 0, false);
-  AZ_PRECONDITION_NOT_NULL(out_mqtt_topic_filter);
+  AZ_PRECONDITION_NOT_NULL(mqtt_topic_filter);
+  AZ_PRECONDITION(mqtt_topic_filter_size > 0);
 
   (void)client;
 
-  int32_t required_length
-      = az_span_size(methods_topic_prefix) + az_span_size(methods_topic_filter_suffix) + 1;
+  az_span mqtt_topic_filter_span
+      = az_span_init((uint8_t*)mqtt_topic_filter, mqtt_topic_filter_size);
 
-  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_filter, required_length);
+  int32_t required_length = az_span_size(methods_topic_prefix)
+      + az_span_size(methods_topic_filter_suffix) + (int32_t)sizeof(hashtag);
+
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(
+      mqtt_topic_filter_span, required_length + (int32_t)sizeof(null_terminator));
 
   // TODO: Merge these two calls into one since they are copying two strings literals.
-  az_span remainder = az_span_copy(mqtt_topic_filter, methods_topic_prefix);
+  az_span remainder = az_span_copy(mqtt_topic_filter_span, methods_topic_prefix);
   remainder = az_span_copy(remainder, methods_topic_filter_suffix);
-  az_span_copy_u8(remainder, '#');
+  remainder = az_span_copy_u8(remainder, hashtag);
+  az_span_copy_u8(remainder, null_terminator);
 
-  *out_mqtt_topic_filter = az_span_slice(mqtt_topic_filter, 0, required_length);
+  if(out_mqtt_topic_filter_length)
+  {
+    *out_mqtt_topic_filter_length = required_length;
+  }
 
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_methods_received_topic_parse(
+AZ_NODISCARD az_result az_iot_hub_client_methods_parse_received_topic(
     az_iot_hub_client const* client,
     az_span received_topic,
     az_iot_hub_client_method_request* out_request)
@@ -91,38 +104,42 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_received_topic_parse(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_methods_response_publish_topic_get(
+AZ_NODISCARD az_result az_iot_hub_client_methods_get_response_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
     uint16_t status,
-    az_span mqtt_topic,
-    az_span* out_mqtt_topic)
+    char* mqtt_topic,
+    int32_t mqtt_topic_size,
+    int32_t* out_mqtt_topic_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_VALID_SPAN(request_id, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(mqtt_topic, 0, false);
-  AZ_PRECONDITION_NOT_NULL(out_mqtt_topic);
+  AZ_PRECONDITION(status == 200 || status == 404 || status == 504);
+  AZ_PRECONDITION_NOT_NULL(mqtt_topic);
+  AZ_PRECONDITION(mqtt_topic_size);
 
   (void)client;
 
-  int32_t required_length
-      = az_span_size(methods_topic_prefix) + az_span_size(methods_response_topic_result);
+  az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, mqtt_topic_size);
+  int32_t required_length = az_span_size(methods_topic_prefix)
+      + az_span_size(methods_response_topic_result) + STATUS_TO_STR_SIZE
+      + az_span_size(methods_response_topic_properties) + az_span_size(request_id);
 
-  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_span, required_length + (int32_t)sizeof(null_terminator));
 
-  az_span remainder = az_span_copy(mqtt_topic, methods_topic_prefix);
+  az_span remainder = az_span_copy(mqtt_topic_span, methods_topic_prefix);
   remainder = az_span_copy(remainder, methods_response_topic_result);
 
   AZ_RETURN_IF_FAILED(az_span_u32toa(remainder, (uint32_t)status, &remainder));
 
-  required_length = az_span_size(methods_response_topic_properties) + az_span_size(request_id);
-
-  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, required_length);
-
   remainder = az_span_copy(remainder, methods_response_topic_properties);
   remainder = az_span_copy(remainder, request_id);
+  az_span_copy_u8(remainder, null_terminator);
 
-  *out_mqtt_topic = az_span_slice(mqtt_topic, 0, _az_span_diff(remainder, mqtt_topic));
+  if(out_mqtt_topic_length)
+  {
+    *out_mqtt_topic_length = required_length;
+  }
 
   return AZ_OK;
 }

--- a/sdk/iot/hub/src/az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_methods.c
@@ -104,7 +104,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_parse_received_topic(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_methods_get_response_publish_topic(
+AZ_NODISCARD az_result az_iot_hub_client_methods_response_get_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
     uint16_t status,

--- a/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
@@ -20,8 +20,8 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
     az_iot_hub_client const* client,
     az_iot_hub_client_properties const* properties,
     char* mqtt_topic,
-    int32_t mqtt_topic_size,
-    int32_t* out_mqtt_topic_length)
+    size_t mqtt_topic_size,
+    size_t* out_mqtt_topic_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_NOT_NULL(mqtt_topic);
@@ -29,7 +29,7 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
 
   const az_span* const module_id = &(client->_internal.options.module_id);
 
-  az_span mqtt_topic_span = az_span_init((uint8_t*) mqtt_topic, mqtt_topic_size);
+  az_span mqtt_topic_span = az_span_init((uint8_t*) mqtt_topic, (int32_t)mqtt_topic_size);
   int32_t required_length = az_span_size(telemetry_topic_prefix)
       + az_span_size(client->_internal.device_id) + az_span_size(telemetry_topic_suffix);
   int32_t module_id_length = az_span_size(*module_id);
@@ -64,7 +64,7 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
 
   if(out_mqtt_topic_length)
   {
-    *out_mqtt_topic_length = required_length;
+    *out_mqtt_topic_length = (size_t)required_length;
   }
 
   return AZ_OK;

--- a/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
@@ -11,22 +11,25 @@
 
 #include <_az_cfg.h>
 
+static const uint8_t null_terminator = '\0';
 static const az_span telemetry_topic_prefix = AZ_SPAN_LITERAL_FROM_STR("devices/");
 static const az_span telemetry_topic_modules_mid = AZ_SPAN_LITERAL_FROM_STR("/modules/");
 static const az_span telemetry_topic_suffix = AZ_SPAN_LITERAL_FROM_STR("/messages/events/");
 
-AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
+AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
     az_iot_hub_client const* client,
     az_iot_hub_client_properties const* properties,
-    az_span mqtt_topic,
-    az_span* out_mqtt_topic)
+    char* mqtt_topic,
+    int32_t mqtt_topic_size,
+    int32_t* out_mqtt_topic_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(mqtt_topic, 0, false);
-  AZ_PRECONDITION_NOT_NULL(out_mqtt_topic);
+  AZ_PRECONDITION_NOT_NULL(mqtt_topic);
+  AZ_PRECONDITION(mqtt_topic_size > 0);
 
   const az_span* const module_id = &(client->_internal.options.module_id);
 
+  az_span mqtt_topic_span = az_span_init((uint8_t*) mqtt_topic, mqtt_topic_size);
   int32_t required_length = az_span_size(telemetry_topic_prefix)
       + az_span_size(client->_internal.device_id) + az_span_size(telemetry_topic_suffix);
   int32_t module_id_length = az_span_size(*module_id);
@@ -39,9 +42,9 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
     required_length += az_span_size(properties->_internal.properties_buffer);
   }
 
-  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_span, required_length + (int32_t)sizeof(null_terminator));
 
-  az_span remainder = az_span_copy(mqtt_topic, telemetry_topic_prefix);
+  az_span remainder = az_span_copy(mqtt_topic_span, telemetry_topic_prefix);
   remainder = az_span_copy(remainder, client->_internal.device_id);
 
   if (module_id_length > 0)
@@ -57,7 +60,10 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_publish_topic_get(
     az_span_copy(remainder, properties->_internal.properties_buffer);
   }
 
-  *out_mqtt_topic = az_span_slice(mqtt_topic, 0, required_length);
+  if(out_mqtt_topic_length)
+  {
+    *out_mqtt_topic_length = required_length;
+  }
 
   return AZ_OK;
 }

--- a/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
@@ -57,8 +57,10 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
 
   if (properties != NULL)
   {
-    az_span_copy(remainder, properties->_internal.properties_buffer);
+    remainder = az_span_copy(remainder, properties->_internal.properties_buffer);
   }
+
+  az_span_copy_u8(remainder, null_terminator);
 
   if(out_mqtt_topic_length)
   {

--- a/sdk/iot/hub/src/az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_twin.c
@@ -25,7 +25,7 @@ static const az_span az_iot_hub_twin_patch_pub_topic
 static const az_span az_iot_hub_twin_patch_sub_topic
     = AZ_SPAN_LITERAL_FROM_STR("PATCH/properties/desired/");
 
-AZ_NODISCARD az_result az_iot_hub_client_twin_get_response_subscribe_topic_filter(
+AZ_NODISCARD az_result az_iot_hub_client_twin_response_get_subscribe_topic_filter(
     az_iot_hub_client const* client,
     char* mqtt_topic_filter,
     size_t mqtt_topic_filter_size,
@@ -58,7 +58,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_response_subscribe_topic_filte
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
+AZ_NODISCARD az_result az_iot_hub_client_twin_patch_get_subscribe_topic_filter(
     az_iot_hub_client const* client,
     char* mqtt_topic_filter,
     size_t mqtt_topic_filter_size,
@@ -129,7 +129,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_document_get_publish_topic(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_publish_topic(
+AZ_NODISCARD az_result az_iot_hub_client_twin_patch_get_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
     char* mqtt_topic,

--- a/sdk/iot/hub/src/az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_twin.c
@@ -28,8 +28,8 @@ static const az_span az_iot_hub_twin_patch_sub_topic
 AZ_NODISCARD az_result az_iot_hub_client_twin_get_response_subscribe_topic_filter(
     az_iot_hub_client const* client,
     char* mqtt_topic_filter,
-    int32_t mqtt_topic_filter_size,
-    int32_t* out_mqtt_topic_filter_length)
+    size_t mqtt_topic_filter_size,
+    size_t* out_mqtt_topic_filter_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_NOT_NULL(mqtt_topic_filter);
@@ -37,7 +37,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_response_subscribe_topic_filte
   (void)client;
 
   az_span mqtt_topic_filter_span
-      = az_span_init((uint8_t*)mqtt_topic_filter, mqtt_topic_filter_size);
+      = az_span_init((uint8_t*)mqtt_topic_filter, (int32_t)mqtt_topic_filter_size);
   int32_t required_length = az_span_size(az_iot_hub_twin_topic_prefix)
       + az_span_size(az_iot_hub_twin_response_sub_topic)
       + (int32_t)sizeof(az_iot_hub_client_twin_hashtag);
@@ -52,7 +52,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_response_subscribe_topic_filte
 
   if (out_mqtt_topic_filter_length)
   {
-    *out_mqtt_topic_filter_length = required_length;
+    *out_mqtt_topic_filter_length = (size_t)required_length;
   }
 
   return AZ_OK;
@@ -61,8 +61,8 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_response_subscribe_topic_filte
 AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
     az_iot_hub_client const* client,
     char* mqtt_topic_filter,
-    int32_t mqtt_topic_filter_size,
-    int32_t* out_mqtt_topic_filter_length)
+    size_t mqtt_topic_filter_size,
+    size_t* out_mqtt_topic_filter_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_NOT_NULL(mqtt_topic_filter);
@@ -70,7 +70,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
   (void)client;
 
   az_span mqtt_topic_filter_span
-      = az_span_init((uint8_t*)mqtt_topic_filter, mqtt_topic_filter_size);
+      = az_span_init((uint8_t*)mqtt_topic_filter, (int32_t)mqtt_topic_filter_size);
   int32_t required_length = az_span_size(az_iot_hub_twin_topic_prefix)
       + az_span_size(az_iot_hub_twin_patch_sub_topic)
       + (int32_t)sizeof(az_iot_hub_client_twin_hashtag);
@@ -85,7 +85,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
 
   if (out_mqtt_topic_filter_length)
   {
-    *out_mqtt_topic_filter_length = required_length;
+    *out_mqtt_topic_filter_length = (size_t)required_length;
   }
 
   return AZ_OK;
@@ -95,8 +95,8 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_get_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
     char* mqtt_topic,
-    int32_t mqtt_topic_size,
-    int32_t* out_mqtt_topic_length)
+    size_t mqtt_topic_size,
+    size_t* out_mqtt_topic_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_VALID_SPAN(request_id, 1, false);
@@ -104,7 +104,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_get_publish_topic(
   AZ_PRECONDITION(mqtt_topic_size > 0);
   (void)client;
 
-  az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, mqtt_topic_size);
+  az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   int32_t required_length = az_span_size(az_iot_hub_twin_topic_prefix)
       + az_span_size(az_iot_hub_twin_get_pub_topic)
       + (int32_t)sizeof(az_iot_hub_client_twin_question)
@@ -123,7 +123,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_get_publish_topic(
 
   if (out_mqtt_topic_length)
   {
-    *out_mqtt_topic_length = required_length;
+    *out_mqtt_topic_length = (size_t)required_length;
   }
 
   return AZ_OK;
@@ -133,8 +133,8 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
     char* mqtt_topic,
-    int32_t mqtt_topic_size,
-    int32_t* out_mqtt_topic_length)
+    size_t mqtt_topic_size,
+    size_t* out_mqtt_topic_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_VALID_SPAN(request_id, 1, false);
@@ -142,7 +142,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_publish_topic(
   AZ_PRECONDITION(mqtt_topic_size > 0);
   (void)client;
 
-  az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, mqtt_topic_size);
+  az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   int32_t required_length = az_span_size(az_iot_hub_twin_topic_prefix)
       + az_span_size(az_iot_hub_twin_patch_pub_topic)
       + (int32_t)sizeof(az_iot_hub_client_twin_question)
@@ -161,7 +161,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_publish_topic(
 
   if (out_mqtt_topic_length)
   {
-    *out_mqtt_topic_length = required_length;
+    *out_mqtt_topic_length = (size_t)required_length;
   }
 
   return AZ_OK;

--- a/sdk/iot/hub/src/az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_twin.c
@@ -91,7 +91,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_twin_get_get_publish_topic(
+AZ_NODISCARD az_result az_iot_hub_client_twin_document_get_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
     char* mqtt_topic,

--- a/sdk/iot/hub/src/az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_twin.c
@@ -11,6 +11,7 @@
 
 #include <_az_cfg.h>
 
+static const uint8_t null_terminator = '\0';
 static const uint8_t az_iot_hub_client_twin_hashtag = '#';
 static const uint8_t az_iot_hub_client_twin_question = '?';
 static const uint8_t az_iot_hub_client_twin_equals = '=';
@@ -24,117 +25,144 @@ static const az_span az_iot_hub_twin_patch_pub_topic
 static const az_span az_iot_hub_twin_patch_sub_topic
     = AZ_SPAN_LITERAL_FROM_STR("PATCH/properties/desired/");
 
-AZ_NODISCARD az_result az_iot_hub_client_twin_response_subscribe_topic_filter_get(
+AZ_NODISCARD az_result az_iot_hub_client_twin_get_response_subscribe_topic_filter(
     az_iot_hub_client const* client,
-    az_span mqtt_topic_filter,
-    az_span* out_mqtt_topic_filter)
+    char* mqtt_topic_filter,
+    int32_t mqtt_topic_filter_size,
+    int32_t* out_mqtt_topic_filter_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(mqtt_topic_filter, 0, false);
-  AZ_PRECONDITION_NOT_NULL(out_mqtt_topic_filter);
+  AZ_PRECONDITION_NOT_NULL(mqtt_topic_filter);
+  AZ_PRECONDITION(mqtt_topic_filter_size > 0);
   (void)client;
 
+  az_span mqtt_topic_filter_span
+      = az_span_init((uint8_t*)mqtt_topic_filter, mqtt_topic_filter_size);
   int32_t required_length = az_span_size(az_iot_hub_twin_topic_prefix)
       + az_span_size(az_iot_hub_twin_response_sub_topic)
       + (int32_t)sizeof(az_iot_hub_client_twin_hashtag);
 
-  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_filter, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(
+      mqtt_topic_filter_span, required_length + (int32_t)sizeof(null_terminator));
 
-  az_span remainder = az_span_copy(mqtt_topic_filter, az_iot_hub_twin_topic_prefix);
+  az_span remainder = az_span_copy(mqtt_topic_filter_span, az_iot_hub_twin_topic_prefix);
   remainder = az_span_copy(remainder, az_iot_hub_twin_response_sub_topic);
   remainder = az_span_copy_u8(remainder, az_iot_hub_client_twin_hashtag);
+  az_span_copy_u8(remainder, null_terminator);
 
-  *out_mqtt_topic_filter = az_span_slice(mqtt_topic_filter, 0, required_length);
+  if (out_mqtt_topic_filter_length)
+  {
+    *out_mqtt_topic_filter_length = required_length;
+  }
 
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_twin_patch_subscribe_topic_filter_get(
+AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
     az_iot_hub_client const* client,
-    az_span mqtt_topic_filter,
-    az_span* out_mqtt_topic_filter)
+    char* mqtt_topic_filter,
+    int32_t mqtt_topic_filter_size,
+    int32_t* out_mqtt_topic_filter_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(mqtt_topic_filter, 0, false);
-  AZ_PRECONDITION_NOT_NULL(out_mqtt_topic_filter);
+  AZ_PRECONDITION_NOT_NULL(mqtt_topic_filter);
+  AZ_PRECONDITION(mqtt_topic_filter_size > 0);
   (void)client;
 
+  az_span mqtt_topic_filter_span
+      = az_span_init((uint8_t*)mqtt_topic_filter, mqtt_topic_filter_size);
   int32_t required_length = az_span_size(az_iot_hub_twin_topic_prefix)
       + az_span_size(az_iot_hub_twin_patch_sub_topic)
       + (int32_t)sizeof(az_iot_hub_client_twin_hashtag);
 
-  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_filter, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(
+      mqtt_topic_filter_span, required_length + (int32_t)sizeof(null_terminator));
 
-  az_span remainder = az_span_copy(mqtt_topic_filter, az_iot_hub_twin_topic_prefix);
+  az_span remainder = az_span_copy(mqtt_topic_filter_span, az_iot_hub_twin_topic_prefix);
   remainder = az_span_copy(remainder, az_iot_hub_twin_patch_sub_topic);
-  az_span_copy_u8(remainder, az_iot_hub_client_twin_hashtag);
+  remainder = az_span_copy_u8(remainder, az_iot_hub_client_twin_hashtag);
+  az_span_copy_u8(remainder, null_terminator);
 
-  *out_mqtt_topic_filter = az_span_slice(mqtt_topic_filter, 0, required_length);
+  if (out_mqtt_topic_filter_length)
+  {
+    *out_mqtt_topic_filter_length = required_length;
+  }
 
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_twin_get_publish_topic_get(
+AZ_NODISCARD az_result az_iot_hub_client_twin_get_get_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
-    az_span mqtt_topic,
-    az_span* out_mqtt_topic)
+    char* mqtt_topic,
+    int32_t mqtt_topic_size,
+    int32_t* out_mqtt_topic_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_VALID_SPAN(request_id, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(mqtt_topic, 0, false);
-  AZ_PRECONDITION_NOT_NULL(out_mqtt_topic);
+  AZ_PRECONDITION_NOT_NULL(mqtt_topic);
+  AZ_PRECONDITION(mqtt_topic_size > 0);
   (void)client;
 
+  az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, mqtt_topic_size);
   int32_t required_length = az_span_size(az_iot_hub_twin_topic_prefix)
       + az_span_size(az_iot_hub_twin_get_pub_topic)
       + (int32_t)sizeof(az_iot_hub_client_twin_question)
       + az_span_size(az_iot_hub_client_request_id_span)
       + (int32_t)sizeof(az_iot_hub_client_twin_equals) + az_span_size(request_id);
 
-  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_span, required_length + (int32_t)sizeof(null_terminator));
 
-  az_span remainder = az_span_copy(mqtt_topic, az_iot_hub_twin_topic_prefix);
+  az_span remainder = az_span_copy(mqtt_topic_span, az_iot_hub_twin_topic_prefix);
   remainder = az_span_copy(remainder, az_iot_hub_twin_get_pub_topic);
   remainder = az_span_copy_u8(remainder, az_iot_hub_client_twin_question);
   remainder = az_span_copy(remainder, az_iot_hub_client_request_id_span);
   remainder = az_span_copy_u8(remainder, az_iot_hub_client_twin_equals);
   remainder = az_span_copy(remainder, request_id);
+  az_span_copy_u8(remainder, null_terminator);
 
-
-  *out_mqtt_topic = az_span_slice(mqtt_topic, 0, required_length);
+  if (out_mqtt_topic_length)
+  {
+    *out_mqtt_topic_length = required_length;
+  }
 
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_twin_patch_publish_topic_get(
+AZ_NODISCARD az_result az_iot_hub_client_twin_get_patch_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
-    az_span mqtt_topic,
-    az_span* out_mqtt_topic)
+    char* mqtt_topic,
+    int32_t mqtt_topic_size,
+    int32_t* out_mqtt_topic_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_VALID_SPAN(request_id, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(mqtt_topic, 0, false);
-  AZ_PRECONDITION_NOT_NULL(out_mqtt_topic);
+  AZ_PRECONDITION_NOT_NULL(mqtt_topic);
+  AZ_PRECONDITION(mqtt_topic_size > 0);
   (void)client;
 
+  az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, mqtt_topic_size);
   int32_t required_length = az_span_size(az_iot_hub_twin_topic_prefix)
       + az_span_size(az_iot_hub_twin_patch_pub_topic)
       + (int32_t)sizeof(az_iot_hub_client_twin_question)
       + az_span_size(az_iot_hub_client_request_id_span)
       + (int32_t)sizeof(az_iot_hub_client_twin_equals) + az_span_size(request_id);
 
-  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_span, required_length + (int32_t)sizeof(null_terminator));
 
-  az_span remainder = az_span_copy(mqtt_topic, az_iot_hub_twin_topic_prefix);
+  az_span remainder = az_span_copy(mqtt_topic_span, az_iot_hub_twin_topic_prefix);
   remainder = az_span_copy(remainder, az_iot_hub_twin_patch_pub_topic);
   remainder = az_span_copy_u8(remainder, az_iot_hub_client_twin_question);
   remainder = az_span_copy(remainder, az_iot_hub_client_request_id_span);
   remainder = az_span_copy_u8(remainder, az_iot_hub_client_twin_equals);
   remainder = az_span_copy(remainder, request_id);
+  az_span_copy_u8(remainder, null_terminator);
 
-  *out_mqtt_topic = az_span_slice(mqtt_topic, 0, required_length);
+  if (out_mqtt_topic_length)
+  {
+    *out_mqtt_topic_length = required_length;
+  }
 
   return AZ_OK;
 }

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
@@ -93,18 +93,18 @@ static void test_az_iot_hub_client_init_NULL_hub_hostname_id_fails(void** state)
   assert_precondition_checked(az_iot_hub_client_init(&client, test_device_id, AZ_SPAN_NULL, NULL));
 }
 
-static void test_az_iot_hub_client_user_name_get_NULL_client_fails(void** state)
+static void test_az_iot_hub_client_get_user_name_NULL_client_fails(void** state)
 {
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_user_name_get(
+  assert_precondition_checked(az_iot_hub_client_get_user_name(
       NULL, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_user_name_get_NULL_input_span_fails(void** state)
+static void test_az_iot_hub_client_get_user_name_NULL_input_span_fails(void** state)
 {
   (void)state;
 
@@ -114,10 +114,10 @@ static void test_az_iot_hub_client_user_name_get_NULL_input_span_fails(void** st
   size_t test_length;
 
   assert_precondition_checked(
-      az_iot_hub_client_user_name_get(&client, NULL, sizeof(test_buf), &test_length));
+      az_iot_hub_client_get_user_name(&client, NULL, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_user_name_get_NULL_output_span_fails(void** state)
+static void test_az_iot_hub_client_get_user_name_NULL_output_span_fails(void** state)
 {
   (void)state;
 
@@ -127,10 +127,10 @@ static void test_az_iot_hub_client_user_name_get_NULL_output_span_fails(void** s
   size_t test_length;
 
   assert_precondition_checked(
-      az_iot_hub_client_user_name_get(&client, test_buf, 0, &test_length));
+      az_iot_hub_client_get_user_name(&client, test_buf, 0, &test_length));
 }
 
-static void test_az_iot_hub_client_id_get_NULL_client_fails(void** state)
+static void test_az_iot_hub_client_get_client_id_NULL_client_fails(void** state)
 {
   (void)state;
 
@@ -138,22 +138,10 @@ static void test_az_iot_hub_client_id_get_NULL_client_fails(void** state)
   size_t test_length;
 
   assert_precondition_checked(
-      az_iot_hub_client_id_get(NULL, test_buf, sizeof(test_buf), &test_length));
+      az_iot_hub_client_get_client_id(NULL, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_id_get_NULL_input_span_fails(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  char test_buf[TEST_SPAN_BUFFER_SIZE];
-  size_t test_length;
-
-  assert_precondition_checked(
-      az_iot_hub_client_id_get(&client, NULL, sizeof(test_buf), &test_length));
-}
-
-static void test_az_iot_hub_client_id_get_NULL_output_span_fails(void** state)
+static void test_az_iot_hub_client_get_client_id_NULL_input_span_fails(void** state)
 {
   (void)state;
 
@@ -162,7 +150,19 @@ static void test_az_iot_hub_client_id_get_NULL_output_span_fails(void** state)
   size_t test_length;
 
   assert_precondition_checked(
-      az_iot_hub_client_id_get(&client, test_buf, 0, &test_length));
+      az_iot_hub_client_get_client_id(&client, NULL, sizeof(test_buf), &test_length));
+}
+
+static void test_az_iot_hub_client_get_client_id_NULL_output_span_fails(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  size_t test_length;
+
+  assert_precondition_checked(
+      az_iot_hub_client_get_client_id(&client, test_buf, 0, &test_length));
 }
 
 static void test_az_iot_hub_client_properties_init_NULL_props_fails(void** state)
@@ -316,7 +316,7 @@ static void test_az_iot_hub_client_init_custom_options_succeed(void** state)
       _az_COUNTOF(TEST_USER_AGENT) - 1);
 }
 
-static void test_az_iot_hub_client_user_name_get_succeed(void** state)
+static void test_az_iot_hub_client_get_user_name_succeed(void** state)
 {
   (void)state;
 
@@ -327,7 +327,7 @@ static void test_az_iot_hub_client_user_name_get_succeed(void** state)
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_user_name_get(
+      az_iot_hub_client_get_user_name(
           &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_OK);
 
@@ -335,7 +335,7 @@ static void test_az_iot_hub_client_user_name_get_succeed(void** state)
   assert_int_equal(sizeof(test_correct_user_name) - 1, test_length);
 }
 
-static void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
+static void test_az_iot_hub_client_get_user_name_small_buffer_fail(void** state)
 {
   (void)state;
 
@@ -346,12 +346,12 @@ static void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_user_name_get(
+      az_iot_hub_client_get_user_name(
           &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-static void test_az_iot_hub_client_user_name_get_user_options_succeed(void** state)
+static void test_az_iot_hub_client_get_user_name_user_options_succeed(void** state)
 {
   (void)state;
 
@@ -366,14 +366,14 @@ static void test_az_iot_hub_client_user_name_get_user_options_succeed(void** sta
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_user_name_get(
+      az_iot_hub_client_get_user_name(
           &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_OK);
   assert_string_equal(test_correct_user_name_with_module_id, mqtt_topic_buf);
   assert_int_equal(sizeof(test_correct_user_name_with_module_id) - 1, test_length);
 }
 
-static void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(void** state)
+static void test_az_iot_hub_client_get_user_name_user_options_small_buffer_fail(void** state)
 {
   (void)state;
 
@@ -388,12 +388,12 @@ static void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_user_name_get(
+      az_iot_hub_client_get_user_name(
           &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-static void test_az_iot_hub_client_id_get_succeed(void** state)
+static void test_az_iot_hub_client_get_client_id_succeed(void** state)
 {
   (void)state;
 
@@ -404,13 +404,13 @@ static void test_az_iot_hub_client_id_get_succeed(void** state)
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
+      az_iot_hub_client_get_client_id(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_OK);
   assert_string_equal(test_correct_client_id, mqtt_topic_buf);
   assert_int_equal(sizeof(test_correct_client_id) - 1, test_length);
 }
 
-static void test_az_iot_hub_client_id_get_small_buffer_fail(void** state)
+static void test_az_iot_hub_client_get_client_id_small_buffer_fail(void** state)
 {
   (void)state;
 
@@ -421,11 +421,11 @@ static void test_az_iot_hub_client_id_get_small_buffer_fail(void** state)
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
+      az_iot_hub_client_get_client_id(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-static void test_az_iot_hub_client_id_get_module_succeed(void** state)
+static void test_az_iot_hub_client_get_client_id_module_succeed(void** state)
 {
   (void)state;
 
@@ -439,13 +439,13 @@ static void test_az_iot_hub_client_id_get_module_succeed(void** state)
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
+      az_iot_hub_client_get_client_id(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_OK);
   assert_string_equal(test_correct_client_id_with_module_id, mqtt_topic_buf);
   assert_int_equal(sizeof(test_correct_client_id_with_module_id) - 1, test_length);
 }
 
-static void test_az_iot_hub_client_id_get_module_small_buffer_fail(void** state)
+static void test_az_iot_hub_client_get_client_id_module_small_buffer_fail(void** state)
 {
   (void)state;
 
@@ -459,7 +459,7 @@ static void test_az_iot_hub_client_id_get_module_small_buffer_fail(void** state)
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
+      az_iot_hub_client_get_client_id(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
@@ -843,12 +843,12 @@ int test_iot_hub_client()
     cmocka_unit_test(test_az_iot_hub_client_init_NULL_client_fails),
     cmocka_unit_test(test_az_iot_hub_client_init_NULL_device_id_fails),
     cmocka_unit_test(test_az_iot_hub_client_init_NULL_hub_hostname_id_fails),
-    cmocka_unit_test(test_az_iot_hub_client_user_name_get_NULL_client_fails),
-    cmocka_unit_test(test_az_iot_hub_client_user_name_get_NULL_input_span_fails),
-    cmocka_unit_test(test_az_iot_hub_client_user_name_get_NULL_output_span_fails),
-    cmocka_unit_test(test_az_iot_hub_client_id_get_NULL_client_fails),
-    cmocka_unit_test(test_az_iot_hub_client_id_get_NULL_input_span_fails),
-    cmocka_unit_test(test_az_iot_hub_client_id_get_NULL_output_span_fails),
+    cmocka_unit_test(test_az_iot_hub_client_get_user_name_NULL_client_fails),
+    cmocka_unit_test(test_az_iot_hub_client_get_user_name_NULL_input_span_fails),
+    cmocka_unit_test(test_az_iot_hub_client_get_user_name_NULL_output_span_fails),
+    cmocka_unit_test(test_az_iot_hub_client_get_client_id_NULL_client_fails),
+    cmocka_unit_test(test_az_iot_hub_client_get_client_id_NULL_input_span_fails),
+    cmocka_unit_test(test_az_iot_hub_client_get_client_id_NULL_output_span_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_init_NULL_props_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_init_NULL_buffer_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_append_get_NULL_props_fails),
@@ -863,14 +863,14 @@ int test_iot_hub_client()
     cmocka_unit_test(test_az_iot_hub_client_get_default_options_succeed),
     cmocka_unit_test(test_az_iot_hub_client_init_succeed),
     cmocka_unit_test(test_az_iot_hub_client_init_custom_options_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_user_name_get_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_user_name_get_small_buffer_fail),
-    cmocka_unit_test(test_az_iot_hub_client_user_name_get_user_options_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail),
-    cmocka_unit_test(test_az_iot_hub_client_id_get_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_id_get_small_buffer_fail),
-    cmocka_unit_test(test_az_iot_hub_client_id_get_module_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_id_get_module_small_buffer_fail),
+    cmocka_unit_test(test_az_iot_hub_client_get_user_name_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_get_user_name_small_buffer_fail),
+    cmocka_unit_test(test_az_iot_hub_client_get_user_name_user_options_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_get_user_name_user_options_small_buffer_fail),
+    cmocka_unit_test(test_az_iot_hub_client_get_client_id_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_get_client_id_small_buffer_fail),
+    cmocka_unit_test(test_az_iot_hub_client_get_client_id_module_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_get_client_id_module_small_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_properties_init_succeed),
     cmocka_unit_test(test_az_iot_hub_client_properties_init_user_set_params_succeed),
     cmocka_unit_test(test_az_iot_hub_client_properties_append_succeed),

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
@@ -97,10 +97,11 @@ static void test_az_iot_hub_client_user_name_get_NULL_client_fails(void** state)
 {
   (void)state;
 
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
 
-  assert_precondition_checked(az_iot_hub_client_user_name_get(NULL, test_span, &test_span));
+  assert_precondition_checked(az_iot_hub_client_user_name_get(
+      NULL, test_buf, sizeof(test_buf), &mqtt_topic_length));
 }
 
 static void test_az_iot_hub_client_user_name_get_NULL_input_span_fails(void** state)
@@ -108,10 +109,12 @@ static void test_az_iot_hub_client_user_name_get_NULL_input_span_fails(void** st
   (void)state;
 
   az_iot_hub_client client;
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
-  assert_precondition_checked(az_iot_hub_client_user_name_get(&client, AZ_SPAN_NULL, &test_span));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
+
+  assert_precondition_checked(
+      az_iot_hub_client_user_name_get(&client, NULL, sizeof(test_buf), &mqtt_topic_length));
 }
 
 static void test_az_iot_hub_client_user_name_get_NULL_output_span_fails(void** state)
@@ -119,20 +122,23 @@ static void test_az_iot_hub_client_user_name_get_NULL_output_span_fails(void** s
   (void)state;
 
   az_iot_hub_client client;
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
 
-  assert_precondition_checked(az_iot_hub_client_user_name_get(&client, test_span, NULL));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
+
+  assert_precondition_checked(
+      az_iot_hub_client_user_name_get(&client, test_buf, 0, &test_length));
 }
 
 static void test_az_iot_hub_client_id_get_NULL_client_fails(void** state)
 {
   (void)state;
 
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_id_get(NULL, test_span, &test_span));
+  assert_precondition_checked(
+      az_iot_hub_client_id_get(NULL, test_buf, sizeof(test_buf), &test_length));
 }
 
 static void test_az_iot_hub_client_id_get_NULL_input_span_fails(void** state)
@@ -140,10 +146,11 @@ static void test_az_iot_hub_client_id_get_NULL_input_span_fails(void** state)
   (void)state;
 
   az_iot_hub_client client;
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_id_get(&client, AZ_SPAN_NULL, &test_span));
+  assert_precondition_checked(
+      az_iot_hub_client_id_get(&client, NULL, sizeof(test_buf), &test_length));
 }
 
 static void test_az_iot_hub_client_id_get_NULL_output_span_fails(void** state)
@@ -151,10 +158,11 @@ static void test_az_iot_hub_client_id_get_NULL_output_span_fails(void** state)
   (void)state;
 
   az_iot_hub_client client;
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_id_get(&client, test_span, NULL));
+  assert_precondition_checked(
+      az_iot_hub_client_id_get(&client, test_buf, 0, &test_length));
 }
 
 static void test_az_iot_hub_client_properties_init_NULL_props_fails(void** state)
@@ -315,39 +323,16 @@ static void test_az_iot_hub_client_user_name_get_succeed(void** state)
   az_iot_hub_client client;
   assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
 
-  assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
-  az_span_for_test_verify(
-      test_span,
-      test_correct_user_name,
-      _az_COUNTOF(test_correct_user_name) - 1,
-      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
-      TEST_SPAN_BUFFER_SIZE);
-}
+  assert_int_equal(
+      az_iot_hub_client_user_name_get(
+          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+      AZ_OK);
 
-static void test_az_iot_hub_client_user_name_get_twice_succeed(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
-
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
-  assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
-
-  assert_memory_equal(
-      test_correct_user_name, az_span_ptr(test_span), sizeof(test_correct_user_name) - 1);
-  assert_int_equal(az_span_size(test_span), _az_COUNTOF(test_correct_user_name) - 1);
-  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
-
-  assert_memory_equal(
-      test_correct_user_name, az_span_ptr(test_span), sizeof(test_correct_user_name) - 1);
-  assert_int_equal(az_span_size(test_span), _az_COUNTOF(test_correct_user_name) - 1);
-  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
+  assert_string_equal(test_correct_user_name, mqtt_topic_buf);
+  assert_int_equal(sizeof(test_correct_user_name) - 1, mqtt_topic_length);
 }
 
 static void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
@@ -357,12 +342,13 @@ static void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
   az_iot_hub_client client;
   assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[sizeof(test_correct_user_name) - 2];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char mqtt_topic_buf[sizeof(test_correct_user_name) - 2];
+  int32_t mqtt_topic_length;
+
   assert_int_equal(
-      az_iot_hub_client_user_name_get(&client, test_span, &test_span),
+      az_iot_hub_client_user_name_get(
+          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-  assert_int_equal(az_span_size(test_span), sizeof(test_correct_user_name) - 2);
 }
 
 static void test_az_iot_hub_client_user_name_get_user_options_succeed(void** state)
@@ -376,16 +362,15 @@ static void test_az_iot_hub_client_user_name_get_user_options_succeed(void** sta
   assert_int_equal(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
 
-  assert_int_equal(az_iot_hub_client_user_name_get(&client, test_span, &test_span), AZ_OK);
-  az_span_for_test_verify(
-      test_span,
-      test_correct_user_name_with_module_id,
-      _az_COUNTOF(test_correct_user_name_with_module_id) - 1,
-      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
-      TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(
+      az_iot_hub_client_user_name_get(
+          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+      AZ_OK);
+  assert_string_equal(test_correct_user_name_with_module_id, mqtt_topic_buf);
+  assert_int_equal(sizeof(test_correct_user_name_with_module_id) - 1, mqtt_topic_length);
 }
 
 static void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(void** state)
@@ -399,12 +384,13 @@ static void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(
   assert_int_equal(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buf[sizeof(test_correct_user_name_with_module_id) - 2];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char mqtt_topic_buf[sizeof(test_correct_user_name_with_module_id) - 2];
+  int32_t mqtt_topic_length;
+
   assert_int_equal(
-      az_iot_hub_client_user_name_get(&client, test_span, &test_span),
+      az_iot_hub_client_user_name_get(
+          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-  assert_int_equal(az_span_size(test_span), sizeof(test_correct_user_name_with_module_id) - 2);
 }
 
 static void test_az_iot_hub_client_id_get_succeed(void** state)
@@ -414,39 +400,14 @@ static void test_az_iot_hub_client_id_get_succeed(void** state)
   az_iot_hub_client client;
   assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
 
-  assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
-  az_span_for_test_verify(
-      test_span,
-      test_correct_client_id,
-      _az_COUNTOF(test_correct_client_id) - 1,
-      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
-      TEST_SPAN_BUFFER_SIZE);
-}
-
-static void test_az_iot_hub_client_id_get_twice_succeed(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
-
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
-  assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
-
-  assert_memory_equal(
-      test_correct_client_id, az_span_ptr(test_span), sizeof(test_correct_client_id) - 1);
-  assert_int_equal(az_span_size(test_span), sizeof(test_correct_client_id) - 1);
-  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
-
-  assert_memory_equal(
-      test_correct_client_id, az_span_ptr(test_span), sizeof(test_correct_client_id) - 1);
-  assert_int_equal(az_span_size(test_span), sizeof(test_correct_client_id) - 1);
-  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
+  assert_int_equal(
+      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+      AZ_OK);
+  assert_string_equal(test_correct_client_id, mqtt_topic_buf);
+  assert_int_equal(sizeof(test_correct_client_id) - 1, mqtt_topic_length);
 }
 
 static void test_az_iot_hub_client_id_get_small_buffer_fail(void** state)
@@ -456,11 +417,12 @@ static void test_az_iot_hub_client_id_get_small_buffer_fail(void** state)
   az_iot_hub_client client;
   assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[sizeof(test_correct_client_id) - 2];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char mqtt_topic_buf[sizeof(test_correct_client_id) - 2];
+  int32_t mqtt_topic_length;
+
   assert_int_equal(
-      az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-  assert_int_equal(az_span_size(test_span), sizeof(test_correct_client_id) - 2);
+      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void test_az_iot_hub_client_id_get_module_succeed(void** state)
@@ -473,16 +435,14 @@ static void test_az_iot_hub_client_id_get_module_succeed(void** state)
   assert_int_equal(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
 
-  assert_int_equal(az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_OK);
-  az_span_for_test_verify(
-      test_span,
-      test_correct_client_id_with_module_id,
-      _az_COUNTOF(test_correct_client_id_with_module_id) - 1,
-      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
-      TEST_SPAN_BUFFER_SIZE);
+  assert_int_equal(
+      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+      AZ_OK);
+  assert_string_equal(test_correct_client_id_with_module_id, mqtt_topic_buf);
+  assert_int_equal(sizeof(test_correct_client_id_with_module_id) - 1, mqtt_topic_length);
 }
 
 static void test_az_iot_hub_client_id_get_module_small_buffer_fail(void** state)
@@ -495,11 +455,12 @@ static void test_az_iot_hub_client_id_get_module_small_buffer_fail(void** state)
   assert_int_equal(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t test_span_buf[sizeof(test_correct_client_id_with_module_id) - 2];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char mqtt_topic_buf[sizeof(test_correct_client_id_with_module_id) - 2];
+  int32_t mqtt_topic_length;
+
   assert_int_equal(
-      az_iot_hub_client_id_get(&client, test_span, &test_span), AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-  assert_int_equal(az_span_size(test_span), sizeof(test_correct_client_id_with_module_id) - 2);
+      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void test_az_iot_hub_client_properties_init_succeed(void** state)
@@ -903,12 +864,10 @@ int test_iot_hub_client()
     cmocka_unit_test(test_az_iot_hub_client_init_succeed),
     cmocka_unit_test(test_az_iot_hub_client_init_custom_options_succeed),
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_user_name_get_twice_succeed),
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_small_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_user_options_succeed),
     cmocka_unit_test(test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_id_get_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_id_get_twice_succeed),
     cmocka_unit_test(test_az_iot_hub_client_id_get_small_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_id_get_module_succeed),
     cmocka_unit_test(test_az_iot_hub_client_id_get_module_small_buffer_fail),

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
@@ -98,10 +98,10 @@ static void test_az_iot_hub_client_user_name_get_NULL_client_fails(void** state)
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_user_name_get(
-      NULL, test_buf, sizeof(test_buf), &mqtt_topic_length));
+      NULL, test_buf, sizeof(test_buf), &test_length));
 }
 
 static void test_az_iot_hub_client_user_name_get_NULL_input_span_fails(void** state)
@@ -111,10 +111,10 @@ static void test_az_iot_hub_client_user_name_get_NULL_input_span_fails(void** st
   az_iot_hub_client client;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t test_length;
 
   assert_precondition_checked(
-      az_iot_hub_client_user_name_get(&client, NULL, sizeof(test_buf), &mqtt_topic_length));
+      az_iot_hub_client_user_name_get(&client, NULL, sizeof(test_buf), &test_length));
 }
 
 static void test_az_iot_hub_client_user_name_get_NULL_output_span_fails(void** state)
@@ -124,7 +124,7 @@ static void test_az_iot_hub_client_user_name_get_NULL_output_span_fails(void** s
   az_iot_hub_client client;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(
       az_iot_hub_client_user_name_get(&client, test_buf, 0, &test_length));
@@ -135,7 +135,7 @@ static void test_az_iot_hub_client_id_get_NULL_client_fails(void** state)
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(
       az_iot_hub_client_id_get(NULL, test_buf, sizeof(test_buf), &test_length));
@@ -147,7 +147,7 @@ static void test_az_iot_hub_client_id_get_NULL_input_span_fails(void** state)
 
   az_iot_hub_client client;
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(
       az_iot_hub_client_id_get(&client, NULL, sizeof(test_buf), &test_length));
@@ -159,7 +159,7 @@ static void test_az_iot_hub_client_id_get_NULL_output_span_fails(void** state)
 
   az_iot_hub_client client;
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(
       az_iot_hub_client_id_get(&client, test_buf, 0, &test_length));
@@ -324,15 +324,15 @@ static void test_az_iot_hub_client_user_name_get_succeed(void** state)
   assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t test_length;
 
   assert_int_equal(
       az_iot_hub_client_user_name_get(
-          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_OK);
 
   assert_string_equal(test_correct_user_name, mqtt_topic_buf);
-  assert_int_equal(sizeof(test_correct_user_name) - 1, mqtt_topic_length);
+  assert_int_equal(sizeof(test_correct_user_name) - 1, test_length);
 }
 
 static void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
@@ -343,11 +343,11 @@ static void test_az_iot_hub_client_user_name_get_small_buffer_fail(void** state)
   assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
   char mqtt_topic_buf[sizeof(test_correct_user_name) - 2];
-  int32_t mqtt_topic_length;
+  size_t test_length;
 
   assert_int_equal(
       az_iot_hub_client_user_name_get(
-          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
@@ -363,14 +363,14 @@ static void test_az_iot_hub_client_user_name_get_user_options_succeed(void** sta
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t test_length;
 
   assert_int_equal(
       az_iot_hub_client_user_name_get(
-          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_OK);
   assert_string_equal(test_correct_user_name_with_module_id, mqtt_topic_buf);
-  assert_int_equal(sizeof(test_correct_user_name_with_module_id) - 1, mqtt_topic_length);
+  assert_int_equal(sizeof(test_correct_user_name_with_module_id) - 1, test_length);
 }
 
 static void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(void** state)
@@ -385,11 +385,11 @@ static void test_az_iot_hub_client_user_name_get_user_options_small_buffer_fail(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
 
   char mqtt_topic_buf[sizeof(test_correct_user_name_with_module_id) - 2];
-  int32_t mqtt_topic_length;
+  size_t test_length;
 
   assert_int_equal(
       az_iot_hub_client_user_name_get(
-          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
@@ -401,13 +401,13 @@ static void test_az_iot_hub_client_id_get_succeed(void** state)
   assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_OK);
   assert_string_equal(test_correct_client_id, mqtt_topic_buf);
-  assert_int_equal(sizeof(test_correct_client_id) - 1, mqtt_topic_length);
+  assert_int_equal(sizeof(test_correct_client_id) - 1, test_length);
 }
 
 static void test_az_iot_hub_client_id_get_small_buffer_fail(void** state)
@@ -418,10 +418,10 @@ static void test_az_iot_hub_client_id_get_small_buffer_fail(void** state)
   assert_int_equal(az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, NULL), AZ_OK);
 
   char mqtt_topic_buf[sizeof(test_correct_client_id) - 2];
-  int32_t mqtt_topic_length;
+  size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
@@ -436,13 +436,13 @@ static void test_az_iot_hub_client_id_get_module_succeed(void** state)
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_OK);
   assert_string_equal(test_correct_client_id_with_module_id, mqtt_topic_buf);
-  assert_int_equal(sizeof(test_correct_client_id_with_module_id) - 1, mqtt_topic_length);
+  assert_int_equal(sizeof(test_correct_client_id_with_module_id) - 1, test_length);
 }
 
 static void test_az_iot_hub_client_id_get_module_small_buffer_fail(void** state)
@@ -456,10 +456,10 @@ static void test_az_iot_hub_client_id_get_module_small_buffer_fail(void** state)
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
 
   char mqtt_topic_buf[sizeof(test_correct_client_id_with_module_id) - 2];
-  int32_t mqtt_topic_length;
+  size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+      az_iot_hub_client_id_get(&client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
@@ -37,7 +37,7 @@ static const az_span test_URL_ENCODED_topic
 #ifndef NO_PRECONDITION_CHECKING
 enable_precondition_check_tests()
 
-static void test_az_iot_hub_client_c2d_received_topic_parse_NULL_client_fail(void** state)
+static void test_az_iot_hub_client_c2d_parse_received_topic_NULL_client_fail(void** state)
 {
   (void)state;
 
@@ -48,10 +48,10 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_NULL_client_fail(voi
   az_iot_hub_client_c2d_request out_request;
 
   assert_precondition_checked(
-      az_iot_hub_client_c2d_received_topic_parse(NULL, received_topic, &out_request));
+      az_iot_hub_client_c2d_parse_received_topic(NULL, received_topic, &out_request));
 }
 
-static void test_az_iot_hub_client_c2d_received_topic_parse_AZ_SPAN_NULL_received_topic_fail(
+static void test_az_iot_hub_client_c2d_parse_received_topic_AZ_SPAN_NULL_received_topic_fail(
     void** state)
 {
   (void)state;
@@ -66,10 +66,10 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_AZ_SPAN_NULL_receive
   az_iot_hub_client_c2d_request out_request;
 
   assert_precondition_checked(
-      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request));
+      az_iot_hub_client_c2d_parse_received_topic(&client, received_topic, &out_request));
 }
 
-static void test_az_iot_hub_client_c2d_received_topic_parse_NULL_out_request_fail(void** state)
+static void test_az_iot_hub_client_c2d_parse_received_topic_NULL_out_request_fail(void** state)
 {
   (void)state;
 
@@ -81,11 +81,11 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_NULL_out_request_fai
   az_span received_topic = test_URL_DECODED_topic;
 
   assert_precondition_checked(
-      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, NULL));
+      az_iot_hub_client_c2d_parse_received_topic(&client, received_topic, NULL));
 }
 
 // Note: c2d messages ALWAYS contain propeties (at least $.to).
-static void test_az_iot_hub_client_c2d_received_topic_parse_no_properties_fail(void** state)
+static void test_az_iot_hub_client_c2d_parse_received_topic_no_properties_fail(void** state)
 {
   (void)state;
 
@@ -100,10 +100,10 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_no_properties_fail(v
   az_iot_hub_client_c2d_request out_request;
 
   assert_precondition_checked(
-      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request));
+      az_iot_hub_client_c2d_parse_received_topic(&client, received_topic, &out_request));
 }
 
-static void test_az_iot_hub_client_c2d_received_topic_parse_MALFORMED_fail(void** state)
+static void test_az_iot_hub_client_c2d_parse_received_topic_MALFORMED_fail(void** state)
 {
   (void)state;
 
@@ -118,7 +118,7 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_MALFORMED_fail(void*
   az_iot_hub_client_c2d_request out_request;
 
   assert_precondition_checked(
-      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request));
+      az_iot_hub_client_c2d_parse_received_topic(&client, received_topic, &out_request));
 }
 
 #endif // NO_PRECONDITION_CHECKING
@@ -134,34 +134,7 @@ static void test_az_iot_hub_client_c2d_get_subscribe_topic_filter_succeed(void**
   assert_true(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
-  size_t returned_size;
-  assert_true(
-      az_iot_hub_client_c2d_get_subscribe_topic_filter(
-          &client, mqtt_sub_topic_buf, sizeof(mqtt_sub_topic_buf), &returned_size)
-      == AZ_OK);
-  assert_string_equal(mqtt_sub_topic_buf, g_test_correct_subscribe_topic);
-  assert_int_equal(returned_size, sizeof(g_test_correct_subscribe_topic) - 1);
-}
-
-static void test_az_iot_hub_client_c2d_get_subscribe_topic_filter_twice_succeed(void** state)
-{
-  (void)state;
-
-  char mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
-
-  az_iot_hub_client client;
-  az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  assert_true(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
-
-  size_t returned_size;
-  assert_true(
-      az_iot_hub_client_c2d_get_subscribe_topic_filter(
-          &client, mqtt_sub_topic_buf, sizeof(mqtt_sub_topic_buf), &returned_size)
-      == AZ_OK);
-  assert_string_equal(mqtt_sub_topic_buf, g_test_correct_subscribe_topic);
-  assert_int_equal(returned_size, sizeof(g_test_correct_subscribe_topic) - 1);
-
+  int32_t returned_size;
   assert_true(
       az_iot_hub_client_c2d_get_subscribe_topic_filter(
           &client, mqtt_sub_topic_buf, sizeof(mqtt_sub_topic_buf), &returned_size)
@@ -181,14 +154,14 @@ static void test_az_iot_hub_client_c2d_get_subscribe_topic_filter_small_buffer_f
   assert_true(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
-  size_t returned_size;
+  int32_t returned_size;
   assert_true(
       az_iot_hub_client_c2d_get_subscribe_topic_filter(
           &client, mqtt_sub_topic_buf, sizeof(mqtt_sub_topic_buf), &returned_size)
       == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-static void test_az_iot_hub_client_c2d_received_topic_parse_URL_DECODED_succeed(void** state)
+static void test_az_iot_hub_client_c2d_parse_received_topic_URL_DECODED_succeed(void** state)
 {
   (void)state;
 
@@ -203,7 +176,7 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_URL_DECODED_succeed(
   az_iot_hub_client_c2d_request out_request;
 
   assert_return_code(
-      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request), AZ_OK);
+      az_iot_hub_client_c2d_parse_received_topic(&client, received_topic, &out_request), AZ_OK);
 
   // TODO: enable after az_iot_hub_client_properties_next() is implemented.
   // assert_return_code(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
@@ -221,7 +194,7 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_URL_DECODED_succeed(
   // assert_true(az_span_is_content_equal(pair.value, AZ_SPAN_FROM_STR("123")));
 }
 
-static void test_az_iot_hub_client_c2d_received_topic_parse_URL_ENCODED_succeed(void** state)
+static void test_az_iot_hub_client_c2d_parse_received_topic_URL_ENCODED_succeed(void** state)
 {
   (void)state;
 
@@ -236,7 +209,7 @@ static void test_az_iot_hub_client_c2d_received_topic_parse_URL_ENCODED_succeed(
   az_iot_hub_client_c2d_request out_request;
 
   assert_return_code(
-      az_iot_hub_client_c2d_received_topic_parse(&client, received_topic, &out_request), AZ_OK);
+      az_iot_hub_client_c2d_parse_received_topic(&client, received_topic, &out_request), AZ_OK);
 
   // TODO: enable after az_iot_hub_client_properties_next() is implemented.
   // assert_return_code(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
@@ -266,18 +239,17 @@ int test_iot_hub_c2d()
 
   const struct CMUnitTest tests[] = {
 #ifndef NO_PRECONDITION_CHECKING
-    cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_NULL_client_fail),
+    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_NULL_client_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_c2d_received_topic_parse_AZ_SPAN_NULL_received_topic_fail),
-    cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_NULL_out_request_fail),
-    cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_no_properties_fail),
-    cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_MALFORMED_fail),
+        test_az_iot_hub_client_c2d_parse_received_topic_AZ_SPAN_NULL_received_topic_fail),
+    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_NULL_out_request_fail),
+    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_no_properties_fail),
+    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_MALFORMED_fail),
 #endif // NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_c2d_get_subscribe_topic_filter_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_c2d_get_subscribe_topic_filter_twice_succeed),
     cmocka_unit_test(test_az_iot_hub_client_c2d_get_subscribe_topic_filter_small_buffer_fail),
-    cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_URL_DECODED_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_c2d_received_topic_parse_URL_ENCODED_succeed)
+    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_URL_DECODED_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_URL_ENCODED_succeed)
   };
   return cmocka_run_group_tests_name("az_iot_hub_c2d", tests, NULL, NULL);
 }

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
@@ -134,7 +134,7 @@ static void test_az_iot_hub_client_c2d_get_subscribe_topic_filter_succeed(void**
   assert_true(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
-  int32_t returned_size;
+  size_t returned_size;
   assert_true(
       az_iot_hub_client_c2d_get_subscribe_topic_filter(
           &client, mqtt_sub_topic_buf, sizeof(mqtt_sub_topic_buf), &returned_size)
@@ -154,7 +154,7 @@ static void test_az_iot_hub_client_c2d_get_subscribe_topic_filter_small_buffer_f
   assert_true(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
-  int32_t returned_size;
+  size_t returned_size;
   assert_true(
       az_iot_hub_client_c2d_get_subscribe_topic_filter(
           &client, mqtt_sub_topic_buf, sizeof(mqtt_sub_topic_buf), &returned_size)

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
@@ -30,141 +30,133 @@ static uint8_t g_expected_methods_subscribe_topic[] = "$iothub/methods/POST/#";
 #ifndef NO_PRECONDITION_CHECKING
 enable_precondition_check_tests()
 
-static void test_az_iot_hub_client_methods_subscribe_topic_filter_get_NULL_client_fail(void** state)
+static void test_az_iot_hub_client_methods_get_subscribe_topic_filter_NULL_client_fail(void** state)
 {
   (void)state;
 
-  uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
   assert_precondition_checked(
-      az_iot_hub_client_methods_subscribe_topic_filter_get(NULL, mqtt_sub_topic, &mqtt_sub_topic));
+      az_iot_hub_client_methods_get_subscribe_topic_filter(NULL, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_methods_subscribe_topic_filter_get_NULL_out_topic_fail(
+static void test_az_iot_hub_client_methods_get_subscribe_topic_filter_NULL_out_topic_fail(
     void** state)
 {
   (void)state;
 
-  uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
-  assert_precondition_checked(
-      az_iot_hub_client_methods_subscribe_topic_filter_get(&client, mqtt_sub_topic, NULL));
+  assert_precondition_checked(az_iot_hub_client_methods_get_subscribe_topic_filter(
+      &client, NULL, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_methods_subscribe_topic_filter_get_empty_topic_fail(void** state)
+static void test_az_iot_hub_client_methods_get_subscribe_topic_filter_empty_topic_fail(void** state)
 {
   (void)state;
 
-  uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
-  assert_precondition_checked(
-      az_iot_hub_client_methods_subscribe_topic_filter_get(&client, AZ_SPAN_NULL, &mqtt_sub_topic));
+  assert_precondition_checked(az_iot_hub_client_methods_get_subscribe_topic_filter(
+      &client, test_buf, 0, &test_length));
 }
 
-static void test_az_iot_hub_client_methods_response_publish_topic_get_NULL_client_fail(void** state)
+static void test_az_iot_hub_client_methods_get_response_publish_topic_NULL_client_fail(void** state)
 {
   (void)state;
 
-  uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
   az_span request_id = AZ_SPAN_LITERAL_FROM_STR("2");
-  uint16_t status = 202;
+  uint16_t status = 200;
 
-  assert_precondition_checked(az_iot_hub_client_methods_response_publish_topic_get(
-      NULL, request_id, status, mqtt_sub_topic, &mqtt_sub_topic));
+  assert_precondition_checked(az_iot_hub_client_methods_get_response_publish_topic(
+      NULL, request_id, status, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_methods_response_publish_topic_get_NULL_out_topic_fail(
+static void test_az_iot_hub_client_methods_get_response_publish_topic_NULL_out_topic_fail(
     void** state)
 {
   (void)state;
 
-  uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
   az_span request_id = AZ_SPAN_LITERAL_FROM_STR("2");
-  uint16_t status = 202;
+  uint16_t status = 200;
 
-  assert_precondition_checked(az_iot_hub_client_methods_response_publish_topic_get(
-      &client, request_id, status, mqtt_sub_topic, NULL));
+  assert_precondition_checked(az_iot_hub_client_methods_get_response_publish_topic(
+      &client, request_id, status, NULL, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_methods_response_publish_topic_get_AZ_SPAN_NULL_topic_fail(
+static void test_az_iot_hub_client_methods_get_response_publish_topic_zero_size_buffer_fail(
     void** state)
 {
   (void)state;
 
-  uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
   az_span request_id = AZ_SPAN_LITERAL_FROM_STR("2");
-  uint16_t status = 202;
+  uint16_t status = 200;
 
-  assert_precondition_checked(az_iot_hub_client_methods_response_publish_topic_get(
-      &client, request_id, status, AZ_SPAN_NULL, &mqtt_sub_topic));
+  assert_precondition_checked(az_iot_hub_client_methods_get_response_publish_topic(
+      &client, request_id, status, test_buf, 0, &test_length));
 }
 
-static void test_az_iot_hub_client_methods_response_publish_topic_get_EMPTY_request_id_fail(
+static void test_az_iot_hub_client_methods_get_response_publish_topic_EMPTY_request_id_fail(
     void** state)
 {
   (void)state;
 
-  uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
   az_span request_id = AZ_SPAN_LITERAL_FROM_STR("");
-  uint16_t status = 202;
+  uint16_t status = 200;
 
-  assert_precondition_checked(az_iot_hub_client_methods_response_publish_topic_get(
-      &client, request_id, status, mqtt_sub_topic, &mqtt_sub_topic));
+  assert_precondition_checked(az_iot_hub_client_methods_get_response_publish_topic(
+      &client, request_id, status, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_methods_response_publish_topic_get_AZ_SPAN_NULL_request_id_fail(
+static void test_az_iot_hub_client_methods_get_response_publish_topic_AZ_SPAN_NULL_request_id_fail(
     void** state)
 {
   (void)state;
 
-  uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
   az_span request_id = AZ_SPAN_NULL;
-  uint16_t status = 202;
+  uint16_t status = 200;
 
-  assert_precondition_checked(az_iot_hub_client_methods_response_publish_topic_get(
-      &client, request_id, status, mqtt_sub_topic, &mqtt_sub_topic));
+  assert_precondition_checked(az_iot_hub_client_methods_get_response_publish_topic(
+      &client, request_id, status, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_methods_received_topic_parse_NULL_client_fail(void** state)
+static void test_az_iot_hub_client_methods_parse_received_topic_NULL_client_fail(void** state)
 {
   (void)state;
 
@@ -173,10 +165,10 @@ static void test_az_iot_hub_client_methods_received_topic_parse_NULL_client_fail
   az_iot_hub_client_method_request out_request;
 
   assert_precondition_checked(
-      az_iot_hub_client_methods_received_topic_parse(NULL, received_topic, &out_request));
+      az_iot_hub_client_methods_parse_received_topic(NULL, received_topic, &out_request));
 }
 
-static void test_az_iot_hub_client_methods_received_topic_parse_EMPTY_received_topic_fail(
+static void test_az_iot_hub_client_methods_parse_received_topic_EMPTY_received_topic_fail(
     void** state)
 {
   (void)state;
@@ -189,10 +181,10 @@ static void test_az_iot_hub_client_methods_received_topic_parse_EMPTY_received_t
   az_iot_hub_client_method_request out_request;
 
   assert_precondition_checked(
-      az_iot_hub_client_methods_received_topic_parse(&client, received_topic, &out_request));
+      az_iot_hub_client_methods_parse_received_topic(&client, received_topic, &out_request));
 }
 
-static void test_az_iot_hub_client_methods_received_topic_parse_AZ_SPAN_NULL_received_topic_fail(
+static void test_az_iot_hub_client_methods_parse_received_topic_AZ_SPAN_NULL_received_topic_fail(
     void** state)
 {
   (void)state;
@@ -205,10 +197,10 @@ static void test_az_iot_hub_client_methods_received_topic_parse_AZ_SPAN_NULL_rec
   az_iot_hub_client_method_request out_request;
 
   assert_precondition_checked(
-      az_iot_hub_client_methods_received_topic_parse(&client, received_topic, &out_request));
+      az_iot_hub_client_methods_parse_received_topic(&client, received_topic, &out_request));
 }
 
-static void test_az_iot_hub_client_methods_received_topic_parse_NULL_out_request_fail(void** state)
+static void test_az_iot_hub_client_methods_parse_received_topic_NULL_out_request_fail(void** state)
 {
   (void)state;
 
@@ -218,146 +210,133 @@ static void test_az_iot_hub_client_methods_received_topic_parse_NULL_out_request
   az_span received_topic = AZ_SPAN_FROM_STR("$iothub/methods/POST/TestMethod/?$rid=1");
 
   assert_precondition_checked(
-      az_iot_hub_client_methods_received_topic_parse(&client, received_topic, NULL));
+      az_iot_hub_client_methods_parse_received_topic(&client, received_topic, NULL));
 }
 
 #endif // NO_PRECONDITION_CHECKING
 
-static void test_az_iot_hub_client_methods_subscribe_topic_filter_get_succeed(void** state)
+static void test_az_iot_hub_client_methods_get_subscribe_topic_filter_succeed(void** state)
 {
   (void)state;
 
-  uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
+  assert_int_equal(
+      az_iot_hub_client_methods_get_subscribe_topic_filter(
+          &client, test_buf, sizeof(test_buf), &test_length),
+      AZ_OK);
+  assert_string_equal(g_expected_methods_subscribe_topic, test_buf);
+  assert_int_equal(sizeof(g_expected_methods_subscribe_topic) - 1, test_length);
+}
+
+static void test_az_iot_hub_client_methods_get_subscribe_topic_filter_INSUFFICIENT_BUFFER_fail(
+    void** state)
+{
+  (void)state;
+
+  char test_buf[5];
+  int32_t test_length;
+
+  az_iot_hub_client client;
+  assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
+
+  assert_int_equal(
+      az_iot_hub_client_methods_get_subscribe_topic_filter(
+          &client, test_buf, sizeof(test_buf), &test_length),
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+}
+
+static void test_az_iot_hub_client_methods_get_response_publish_topic_succeed(void** state)
+{
+  (void)state;
+
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
+
+  az_iot_hub_client client;
+  assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
+
+  az_span request_id = AZ_SPAN_LITERAL_FROM_STR("2");
+  uint16_t status = 200;
+  const char expected_topic[] = "$iothub/methods/res/200/?$rid=2";
+
   assert_true(
-      az_iot_hub_client_methods_subscribe_topic_filter_get(&client, mqtt_sub_topic, &mqtt_sub_topic)
+      az_iot_hub_client_methods_get_response_publish_topic(
+          &client, request_id, status, test_buf, sizeof(test_buf), &test_length)
       == AZ_OK);
 
-  az_span_for_test_verify(
-      mqtt_sub_topic,
-      g_expected_methods_subscribe_topic,
-      _az_COUNTOF(g_expected_methods_subscribe_topic) - 1,
-      az_span_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf)),
-      TEST_SPAN_BUFFER_SIZE);
-}
-
-static void test_az_iot_hub_client_methods_subscribe_topic_filter_get_INSUFFICIENT_BUFFER_fail(
-    void** state)
-{
-  (void)state;
-
-  uint8_t mqtt_sub_topic_buf[5];
-  az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
-
-  az_iot_hub_client client;
-  assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
-
-  assert_true(
-      az_iot_hub_client_methods_subscribe_topic_filter_get(&client, mqtt_sub_topic, &mqtt_sub_topic)
-      == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-}
-
-static void test_az_iot_hub_client_methods_response_publish_topic_get_succeed(void** state)
-{
-  (void)state;
-
-  uint8_t mqtt_sub_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
-
-  az_iot_hub_client client;
-  assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
-
-  az_span request_id = AZ_SPAN_LITERAL_FROM_STR("2");
-  uint16_t status = 202;
-  const char expected_topic[] = "$iothub/methods/res/202/?$rid=2";
-
-  assert_true(
-      az_iot_hub_client_methods_response_publish_topic_get(
-          &client, request_id, status, mqtt_sub_topic, &mqtt_sub_topic)
-      == AZ_OK);
-
-  az_span_for_test_verify(
-      mqtt_sub_topic,
-      expected_topic,
-      _az_COUNTOF(expected_topic) - 1,
-      az_span_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf)),
-      TEST_SPAN_BUFFER_SIZE);
+  assert_string_equal(expected_topic, test_buf);
+  assert_int_equal(sizeof(expected_topic) - 1, test_length);
 }
 
 static void
-test_az_iot_hub_client_methods_response_publish_topic_get_INSUFFICIENT_BUFFER_for_prefix_fail(
+test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_for_prefix_fail(
     void** state)
 {
   (void)state;
 
-  uint8_t mqtt_sub_topic_buf[10];
-  az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
+  char test_buf[10];
+  int32_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
   az_span request_id = AZ_SPAN_LITERAL_FROM_STR("2");
-  uint16_t status = 202;
+  uint16_t status = 200;
 
   assert_true(
-      az_iot_hub_client_methods_response_publish_topic_get(
-          &client, request_id, status, mqtt_sub_topic, &mqtt_sub_topic)
+      az_iot_hub_client_methods_get_response_publish_topic(
+          &client, request_id, status, test_buf, sizeof(test_buf), &test_length)
       == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void
-test_az_iot_hub_client_methods_response_publish_topic_get_INSUFFICIENT_BUFFER_for_status_fail(
+test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_for_status_fail(
     void** state)
 {
   (void)state;
 
-  uint8_t mqtt_sub_topic_buf[21]; // Enough for "$iothub/methods/res/2"
-  az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
+  char test_buf[21];  // Enough for "$iothub/methods/res/2"
+  int32_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
   az_span request_id = AZ_SPAN_LITERAL_FROM_STR("2");
-  uint16_t status = 202;
+  uint16_t status = 200;
 
   assert_true(
-      az_iot_hub_client_methods_response_publish_topic_get(
-          &client, request_id, status, mqtt_sub_topic, &mqtt_sub_topic)
+      az_iot_hub_client_methods_get_response_publish_topic(
+          &client, request_id, status, test_buf, sizeof(test_buf), &test_length)
       == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void
-test_az_iot_hub_client_methods_response_publish_topic_get_INSUFFICIENT_BUFFER_for_reqid_fail(
+test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_for_reqid_fail(
     void** state)
 {
   (void)state;
 
-  uint8_t mqtt_sub_topic_buf[24]; // Enough for "$iothub/methods/res/202/"
-  az_span mqtt_sub_topic
-      = az_span_for_test_init(mqtt_sub_topic_buf, _az_COUNTOF(mqtt_sub_topic_buf));
+  char test_buf[24]; // Enough for "$iothub/methods/res/200/"
+  int32_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
   az_span request_id = AZ_SPAN_LITERAL_FROM_STR("2");
-  uint16_t status = 202;
+  uint16_t status = 200;
 
   assert_true(
-      az_iot_hub_client_methods_response_publish_topic_get(
-          &client, request_id, status, mqtt_sub_topic, &mqtt_sub_topic)
+      az_iot_hub_client_methods_get_response_publish_topic(
+          &client, request_id, status, test_buf, sizeof(test_buf), &test_length)
       == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-static void test_az_iot_hub_client_methods_received_topic_parse_succeed(void** state)
+static void test_az_iot_hub_client_methods_parse_received_topic_succeed(void** state)
 {
   (void)state;
 
@@ -371,7 +350,7 @@ static void test_az_iot_hub_client_methods_received_topic_parse_succeed(void** s
   az_iot_hub_client_method_request out_request;
 
   assert_true(
-      az_iot_hub_client_methods_received_topic_parse(&client, received_topic, &out_request)
+      az_iot_hub_client_methods_parse_received_topic(&client, received_topic, &out_request)
       == AZ_OK);
   assert_int_equal(az_span_size(out_request.name), _az_COUNTOF(expected_name) - 1);
   assert_memory_equal(az_span_ptr(out_request.name), expected_name, _az_COUNTOF(expected_name) - 1);
@@ -382,7 +361,7 @@ static void test_az_iot_hub_client_methods_received_topic_parse_succeed(void** s
       _az_COUNTOF(expected_request_id) - 1);
 }
 
-static void test_az_iot_hub_client_methods_received_topic_parse_c2d_topic_fail(void** state)
+static void test_az_iot_hub_client_methods_parse_received_topic_c2d_topic_fail(void** state)
 {
   (void)state;
 
@@ -397,11 +376,11 @@ static void test_az_iot_hub_client_methods_received_topic_parse_c2d_topic_fail(v
   az_iot_hub_client_method_request out_request;
 
   assert_true(
-      az_iot_hub_client_methods_received_topic_parse(&client, received_topic, &out_request)
+      az_iot_hub_client_methods_parse_received_topic(&client, received_topic, &out_request)
       == AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
-static void test_az_iot_hub_client_methods_received_topic_parse_get_twin_topic_fail(void** state)
+static void test_az_iot_hub_client_methods_parse_received_topic_get_twin_topic_fail(void** state)
 {
   (void)state;
 
@@ -413,11 +392,11 @@ static void test_az_iot_hub_client_methods_received_topic_parse_get_twin_topic_f
   az_iot_hub_client_method_request out_request;
 
   assert_true(
-      az_iot_hub_client_methods_received_topic_parse(&client, received_topic, &out_request)
+      az_iot_hub_client_methods_parse_received_topic(&client, received_topic, &out_request)
       == AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
-static void test_az_iot_hub_client_methods_received_topic_parse_twin_patch_topic_fail(void** state)
+static void test_az_iot_hub_client_methods_parse_received_topic_twin_patch_topic_fail(void** state)
 {
   (void)state;
 
@@ -429,11 +408,11 @@ static void test_az_iot_hub_client_methods_received_topic_parse_twin_patch_topic
   az_iot_hub_client_method_request out_request;
 
   assert_true(
-      az_iot_hub_client_methods_received_topic_parse(&client, received_topic, &out_request)
+      az_iot_hub_client_methods_parse_received_topic(&client, received_topic, &out_request)
       == AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
-static void test_az_iot_hub_client_methods_received_topic_parse_topic_filter_fail(void** state)
+static void test_az_iot_hub_client_methods_parse_received_topic_topic_filter_fail(void** state)
 {
   (void)state;
 
@@ -446,23 +425,23 @@ static void test_az_iot_hub_client_methods_received_topic_parse_topic_filter_fai
   az_iot_hub_client_method_request out_request;
 
   assert_true(
-      az_iot_hub_client_methods_received_topic_parse(&client, received_topic, &out_request)
+      az_iot_hub_client_methods_parse_received_topic(&client, received_topic, &out_request)
       == AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
-static void test_az_iot_hub_client_methods_received_topic_parse_response_topic_fail(void** state)
+static void test_az_iot_hub_client_methods_parse_received_topic_response_topic_fail(void** state)
 {
   (void)state;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
-  az_span received_topic = AZ_SPAN_FROM_STR("$iothub/methods/res/202/?$rid=2");
+  az_span received_topic = AZ_SPAN_FROM_STR("$iothub/methods/res/200/?$rid=2");
 
   az_iot_hub_client_method_request out_request;
 
   assert_true(
-      az_iot_hub_client_methods_received_topic_parse(&client, received_topic, &out_request)
+      az_iot_hub_client_methods_parse_received_topic(&client, received_topic, &out_request)
       == AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
@@ -474,39 +453,39 @@ int test_iot_hub_methods()
 
   const struct CMUnitTest tests[] = {
 #ifndef NO_PRECONDITION_CHECKING
-    cmocka_unit_test(test_az_iot_hub_client_methods_subscribe_topic_filter_get_NULL_client_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_subscribe_topic_filter_get_NULL_out_topic_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_subscribe_topic_filter_get_empty_topic_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_response_publish_topic_get_NULL_out_topic_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_response_publish_topic_get_NULL_client_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_get_subscribe_topic_filter_NULL_client_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_get_subscribe_topic_filter_NULL_out_topic_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_get_subscribe_topic_filter_empty_topic_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_get_response_publish_topic_NULL_out_topic_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_get_response_publish_topic_NULL_client_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_response_publish_topic_get_AZ_SPAN_NULL_topic_fail),
+        test_az_iot_hub_client_methods_get_response_publish_topic_zero_size_buffer_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_response_publish_topic_get_EMPTY_request_id_fail),
+        test_az_iot_hub_client_methods_get_response_publish_topic_EMPTY_request_id_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_response_publish_topic_get_AZ_SPAN_NULL_request_id_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_received_topic_parse_NULL_client_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_received_topic_parse_EMPTY_received_topic_fail),
+        test_az_iot_hub_client_methods_get_response_publish_topic_AZ_SPAN_NULL_request_id_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_NULL_client_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_EMPTY_received_topic_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_received_topic_parse_AZ_SPAN_NULL_received_topic_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_received_topic_parse_NULL_out_request_fail),
+        test_az_iot_hub_client_methods_parse_received_topic_AZ_SPAN_NULL_received_topic_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_NULL_out_request_fail),
 #endif // NO_PRECONDITION_CHECKING
-    cmocka_unit_test(test_az_iot_hub_client_methods_subscribe_topic_filter_get_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_methods_get_subscribe_topic_filter_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_subscribe_topic_filter_get_INSUFFICIENT_BUFFER_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_response_publish_topic_get_succeed),
+        test_az_iot_hub_client_methods_get_subscribe_topic_filter_INSUFFICIENT_BUFFER_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_get_response_publish_topic_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_response_publish_topic_get_INSUFFICIENT_BUFFER_for_prefix_fail),
+        test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_for_prefix_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_response_publish_topic_get_INSUFFICIENT_BUFFER_for_status_fail),
+        test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_for_status_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_response_publish_topic_get_INSUFFICIENT_BUFFER_for_reqid_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_received_topic_parse_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_methods_received_topic_parse_c2d_topic_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_received_topic_parse_get_twin_topic_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_received_topic_parse_twin_patch_topic_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_received_topic_parse_topic_filter_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_received_topic_parse_response_topic_fail)
+        test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_for_reqid_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_c2d_topic_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_get_twin_topic_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_twin_patch_topic_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_topic_filter_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_response_topic_fail)
   };
 
   return cmocka_run_group_tests_name("az_iot_hub_methods", tests, NULL, NULL);

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
@@ -70,7 +70,7 @@ static void test_az_iot_hub_client_methods_get_subscribe_topic_filter_empty_topi
       &client, test_buf, 0, &test_length));
 }
 
-static void test_az_iot_hub_client_methods_get_response_publish_topic_NULL_client_fail(void** state)
+static void test_az_iot_hub_client_methods_response_get_publish_topic_NULL_client_fail(void** state)
 {
   (void)state;
 
@@ -80,11 +80,11 @@ static void test_az_iot_hub_client_methods_get_response_publish_topic_NULL_clien
   az_span request_id = AZ_SPAN_LITERAL_FROM_STR("2");
   uint16_t status = 200;
 
-  assert_precondition_checked(az_iot_hub_client_methods_get_response_publish_topic(
+  assert_precondition_checked(az_iot_hub_client_methods_response_get_publish_topic(
       NULL, request_id, status, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_methods_get_response_publish_topic_NULL_out_topic_fail(
+static void test_az_iot_hub_client_methods_response_get_publish_topic_NULL_out_topic_fail(
     void** state)
 {
   (void)state;
@@ -98,11 +98,11 @@ static void test_az_iot_hub_client_methods_get_response_publish_topic_NULL_out_t
   az_span request_id = AZ_SPAN_LITERAL_FROM_STR("2");
   uint16_t status = 200;
 
-  assert_precondition_checked(az_iot_hub_client_methods_get_response_publish_topic(
+  assert_precondition_checked(az_iot_hub_client_methods_response_get_publish_topic(
       &client, request_id, status, NULL, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_methods_get_response_publish_topic_zero_size_buffer_fail(
+static void test_az_iot_hub_client_methods_response_get_publish_topic_zero_size_buffer_fail(
     void** state)
 {
   (void)state;
@@ -116,11 +116,11 @@ static void test_az_iot_hub_client_methods_get_response_publish_topic_zero_size_
   az_span request_id = AZ_SPAN_LITERAL_FROM_STR("2");
   uint16_t status = 200;
 
-  assert_precondition_checked(az_iot_hub_client_methods_get_response_publish_topic(
+  assert_precondition_checked(az_iot_hub_client_methods_response_get_publish_topic(
       &client, request_id, status, test_buf, 0, &test_length));
 }
 
-static void test_az_iot_hub_client_methods_get_response_publish_topic_EMPTY_request_id_fail(
+static void test_az_iot_hub_client_methods_response_get_publish_topic_EMPTY_request_id_fail(
     void** state)
 {
   (void)state;
@@ -134,11 +134,11 @@ static void test_az_iot_hub_client_methods_get_response_publish_topic_EMPTY_requ
   az_span request_id = AZ_SPAN_LITERAL_FROM_STR("");
   uint16_t status = 200;
 
-  assert_precondition_checked(az_iot_hub_client_methods_get_response_publish_topic(
+  assert_precondition_checked(az_iot_hub_client_methods_response_get_publish_topic(
       &client, request_id, status, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_methods_get_response_publish_topic_AZ_SPAN_NULL_request_id_fail(
+static void test_az_iot_hub_client_methods_response_get_publish_topic_AZ_SPAN_NULL_request_id_fail(
     void** state)
 {
   (void)state;
@@ -152,7 +152,7 @@ static void test_az_iot_hub_client_methods_get_response_publish_topic_AZ_SPAN_NU
   az_span request_id = AZ_SPAN_NULL;
   uint16_t status = 200;
 
-  assert_precondition_checked(az_iot_hub_client_methods_get_response_publish_topic(
+  assert_precondition_checked(az_iot_hub_client_methods_response_get_publish_topic(
       &client, request_id, status, test_buf, sizeof(test_buf), &test_length));
 }
 
@@ -250,7 +250,7 @@ static void test_az_iot_hub_client_methods_get_subscribe_topic_filter_INSUFFICIE
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-static void test_az_iot_hub_client_methods_get_response_publish_topic_succeed(void** state)
+static void test_az_iot_hub_client_methods_response_get_publish_topic_succeed(void** state)
 {
   (void)state;
 
@@ -265,7 +265,7 @@ static void test_az_iot_hub_client_methods_get_response_publish_topic_succeed(vo
   const char expected_topic[] = "$iothub/methods/res/200/?$rid=2";
 
   assert_true(
-      az_iot_hub_client_methods_get_response_publish_topic(
+      az_iot_hub_client_methods_response_get_publish_topic(
           &client, request_id, status, test_buf, sizeof(test_buf), &test_length)
       == AZ_OK);
 
@@ -274,7 +274,7 @@ static void test_az_iot_hub_client_methods_get_response_publish_topic_succeed(vo
 }
 
 static void
-test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_for_prefix_fail(
+test_az_iot_hub_client_methods_response_get_publish_topic_INSUFFICIENT_BUFFER_for_prefix_fail(
     void** state)
 {
   (void)state;
@@ -289,13 +289,13 @@ test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_fo
   uint16_t status = 200;
 
   assert_true(
-      az_iot_hub_client_methods_get_response_publish_topic(
+      az_iot_hub_client_methods_response_get_publish_topic(
           &client, request_id, status, test_buf, sizeof(test_buf), &test_length)
       == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void
-test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_for_status_fail(
+test_az_iot_hub_client_methods_response_get_publish_topic_INSUFFICIENT_BUFFER_for_status_fail(
     void** state)
 {
   (void)state;
@@ -310,13 +310,13 @@ test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_fo
   uint16_t status = 200;
 
   assert_true(
-      az_iot_hub_client_methods_get_response_publish_topic(
+      az_iot_hub_client_methods_response_get_publish_topic(
           &client, request_id, status, test_buf, sizeof(test_buf), &test_length)
       == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void
-test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_for_reqid_fail(
+test_az_iot_hub_client_methods_response_get_publish_topic_INSUFFICIENT_BUFFER_for_reqid_fail(
     void** state)
 {
   (void)state;
@@ -331,7 +331,7 @@ test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_fo
   uint16_t status = 200;
 
   assert_true(
-      az_iot_hub_client_methods_get_response_publish_topic(
+      az_iot_hub_client_methods_response_get_publish_topic(
           &client, request_id, status, test_buf, sizeof(test_buf), &test_length)
       == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
@@ -456,14 +456,14 @@ int test_iot_hub_methods()
     cmocka_unit_test(test_az_iot_hub_client_methods_get_subscribe_topic_filter_NULL_client_fail),
     cmocka_unit_test(test_az_iot_hub_client_methods_get_subscribe_topic_filter_NULL_out_topic_fail),
     cmocka_unit_test(test_az_iot_hub_client_methods_get_subscribe_topic_filter_empty_topic_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_get_response_publish_topic_NULL_out_topic_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_get_response_publish_topic_NULL_client_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_response_get_publish_topic_NULL_out_topic_fail),
+    cmocka_unit_test(test_az_iot_hub_client_methods_response_get_publish_topic_NULL_client_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_get_response_publish_topic_zero_size_buffer_fail),
+        test_az_iot_hub_client_methods_response_get_publish_topic_zero_size_buffer_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_get_response_publish_topic_EMPTY_request_id_fail),
+        test_az_iot_hub_client_methods_response_get_publish_topic_EMPTY_request_id_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_get_response_publish_topic_AZ_SPAN_NULL_request_id_fail),
+        test_az_iot_hub_client_methods_response_get_publish_topic_AZ_SPAN_NULL_request_id_fail),
     cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_NULL_client_fail),
     cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_EMPTY_received_topic_fail),
     cmocka_unit_test(
@@ -473,13 +473,13 @@ int test_iot_hub_methods()
     cmocka_unit_test(test_az_iot_hub_client_methods_get_subscribe_topic_filter_succeed),
     cmocka_unit_test(
         test_az_iot_hub_client_methods_get_subscribe_topic_filter_INSUFFICIENT_BUFFER_fail),
-    cmocka_unit_test(test_az_iot_hub_client_methods_get_response_publish_topic_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_methods_response_get_publish_topic_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_for_prefix_fail),
+        test_az_iot_hub_client_methods_response_get_publish_topic_INSUFFICIENT_BUFFER_for_prefix_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_for_status_fail),
+        test_az_iot_hub_client_methods_response_get_publish_topic_INSUFFICIENT_BUFFER_for_status_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_for_reqid_fail),
+        test_az_iot_hub_client_methods_response_get_publish_topic_INSUFFICIENT_BUFFER_for_reqid_fail),
     cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_succeed),
     cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_c2d_topic_fail),
     cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_get_twin_topic_fail),

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
@@ -35,7 +35,7 @@ static void test_az_iot_hub_client_methods_get_subscribe_topic_filter_NULL_clien
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(
       az_iot_hub_client_methods_get_subscribe_topic_filter(NULL, test_buf, sizeof(test_buf), &test_length));
@@ -47,7 +47,7 @@ static void test_az_iot_hub_client_methods_get_subscribe_topic_filter_NULL_out_t
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -61,7 +61,7 @@ static void test_az_iot_hub_client_methods_get_subscribe_topic_filter_empty_topi
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -75,7 +75,7 @@ static void test_az_iot_hub_client_methods_get_response_publish_topic_NULL_clien
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   az_span request_id = AZ_SPAN_LITERAL_FROM_STR("2");
   uint16_t status = 200;
@@ -90,7 +90,7 @@ static void test_az_iot_hub_client_methods_get_response_publish_topic_NULL_out_t
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -108,7 +108,7 @@ static void test_az_iot_hub_client_methods_get_response_publish_topic_zero_size_
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -126,7 +126,7 @@ static void test_az_iot_hub_client_methods_get_response_publish_topic_EMPTY_requ
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -144,7 +144,7 @@ static void test_az_iot_hub_client_methods_get_response_publish_topic_AZ_SPAN_NU
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -220,7 +220,7 @@ static void test_az_iot_hub_client_methods_get_subscribe_topic_filter_succeed(vo
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -239,7 +239,7 @@ static void test_az_iot_hub_client_methods_get_subscribe_topic_filter_INSUFFICIE
   (void)state;
 
   char test_buf[5];
-  int32_t test_length;
+  size_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -255,7 +255,7 @@ static void test_az_iot_hub_client_methods_get_response_publish_topic_succeed(vo
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -280,7 +280,7 @@ test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_fo
   (void)state;
 
   char test_buf[10];
-  int32_t test_length;
+  size_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -301,7 +301,7 @@ test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_fo
   (void)state;
 
   char test_buf[21];  // Enough for "$iothub/methods/res/2"
-  int32_t test_length;
+  size_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
@@ -322,7 +322,7 @@ test_az_iot_hub_client_methods_get_response_publish_topic_INSUFFICIENT_BUFFER_fo
   (void)state;
 
   char test_buf[24]; // Enough for "$iothub/methods/res/200/"
-  int32_t test_length;
+  size_t test_length;
 
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -43,7 +43,7 @@ static void test_az_iot_hub_client_telemetry_get_publish_topic_NULL_client_fails
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_telemetry_get_publish_topic(
       NULL, NULL, test_buf, sizeof(test_buf), &test_length));
@@ -57,7 +57,7 @@ static void test_az_iot_hub_client_telemetry_get_publish_topic_NULL_mqtt_topic_f
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_telemetry_get_publish_topic(
       &client, NULL, NULL, TEST_SPAN_BUFFER_SIZE, &test_length));
@@ -73,7 +73,7 @@ static void test_az_iot_hub_client_telemetry_get_publish_topic_NULL_out_mqtt_top
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_telemetry_get_publish_topic(
       &client, NULL, test_buf, 0, &test_length));
@@ -91,7 +91,7 @@ static void test_az_iot_hub_client_telemetry_get_publish_topic_no_options_no_pro
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_true(
       az_iot_hub_client_telemetry_get_publish_topic(
@@ -114,7 +114,7 @@ static void test_az_iot_hub_client_telemetry_get_publish_topic_with_options_no_p
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_true(
       az_iot_hub_client_telemetry_get_publish_topic(
@@ -142,7 +142,7 @@ static void test_az_iot_hub_client_telemetry_get_publish_topic_with_options_with
       az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_true(
       az_iot_hub_client_telemetry_get_publish_topic(
@@ -171,7 +171,7 @@ test_az_iot_hub_client_telemetry_get_publish_topic_with_options_with_props_small
       az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
   char test_buf[sizeof(g_test_correct_topic_with_options_with_props) - 2];
-  int32_t test_length;
+  size_t test_length;
 
   assert_true(
       az_iot_hub_client_telemetry_get_publish_topic(
@@ -193,7 +193,7 @@ static void test_az_iot_hub_client_telemetry_get_publish_topic_no_options_with_p
       az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_true(
       az_iot_hub_client_telemetry_get_publish_topic(
@@ -219,7 +219,7 @@ test_az_iot_hub_client_telemetry_get_publish_topic_no_options_with_props_small_b
       az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
   char test_buf[sizeof(g_test_correct_topic_no_options_with_props) - 2];
-  int32_t test_length;
+  size_t test_length;
 
   assert_true(
       az_iot_hub_client_telemetry_get_publish_topic(
@@ -245,7 +245,7 @@ test_az_iot_hub_client_telemetry_get_publish_topic_with_options_module_id_with_p
       az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_true(
       az_iot_hub_client_telemetry_get_publish_topic(
@@ -274,7 +274,7 @@ test_az_iot_hub_client_telemetry_get_publish_topic_with_options_module_id_with_p
       az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
   char test_buf[sizeof(g_test_correct_topic_with_options_module_id_with_props) - 2];
-  int32_t test_length;
+  size_t test_length;
 
   assert_true(
       az_iot_hub_client_telemetry_get_publish_topic(

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -38,19 +38,18 @@ static const char g_test_correct_topic_with_options_module_id_with_props[]
 #ifndef NO_PRECONDITION_CHECKING
 enable_precondition_check_tests()
 
-static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_client_fails(void** state)
+static void test_az_iot_hub_client_telemetry_get_publish_topic_NULL_client_fails(void** state)
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
-
-  assert_precondition_checked(
-      az_iot_hub_client_telemetry_publish_topic_get(NULL, NULL, mqtt_topic, &mqtt_topic));
+  assert_precondition_checked(az_iot_hub_client_telemetry_get_publish_topic(
+      NULL, NULL, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_mqtt_topic_fails(void** state)
+static void test_az_iot_hub_client_telemetry_get_publish_topic_NULL_mqtt_topic_fails(void** state)
 {
   (void)state;
 
@@ -58,15 +57,13 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_mqtt_topic_f
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_buf[1];
-  az_span bad_mqtt_topic = az_span_init(test_buf, _az_COUNTOF(test_buf));
-  bad_mqtt_topic._internal.ptr = NULL;
+  int32_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_telemetry_publish_topic_get(
-      &client, NULL, bad_mqtt_topic, &bad_mqtt_topic));
+  assert_precondition_checked(az_iot_hub_client_telemetry_get_publish_topic(
+      &client, NULL, NULL, TEST_SPAN_BUFFER_SIZE, &test_length));
 }
 
-static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_out_mqtt_topic_fails(
+static void test_az_iot_hub_client_telemetry_get_publish_topic_NULL_out_mqtt_topic_fails(
     void** state)
 {
   (void)state;
@@ -75,16 +72,16 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_NULL_out_mqtt_top
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_precondition_checked(
-      az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, NULL));
+  assert_precondition_checked(az_iot_hub_client_telemetry_get_publish_topic(
+      &client, NULL, test_buf, 0, &test_length));
 }
 
 #endif // NO_PRECONDITION_CHECKING
 
-static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_succeed(
+static void test_az_iot_hub_client_telemetry_get_publish_topic_no_options_no_props_succeed(
     void** state)
 {
   (void)state;
@@ -93,54 +90,18 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_pro
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  memset(mqtt_topic_buf, 0xFF, _az_COUNTOF(mqtt_topic_buf));
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
   assert_true(
-      az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, &mqtt_topic)
+      az_iot_hub_client_telemetry_get_publish_topic(
+          &client, NULL, test_buf, sizeof(test_buf), &test_length)
       == AZ_OK);
-  assert_memory_equal(
-      g_test_correct_topic_no_options_no_props,
-      (char*)az_span_ptr(mqtt_topic),
-      _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1);
-  assert_int_equal(
-      az_span_size(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1);
-  assert_int_equal(mqtt_topic_buf[az_span_size(mqtt_topic)], 0xFF);
+  assert_string_equal(g_test_correct_topic_no_options_no_props, test_buf);
+  assert_int_equal(sizeof(g_test_correct_topic_no_options_no_props) - 1, test_length);
 }
 
-static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_twice_succeed(
-    void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
-
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
-
-  assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, &mqtt_topic), AZ_OK);
-  az_span_for_test_verify(
-      mqtt_topic,
-      g_test_correct_topic_no_options_no_props,
-      _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1,
-      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
-      TEST_SPAN_BUFFER_SIZE);
-
-  assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, &mqtt_topic), AZ_OK);
-  az_span_for_test_verify(
-      mqtt_topic,
-      g_test_correct_topic_no_options_no_props,
-      _az_COUNTOF(g_test_correct_topic_no_options_no_props) - 1,
-      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
-      TEST_SPAN_BUFFER_SIZE);
-}
-
-static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_props_succeed(
+static void test_az_iot_hub_client_telemetry_get_publish_topic_with_options_no_props_succeed(
     void** state)
 {
   (void)state;
@@ -152,21 +113,19 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_p
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(&client, NULL, mqtt_topic, &mqtt_topic), AZ_OK);
+  assert_true(
+      az_iot_hub_client_telemetry_get_publish_topic(
+          &client, NULL, test_buf, sizeof(test_buf), &test_length)
+      == AZ_OK);
 
-  az_span_for_test_verify(
-      mqtt_topic,
-      g_test_correct_topic_with_options_no_props,
-      _az_COUNTOF(g_test_correct_topic_with_options_no_props) - 1,
-      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
-      TEST_SPAN_BUFFER_SIZE);
+  assert_string_equal(g_test_correct_topic_with_options_no_props, test_buf);
+  assert_int_equal(sizeof(g_test_correct_topic_with_options_no_props) - 1, test_length);
 }
 
-static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_props_succeed(
+static void test_az_iot_hub_client_telemetry_get_publish_topic_with_options_with_props_succeed(
     void** state)
 {
   (void)state;
@@ -182,23 +141,20 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with
   assert_int_equal(
       az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
-      AZ_OK);
+  assert_true(
+      az_iot_hub_client_telemetry_get_publish_topic(
+          &client, &props, test_buf, sizeof(test_buf), &test_length)
+      == AZ_OK);
 
-  az_span_for_test_verify(
-      mqtt_topic,
-      g_test_correct_topic_with_options_with_props,
-      _az_COUNTOF(g_test_correct_topic_with_options_with_props) - 1,
-      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
-      TEST_SPAN_BUFFER_SIZE);
+  assert_string_equal(g_test_correct_topic_with_options_with_props, test_buf);
+  assert_int_equal(sizeof(g_test_correct_topic_with_options_with_props) - 1, test_length);
 }
 
 static void
-test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_props_small_buffer_fails(
+test_az_iot_hub_client_telemetry_get_publish_topic_with_options_with_props_small_buffer_fails(
     void** state)
 {
   (void)state;
@@ -214,17 +170,16 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_props_small
   assert_int_equal(
       az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
-  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_with_options_with_props) - 2];
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char test_buf[sizeof(g_test_correct_topic_with_options_with_props) - 2];
+  int32_t test_length;
 
-  assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
-      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-  assert_int_equal(
-      az_span_size(mqtt_topic), _az_COUNTOF(g_test_correct_topic_with_options_with_props) - 2);
+  assert_true(
+      az_iot_hub_client_telemetry_get_publish_topic(
+          &client, &props, test_buf, sizeof(test_buf), &test_length)
+      == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_props_succeed(
+static void test_az_iot_hub_client_telemetry_get_publish_topic_no_options_with_props_succeed(
     void** state)
 {
   (void)state;
@@ -237,23 +192,20 @@ static void test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_p
   assert_int_equal(
       az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
-      AZ_OK);
+  assert_true(
+      az_iot_hub_client_telemetry_get_publish_topic(
+          &client, &props, test_buf, sizeof(test_buf), &test_length)
+      == AZ_OK);
 
-  az_span_for_test_verify(
-      mqtt_topic,
-      g_test_correct_topic_no_options_with_props,
-      _az_COUNTOF(g_test_correct_topic_no_options_with_props) - 1,
-      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
-      TEST_SPAN_BUFFER_SIZE);
+  assert_string_equal(g_test_correct_topic_no_options_with_props, test_buf);
+  assert_int_equal(sizeof(g_test_correct_topic_no_options_with_props) - 1, test_length);
 }
 
 static void
-test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_props_small_buffer_fails(
+test_az_iot_hub_client_telemetry_get_publish_topic_no_options_with_props_small_buffer_fails(
     void** state)
 {
   (void)state;
@@ -266,18 +218,17 @@ test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_props_small_b
   assert_int_equal(
       az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
-  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_no_options_with_props) - 2];
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char test_buf[sizeof(g_test_correct_topic_no_options_with_props) - 2];
+  int32_t test_length;
 
-  assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
-      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-  assert_int_equal(
-      az_span_size(mqtt_topic), _az_COUNTOF(g_test_correct_topic_no_options_with_props) - 2);
+  assert_true(
+      az_iot_hub_client_telemetry_get_publish_topic(
+          &client, &props, test_buf, sizeof(test_buf), &test_length)
+      == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 static void
-test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_props_succeed(
+test_az_iot_hub_client_telemetry_get_publish_topic_with_options_module_id_with_props_succeed(
     void** state)
 {
   (void)state;
@@ -293,23 +244,20 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_p
   assert_int_equal(
       az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
-      AZ_OK);
+  assert_true(
+      az_iot_hub_client_telemetry_get_publish_topic(
+          &client, &props, test_buf, sizeof(test_buf), &test_length)
+      == AZ_OK);
 
-  az_span_for_test_verify(
-      mqtt_topic,
-      g_test_correct_topic_with_options_module_id_with_props,
-      _az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 1,
-      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
-      TEST_SPAN_BUFFER_SIZE);
+  assert_string_equal(g_test_correct_topic_with_options_module_id_with_props, test_buf);
+  assert_int_equal(sizeof(g_test_correct_topic_with_options_module_id_with_props) - 1, test_length);
 }
 
 static void
-test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_props_small_buffer_fails(
+test_az_iot_hub_client_telemetry_get_publish_topic_with_options_module_id_with_props_small_buffer_fails(
     void** state)
 {
   (void)state;
@@ -325,15 +273,13 @@ test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_p
   assert_int_equal(
       az_iot_hub_client_properties_init(&props, test_props, az_span_size(test_props)), AZ_OK);
 
-  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 2];
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char test_buf[sizeof(g_test_correct_topic_with_options_module_id_with_props) - 2];
+  int32_t test_length;
 
-  assert_int_equal(
-      az_iot_hub_client_telemetry_publish_topic_get(&client, &props, mqtt_topic, &mqtt_topic),
-      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-  assert_int_equal(
-      az_span_size(mqtt_topic),
-      _az_COUNTOF(g_test_correct_topic_with_options_module_id_with_props) - 2);
+  assert_true(
+      az_iot_hub_client_telemetry_get_publish_topic(
+          &client, &props, test_buf, sizeof(test_buf), &test_length)
+      == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
 int test_iot_hub_telemetry()
@@ -344,28 +290,26 @@ int test_iot_hub_telemetry()
 
   const struct CMUnitTest tests[] = {
 #ifndef NO_PRECONDITION_CHECKING
-    cmocka_unit_test(test_az_iot_hub_client_telemetry_publish_topic_get_NULL_client_fails),
-    cmocka_unit_test(test_az_iot_hub_client_telemetry_publish_topic_get_NULL_mqtt_topic_fails),
-    cmocka_unit_test(test_az_iot_hub_client_telemetry_publish_topic_get_NULL_out_mqtt_topic_fails),
+    cmocka_unit_test(test_az_iot_hub_client_telemetry_get_publish_topic_NULL_client_fails),
+    cmocka_unit_test(test_az_iot_hub_client_telemetry_get_publish_topic_NULL_mqtt_topic_fails),
+    cmocka_unit_test(test_az_iot_hub_client_telemetry_get_publish_topic_NULL_out_mqtt_topic_fails),
 #endif // NO_PRECONDITION_CHECKING
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_succeed),
+        test_az_iot_hub_client_telemetry_get_publish_topic_no_options_no_props_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_no_options_no_props_twice_succeed),
+        test_az_iot_hub_client_telemetry_get_publish_topic_with_options_no_props_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_no_props_succeed),
+        test_az_iot_hub_client_telemetry_get_publish_topic_with_options_with_props_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_props_succeed),
+        test_az_iot_hub_client_telemetry_get_publish_topic_with_options_with_props_small_buffer_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_with_props_small_buffer_fails),
+        test_az_iot_hub_client_telemetry_get_publish_topic_no_options_with_props_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_props_succeed),
+        test_az_iot_hub_client_telemetry_get_publish_topic_no_options_with_props_small_buffer_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_no_options_with_props_small_buffer_fails),
+        test_az_iot_hub_client_telemetry_get_publish_topic_with_options_module_id_with_props_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_props_succeed),
-    cmocka_unit_test(
-        test_az_iot_hub_client_telemetry_publish_topic_get_with_options_module_id_with_props_small_buffer_fails),
+        test_az_iot_hub_client_telemetry_get_publish_topic_with_options_module_id_with_props_small_buffer_fails),
   };
 
   return cmocka_run_group_tests_name("az_iot_hub_client_telemetry", tests, NULL, NULL);

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
@@ -132,18 +132,18 @@ static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_ou
       az_iot_hub_client_twin_get_patch_subscribe_topic_filter(&client, test_buf, 0, &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_client_fails(void** state)
+static void test_az_iot_hub_client_twin_document_get_publish_topic_NULL_client_fails(void** state)
 {
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_get_publish_topic(
+  assert_precondition_checked(az_iot_hub_client_twin_document_get_publish_topic(
       NULL, test_device_request_id, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_request_id_fails(void** state)
+static void test_az_iot_hub_client_twin_document_get_publish_topic_NULL_request_id_fails(void** state)
 {
   (void)state;
 
@@ -159,11 +159,11 @@ static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_request_id_fa
       = az_span_init(test_bad_request_id_buf, _az_COUNTOF(test_bad_request_id_buf));
   test_bad_request_id._internal.ptr = NULL;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_get_publish_topic(
+  assert_precondition_checked(az_iot_hub_client_twin_document_get_publish_topic(
       &client, test_bad_request_id, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_span_fails(void** state)
+static void test_az_iot_hub_client_twin_document_get_publish_topic_NULL_span_fails(void** state)
 {
   (void)state;
 
@@ -174,11 +174,11 @@ static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_span_fails(vo
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_get_publish_topic(
+  assert_precondition_checked(az_iot_hub_client_twin_document_get_publish_topic(
       &client, test_device_request_id, NULL, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_out_span_fails(void** state)
+static void test_az_iot_hub_client_twin_document_get_publish_topic_NULL_out_span_fails(void** state)
 {
   (void)state;
 
@@ -189,7 +189,7 @@ static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_out_span_fail
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_get_publish_topic(
+  assert_precondition_checked(az_iot_hub_client_twin_document_get_publish_topic(
       &client, test_device_request_id, test_buf, 0, &test_length));
 }
 
@@ -332,7 +332,7 @@ static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_smal
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-static void test_az_iot_hub_client_twin_get_get_publish_topic_succeed(void** state)
+static void test_az_iot_hub_client_twin_document_get_publish_topic_succeed(void** state)
 {
   (void)state;
 
@@ -344,14 +344,14 @@ static void test_az_iot_hub_client_twin_get_get_publish_topic_succeed(void** sta
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_twin_get_get_publish_topic(
+      az_iot_hub_client_twin_document_get_publish_topic(
           &client, test_device_request_id, test_buf, sizeof(test_buf), &test_length),
       AZ_OK);
   assert_string_equal(test_correct_twin_get_request_topic, test_buf);
   assert_int_equal(sizeof(test_correct_twin_get_request_topic) - 1, test_length);
 }
 
-static void test_az_iot_hub_client_twin_get_get_publish_topic_small_buffer_fails(void** state)
+static void test_az_iot_hub_client_twin_document_get_publish_topic_small_buffer_fails(void** state)
 {
   (void)state;
 
@@ -363,7 +363,7 @@ static void test_az_iot_hub_client_twin_get_get_publish_topic_small_buffer_fails
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_twin_get_get_publish_topic(
+      az_iot_hub_client_twin_document_get_publish_topic(
           &client, test_device_request_id, test_buf, sizeof(test_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
@@ -549,10 +549,10 @@ int test_az_iot_hub_client_twin()
     cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_span_fails),
     cmocka_unit_test(
         test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_out_span_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_get_publish_topic_NULL_client_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_get_publish_topic_NULL_request_id_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_get_publish_topic_NULL_span_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_get_publish_topic_NULL_out_span_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_document_get_publish_topic_NULL_client_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_document_get_publish_topic_NULL_request_id_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_document_get_publish_topic_NULL_span_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_document_get_publish_topic_NULL_out_span_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_client_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_invalid_request_id_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_char_buf_fails),
@@ -564,8 +564,8 @@ int test_az_iot_hub_client_twin()
     cmocka_unit_test(test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_succeed),
     cmocka_unit_test(
         test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_small_buffer_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_get_publish_topic_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_get_publish_topic_small_buffer_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_document_get_publish_topic_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_twin_document_get_publish_topic_small_buffer_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_succeed),
     cmocka_unit_test(
         test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_small_buffer_fails),

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
@@ -50,7 +50,7 @@ enable_precondition_check_tests()
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_twin_get_response_subscribe_topic_filter(
       NULL, test_buf, sizeof(test_buf), &test_length));
@@ -66,7 +66,7 @@ static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_NULL
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_twin_get_response_subscribe_topic_filter(
       &client, NULL, sizeof(test_buf), &test_length));
@@ -82,7 +82,7 @@ static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_NULL
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_twin_get_response_subscribe_topic_filter(
       &client, test_buf, 0, &test_length));
@@ -94,7 +94,7 @@ static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_cl
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
       NULL, test_buf, sizeof(test_buf), &test_length));
@@ -110,7 +110,7 @@ static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_sp
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
       &client, NULL, sizeof(test_buf), &test_length));
@@ -126,7 +126,7 @@ static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_ou
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(
       az_iot_hub_client_twin_get_patch_subscribe_topic_filter(&client, test_buf, 0, &test_length));
@@ -137,7 +137,7 @@ static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_client_fails(
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_twin_get_get_publish_topic(
       NULL, test_device_request_id, test_buf, sizeof(test_buf), &test_length));
@@ -152,7 +152,7 @@ static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_request_id_fa
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   uint8_t test_bad_request_id_buf[1];
   az_span test_bad_request_id
@@ -172,7 +172,7 @@ static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_span_fails(vo
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_twin_get_get_publish_topic(
       &client, test_device_request_id, NULL, sizeof(test_buf), &test_length));
@@ -187,7 +187,7 @@ static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_out_span_fail
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_twin_get_get_publish_topic(
       &client, test_device_request_id, test_buf, 0, &test_length));
@@ -198,7 +198,7 @@ static void test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_client_fail
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_twin_get_patch_publish_topic(
       NULL, test_device_request_id, test_buf, sizeof(test_buf), &test_length));
@@ -214,7 +214,7 @@ static void test_az_iot_hub_client_twin_get_patch_publish_topic_invalid_request_
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   uint8_t test_bad_request_id_buf[1];
   az_span test_bad_request_id
@@ -234,7 +234,7 @@ static void test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_char_buf_fa
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_twin_get_patch_publish_topic(
       &client, test_device_request_id, NULL, sizeof(test_buf), &test_length));
@@ -249,7 +249,7 @@ static void test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_out_span_fa
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_precondition_checked(az_iot_hub_client_twin_get_patch_publish_topic(
       &client, test_device_request_id, test_buf, 0, &test_length));
@@ -303,7 +303,7 @@ static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_succ
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_int_equal(
       az_iot_hub_client_twin_get_response_subscribe_topic_filter(
@@ -324,7 +324,7 @@ static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_smal
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[sizeof(test_correct_twin_response_topic_filter) - 2];
-  int32_t test_length;
+  size_t test_length;
 
   assert_int_equal(
       az_iot_hub_client_twin_get_response_subscribe_topic_filter(
@@ -341,7 +341,7 @@ static void test_az_iot_hub_client_twin_get_get_publish_topic_succeed(void** sta
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_int_equal(
       az_iot_hub_client_twin_get_get_publish_topic(
@@ -360,7 +360,7 @@ static void test_az_iot_hub_client_twin_get_get_publish_topic_small_buffer_fails
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[_az_COUNTOF(test_correct_twin_get_request_topic) - 2];
-  int32_t test_length;
+  size_t test_length;
 
   assert_int_equal(
       az_iot_hub_client_twin_get_get_publish_topic(
@@ -377,7 +377,7 @@ static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_succeed
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_int_equal(
       az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
@@ -397,7 +397,7 @@ static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_small_b
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[_az_COUNTOF(test_correct_twin_path_subscribe_topic) - 2];
-  int32_t test_length;
+  size_t test_length;
 
   assert_int_equal(
       az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
@@ -414,7 +414,7 @@ static void test_az_iot_hub_client_twin_get_patch_publish_topic_succeed(void** s
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t test_length;
+  size_t test_length;
 
   assert_int_equal(
       az_iot_hub_client_twin_get_patch_publish_topic(
@@ -433,7 +433,7 @@ static void test_az_iot_hub_client_twin_get_patch_publish_topic_small_buffer_fai
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
   char test_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 2];
-  int32_t test_length;
+  size_t test_length;
 
   assert_int_equal(
       az_iot_hub_client_twin_get_patch_publish_topic(

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
@@ -44,36 +44,19 @@ static const char test_correct_twin_patch_pub_topic[]
 #ifndef NO_PRECONDITION_CHECKING
 enable_precondition_check_tests()
 
-static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_null_client_fails(
-    void** state)
+    static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_null_client_fails(
+        void** state)
 {
   (void)state;
 
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_precondition_checked(
-      az_iot_hub_client_twin_response_subscribe_topic_filter_get(NULL, test_span, &test_span));
+  assert_precondition_checked(az_iot_hub_client_twin_get_response_subscribe_topic_filter(
+      NULL, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_NULL_span_fails(
-    void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
-
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
-  test_span._internal.ptr = NULL;
-
-  assert_precondition_checked(
-      az_iot_hub_client_twin_response_subscribe_topic_filter_get(&client, test_span, &test_span));
-}
-
-static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_NULL_out_span_fails(
+static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_NULL_mqtt_buf_fails(
     void** state)
 {
   (void)state;
@@ -82,26 +65,14 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_NULL
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_precondition_checked(
-      az_iot_hub_client_twin_response_subscribe_topic_filter_get(&client, test_span, NULL));
+  assert_precondition_checked(az_iot_hub_client_twin_get_response_subscribe_topic_filter(
+      &client, NULL, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_NULL_client_fails(
-    void** state)
-{
-  (void)state;
-
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
-
-  assert_precondition_checked(
-      az_iot_hub_client_twin_patch_subscribe_topic_filter_get(NULL, test_span, &test_span));
-}
-
-static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_NULL_span_fails(
+static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_NULL_out_span_fails(
     void** state)
 {
   (void)state;
@@ -110,15 +81,26 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_NULL_sp
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
-  test_span._internal.ptr = NULL;
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_precondition_checked(
-      az_iot_hub_client_twin_patch_subscribe_topic_filter_get(&client, test_span, &test_span));
+  assert_precondition_checked(az_iot_hub_client_twin_get_response_subscribe_topic_filter(
+      &client, test_buf, 0, &test_length));
 }
 
-static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_NULL_out_span_fails(
+static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_client_fails(
+    void** state)
+{
+  (void)state;
+
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
+
+  assert_precondition_checked(az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
+      NULL, test_buf, sizeof(test_buf), &test_length));
+}
+
+static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_span_fails(
     void** state)
 {
   (void)state;
@@ -127,25 +109,15 @@ static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_NULL_ou
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_precondition_checked(
-      az_iot_hub_client_twin_patch_subscribe_topic_filter_get(&client, test_span, NULL));
+  assert_precondition_checked(az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
+      &client, NULL, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_client_fails(void** state)
-{
-  (void)state;
-
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 1];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
-
-  assert_precondition_checked(az_iot_hub_client_twin_get_publish_topic_get(
-      NULL, test_device_request_id, test_span, &test_span));
-}
-
-static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_request_id_fails(void** state)
+static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_out_span_fails(
+    void** state)
 {
   (void)state;
 
@@ -153,19 +125,45 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_request_id_fa
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_get_request_topic) - 1];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
+
+  assert_precondition_checked(
+      az_iot_hub_client_twin_get_patch_subscribe_topic_filter(&client, test_buf, 0, &test_length));
+}
+
+static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_client_fails(void** state)
+{
+  (void)state;
+
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
+
+  assert_precondition_checked(az_iot_hub_client_twin_get_get_publish_topic(
+      NULL, test_device_request_id, test_buf, sizeof(test_buf), &test_length));
+}
+
+static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_request_id_fails(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
+
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
   uint8_t test_bad_request_id_buf[1];
   az_span test_bad_request_id
       = az_span_init(test_bad_request_id_buf, _az_COUNTOF(test_bad_request_id_buf));
   test_bad_request_id._internal.ptr = NULL;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_publish_topic_get(
-      &client, test_bad_request_id, test_span, &test_span));
+  assert_precondition_checked(az_iot_hub_client_twin_get_get_publish_topic(
+      &client, test_bad_request_id, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_span_fails(void** state)
+static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_span_fails(void** state)
 {
   (void)state;
 
@@ -173,15 +171,14 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_span_fails(vo
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_get_request_topic) - 1];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
-  test_span._internal.ptr = NULL;
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_publish_topic_get(
-      &client, test_device_request_id, test_span, &test_span));
+  assert_precondition_checked(az_iot_hub_client_twin_get_get_publish_topic(
+      &client, test_device_request_id, NULL, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_out_span_fails(void** state)
+static void test_az_iot_hub_client_twin_get_get_publish_topic_NULL_out_span_fails(void** state)
 {
   (void)state;
 
@@ -189,25 +186,25 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_NULL_out_span_fail
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_get_request_topic) - 1];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_publish_topic_get(
-      &client, test_device_request_id, test_span, NULL));
+  assert_precondition_checked(az_iot_hub_client_twin_get_get_publish_topic(
+      &client, test_device_request_id, test_buf, 0, &test_length));
 }
 
-static void test_az_iot_hub_client_twin_patch_publish_topic_get_NULL_client_fails(void** state)
+static void test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_client_fails(void** state)
 {
   (void)state;
 
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_patch_publish_topic_get(
-      NULL, test_device_request_id, test_span, &test_span));
+  assert_precondition_checked(az_iot_hub_client_twin_get_patch_publish_topic(
+      NULL, test_device_request_id, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_patch_publish_topic_get_invalid_request_id_fails(
+static void test_az_iot_hub_client_twin_get_patch_publish_topic_invalid_request_id_fails(
     void** state)
 {
   (void)state;
@@ -216,19 +213,19 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_invalid_request_
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
   uint8_t test_bad_request_id_buf[1];
   az_span test_bad_request_id
       = az_span_init(test_bad_request_id_buf, _az_COUNTOF(test_bad_request_id_buf));
   test_bad_request_id._internal.ptr = NULL;
 
-  assert_precondition_checked(az_iot_hub_client_twin_patch_publish_topic_get(
-      &client, test_bad_request_id, test_span, &test_span));
+  assert_precondition_checked(az_iot_hub_client_twin_get_patch_publish_topic(
+      &client, test_bad_request_id, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_patch_publish_topic_get_NULL_span_fails(void** state)
+static void test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_char_buf_fails(void** state)
 {
   (void)state;
 
@@ -236,15 +233,14 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_NULL_span_fails(
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
-  test_span._internal.ptr = NULL;
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_patch_publish_topic_get(
-      &client, test_device_request_id, test_span, &test_span));
+  assert_precondition_checked(az_iot_hub_client_twin_get_patch_publish_topic(
+      &client, test_device_request_id, NULL, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_patch_publish_topic_get_NULL_out_span_fails(void** state)
+static void test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_out_span_fails(void** state)
 {
   (void)state;
 
@@ -252,15 +248,14 @@ static void test_az_iot_hub_client_twin_patch_publish_topic_get_NULL_out_span_fa
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 1];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_patch_publish_topic_get(
-      &client, test_device_request_id, test_span, NULL));
+  assert_precondition_checked(az_iot_hub_client_twin_get_patch_publish_topic(
+      &client, test_device_request_id, test_buf, 0, &test_length));
 }
 
-static void test_az_iot_hub_client_twin_parse_received_topic_NULL_client_fails(
-    void** state)
+static void test_az_iot_hub_client_twin_parse_received_topic_NULL_client_fails(void** state)
 {
   (void)state;
 
@@ -270,8 +265,7 @@ static void test_az_iot_hub_client_twin_parse_received_topic_NULL_client_fails(
       NULL, test_twin_received_topic_desired_success, &response));
 }
 
-static void test_az_iot_hub_client_twin_parse_received_topic_NULL_rec_topic_fails(
-    void** state)
+static void test_az_iot_hub_client_twin_parse_received_topic_NULL_rec_topic_fails(void** state)
 {
   (void)state;
 
@@ -281,18 +275,18 @@ static void test_az_iot_hub_client_twin_parse_received_topic_NULL_rec_topic_fail
 
   az_iot_hub_client_twin_response response;
 
-  assert_precondition_checked(az_iot_hub_client_twin_parse_received_topic(
-      &client, AZ_SPAN_NULL, &response));
+  assert_precondition_checked(
+      az_iot_hub_client_twin_parse_received_topic(&client, AZ_SPAN_NULL, &response));
 }
 
-static void test_az_iot_hub_client_twin_parse_received_topic_NULL_response_fails(
-    void** state)
+static void test_az_iot_hub_client_twin_parse_received_topic_NULL_response_fails(void** state)
 {
   (void)state;
 
   az_iot_hub_client client;
   assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);;
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
+  ;
 
   assert_precondition_checked(az_iot_hub_client_twin_parse_received_topic(
       &client, test_twin_received_topic_desired_success, NULL));
@@ -300,7 +294,7 @@ static void test_az_iot_hub_client_twin_parse_received_topic_NULL_response_fails
 
 #endif // NO_PRECONDITION_CHECKING
 
-static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_succeed(void** state)
+static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_succeed(void** state)
 {
   (void)state;
 
@@ -308,21 +302,19 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_succ
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_twin_response_subscribe_topic_filter_get(&client, test_span, &test_span),
+      az_iot_hub_client_twin_get_response_subscribe_topic_filter(
+          &client, test_buf, sizeof(test_buf), &test_length),
       AZ_OK);
-  az_span_for_test_verify(
-      test_span,
-      test_correct_twin_response_topic_filter,
-      _az_COUNTOF(test_correct_twin_response_topic_filter) - 1,
-      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
-      TEST_SPAN_BUFFER_SIZE);
+
+  assert_string_equal(test_correct_twin_response_topic_filter, test_buf);
+  assert_int_equal(sizeof(test_correct_twin_response_topic_filter) - 1, test_length);
 }
 
-static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_twice_succeed(
+static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_small_buffer_fails(
     void** state)
 {
   (void)state;
@@ -331,32 +323,71 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_twic
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[sizeof(test_correct_twin_response_topic_filter) - 2];
+  int32_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_twin_response_subscribe_topic_filter_get(&client, test_span, &test_span),
-      AZ_OK);
-  assert_memory_equal(
-      az_span_ptr(test_span),
-      test_correct_twin_response_topic_filter,
-      _az_COUNTOF(test_correct_twin_response_topic_filter) - 1);
-  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_response_topic_filter) - 1);
-  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
-
-  assert_int_equal(
-      az_iot_hub_client_twin_response_subscribe_topic_filter_get(&client, test_span, &test_span),
-      AZ_OK);
-  assert_memory_equal(
-      az_span_ptr(test_span),
-      test_correct_twin_response_topic_filter,
-      _az_COUNTOF(test_correct_twin_response_topic_filter) - 1);
-  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_response_topic_filter) - 1);
-  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
+      az_iot_hub_client_twin_get_response_subscribe_topic_filter(
+          &client, test_buf, sizeof(test_buf), &test_length),
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_small_buffer_fails(
+static void test_az_iot_hub_client_twin_get_get_publish_topic_succeed(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
+
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
+
+  assert_int_equal(
+      az_iot_hub_client_twin_get_get_publish_topic(
+          &client, test_device_request_id, test_buf, sizeof(test_buf), &test_length),
+      AZ_OK);
+  assert_string_equal(test_correct_twin_get_request_topic, test_buf);
+  assert_int_equal(sizeof(test_correct_twin_get_request_topic) - 1, test_length);
+}
+
+static void test_az_iot_hub_client_twin_get_get_publish_topic_small_buffer_fails(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
+
+  char test_buf[_az_COUNTOF(test_correct_twin_get_request_topic) - 2];
+  int32_t test_length;
+
+  assert_int_equal(
+      az_iot_hub_client_twin_get_get_publish_topic(
+          &client, test_device_request_id, test_buf, sizeof(test_buf), &test_length),
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+}
+
+static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_succeed(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
+
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
+
+  assert_int_equal(
+      az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
+          &client, test_buf, sizeof(test_buf), &test_length),
+      AZ_OK);
+  assert_string_equal(test_correct_twin_path_subscribe_topic, test_buf);
+  assert_int_equal(sizeof(test_correct_twin_path_subscribe_topic) - 1, test_length);
+}
+
+static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_small_buffer_fails(
     void** state)
 {
   (void)state;
@@ -365,17 +396,16 @@ static void test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_smal
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_response_topic_filter) - 2];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[_az_COUNTOF(test_correct_twin_path_subscribe_topic) - 2];
+  int32_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_twin_response_subscribe_topic_filter_get(&client, test_span, &test_span),
+      az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
+          &client, test_buf, sizeof(test_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-  assert_int_equal(
-      az_span_size(test_span), _az_COUNTOF(test_correct_twin_response_topic_filter) - 2);
 }
 
-static void test_az_iot_hub_client_twin_get_publish_topic_get_succeed(void** state)
+static void test_az_iot_hub_client_twin_get_patch_publish_topic_succeed(void** state)
 {
   (void)state;
 
@@ -383,22 +413,18 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_succeed(void** sta
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_twin_get_publish_topic_get(
-          &client, test_device_request_id, test_span, &test_span),
+      az_iot_hub_client_twin_get_patch_publish_topic(
+          &client, test_device_request_id, test_buf, sizeof(test_buf), &test_length),
       AZ_OK);
-  az_span_for_test_verify(
-      test_span,
-      test_correct_twin_get_request_topic,
-      _az_COUNTOF(test_correct_twin_get_request_topic) - 1,
-      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
-      TEST_SPAN_BUFFER_SIZE);
+  assert_string_equal(test_correct_twin_patch_pub_topic, test_buf);
+  assert_int_equal(sizeof(test_correct_twin_patch_pub_topic) - 1, test_length);
 }
 
-static void test_az_iot_hub_client_twin_get_publish_topic_get_twice_succeed(void** state)
+static void test_az_iot_hub_client_twin_get_patch_publish_topic_small_buffer_fails(void** state)
 {
   (void)state;
 
@@ -406,199 +432,13 @@ static void test_az_iot_hub_client_twin_get_publish_topic_get_twice_succeed(void
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
 
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
+  char test_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 2];
+  int32_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_twin_get_publish_topic_get(
-          &client, test_device_request_id, test_span, &test_span),
-      AZ_OK);
-  assert_memory_equal(
-      az_span_ptr(test_span),
-      test_correct_twin_get_request_topic,
-      _az_COUNTOF(test_correct_twin_get_request_topic) - 1);
-  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_get_request_topic) - 1);
-  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
-
-  assert_int_equal(
-      az_iot_hub_client_twin_get_publish_topic_get(
-          &client, test_device_request_id, test_span, &test_span),
-      AZ_OK);
-  assert_memory_equal(
-      az_span_ptr(test_span),
-      test_correct_twin_get_request_topic,
-      _az_COUNTOF(test_correct_twin_get_request_topic) - 1);
-  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_get_request_topic) - 1);
-  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
-}
-
-static void test_az_iot_hub_client_twin_get_publish_topic_get_small_buffer_fails(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
-
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_get_request_topic) - 2];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
-
-  assert_int_equal(
-      az_iot_hub_client_twin_get_publish_topic_get(
-          &client, test_device_request_id, test_span, &test_span),
+      az_iot_hub_client_twin_get_patch_publish_topic(
+          &client, test_device_request_id, test_buf, sizeof(test_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-  assert_int_equal(az_span_size(test_span), _az_COUNTOF(test_correct_twin_get_request_topic) - 2);
-}
-
-static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_succeed(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
-
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
-
-  assert_int_equal(
-      az_iot_hub_client_twin_patch_subscribe_topic_filter_get(&client, test_span, &test_span),
-      AZ_OK);
-  az_span_for_test_verify(
-      test_span,
-      test_correct_twin_path_subscribe_topic,
-      _az_COUNTOF(test_correct_twin_path_subscribe_topic) - 1,
-      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
-      TEST_SPAN_BUFFER_SIZE);
-}
-
-static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_twice_succeed(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
-
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
-
-  assert_int_equal(
-      az_iot_hub_client_twin_patch_subscribe_topic_filter_get(&client, test_span, &test_span),
-      AZ_OK);
-  assert_memory_equal(
-      az_span_ptr(test_span),
-      test_correct_twin_path_subscribe_topic,
-      _az_COUNTOF(test_correct_twin_path_subscribe_topic) - 1);
-  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_path_subscribe_topic) - 1);
-  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
-
-  assert_int_equal(
-      az_iot_hub_client_twin_patch_subscribe_topic_filter_get(&client, test_span, &test_span),
-      AZ_OK);
-  assert_memory_equal(
-      az_span_ptr(test_span),
-      test_correct_twin_path_subscribe_topic,
-      _az_COUNTOF(test_correct_twin_path_subscribe_topic) - 1);
-  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_path_subscribe_topic) - 1);
-  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
-}
-
-static void test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_small_buffer_fails(
-    void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
-
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_path_subscribe_topic) - 2];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
-
-  assert_int_equal(
-      az_iot_hub_client_twin_patch_subscribe_topic_filter_get(&client, test_span, &test_span),
-      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-  assert_int_equal(
-      az_span_size(test_span), _az_COUNTOF(test_correct_twin_path_subscribe_topic) - 2);
-}
-
-static void test_az_iot_hub_client_twin_patch_publish_topic_get_succeed(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
-
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span test_span = az_span_for_test_init(test_span_buf, _az_COUNTOF(test_span_buf));
-
-  assert_int_equal(
-      az_iot_hub_client_twin_patch_publish_topic_get(
-          &client, test_device_request_id, test_span, &test_span),
-      AZ_OK);
-  az_span_for_test_verify(
-      test_span,
-      test_correct_twin_patch_pub_topic,
-      _az_COUNTOF(test_correct_twin_patch_pub_topic) - 1,
-      az_span_init(test_span_buf, _az_COUNTOF(test_span_buf)),
-      TEST_SPAN_BUFFER_SIZE);
-}
-
-static void test_az_iot_hub_client_twin_patch_publish_topic_get_twice_succeed(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
-
-  uint8_t test_span_buf[TEST_SPAN_BUFFER_SIZE];
-  memset(test_span_buf, 0xFF, _az_COUNTOF(test_span_buf));
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
-
-  assert_int_equal(
-      az_iot_hub_client_twin_patch_publish_topic_get(
-          &client, test_device_request_id, test_span, &test_span),
-      AZ_OK);
-  assert_memory_equal(
-      az_span_ptr(test_span),
-      test_correct_twin_patch_pub_topic,
-      _az_COUNTOF(test_correct_twin_patch_pub_topic) - 1);
-  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_patch_pub_topic) - 1);
-  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
-
-  assert_int_equal(
-      az_iot_hub_client_twin_patch_publish_topic_get(
-          &client, test_device_request_id, test_span, &test_span),
-      AZ_OK);
-  assert_memory_equal(
-      az_span_ptr(test_span),
-      test_correct_twin_patch_pub_topic,
-      _az_COUNTOF(test_correct_twin_patch_pub_topic) - 1);
-  assert_int_equal(az_span_size(test_span), sizeof(test_correct_twin_patch_pub_topic) - 1);
-  assert_int_equal(test_span_buf[az_span_size(test_span)], 0xFF);
-}
-
-static void test_az_iot_hub_client_twin_patch_publish_topic_get_small_buffer_fails(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
-
-  uint8_t test_span_buf[_az_COUNTOF(test_correct_twin_patch_pub_topic) - 2];
-  az_span test_span = az_span_init(test_span_buf, _az_COUNTOF(test_span_buf));
-
-  assert_int_equal(
-      az_iot_hub_client_twin_patch_publish_topic_get(
-          &client, test_device_request_id, test_span, &test_span),
-      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-  assert_int_equal(az_span_size(test_span), _az_COUNTOF(test_correct_twin_patch_pub_topic) - 2);
 }
 
 static void test_az_iot_hub_client_twin_parse_received_topic_desired_found_succeed(void** state)
@@ -620,7 +460,8 @@ static void test_az_iot_hub_client_twin_parse_received_topic_desired_found_succe
   assert_int_equal(response.response_type, AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES);
 }
 
-static void test_az_iot_hub_client_twin_parse_received_topic_get_response_found_succeed(void** state)
+static void test_az_iot_hub_client_twin_parse_received_topic_get_response_found_succeed(
+    void** state)
 {
   (void)state;
 
@@ -639,7 +480,8 @@ static void test_az_iot_hub_client_twin_parse_received_topic_get_response_found_
   assert_int_equal(response.response_type, AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_GET);
 }
 
-static void test_az_iot_hub_client_twin_parse_received_topic_reported_props_found_succeed(void** state)
+static void test_az_iot_hub_client_twin_parse_received_topic_reported_props_found_succeed(
+    void** state)
 {
   (void)state;
 
@@ -697,42 +539,38 @@ int test_az_iot_hub_client_twin()
   const struct CMUnitTest tests[] = {
 #ifndef NO_PRECONDITION_CHECKING
     cmocka_unit_test(
-        test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_null_client_fails),
+        test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_null_client_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_NULL_span_fails),
+        test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_NULL_mqtt_buf_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_NULL_out_span_fails),
+        test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_NULL_out_span_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_NULL_client_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_NULL_span_fails),
+        test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_client_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_span_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_NULL_out_span_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_publish_topic_get_NULL_client_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_publish_topic_get_NULL_request_id_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_publish_topic_get_NULL_span_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_publish_topic_get_NULL_out_span_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_patch_publish_topic_get_NULL_client_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_patch_publish_topic_get_invalid_request_id_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_patch_publish_topic_get_NULL_span_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_patch_publish_topic_get_NULL_out_span_fails),
+        test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_out_span_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_get_publish_topic_NULL_client_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_get_publish_topic_NULL_request_id_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_get_publish_topic_NULL_span_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_get_publish_topic_NULL_out_span_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_client_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_invalid_request_id_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_char_buf_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_out_span_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_NULL_client_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_NULL_rec_topic_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_NULL_response_fails),
 #endif // NO_PRECONDITION_CHECKING
-    cmocka_unit_test(test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_twice_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_twin_response_subscribe_topic_filter_get_small_buffer_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_publish_topic_get_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_publish_topic_get_twice_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_publish_topic_get_small_buffer_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_twice_succeed),
+        test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_small_buffer_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_get_publish_topic_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_get_publish_topic_small_buffer_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_twin_patch_subscribe_topic_filter_get_small_buffer_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_patch_publish_topic_get_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_twin_patch_publish_topic_get_twice_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_twin_patch_publish_topic_get_small_buffer_fails),
+        test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_small_buffer_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_small_buffer_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_desired_found_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_get_response_found_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_reported_props_found_succeed),

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
@@ -44,7 +44,7 @@ static const char test_correct_twin_patch_pub_topic[]
 #ifndef NO_PRECONDITION_CHECKING
 enable_precondition_check_tests()
 
-    static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_null_client_fails(
+    static void test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_null_client_fails(
         void** state)
 {
   (void)state;
@@ -52,11 +52,11 @@ enable_precondition_check_tests()
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_response_subscribe_topic_filter(
+  assert_precondition_checked(az_iot_hub_client_twin_response_get_subscribe_topic_filter(
       NULL, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_NULL_mqtt_buf_fails(
+static void test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_NULL_mqtt_buf_fails(
     void** state)
 {
   (void)state;
@@ -68,11 +68,11 @@ static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_NULL
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_response_subscribe_topic_filter(
+  assert_precondition_checked(az_iot_hub_client_twin_response_get_subscribe_topic_filter(
       &client, NULL, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_NULL_out_span_fails(
+static void test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_NULL_out_span_fails(
     void** state)
 {
   (void)state;
@@ -84,11 +84,11 @@ static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_NULL
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_response_subscribe_topic_filter(
+  assert_precondition_checked(az_iot_hub_client_twin_response_get_subscribe_topic_filter(
       &client, test_buf, 0, &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_client_fails(
+static void test_az_iot_hub_client_twin_patch_get_subscribe_topic_filter_NULL_client_fails(
     void** state)
 {
   (void)state;
@@ -96,11 +96,11 @@ static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_cl
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
+  assert_precondition_checked(az_iot_hub_client_twin_patch_get_subscribe_topic_filter(
       NULL, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_span_fails(
+static void test_az_iot_hub_client_twin_patch_get_subscribe_topic_filter_NULL_span_fails(
     void** state)
 {
   (void)state;
@@ -112,11 +112,11 @@ static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_sp
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
+  assert_precondition_checked(az_iot_hub_client_twin_patch_get_subscribe_topic_filter(
       &client, NULL, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_out_span_fails(
+static void test_az_iot_hub_client_twin_patch_get_subscribe_topic_filter_NULL_out_span_fails(
     void** state)
 {
   (void)state;
@@ -129,7 +129,7 @@ static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_ou
   size_t test_length;
 
   assert_precondition_checked(
-      az_iot_hub_client_twin_get_patch_subscribe_topic_filter(&client, test_buf, 0, &test_length));
+      az_iot_hub_client_twin_patch_get_subscribe_topic_filter(&client, test_buf, 0, &test_length));
 }
 
 static void test_az_iot_hub_client_twin_document_get_publish_topic_NULL_client_fails(void** state)
@@ -193,18 +193,18 @@ static void test_az_iot_hub_client_twin_document_get_publish_topic_NULL_out_span
       &client, test_device_request_id, test_buf, 0, &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_client_fails(void** state)
+static void test_az_iot_hub_client_twin_patch_get_publish_topic_NULL_client_fails(void** state)
 {
   (void)state;
 
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_patch_publish_topic(
+  assert_precondition_checked(az_iot_hub_client_twin_patch_get_publish_topic(
       NULL, test_device_request_id, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_patch_publish_topic_invalid_request_id_fails(
+static void test_az_iot_hub_client_twin_patch_get_publish_topic_invalid_request_id_fails(
     void** state)
 {
   (void)state;
@@ -221,11 +221,11 @@ static void test_az_iot_hub_client_twin_get_patch_publish_topic_invalid_request_
       = az_span_init(test_bad_request_id_buf, _az_COUNTOF(test_bad_request_id_buf));
   test_bad_request_id._internal.ptr = NULL;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_patch_publish_topic(
+  assert_precondition_checked(az_iot_hub_client_twin_patch_get_publish_topic(
       &client, test_bad_request_id, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_char_buf_fails(void** state)
+static void test_az_iot_hub_client_twin_patch_get_publish_topic_NULL_char_buf_fails(void** state)
 {
   (void)state;
 
@@ -236,11 +236,11 @@ static void test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_char_buf_fa
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_patch_publish_topic(
+  assert_precondition_checked(az_iot_hub_client_twin_patch_get_publish_topic(
       &client, test_device_request_id, NULL, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_out_span_fails(void** state)
+static void test_az_iot_hub_client_twin_patch_get_publish_topic_NULL_out_span_fails(void** state)
 {
   (void)state;
 
@@ -251,7 +251,7 @@ static void test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_out_span_fa
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  assert_precondition_checked(az_iot_hub_client_twin_get_patch_publish_topic(
+  assert_precondition_checked(az_iot_hub_client_twin_patch_get_publish_topic(
       &client, test_device_request_id, test_buf, 0, &test_length));
 }
 
@@ -294,7 +294,7 @@ static void test_az_iot_hub_client_twin_parse_received_topic_NULL_response_fails
 
 #endif // NO_PRECONDITION_CHECKING
 
-static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_succeed(void** state)
+static void test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_succeed(void** state)
 {
   (void)state;
 
@@ -306,7 +306,7 @@ static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_succ
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_twin_get_response_subscribe_topic_filter(
+      az_iot_hub_client_twin_response_get_subscribe_topic_filter(
           &client, test_buf, sizeof(test_buf), &test_length),
       AZ_OK);
 
@@ -314,7 +314,7 @@ static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_succ
   assert_int_equal(sizeof(test_correct_twin_response_topic_filter) - 1, test_length);
 }
 
-static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_small_buffer_fails(
+static void test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_small_buffer_fails(
     void** state)
 {
   (void)state;
@@ -327,7 +327,7 @@ static void test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_smal
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_twin_get_response_subscribe_topic_filter(
+      az_iot_hub_client_twin_response_get_subscribe_topic_filter(
           &client, test_buf, sizeof(test_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
@@ -368,7 +368,7 @@ static void test_az_iot_hub_client_twin_document_get_publish_topic_small_buffer_
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_succeed(void** state)
+static void test_az_iot_hub_client_twin_patch_get_subscribe_topic_filter_succeed(void** state)
 {
   (void)state;
 
@@ -380,14 +380,14 @@ static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_succeed
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
+      az_iot_hub_client_twin_patch_get_subscribe_topic_filter(
           &client, test_buf, sizeof(test_buf), &test_length),
       AZ_OK);
   assert_string_equal(test_correct_twin_path_subscribe_topic, test_buf);
   assert_int_equal(sizeof(test_correct_twin_path_subscribe_topic) - 1, test_length);
 }
 
-static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_small_buffer_fails(
+static void test_az_iot_hub_client_twin_patch_get_subscribe_topic_filter_small_buffer_fails(
     void** state)
 {
   (void)state;
@@ -400,12 +400,12 @@ static void test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_small_b
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_twin_get_patch_subscribe_topic_filter(
+      az_iot_hub_client_twin_patch_get_subscribe_topic_filter(
           &client, test_buf, sizeof(test_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-static void test_az_iot_hub_client_twin_get_patch_publish_topic_succeed(void** state)
+static void test_az_iot_hub_client_twin_patch_get_publish_topic_succeed(void** state)
 {
   (void)state;
 
@@ -417,14 +417,14 @@ static void test_az_iot_hub_client_twin_get_patch_publish_topic_succeed(void** s
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_twin_get_patch_publish_topic(
+      az_iot_hub_client_twin_patch_get_publish_topic(
           &client, test_device_request_id, test_buf, sizeof(test_buf), &test_length),
       AZ_OK);
   assert_string_equal(test_correct_twin_patch_pub_topic, test_buf);
   assert_int_equal(sizeof(test_correct_twin_patch_pub_topic) - 1, test_length);
 }
 
-static void test_az_iot_hub_client_twin_get_patch_publish_topic_small_buffer_fails(void** state)
+static void test_az_iot_hub_client_twin_patch_get_publish_topic_small_buffer_fails(void** state)
 {
   (void)state;
 
@@ -436,7 +436,7 @@ static void test_az_iot_hub_client_twin_get_patch_publish_topic_small_buffer_fai
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_twin_get_patch_publish_topic(
+      az_iot_hub_client_twin_patch_get_publish_topic(
           &client, test_device_request_id, test_buf, sizeof(test_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
@@ -539,38 +539,38 @@ int test_az_iot_hub_client_twin()
   const struct CMUnitTest tests[] = {
 #ifndef NO_PRECONDITION_CHECKING
     cmocka_unit_test(
-        test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_null_client_fails),
+        test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_null_client_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_NULL_mqtt_buf_fails),
+        test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_NULL_mqtt_buf_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_NULL_out_span_fails),
+        test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_NULL_out_span_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_client_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_span_fails),
+        test_az_iot_hub_client_twin_patch_get_subscribe_topic_filter_NULL_client_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_patch_get_subscribe_topic_filter_NULL_span_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_NULL_out_span_fails),
+        test_az_iot_hub_client_twin_patch_get_subscribe_topic_filter_NULL_out_span_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_document_get_publish_topic_NULL_client_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_document_get_publish_topic_NULL_request_id_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_document_get_publish_topic_NULL_span_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_document_get_publish_topic_NULL_out_span_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_client_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_invalid_request_id_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_char_buf_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_NULL_out_span_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_patch_get_publish_topic_NULL_client_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_patch_get_publish_topic_invalid_request_id_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_patch_get_publish_topic_NULL_char_buf_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_patch_get_publish_topic_NULL_out_span_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_NULL_client_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_NULL_rec_topic_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_NULL_response_fails),
 #endif // NO_PRECONDITION_CHECKING
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_twin_get_response_subscribe_topic_filter_small_buffer_fails),
+        test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_small_buffer_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_document_get_publish_topic_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_document_get_publish_topic_small_buffer_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_twin_patch_get_subscribe_topic_filter_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_twin_get_patch_subscribe_topic_filter_small_buffer_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_twin_get_patch_publish_topic_small_buffer_fails),
+        test_az_iot_hub_client_twin_patch_get_subscribe_topic_filter_small_buffer_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_patch_get_publish_topic_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_twin_patch_get_publish_topic_small_buffer_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_desired_found_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_get_response_found_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_reported_props_found_succeed),

--- a/sdk/iot/pnp/inc/az_iot_pnp_client.h
+++ b/sdk/iot/pnp/inc/az_iot_pnp_client.h
@@ -80,14 +80,17 @@ AZ_NODISCARD az_result az_iot_pnp_client_init(
  * {iothubhostname}/{device_id}/?api-version=2018-06-30&{user_agent}&digital-twin-model-id={root_interface_name}
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
- * @param[in] mqtt_user_name An empty #az_span with sufficient capacity to hold the MQTT user name.
- * @param[out] out_mqtt_user_name The output #az_span containing the MQTT user name.
+ * @param[out] mqtt_user_name A char buffer with sufficient capacity to hold the MQTT user name.
+ * @param[in] mqtt_user_name_size The size of the passed buffer. Must be greater than 0.
+ * @param[out] out_mqtt_user_name_length The optional output length of the mqtt user name. Can
+ * be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
     az_iot_pnp_client const* client,
-    az_span mqtt_user_name,
-    az_span* out_mqtt_user_name);
+    char* mqtt_user_name,
+    int32_t mqtt_user_name_size,
+    int32_t* out_mqtt_user_name_length);
 
 /**
  * @brief Gets the MQTT client id.
@@ -96,17 +99,23 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
  * {device_id}
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
- * @param[in] mqtt_client_id An empty #az_span with sufficient capacity to hold the MQTT client id.
- * @param[out] out_mqtt_client_id The output #az_span containing the MQTT client id.
+ * @param[out] mqtt_client_id A char buffer with sufficient capacity to hold the MQTT client id.
+ * @param[in] mqtt_client_id_size The size of the passed buffer. Must be greater than 0.
+ * @param[out] out_mqtt_client_id_length The optional output length of the mqtt client id. Can
+ * be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD AZ_INLINE az_result az_iot_pnp_client_get_id(
     az_iot_pnp_client const* client,
-    az_span mqtt_client_id,
-    az_span* out_mqtt_client_id)
+    char* mqtt_client_id,
+    int32_t mqtt_client_id_size,
+    int32_t* out_mqtt_client_id_length)
 {
   return az_iot_hub_client_id_get(
-      &client->_internal.iot_hub_client, mqtt_client_id, out_mqtt_client_id);
+      &client->_internal.iot_hub_client,
+      mqtt_client_id,
+      mqtt_client_id_size,
+      out_mqtt_client_id_length);
 }
 
 /*
@@ -196,17 +205,21 @@ AZ_NODISCARD AZ_INLINE az_result az_iot_pnp_client_get_sas_password(
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
  * @param[in] component_name An #az_span specifying the component name to publish telemetry on.
- * @param[in] mqtt_topic An empty #az_span with sufficient capacity to hold the MQTT topic.
+ * @param[out] mqtt_topic A char buffer with sufficient capacity to hold the MQTT topic
+ * filter. On success, will be `NULL` terminated.
+ * @param[in] mqtt_topic_size The size of the passed buffer. Must be greater than 0.
  * @param[in] reserved Reserved for future use.  Must be NULL.
- * @param[out] out_mqtt_topic The output #az_span containing the MQTT topic.
+ * @param[out] out_mqtt_topic_length The optional output length of the mqtt topic filter. Can
+ * be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
     az_iot_pnp_client const* client,
     az_span component_name,
-    az_span mqtt_topic,
+    char* mqtt_topic,
+    int32_t mqtt_topic_size,
     void* reserved,
-    az_span* out_mqtt_topic);
+    int32_t* out_mqtt_topic_length);
 
 /*
  *

--- a/sdk/iot/pnp/inc/az_iot_pnp_client.h
+++ b/sdk/iot/pnp/inc/az_iot_pnp_client.h
@@ -89,8 +89,8 @@ AZ_NODISCARD az_result az_iot_pnp_client_init(
 AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
     az_iot_pnp_client const* client,
     char* mqtt_user_name,
-    int32_t mqtt_user_name_size,
-    int32_t* out_mqtt_user_name_length);
+    size_t mqtt_user_name_size,
+    size_t* out_mqtt_user_name_length);
 
 /**
  * @brief Gets the MQTT client id.
@@ -108,8 +108,8 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
 AZ_NODISCARD AZ_INLINE az_result az_iot_pnp_client_get_id(
     az_iot_pnp_client const* client,
     char* mqtt_client_id,
-    int32_t mqtt_client_id_size,
-    int32_t* out_mqtt_client_id_length)
+    size_t mqtt_client_id_size,
+    size_t* out_mqtt_client_id_length)
 {
   return az_iot_hub_client_id_get(
       &client->_internal.iot_hub_client,
@@ -217,9 +217,9 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
     az_iot_pnp_client const* client,
     az_span component_name,
     char* mqtt_topic,
-    int32_t mqtt_topic_size,
+    size_t mqtt_topic_size,
     void* reserved,
-    int32_t* out_mqtt_topic_length);
+    size_t* out_mqtt_topic_length);
 
 /*
  *

--- a/sdk/iot/pnp/inc/az_iot_pnp_client.h
+++ b/sdk/iot/pnp/inc/az_iot_pnp_client.h
@@ -109,7 +109,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
  *                                                      of \p mqtt_client_id. Can be `NULL`.
  * @return #az_result
  */
-AZ_NODISCARD AZ_INLINE az_result az_iot_pnp_client_get_id(
+AZ_NODISCARD AZ_INLINE az_result az_iot_pnp_client_get_client_id(
     az_iot_pnp_client const* client,
     char* mqtt_client_id,
     size_t mqtt_client_id_size,
@@ -290,7 +290,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_command_parse_received_topic(
  * @param[out] out_mqtt_topic The output #az_span containing the MQTT topic.
  * @return #az_result
  */
-AZ_NODISCARD az_result az_iot_pnp_client_command_get_response_publish_topic(
+AZ_NODISCARD az_result az_iot_pnp_client_command_response_get_publish_topic(
     az_iot_pnp_client const* client,
     az_span request_id,
     uint16_t status,

--- a/sdk/iot/pnp/inc/az_iot_pnp_client.h
+++ b/sdk/iot/pnp/inc/az_iot_pnp_client.h
@@ -115,7 +115,7 @@ AZ_NODISCARD AZ_INLINE az_result az_iot_pnp_client_get_id(
     size_t mqtt_client_id_size,
     size_t* out_mqtt_client_id_length)
 {
-  return az_iot_hub_client_id_get(
+  return az_iot_hub_client_get_client_id(
       &client->_internal.iot_hub_client,
       mqtt_client_id,
       mqtt_client_id_size,

--- a/sdk/iot/pnp/inc/az_iot_pnp_client.h
+++ b/sdk/iot/pnp/inc/az_iot_pnp_client.h
@@ -209,11 +209,11 @@ AZ_NODISCARD AZ_INLINE az_result az_iot_pnp_client_get_sas_password(
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
  * @param[in] component_name An #az_span specifying the component name to publish telemetry on.
+ * @param[in] reserved Reserved for future use.  Must be NULL.
  * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If
  *                        successful, contains a null-terminated string with the topic that
  *                        needs to be passed to the MQTT client.
  * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
- * @param[in] reserved Reserved for future use.  Must be NULL.
  * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of
  *                                                  \p mqtt_topic. Can be `NULL`.
  * @return #az_result
@@ -221,9 +221,9 @@ AZ_NODISCARD AZ_INLINE az_result az_iot_pnp_client_get_sas_password(
 AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
     az_iot_pnp_client const* client,
     az_span component_name,
+    void* reserved,
     char* mqtt_topic,
     size_t mqtt_topic_size,
-    void* reserved,
     size_t* out_mqtt_topic_length);
 
 /*

--- a/sdk/iot/pnp/inc/az_iot_pnp_client.h
+++ b/sdk/iot/pnp/inc/az_iot_pnp_client.h
@@ -237,16 +237,20 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
  * @param[in] reserved Reserved for future use.  Must be NULL.
- * @param[in] mqtt_topic_filter An empty #az_span with sufficient capacity to hold the MQTT topic
- *                              filter.
- * @param[out] out_mqtt_topic_filter The output #az_span containing the MQTT topic filter.
+ * @param[out] mqtt_topic_filter A buffer with sufficient capacity to hold the MQTT topic filter.
+ *                               If successful, contains a null-terminated string with the topic
+ *                               filter that needs to be passed to the MQTT client.
+ * @param[in] mqtt_topic_filter_size The size, in bytes of \p mqtt_topic_filter.
+ * @param[out] out_mqtt_topic_filter_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                         \p mqtt_topic_filter. Can be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_pnp_client_command_get_subscribe_topic_filter(
     az_iot_pnp_client const* client,
     void* reserved,
-    az_span mqtt_topic_filter,
-    az_span* out_mqtt_topic_filter);
+    char* mqtt_topic_filter,
+    size_t mqtt_topic_filter_size,
+    size_t* out_mqtt_topic_filter_length);
 
 /**
  * @brief A command request received from the PnP service.

--- a/sdk/iot/pnp/inc/az_iot_pnp_client.h
+++ b/sdk/iot/pnp/inc/az_iot_pnp_client.h
@@ -236,16 +236,16 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
  * @brief Gets the MQTT topic filter to subscribe to PnP commands.
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
+ * @param[in] reserved Reserved for future use.  Must be NULL.
  * @param[in] mqtt_topic_filter An empty #az_span with sufficient capacity to hold the MQTT topic
  *                              filter.
- * @param[in] reserved Reserved for future use.  Must be NULL.
  * @param[out] out_mqtt_topic_filter The output #az_span containing the MQTT topic filter.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_pnp_client_command_get_subscribe_topic_filter(
     az_iot_pnp_client const* client,
-    az_span mqtt_topic_filter,
     void* reserved,
+    az_span mqtt_topic_filter,
     az_span* out_mqtt_topic_filter);
 
 /**
@@ -285,18 +285,23 @@ AZ_NODISCARD az_result az_iot_pnp_client_command_parse_received_topic(
  * @param[in] request_id The request id. Must match a received #az_iot_pnp_client_command_request
  *                       request_id.
  * @param[in] status The status. (E.g. 200 for success.)
- * @param[in] mqtt_topic An empty #az_span with sufficient capacity to hold the MQTT topic.
  * @param[in] reserved Reserved for future use.  Must be NULL.
- * @param[out] out_mqtt_topic The output #az_span containing the MQTT topic.
+ * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If
+ *                        successful, contains a null-terminated string with the topic that
+ *                        needs to be passed to the MQTT client.
+ * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
+ * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                  \p mqtt_topic. Can be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_pnp_client_command_response_get_publish_topic(
     az_iot_pnp_client const* client,
     az_span request_id,
     uint16_t status,
-    az_span mqtt_topic,
     void* reserved,
-    az_span* out_mqtt_topic);
+    char* mqtt_topic,
+    size_t mqtt_topic_size,
+    size_t* out_mqtt_topic_length);
 
 #include <_az_cfg_suffix.h>
 

--- a/sdk/iot/pnp/inc/az_iot_pnp_client.h
+++ b/sdk/iot/pnp/inc/az_iot_pnp_client.h
@@ -80,10 +80,12 @@ AZ_NODISCARD az_result az_iot_pnp_client_init(
  * {iothubhostname}/{device_id}/?api-version=2018-06-30&{user_agent}&digital-twin-model-id={root_interface_name}
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
- * @param[out] mqtt_user_name A char buffer with sufficient capacity to hold the MQTT user name.
- * @param[in] mqtt_user_name_size The size of the passed buffer. Must be greater than 0.
- * @param[out] out_mqtt_user_name_length The optional output length of the mqtt user name. Can
- * be `NULL`.
+ * @param[out] mqtt_user_name A buffer with sufficient capacity to hold the MQTT user name.
+ *                            If successful, contains a null-terminated string with the user name
+ *                            that needs to be passed to the MQTT client.
+ * @param[in] mqtt_user_name_size The size, in bytes of \p mqtt_user_name.
+ * @param[out] out_mqtt_user_name_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                      \p mqtt_user_name. Can be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
@@ -99,10 +101,12 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
  * {device_id}
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
- * @param[out] mqtt_client_id A char buffer with sufficient capacity to hold the MQTT client id.
- * @param[in] mqtt_client_id_size The size of the passed buffer. Must be greater than 0.
- * @param[out] out_mqtt_client_id_length The optional output length of the mqtt client id. Can
- * be `NULL`.
+ * @param[out] mqtt_client_id A buffer with sufficient capacity to hold the MQTT client id.
+ *                            If successful, contains a null-terminated string with the client id
+ *                            that needs to be passed to the MQTT client.
+ * @param[in] mqtt_client_id_size The size, in bytes of \p mqtt_client_id.
+ * @param[out] out_mqtt_client_id_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                      of \p mqtt_client_id. Can be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD AZ_INLINE az_result az_iot_pnp_client_get_id(
@@ -205,12 +209,13 @@ AZ_NODISCARD AZ_INLINE az_result az_iot_pnp_client_get_sas_password(
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
  * @param[in] component_name An #az_span specifying the component name to publish telemetry on.
- * @param[out] mqtt_topic A char buffer with sufficient capacity to hold the MQTT topic
- * filter. On success, will be `NULL` terminated.
- * @param[in] mqtt_topic_size The size of the passed buffer. Must be greater than 0.
+ * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If
+ *                        successful, contains a null-terminated string with the topic that
+ *                        needs to be passed to the MQTT client.
+ * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
  * @param[in] reserved Reserved for future use.  Must be NULL.
- * @param[out] out_mqtt_topic_length The optional output length of the mqtt topic filter. Can
- * be `NULL`.
+ * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of
+ *                                                  \p mqtt_topic. Can be `NULL`.
  * @return #az_result
  */
 AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(

--- a/sdk/iot/pnp/src/az_iot_pnp_client.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client.c
@@ -62,23 +62,23 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
   AZ_PRECONDITION_NOT_NULL(mqtt_user_name);
   AZ_PRECONDITION(mqtt_user_name_size > 0);
 
-  int32_t written;
+  size_t written;
 
   // First get hub user name since it is unknown how long it will be
   AZ_RETURN_IF_FAILED(az_iot_hub_client_user_name_get(
-      &client->_internal.iot_hub_client, mqtt_user_name, mqtt_user_name_size, (size_t*)&written));
+      &client->_internal.iot_hub_client, mqtt_user_name, mqtt_user_name_size, &written));
 
   az_span mqtt_user_name_span
       = az_span_init((uint8_t*)mqtt_user_name, (int32_t)mqtt_user_name_size);
 
-  int32_t required_length = written + (int32_t)sizeof(pnp_client_param_separator)
+  int32_t required_length = (int32_t)written + (int32_t)sizeof(pnp_client_param_separator)
       + az_span_size(pnp_model_id) + (int32_t)sizeof(pnp_client_param_equals)
       + az_span_size(client->_internal.root_interface_name);
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(
-      mqtt_user_name_span, required_length + (int32_t)sizeof(null_terminator));
+      mqtt_user_name_span, (int32_t)(required_length + sizeof(null_terminator)));
 
-  az_span remainder = az_span_slice_to_end(mqtt_user_name_span, written);
+  az_span remainder = az_span_slice_to_end(mqtt_user_name_span, (int32_t)written);
 
   remainder = az_span_copy_u8(remainder, pnp_client_param_separator);
   remainder = az_span_copy(remainder, pnp_model_id);
@@ -86,7 +86,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
   remainder = az_span_copy(remainder, client->_internal.root_interface_name);
   az_span_copy_u8(remainder, null_terminator);
 
-  if(out_mqtt_user_name_length)
+  if (out_mqtt_user_name_length)
   {
     *out_mqtt_user_name_length = (size_t)required_length;
   }

--- a/sdk/iot/pnp/src/az_iot_pnp_client.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client.c
@@ -65,7 +65,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
   size_t hub_user_name_length;
 
   // First get hub user name
-  AZ_RETURN_IF_FAILED(az_iot_hub_client_user_name_get(
+  AZ_RETURN_IF_FAILED(az_iot_hub_client_get_user_name(
       &client->_internal.iot_hub_client,
       mqtt_user_name,
       mqtt_user_name_size,

--- a/sdk/iot/pnp/src/az_iot_pnp_client.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client.c
@@ -71,10 +71,12 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
   az_span mqtt_user_name_span
       = az_span_init((uint8_t*)mqtt_user_name, (int32_t)mqtt_user_name_size);
 
-  int32_t required_length = written + az_span_size(pnp_model_id)
-      + az_span_size(client->_internal.root_interface_name) + 2;
+  int32_t required_length = written + (int32_t)sizeof(pnp_client_param_separator)
+      + az_span_size(pnp_model_id) + (int32_t)sizeof(pnp_client_param_equals)
+      + az_span_size(client->_internal.root_interface_name);
 
-  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_user_name_span, required_length);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(
+      mqtt_user_name_span, required_length + (int32_t)sizeof(null_terminator));
 
   az_span remainder = az_span_slice_to_end(mqtt_user_name_span, written);
 

--- a/sdk/iot/pnp/src/az_iot_pnp_client.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client.c
@@ -76,7 +76,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
       + az_span_size(client->_internal.root_interface_name);
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(
-      mqtt_user_name_span, (int32_t)(required_length + sizeof(null_terminator)));
+      mqtt_user_name_span, required_length + (int32_t)sizeof(null_terminator));
 
   az_span remainder = az_span_slice_to_end(mqtt_user_name_span, (int32_t)written);
 

--- a/sdk/iot/pnp/src/az_iot_pnp_client.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client.c
@@ -62,23 +62,28 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
   AZ_PRECONDITION_NOT_NULL(mqtt_user_name);
   AZ_PRECONDITION(mqtt_user_name_size > 0);
 
-  size_t written;
+  size_t hub_user_name_written_length;
 
-  // First get hub user name since it is unknown how long it will be
+  // First get hub user name
   AZ_RETURN_IF_FAILED(az_iot_hub_client_user_name_get(
-      &client->_internal.iot_hub_client, mqtt_user_name, mqtt_user_name_size, &written));
+      &client->_internal.iot_hub_client,
+      mqtt_user_name,
+      mqtt_user_name_size,
+      &hub_user_name_written_length));
 
   az_span mqtt_user_name_span
       = az_span_init((uint8_t*)mqtt_user_name, (int32_t)mqtt_user_name_size);
 
-  int32_t required_length = (int32_t)written + (int32_t)sizeof(pnp_client_param_separator)
-      + az_span_size(pnp_model_id) + (int32_t)sizeof(pnp_client_param_equals)
+  int32_t required_length = (int32_t)hub_user_name_written_length
+      + (int32_t)sizeof(pnp_client_param_separator) + az_span_size(pnp_model_id)
+      + (int32_t)sizeof(pnp_client_param_equals)
       + az_span_size(client->_internal.root_interface_name);
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(
       mqtt_user_name_span, required_length + (int32_t)sizeof(null_terminator));
 
-  az_span remainder = az_span_slice_to_end(mqtt_user_name_span, (int32_t)written);
+  az_span remainder
+      = az_span_slice_to_end(mqtt_user_name_span, (int32_t)hub_user_name_written_length);
 
   remainder = az_span_copy_u8(remainder, pnp_client_param_separator);
   remainder = az_span_copy(remainder, pnp_model_id);

--- a/sdk/iot/pnp/src/az_iot_pnp_client.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client.c
@@ -55,8 +55,8 @@ AZ_NODISCARD az_result az_iot_pnp_client_init(
 AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
     az_iot_pnp_client const* client,
     char* mqtt_user_name,
-    int32_t mqtt_user_name_size,
-    int32_t* out_mqtt_user_name_length)
+    size_t mqtt_user_name_size,
+    size_t* out_mqtt_user_name_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_NOT_NULL(mqtt_user_name);
@@ -66,9 +66,10 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
 
   // First get hub user name since it is unknown how long it will be
   AZ_RETURN_IF_FAILED(az_iot_hub_client_user_name_get(
-      &client->_internal.iot_hub_client, mqtt_user_name, mqtt_user_name_size, &written));
+      &client->_internal.iot_hub_client, mqtt_user_name, mqtt_user_name_size, (size_t*)&written));
 
-  az_span mqtt_user_name_span = az_span_init((uint8_t*)mqtt_user_name, mqtt_user_name_size);
+  az_span mqtt_user_name_span
+      = az_span_init((uint8_t*)mqtt_user_name, (int32_t)mqtt_user_name_size);
 
   int32_t required_length = written + az_span_size(pnp_model_id)
       + az_span_size(client->_internal.root_interface_name) + 2;
@@ -85,7 +86,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
 
   if(out_mqtt_user_name_length)
   {
-    *out_mqtt_user_name_length = required_length;
+    *out_mqtt_user_name_length = (size_t)required_length;
   }
 
   return AZ_OK;

--- a/sdk/iot/pnp/src/az_iot_pnp_client.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client.c
@@ -62,19 +62,19 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
   AZ_PRECONDITION_NOT_NULL(mqtt_user_name);
   AZ_PRECONDITION(mqtt_user_name_size > 0);
 
-  size_t hub_user_name_written_length;
+  size_t hub_user_name_length;
 
   // First get hub user name
   AZ_RETURN_IF_FAILED(az_iot_hub_client_user_name_get(
       &client->_internal.iot_hub_client,
       mqtt_user_name,
       mqtt_user_name_size,
-      &hub_user_name_written_length));
+      &hub_user_name_length));
 
   az_span mqtt_user_name_span
       = az_span_init((uint8_t*)mqtt_user_name, (int32_t)mqtt_user_name_size);
 
-  int32_t required_length = (int32_t)hub_user_name_written_length
+  int32_t required_length = (int32_t)hub_user_name_length
       + (int32_t)sizeof(pnp_client_param_separator) + az_span_size(pnp_model_id)
       + (int32_t)sizeof(pnp_client_param_equals)
       + az_span_size(client->_internal.root_interface_name);
@@ -83,7 +83,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
       mqtt_user_name_span, required_length + (int32_t)sizeof(null_terminator));
 
   az_span remainder
-      = az_span_slice_to_end(mqtt_user_name_span, (int32_t)hub_user_name_written_length);
+      = az_span_slice_to_end(mqtt_user_name_span, (int32_t)hub_user_name_length);
 
   remainder = az_span_copy_u8(remainder, pnp_client_param_separator);
   remainder = az_span_copy(remainder, pnp_model_id);

--- a/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
@@ -63,7 +63,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
   AZ_PRECONDITION_IS_NULL(reserved);
   (void)reserved;
 
-  int32_t written;
+  size_t written;
 
   // First get hub topic since it is unknown how long it will be
   AZ_RETURN_IF_FAILED(az_iot_hub_client_telemetry_get_publish_topic(
@@ -72,7 +72,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
   az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
 
   // Hub topic plus pnp values
-  int32_t required_length = written + az_span_size(pnp_telemetry_component_name_param)
+  int32_t required_length = (int32_t)written + az_span_size(pnp_telemetry_component_name_param)
       + (int32_t)sizeof(pnp_telemetry_param_equals) + az_span_size(component_name);
 
   // Content type size if applicable
@@ -96,7 +96,8 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_span, required_length + (int32_t)sizeof(null_terminator));
 
   // Proceed with appending since there is enough size
-  az_span remaining = az_span_init((uint8_t*)mqtt_topic + written, (int32_t)mqtt_topic_size - written);
+  az_span remaining
+      = az_span_init((uint8_t*)(mqtt_topic + written), (int32_t)(mqtt_topic_size - written));
 
   remaining = _az_add_telemetry_property(
       remaining, pnp_telemetry_component_name_param, component_name, false);

--- a/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
@@ -63,7 +63,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
   AZ_PRECONDITION_IS_NULL(reserved);
   (void)reserved;
 
-  size_t hub_topic_written_length;
+  size_t hub_topic_length;
 
   // First get hub topic
   AZ_RETURN_IF_FAILED(az_iot_hub_client_telemetry_get_publish_topic(
@@ -71,12 +71,12 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
       NULL,
       mqtt_topic,
       mqtt_topic_size,
-      (size_t*)&hub_topic_written_length));
+      (size_t*)&hub_topic_length));
 
   az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
 
   // Hub topic plus pnp values
-  int32_t required_length = (int32_t)hub_topic_written_length
+  int32_t required_length = (int32_t)hub_topic_length
       + az_span_size(pnp_telemetry_component_name_param)
       + (int32_t)sizeof(pnp_telemetry_param_equals) + az_span_size(component_name);
 
@@ -102,8 +102,8 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
 
   // Proceed with appending since there is enough size
   az_span remaining = az_span_init(
-      (uint8_t*)(mqtt_topic + hub_topic_written_length),
-      (int32_t)(mqtt_topic_size - hub_topic_written_length));
+      (uint8_t*)(mqtt_topic + hub_topic_length),
+      (int32_t)(mqtt_topic_size - hub_topic_length));
 
   remaining = _az_add_telemetry_property(
       remaining, pnp_telemetry_component_name_param, component_name, false);

--- a/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
@@ -52,9 +52,9 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
     az_iot_pnp_client const* client,
     az_span component_name,
     char* mqtt_topic,
-    int32_t mqtt_topic_size,
+    size_t mqtt_topic_size,
     void* reserved,
-    int32_t* out_mqtt_topic_length)
+    size_t* out_mqtt_topic_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_VALID_SPAN(component_name, 1, false);
@@ -67,9 +67,9 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
 
   // First get hub topic since it is unknown how long it will be
   AZ_RETURN_IF_FAILED(az_iot_hub_client_telemetry_get_publish_topic(
-      &client->_internal.iot_hub_client, NULL, mqtt_topic, mqtt_topic_size, &written));
+      &client->_internal.iot_hub_client, NULL, mqtt_topic, mqtt_topic_size, (size_t*)&written));
 
-  az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, mqtt_topic_size);
+  az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
 
   // Hub topic plus pnp values
   int32_t required_length = written + az_span_size(pnp_telemetry_component_name_param)
@@ -96,7 +96,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_span, required_length + (int32_t)sizeof(null_terminator));
 
   // Proceed with appending since there is enough size
-  az_span remaining = az_span_init((uint8_t*)mqtt_topic + written, mqtt_topic_size - written);
+  az_span remaining = az_span_init((uint8_t*)mqtt_topic + written, (int32_t)mqtt_topic_size - written);
 
   remaining = _az_add_telemetry_property(
       remaining, pnp_telemetry_component_name_param, component_name, false);
@@ -120,7 +120,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
 
   if (out_mqtt_topic_length)
   {
-    *out_mqtt_topic_length = required_length;
+    *out_mqtt_topic_length = (size_t)required_length;
   }
 
   return AZ_OK;

--- a/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
@@ -11,6 +11,7 @@
 
 #include <_az_cfg.h>
 
+static const uint8_t null_terminator = '\0';
 static const uint8_t pnp_telemetry_param_separator = '&';
 static const uint8_t pnp_telemetry_param_equals = '=';
 
@@ -18,12 +19,11 @@ static const az_span pnp_telemetry_component_name_param = AZ_SPAN_LITERAL_FROM_S
 static const az_span pnp_telemetry_content_type_param = AZ_SPAN_LITERAL_FROM_STR("%24.ct");
 static const az_span pnp_telemetry_content_encoding_param = AZ_SPAN_LITERAL_FROM_STR("%24.ce");
 
-static az_result _az_add_telemetry_property(
+static az_span _az_add_telemetry_property(
     az_span mqtt_topic,
     az_span property_name,
     az_span property_value,
-    bool add_separator,
-    az_span* out_mqtt_topic)
+    bool add_separator)
 {
   int32_t required_length = az_span_size(property_name) + az_span_size(property_value) + 1;
   if (add_separator)
@@ -31,7 +31,10 @@ static az_result _az_add_telemetry_property(
     required_length++;
   }
 
-  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic, required_length);
+  if (required_length > az_span_size(mqtt_topic))
+  {
+    return AZ_SPAN_NULL;
+  }
 
   az_span remainder = mqtt_topic;
   if (add_separator)
@@ -42,70 +45,83 @@ static az_result _az_add_telemetry_property(
   remainder = az_span_copy_u8(remainder, pnp_telemetry_param_equals);
   az_span_copy(remainder, property_value);
 
-  *out_mqtt_topic = az_span_slice(mqtt_topic, 0, required_length);
-
-  return AZ_OK;
+  return az_span_slice_to_end(mqtt_topic, required_length);
 }
 
 AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
     az_iot_pnp_client const* client,
     az_span component_name,
-    az_span mqtt_topic,
+    char* mqtt_topic,
+    int32_t mqtt_topic_size,
     void* reserved,
-    az_span* out_mqtt_topic)
+    int32_t* out_mqtt_topic_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION_VALID_SPAN(component_name, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(mqtt_topic, 0, false);
+  AZ_PRECONDITION_NOT_NULL(mqtt_topic);
+  AZ_PRECONDITION(mqtt_topic_size > 0);
   AZ_PRECONDITION_IS_NULL(reserved);
-  AZ_PRECONDITION_NOT_NULL(out_mqtt_topic);
   (void)reserved;
 
-  az_span written_span;
-  int32_t written = 0;
+  int32_t written;
 
-  AZ_RETURN_IF_FAILED(az_iot_hub_client_telemetry_publish_topic_get(
-      &client->_internal.iot_hub_client,
-      NULL,
-      az_span_slice_to_end(mqtt_topic, written),
-      &written_span));
+  // First get hub topic since it is unknown how long it will be
+  AZ_RETURN_IF_FAILED(az_iot_hub_client_telemetry_get_publish_topic(
+      &client->_internal.iot_hub_client, NULL, mqtt_topic, mqtt_topic_size, &written));
 
-  written += az_span_size(written_span);
+  az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, mqtt_topic_size);
 
-  AZ_RETURN_IF_FAILED(_az_add_telemetry_property(
-      az_span_slice_to_end(mqtt_topic, written),
-      pnp_telemetry_component_name_param,
-      component_name,
-      false,
-      &written_span));
+  // Hub topic plus pnp values
+  int32_t required_length = written + az_span_size(pnp_telemetry_component_name_param)
+      + (int32_t)sizeof(pnp_telemetry_param_equals) + az_span_size(component_name);
 
-  written += az_span_size(written_span);
+  // Content type size if applicable
+  if (az_span_ptr(client->_internal.options.content_type) != NULL)
+  {
+    required_length += (int32_t)sizeof(pnp_telemetry_param_separator)
+        + az_span_size(pnp_telemetry_content_type_param)
+        + (int32_t)sizeof(pnp_telemetry_param_equals)
+        + az_span_size(client->_internal.options.content_type);
+  }
+
+  // Content encoding size if applicable
+  if (az_span_ptr(client->_internal.options.content_encoding) != NULL)
+  {
+    required_length += (int32_t)sizeof(pnp_telemetry_param_separator)
+        + az_span_size(pnp_telemetry_content_encoding_param)
+        + (int32_t)sizeof(pnp_telemetry_param_equals)
+        + az_span_size(client->_internal.options.content_encoding);
+  }
+
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_span, required_length + (int32_t)sizeof(null_terminator));
+
+  // Proceed with appending since there is enough size
+  az_span remaining = az_span_init((uint8_t*)mqtt_topic + written, mqtt_topic_size - written);
+
+  remaining = _az_add_telemetry_property(
+      remaining, pnp_telemetry_component_name_param, component_name, false);
 
   if (az_span_ptr(client->_internal.options.content_type) != NULL)
   {
-    AZ_RETURN_IF_FAILED(_az_add_telemetry_property(
-        az_span_slice_to_end(mqtt_topic, written),
-        pnp_telemetry_content_type_param,
-        client->_internal.options.content_type,
-        true,
-        &written_span));
-
-    written += az_span_size(written_span);
+    remaining = _az_add_telemetry_property(
+        remaining, pnp_telemetry_content_type_param, client->_internal.options.content_type, true);
   }
 
   if (az_span_ptr(client->_internal.options.content_encoding) != NULL)
   {
-    AZ_RETURN_IF_FAILED(_az_add_telemetry_property(
-        az_span_slice_to_end(mqtt_topic, written),
+    remaining = _az_add_telemetry_property(
+        remaining,
         pnp_telemetry_content_encoding_param,
         client->_internal.options.content_encoding,
-        true,
-        &written_span));
-
-    written += az_span_size(written_span);
+        true);
   }
 
-  *out_mqtt_topic = az_span_slice(mqtt_topic, 0, written);
+  az_span_copy_u8(remaining, null_terminator);
+
+  if (out_mqtt_topic_length)
+  {
+    *out_mqtt_topic_length = required_length;
+  }
 
   return AZ_OK;
 }

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
@@ -140,7 +140,7 @@ static void test_az_iot_pnp_client_get_user_name_succeed(void** state)
       AZ_OK);
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
   assert_int_equal(
       az_iot_pnp_client_get_user_name(
           &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
@@ -160,7 +160,7 @@ static void test_az_iot_pnp_client_get_user_name_small_buffer_fail(void** state)
       AZ_OK);
 
   char mqtt_topic_buf[_az_COUNTOF(test_correct_pnp_user_name) - 2];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_get_user_name(
@@ -184,7 +184,7 @@ static void test_az_iot_pnp_client_get_user_name_user_options_succeed(void** sta
       AZ_OK);
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
   assert_int_equal(
       az_iot_pnp_client_get_user_name(
           &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
@@ -209,7 +209,7 @@ static void test_az_iot_pnp_client_get_user_name_user_options_small_buffer_fail(
       AZ_OK);
 
   char mqtt_topic_buf[_az_COUNTOF(test_correct_pnp_user_name_with_user_agent) - 2];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
   assert_int_equal(
       az_iot_pnp_client_get_user_name(
           &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
@@ -216,7 +216,7 @@ static void test_az_iot_pnp_client_get_user_name_user_options_small_buffer_fail(
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-// TODO: Add tests for inline functions (e.g. az_iot_pnp_client_get_id).  Will add them prior to
+// TODO: Add tests for inline functions (e.g. az_iot_pnp_client_get_client_id).  Will add them prior to
 // merge if guidance is available.  Otherwise will open separate GitHub bug to not block merge
 // and record number here.
 

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
@@ -139,14 +139,14 @@ static void test_az_iot_pnp_client_get_user_name_succeed(void** state)
           &client, test_device_hostname, test_device_id, test_root_interface_name, NULL),
       AZ_OK);
 
-  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  size_t mqtt_topic_length;
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  size_t test_length;
   assert_int_equal(
       az_iot_pnp_client_get_user_name(
-          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+          &client, test_buf, sizeof(test_buf), &test_length),
       AZ_OK);
-  assert_string_equal(test_correct_pnp_user_name, mqtt_topic_buf);
-  assert_int_equal(sizeof(test_correct_pnp_user_name) - 1, mqtt_topic_length);
+  assert_string_equal(test_correct_pnp_user_name, test_buf);
+  assert_int_equal(sizeof(test_correct_pnp_user_name) - 1, test_length);
 }
 
 static void test_az_iot_pnp_client_get_user_name_small_buffer_fail(void** state)
@@ -159,12 +159,12 @@ static void test_az_iot_pnp_client_get_user_name_small_buffer_fail(void** state)
           &client, test_device_hostname, test_device_id, test_root_interface_name, NULL),
       AZ_OK);
 
-  char mqtt_topic_buf[_az_COUNTOF(test_correct_pnp_user_name) - 2];
-  size_t mqtt_topic_length;
+  char test_buf[_az_COUNTOF(test_correct_pnp_user_name) - 2];
+  size_t test_length;
 
   assert_int_equal(
       az_iot_pnp_client_get_user_name(
-          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+          &client, test_buf, sizeof(test_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
@@ -183,14 +183,14 @@ static void test_az_iot_pnp_client_get_user_name_user_options_succeed(void** sta
           &client, test_device_hostname, test_device_id, test_root_interface_name, &options),
       AZ_OK);
 
-  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  size_t mqtt_topic_length;
+  char test_buf[TEST_SPAN_BUFFER_SIZE];
+  size_t test_length;
   assert_int_equal(
       az_iot_pnp_client_get_user_name(
-          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+          &client, test_buf, sizeof(test_buf), &test_length),
       AZ_OK);
-  assert_string_equal(test_correct_pnp_user_name_with_user_agent, mqtt_topic_buf);
-  assert_int_equal(sizeof(test_correct_pnp_user_name_with_user_agent) - 1, mqtt_topic_length);
+  assert_string_equal(test_correct_pnp_user_name_with_user_agent, test_buf);
+  assert_int_equal(sizeof(test_correct_pnp_user_name_with_user_agent) - 1, test_length);
 }
 
 static void test_az_iot_pnp_client_get_user_name_user_options_small_buffer_fail(void** state)
@@ -208,11 +208,11 @@ static void test_az_iot_pnp_client_get_user_name_user_options_small_buffer_fail(
           &client, test_device_hostname, test_device_id, test_root_interface_name, &options),
       AZ_OK);
 
-  char mqtt_topic_buf[_az_COUNTOF(test_correct_pnp_user_name_with_user_agent) - 2];
-  size_t mqtt_topic_length;
+  char test_buf[_az_COUNTOF(test_correct_pnp_user_name_with_user_agent) - 2];
+  size_t test_length;
   assert_int_equal(
       az_iot_pnp_client_get_user_name(
-          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+          &client, test_buf, sizeof(test_buf), &test_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
@@ -16,6 +16,8 @@
 #include <az_test_precondition.h>
 #include <cmocka.h>
 
+#define TEST_SPAN_BUFFER_SIZE 128
+
 // PnP Client
 #define TEST_DEVICE_ID_STR "my_device"
 #define TEST_DEVICE_HOSTNAME_STR "myiothub.azure-devices.net"
@@ -137,15 +139,14 @@ static void test_az_iot_pnp_client_get_user_name_succeed(void** state)
           &client, test_device_hostname, test_device_id, test_root_interface_name, NULL),
       AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_pnp_user_name) - 1];
-  az_span test_span = az_span_init(test_span_buffer, _az_COUNTOF(test_span_buffer));
-  assert_int_equal(az_iot_pnp_client_get_user_name(&client, test_span, &test_span), AZ_OK);
-
-  assert_int_equal(az_span_size(test_span), _az_COUNTOF(test_correct_pnp_user_name) - 1);
-  assert_memory_equal(
-      test_correct_pnp_user_name,
-      az_span_ptr(test_span),
-      _az_COUNTOF(test_correct_pnp_user_name) - 1);
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
+  assert_int_equal(
+      az_iot_pnp_client_get_user_name(
+          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+      AZ_OK);
+  assert_string_equal(test_correct_pnp_user_name, mqtt_topic_buf);
+  assert_int_equal(sizeof(test_correct_pnp_user_name) - 1, mqtt_topic_length);
 }
 
 static void test_az_iot_pnp_client_get_user_name_small_buffer_fail(void** state)
@@ -158,10 +159,12 @@ static void test_az_iot_pnp_client_get_user_name_small_buffer_fail(void** state)
           &client, test_device_hostname, test_device_id, test_root_interface_name, NULL),
       AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_pnp_user_name) - 2];
-  az_span test_span = az_span_init(test_span_buffer, _az_COUNTOF(test_span_buffer));
+  char mqtt_topic_buf[_az_COUNTOF(test_correct_pnp_user_name) - 2];
+  int32_t mqtt_topic_length;
+
   assert_int_equal(
-      az_iot_pnp_client_get_user_name(&client, test_span, &test_span),
+      az_iot_pnp_client_get_user_name(
+          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
@@ -180,16 +183,14 @@ static void test_az_iot_pnp_client_get_user_name_user_options_succeed(void** sta
           &client, test_device_hostname, test_device_id, test_root_interface_name, &options),
       AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_pnp_user_name_with_user_agent) - 1];
-  az_span test_span = az_span_init(test_span_buffer, _az_COUNTOF(test_span_buffer));
-  assert_int_equal(az_iot_pnp_client_get_user_name(&client, test_span, &test_span), AZ_OK);
-
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
   assert_int_equal(
-      az_span_size(test_span), _az_COUNTOF(test_correct_pnp_user_name_with_user_agent) - 1);
-  assert_memory_equal(
-      test_correct_pnp_user_name_with_user_agent,
-      az_span_ptr(test_span),
-      _az_COUNTOF(test_correct_pnp_user_name_with_user_agent) - 1);
+      az_iot_pnp_client_get_user_name(
+          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
+      AZ_OK);
+  assert_string_equal(test_correct_pnp_user_name_with_user_agent, mqtt_topic_buf);
+  assert_int_equal(sizeof(test_correct_pnp_user_name_with_user_agent) - 1, mqtt_topic_length);
 }
 
 static void test_az_iot_pnp_client_get_user_name_user_options_small_buffer_fail(void** state)
@@ -207,10 +208,11 @@ static void test_az_iot_pnp_client_get_user_name_user_options_small_buffer_fail(
           &client, test_device_hostname, test_device_id, test_root_interface_name, &options),
       AZ_OK);
 
-  uint8_t test_span_buffer[_az_COUNTOF(test_correct_pnp_user_name_with_user_agent) - 2];
-  az_span test_span = az_span_init(test_span_buffer, _az_COUNTOF(test_span_buffer));
+  char mqtt_topic_buf[_az_COUNTOF(test_correct_pnp_user_name_with_user_agent) - 2];
+  int32_t mqtt_topic_length;
   assert_int_equal(
-      az_iot_pnp_client_get_user_name(&client, test_span, &test_span),
+      az_iot_pnp_client_get_user_name(
+          &client, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
@@ -51,12 +51,11 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_client_fails
 {
   (void)state;
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
-      NULL, test_component_name, mqtt_topic, NULL, &mqtt_topic));
+      NULL, test_component_name, mqtt_topic_buf, sizeof(mqtt_topic_buf), NULL, &mqtt_topic_length));
 }
 
 static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_mqtt_topic_fails(void** state)
@@ -69,12 +68,11 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_mqtt_topic_f
           &client, test_device_hostname, test_device_id, test_root_interface_name, NULL),
       AZ_OK);
 
-  uint8_t test_buf[1];
-  az_span bad_mqtt_topic = az_span_init(test_buf, _az_COUNTOF(test_buf));
-  bad_mqtt_topic._internal.ptr = NULL;
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
-      &client, test_component_name, bad_mqtt_topic, NULL, &bad_mqtt_topic));
+      &client, test_component_name, NULL, sizeof(mqtt_topic_buf), NULL, &mqtt_topic_length));
 }
 
 static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_out_mqtt_topic_fails(
@@ -88,11 +86,11 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_out_mqtt_top
           &client, test_device_hostname, test_device_id, test_root_interface_name, NULL),
       AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
-      &client, test_component_name, mqtt_topic, NULL, NULL));
+      &client, test_component_name, mqtt_topic_buf, 0, NULL, &mqtt_topic_length));
 }
 
 static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_component_name_fails(
@@ -106,11 +104,11 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_component_na
           &client, test_device_hostname, test_device_id, test_root_interface_name, NULL),
       AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
-      &client, AZ_SPAN_NULL, mqtt_topic, NULL, &mqtt_topic));
+      &client, AZ_SPAN_NULL, mqtt_topic_buf, sizeof(mqtt_topic_buf), NULL, &mqtt_topic_length));
 }
 
 static void test_az_iot_pnp_client_telemetry_get_publish_topic_non_NULL_reserved_fails(void** state)
@@ -123,11 +121,11 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_non_NULL_reserved
           &client, test_device_hostname, test_device_id, test_root_interface_name, NULL),
       AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
-      &client, test_component_name, AZ_SPAN_NULL, (void*)0x1, &mqtt_topic));
+      &client, AZ_SPAN_NULL, mqtt_topic_buf, sizeof(mqtt_topic_buf), (void*)0x1, &mqtt_topic_length));
 }
 
 #endif // NO_PRECONDITION_CHECKING
@@ -142,20 +140,16 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_no_options_succee
           &client, test_device_hostname, test_device_id, test_root_interface_name, NULL),
       AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
-          &client, test_component_name, mqtt_topic, NULL, &mqtt_topic),
+          &client, test_component_name, mqtt_topic_buf, sizeof(mqtt_topic_buf), NULL, &mqtt_topic_length),
       AZ_OK);
 
-  az_span_for_test_verify(
-      mqtt_topic,
-      g_test_correct_pnp_topic_no_options,
-      _az_COUNTOF(g_test_correct_pnp_topic_no_options) - 1,
-      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
-      TEST_SPAN_BUFFER_SIZE);
+  assert_string_equal(g_test_correct_pnp_topic_no_options, mqtt_topic_buf);
+  assert_int_equal(sizeof(g_test_correct_pnp_topic_no_options) - 1, mqtt_topic_length);
 }
 
 static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_succeed(void** state)
@@ -171,20 +165,21 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_succ
           &client, test_device_hostname, test_device_id, test_root_interface_name, &options),
       AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
-          &client, test_component_name, mqtt_topic, NULL, &mqtt_topic),
+          &client,
+          test_component_name,
+          mqtt_topic_buf,
+          sizeof(mqtt_topic_buf),
+          NULL,
+          &mqtt_topic_length),
       AZ_OK);
 
-  az_span_for_test_verify(
-      mqtt_topic,
-      g_test_correct_pnp_topic_content_type,
-      _az_COUNTOF(g_test_correct_pnp_topic_content_type) - 1,
-      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
-      TEST_SPAN_BUFFER_SIZE);
+  assert_string_equal(g_test_correct_pnp_topic_content_type, mqtt_topic_buf);
+  assert_int_equal(sizeof(g_test_correct_pnp_topic_content_type) - 1, mqtt_topic_length);
 }
 
 static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_encoding_succeed(
@@ -201,20 +196,21 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_encoding_
           &client, test_device_hostname, test_device_id, test_root_interface_name, &options),
       AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
-          &client, test_component_name, mqtt_topic, NULL, &mqtt_topic),
+          &client,
+          test_component_name,
+          mqtt_topic_buf,
+          sizeof(mqtt_topic_buf),
+          NULL,
+          &mqtt_topic_length),
       AZ_OK);
 
-  az_span_for_test_verify(
-      mqtt_topic,
-      g_test_correct_pnp_topic_content_encoding,
-      _az_COUNTOF(g_test_correct_pnp_topic_content_encoding) - 1,
-      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
-      TEST_SPAN_BUFFER_SIZE);
+  assert_string_equal(g_test_correct_pnp_topic_content_encoding, mqtt_topic_buf);
+  assert_int_equal(sizeof(g_test_correct_pnp_topic_content_encoding) - 1, mqtt_topic_length);
 }
 
 static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_and_encoding_succeed(
@@ -232,20 +228,21 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_and_
           &client, test_device_hostname, test_device_id, test_root_interface_name, &options),
       AZ_OK);
 
-  uint8_t mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
+  int32_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
-          &client, test_component_name, mqtt_topic, NULL, &mqtt_topic),
+          &client,
+          test_component_name,
+          mqtt_topic_buf,
+          sizeof(mqtt_topic_buf),
+          NULL,
+          &mqtt_topic_length),
       AZ_OK);
 
-  az_span_for_test_verify(
-      mqtt_topic,
-      g_test_correct_pnp_topic_content_type_and_encoding,
-      _az_COUNTOF(g_test_correct_pnp_topic_content_type_and_encoding) - 1,
-      az_span_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf)),
-      TEST_SPAN_BUFFER_SIZE);
+  assert_string_equal(g_test_correct_pnp_topic_content_type_and_encoding, mqtt_topic_buf);
+  assert_int_equal(sizeof(g_test_correct_pnp_topic_content_type_and_encoding) - 1, mqtt_topic_length);
 }
 
 static void test_az_iot_pnp_client_telemetry_publish_topic_get_with_small_buffer_fails(void** state)
@@ -258,12 +255,17 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_with_small_buffer
           &client, test_device_hostname, test_device_id, test_root_interface_name, NULL),
       AZ_OK);
 
-  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_no_options) - 2];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_no_options) - 2];
+  int32_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
-          &client, test_component_name, mqtt_topic, NULL, &mqtt_topic),
+          &client,
+          test_component_name,
+          mqtt_topic_buf,
+          sizeof(mqtt_topic_buf),
+          NULL,
+          &mqtt_topic_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
@@ -281,12 +283,17 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_with
           &client, test_device_hostname, test_device_id, test_root_interface_name, &options),
       AZ_OK);
 
-  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_content_type) - 2];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_content_type) - 2];
+  int32_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
-          &client, test_component_name, mqtt_topic, NULL, &mqtt_topic),
+          &client,
+          test_component_name,
+          mqtt_topic_buf,
+          sizeof(mqtt_topic_buf),
+          NULL,
+          &mqtt_topic_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
@@ -305,12 +312,17 @@ test_az_iot_pnp_client_telemetry_publish_topic_get_content_encoding_with_small_b
           &client, test_device_hostname, test_device_id, test_root_interface_name, &options),
       AZ_OK);
 
-  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_content_type) - 2];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_content_type) - 2];
+  int32_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
-          &client, test_component_name, mqtt_topic, NULL, &mqtt_topic),
+          &client,
+          test_component_name,
+          mqtt_topic_buf,
+          sizeof(mqtt_topic_buf),
+          NULL,
+          &mqtt_topic_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
@@ -330,12 +342,17 @@ test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_and_encoding_wit
           &client, test_device_hostname, test_device_id, test_root_interface_name, &options),
       AZ_OK);
 
-  uint8_t mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_content_type_and_encoding) - 2];
-  az_span mqtt_topic = az_span_for_test_init(mqtt_topic_buf, _az_COUNTOF(mqtt_topic_buf));
+  char mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_content_type_and_encoding) - 2];
+  int32_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
-          &client, test_component_name, mqtt_topic, NULL, &mqtt_topic),
+          &client,
+          test_component_name,
+          mqtt_topic_buf,
+          sizeof(mqtt_topic_buf),
+          NULL,
+          &mqtt_topic_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
@@ -52,7 +52,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_client_fails
   (void)state;
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
       NULL, test_component_name, mqtt_topic_buf, sizeof(mqtt_topic_buf), NULL, &mqtt_topic_length));
@@ -69,7 +69,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_mqtt_topic_f
       AZ_OK);
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
       &client, test_component_name, NULL, sizeof(mqtt_topic_buf), NULL, &mqtt_topic_length));
@@ -87,7 +87,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_out_mqtt_top
       AZ_OK);
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
       &client, test_component_name, mqtt_topic_buf, 0, NULL, &mqtt_topic_length));
@@ -105,7 +105,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_component_na
       AZ_OK);
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
       &client, AZ_SPAN_NULL, mqtt_topic_buf, sizeof(mqtt_topic_buf), NULL, &mqtt_topic_length));
@@ -122,7 +122,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_non_NULL_reserved
       AZ_OK);
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
       &client, AZ_SPAN_NULL, mqtt_topic_buf, sizeof(mqtt_topic_buf), (void*)0x1, &mqtt_topic_length));
@@ -141,7 +141,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_no_options_succee
       AZ_OK);
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
@@ -166,7 +166,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_succ
       AZ_OK);
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
@@ -197,7 +197,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_encoding_
       AZ_OK);
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
@@ -229,7 +229,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_and_
       AZ_OK);
 
   char mqtt_topic_buf[TEST_SPAN_BUFFER_SIZE];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
@@ -256,7 +256,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_with_small_buffer
       AZ_OK);
 
   char mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_no_options) - 2];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
@@ -284,7 +284,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_with
       AZ_OK);
 
   char mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_content_type) - 2];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
@@ -313,7 +313,7 @@ test_az_iot_pnp_client_telemetry_publish_topic_get_content_encoding_with_small_b
       AZ_OK);
 
   char mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_content_type) - 2];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
@@ -343,7 +343,7 @@ test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_and_encoding_wit
       AZ_OK);
 
   char mqtt_topic_buf[_az_COUNTOF(g_test_correct_pnp_topic_content_type_and_encoding) - 2];
-  int32_t mqtt_topic_length;
+  size_t mqtt_topic_length;
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
@@ -55,7 +55,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_client_fails
   size_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
-      NULL, test_component_name, mqtt_topic_buf, sizeof(mqtt_topic_buf), NULL, &mqtt_topic_length));
+      NULL, test_component_name, NULL, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length));
 }
 
 static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_mqtt_topic_fails(void** state)
@@ -72,7 +72,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_mqtt_topic_f
   size_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
-      &client, test_component_name, NULL, sizeof(mqtt_topic_buf), NULL, &mqtt_topic_length));
+      &client, test_component_name, NULL, NULL, sizeof(mqtt_topic_buf), &mqtt_topic_length));
 }
 
 static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_out_mqtt_topic_fails(
@@ -90,7 +90,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_out_mqtt_top
   size_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
-      &client, test_component_name, mqtt_topic_buf, 0, NULL, &mqtt_topic_length));
+      &client, test_component_name, NULL, mqtt_topic_buf, 0, &mqtt_topic_length));
 }
 
 static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_component_name_fails(
@@ -108,7 +108,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_component_na
   size_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
-      &client, AZ_SPAN_NULL, mqtt_topic_buf, sizeof(mqtt_topic_buf), NULL, &mqtt_topic_length));
+      &client, AZ_SPAN_NULL, NULL, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length));
 }
 
 static void test_az_iot_pnp_client_telemetry_get_publish_topic_non_NULL_reserved_fails(void** state)
@@ -125,7 +125,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_non_NULL_reserved
   size_t mqtt_topic_length;
 
   assert_precondition_checked(az_iot_pnp_client_telemetry_get_publish_topic(
-      &client, AZ_SPAN_NULL, mqtt_topic_buf, sizeof(mqtt_topic_buf), (void*)0x1, &mqtt_topic_length));
+      &client, AZ_SPAN_NULL, (void*)0x1, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length));
 }
 
 #endif // NO_PRECONDITION_CHECKING
@@ -145,7 +145,7 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_no_options_succee
 
   assert_int_equal(
       az_iot_pnp_client_telemetry_get_publish_topic(
-          &client, test_component_name, mqtt_topic_buf, sizeof(mqtt_topic_buf), NULL, &mqtt_topic_length),
+          &client, test_component_name, NULL, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length),
       AZ_OK);
 
   assert_string_equal(g_test_correct_pnp_topic_no_options, mqtt_topic_buf);
@@ -172,9 +172,9 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_succ
       az_iot_pnp_client_telemetry_get_publish_topic(
           &client,
           test_component_name,
+          NULL,
           mqtt_topic_buf,
           sizeof(mqtt_topic_buf),
-          NULL,
           &mqtt_topic_length),
       AZ_OK);
 
@@ -203,9 +203,9 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_encoding_
       az_iot_pnp_client_telemetry_get_publish_topic(
           &client,
           test_component_name,
+          NULL,
           mqtt_topic_buf,
           sizeof(mqtt_topic_buf),
-          NULL,
           &mqtt_topic_length),
       AZ_OK);
 
@@ -235,9 +235,9 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_and_
       az_iot_pnp_client_telemetry_get_publish_topic(
           &client,
           test_component_name,
+          NULL,
           mqtt_topic_buf,
           sizeof(mqtt_topic_buf),
-          NULL,
           &mqtt_topic_length),
       AZ_OK);
 
@@ -262,9 +262,9 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_with_small_buffer
       az_iot_pnp_client_telemetry_get_publish_topic(
           &client,
           test_component_name,
+          NULL,
           mqtt_topic_buf,
           sizeof(mqtt_topic_buf),
-          NULL,
           &mqtt_topic_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
@@ -290,9 +290,9 @@ static void test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_with
       az_iot_pnp_client_telemetry_get_publish_topic(
           &client,
           test_component_name,
+          NULL,
           mqtt_topic_buf,
           sizeof(mqtt_topic_buf),
-          NULL,
           &mqtt_topic_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
@@ -319,9 +319,9 @@ test_az_iot_pnp_client_telemetry_publish_topic_get_content_encoding_with_small_b
       az_iot_pnp_client_telemetry_get_publish_topic(
           &client,
           test_component_name,
+          NULL,
           mqtt_topic_buf,
           sizeof(mqtt_topic_buf),
-          NULL,
           &mqtt_topic_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
@@ -349,9 +349,9 @@ test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_and_encoding_wit
       az_iot_pnp_client_telemetry_get_publish_topic(
           &client,
           test_component_name,
+          NULL,
           mqtt_topic_buf,
           sizeof(mqtt_topic_buf),
-          NULL,
           &mqtt_topic_length),
       AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }


### PR DESCRIPTION
List of updates in this PR:
- Updated output of all get functions to use `char*` and length instead of `az_span` for the cases in which the returned "thing" will be input to some outside module/lib/function, which usually expect either a `NULL` terminated string or `char*` with length.
- Length and size for these functions are now `int32_t` instead of `size_t` to mirror sdk wide usage.
- Changed the names of functions to new guidelines where the verb comes after the module instead of at the end of the function. 
EX: `az_iot_hub_client_telemetry_publish_topic_get` -> `az_iot_hub_client_telemetry_get_publish_topic`
- Removed the unit tests which "get twice" since we don't append anything anymore (don't seem useful).
- Updated precondition on `az_iot_hub_client_methods_get_response_publish_topic` which requires the status to be one of three values (200, 404, 504). Link to docs for that here: https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-direct-methods#response

Things needing more attention (since a lot of it is sort of cosmetic):
- The name for `az_iot_hub_client_twin_get_get_publish_topic`
- The reworked code for pnp telemetry topic to work (`az_iot_pnp_client_telemetry_get_publish_topic` and the static function `_az_add_telemetry_property`). @jspaith maybe for this one