### PR TITLE
adding Expect: header

### DIFF
--- a/sdk/platform/http_client/curl/src/az_curl.c
+++ b/sdk/platform/http_client/curl/src/az_curl.c
@@ -173,7 +173,19 @@ static AZ_NODISCARD az_result _az_http_client_curl_add_header_to_curl_list(
 /**
  * @brief Adds special header "Expect:" for libcurl to avoid sending only headers to server and wait
  * for a 100 Continue response before sending a PUT method
- * see:https://gms.tf/when-curl-sends-100-continue.html
+ *
+ * libcurl makes all POST and PUT requests (except for POST requests with a
+ * very tiny request body) use the "Expect: 100-continue" header. This header
+ * allows the server to deny the operation early so that libcurl can bail out
+ * before having to send any data. This is useful in authentication
+ * cases and others.
+ *
+ * However, many servers don't implement the Expect: stuff properly and if the
+ * server doesn't respond (positively) within 1 second libcurl will continue
+ * and send off the data anyway.
+ *
+ * You can disable libcurl's use of the Expect: header the same way you disable
+ * any header, using -H / CURLOPT_HTTPHEADER, or by forcing it to use HTTP 1.0.
  *
  * This function is meant to be called after all headers from original request was called. It will
  * append another header and set headers for a p_curl session

--- a/sdk/platform/http_client/curl/src/az_curl.c
+++ b/sdk/platform/http_client/curl/src/az_curl.c
@@ -174,6 +174,7 @@ static AZ_NODISCARD az_result _az_http_client_curl_add_header_to_curl_list(
  * @brief Adds special header "Expect:" for libcurl to avoid sending only headers to server and wait
  * for a 100 Continue response before sending a PUT method
  *
+ * see: https://github.com/curl/curl/blob/master/docs/FAQ#L1033
  * libcurl makes all POST and PUT requests (except for POST requests with a
  * very tiny request body) use the "Expect: 100-continue" header. This header
  * allows the server to deny the operation early so that libcurl can bail out


### PR DESCRIPTION
fixes: https://github.com/Azure/azure-sdk-for-c/issues/615

Making curl transport adapter to automatically sets header "Expect:"
This makes libcurl to disable its behavior of sending headers only to Server and expect a Continue response to start uploading for PUT requests or POST with payload greater than 1024.