### PR TITLE
Adding branch coverage support and reporting.

### DIFF
--- a/cmake-modules/CodeCoverage.cmake
+++ b/cmake-modules/CodeCoverage.cmake
@@ -227,14 +227,14 @@ function(setup_target_for_coverage_lcov)
         COMMAND ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
 
         # Capturing lcov counters and generating report
-        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory . -b ${BASEDIR} --capture --output-file ${Coverage_NAME}.capture
+        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --rc lcov_branch_coverage=1 --gcov-tool ${GCOV_PATH} --directory . -b ${BASEDIR} --capture --output-file ${Coverage_NAME}.capture
         # add baseline counters
-        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
+        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --rc lcov_branch_coverage=1 --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
         # filter collected data to final coverage report
-        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
+        COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --rc lcov_branch_coverage=1 --gcov-tool ${GCOV_PATH} --remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
 
         # Generate HTML output
-        COMMAND ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${Coverage_NAME}.info
+        COMMAND ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} --rc lcov_branch_coverage=1 -o ${Coverage_NAME} ${Coverage_NAME}.info
 
         # Set output files as GENERATED (will be removed on 'make clean')
         BYPRODUCTS


### PR DESCRIPTION
After support gcov will include the branches calculation (the `.info` file will contain the branch misses):
```
Overall coverage rate:
  lines......: 94.9% (169 of 178 lines)
  functions..: 100.0% (8 of 8 functions)
  branches...: 63.9% (106 of 166 branches)
```

HTML reports will also include the new information:
![image](https://user-images.githubusercontent.com/8635911/80175764-63e3d980-85ab-11ea-866c-4f31ad687125.png)

