### PR TITLE
adding az_span_atod

### DIFF
--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -305,27 +305,27 @@ AZ_NODISCARD az_result az_span_atou64(az_span span, uint64_t* out_number);
 AZ_NODISCARD az_result az_span_atou32(az_span span, uint32_t* out_number);
 
 /**
- * @brief Parses an #az_span containing ASCII digits into positive or negative double number. This
+ * @brief Parses an #az_span containing ASCII digits into double number. This
  * function uses atof from standard library, so it will convert digits until the last valid
  * character is found.
  *
- * If there is not an invalid character before the end of \p content, function will use
- * \p conversion_buffer to copy \p span content and attach a \0 at the end to set
- * the end of the digits.
+ * @remarks If there is not a non-digit character before the end of \p span content, function will
+ * use \p copy_buffer to copy \p span content and attach a \0 at the end to set the end of the
+ * digits.
  *
- * Use NULL for \p conversion_buffer if \p span content has already an invalid character or \0
- * after the last digit to convert.
+ * @remarks Use `NULL` for \p copy_buffer if \p span content has already a non-digit character
+ * or \0 after the last digit to convert.
  *
  * @param[in] span The #az_span containing the ASCII digits to be parsed.
- * @param[in] conversion_buffer \p span content will be copied here and a \0 is appended at the end
+ * @param[in] copy_buffer \p span content will be copied here and a \0 is appended at the end
  * before converting. Use NULL if there is already a \0 after the last digit to convert.
  * @param[out] out_number The pointer to the variable that is to receive the number.
  * @return An #az_result value indicating the result of the operation:
  *         - #AZ_OK if successful
- *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if \p conversion_buffer has not enough size to copy \p
+ *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if \p copy_buffer has not enough size to copy \p
  * span content
  */
-AZ_NODISCARD az_result az_span_atod(az_span span, az_span* conversion_buffer, double* out_number);
+AZ_NODISCARD az_result az_span_atod(az_span span, az_span* copy_buffer, double* out_number);
 
 /**
  * @brief Converts an int32 into its digit characters and copies them to the \p destination #az_span

--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -305,6 +305,29 @@ AZ_NODISCARD az_result az_span_atou64(az_span span, uint64_t* out_number);
 AZ_NODISCARD az_result az_span_atou32(az_span span, uint32_t* out_number);
 
 /**
+ * @brief Parses an #az_span containing ASCII digits into positive or negative double number. This
+ * function uses atof from standard library, so it will convert digits until the last valid
+ * character is found.
+ *
+ * If there is not an invalid character before the end of \p content, function will use
+ * \p conversion_buffer to copy \p span content and attach a \0 at the end to set
+ * the end of the digits.
+ *
+ * Use NULL for \p conversion_buffer if \p span content has already an invalid character or \0
+ * after the last digit to convert.
+ *
+ * @param[in] span The #az_span containing the ASCII digits to be parsed.
+ * @param[in] conversion_buffer \p span content will be copied here and a \0 is appended at the end
+ * before converting. Use NULL if there is already a \0 after the last digit to convert.
+ * @param[out] out_number The pointer to the variable that is to receive the number.
+ * @return An #az_result value indicating the result of the operation:
+ *         - #AZ_OK if successful
+ *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if \p conversion_buffer has not enough size to copy \p
+ * span content
+ */
+AZ_NODISCARD az_result az_span_atod(az_span span, az_span* conversion_buffer, double* out_number);
+
+/**
  * @brief Converts an int32 into its digit characters and copies them to the \p destination #az_span
  * starting at its 0-th index.
  *

--- a/sdk/core/core/src/az_span.c
+++ b/sdk/core/core/src/az_span.c
@@ -154,12 +154,12 @@ AZ_NODISCARD az_result az_span_atou32(az_span span, uint32_t* out_number)
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_span_atod(az_span span, az_span* conversion_buffer, double* out_number)
+AZ_NODISCARD az_result az_span_atod(az_span span, az_span* copy_buffer, double* out_number)
 {
   AZ_PRECONDITION_VALID_SPAN(span, 1, false);
   AZ_PRECONDITION_NOT_NULL(out_number);
 
-  if (conversion_buffer == NULL)
+  if (copy_buffer == NULL)
   {
     // This means there is already an invalid character after the last digit to convert
     *out_number = atof((char*)az_span_ptr(span));
@@ -167,14 +167,14 @@ AZ_NODISCARD az_result az_span_atod(az_span span, az_span* conversion_buffer, do
   }
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(
-      *conversion_buffer, az_span_size(span) + 1 /*plus 1 for the extra char to be added*/);
+      *copy_buffer, az_span_size(span) + 1 /*plus 1 for the extra char to be added*/);
 
   // Copy content to conversion buffer
-  az_span remainder = az_span_copy(*conversion_buffer, span);
+  az_span remainder = az_span_copy(*copy_buffer, span);
   remainder = az_span_copy_u8(remainder, '\0');
 
   // call atof with copied content plus invalid character at the end
-  *out_number = atof((char*)az_span_ptr(*conversion_buffer));
+  *out_number = atof((char*)az_span_ptr(*copy_buffer));
   return AZ_OK;
 }
 

--- a/sdk/core/core/src/az_span.c
+++ b/sdk/core/core/src/az_span.c
@@ -10,6 +10,7 @@
 
 #include <ctype.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #include <_az_cfg.h>
 
@@ -150,6 +151,30 @@ AZ_NODISCARD az_result az_span_atou32(az_span span, uint32_t* out_number)
   }
 
   *out_number = value;
+  return AZ_OK;
+}
+
+AZ_NODISCARD az_result az_span_atod(az_span span, az_span* conversion_buffer, double* out_number)
+{
+  AZ_PRECONDITION_VALID_SPAN(span, 1, false);
+  AZ_PRECONDITION_NOT_NULL(out_number);
+
+  if (conversion_buffer == NULL)
+  {
+    // This means there is already an invalid character after the last digit to convert
+    *out_number = atof((char*)az_span_ptr(span));
+    return AZ_OK;
+  }
+
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(
+      *conversion_buffer, az_span_size(span) + 1 /*plus 1 for the extra char to be added*/);
+
+  // Copy content to conversion buffer
+  az_span remainder = az_span_copy(*conversion_buffer, span);
+  remainder = az_span_copy_u8(remainder, '\0');
+
+  // call atof with copied content plus invalid character at the end
+  *out_number = atof((char*)az_span_ptr(*conversion_buffer));
   return AZ_OK;
 }
 

--- a/sdk/core/core/test/cmocka/test_az_span.c
+++ b/sdk/core/core/test/cmocka/test_az_span.c
@@ -805,6 +805,31 @@ static void az_span_atod_test_possitive(void** state)
   assert_true(number - result < 0.00001);
 }
 
+static void az_span_atod_test_not_enough_space(void** state)
+{
+  (void)state;
+  uint8_t buff[10];
+  az_span buff_span = AZ_SPAN_FROM_BUFFER(buff);
+  az_span remainder = { 0 };
+  remainder = az_span_copy_u8(buff_span, '9');
+  remainder = az_span_copy_u8(remainder, '1');
+  remainder = az_span_copy_u8(remainder, '2');
+  remainder = az_span_copy_u8(remainder, '2');
+  remainder = az_span_copy_u8(remainder, '2');
+  remainder = az_span_copy_u8(remainder, '.');
+  remainder = az_span_copy_u8(remainder, '5');
+  remainder = az_span_copy_u8(remainder, '6');
+  remainder = az_span_copy_u8(remainder, '8');
+  remainder = az_span_copy_u8(remainder, '1');
+
+  uint8_t convertion_buff[10];
+  az_span conv_span = AZ_SPAN_FROM_BUFFER(convertion_buff);
+
+  double result = 0;
+  az_result result_op = az_span_atod(buff_span, &conv_span, &result);
+  assert_true(result_op == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+}
+
 static void az_span_atod_test_no_extra_buffer(void** state)
 {
   (void)state;
@@ -859,6 +884,7 @@ int test_az_span()
     cmocka_unit_test(az_span_atod_test),
     cmocka_unit_test(az_span_atod_test_no_extra_buffer),
     cmocka_unit_test(az_span_atod_test_possitive),
+    cmocka_unit_test(az_span_atod_test_not_enough_space),
   };
   return cmocka_run_group_tests_name("az_core_span", tests, NULL, NULL);
 }

--- a/sdk/core/core/test/cmocka/test_az_span.c
+++ b/sdk/core/core/test/cmocka/test_az_span.c
@@ -751,6 +751,73 @@ static void az_span_u32toa_overflow_fails(void** state)
   assert_true(az_span_u32toa(buffer, v, &out_span) == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
+static void az_span_atod_test(void** state)
+{
+  (void)state;
+  uint8_t buff[10];
+  az_span buff_span = AZ_SPAN_FROM_BUFFER(buff);
+  az_span remainder = { 0 };
+  remainder = az_span_copy_u8(buff_span, '-');
+  remainder = az_span_copy_u8(remainder, '1');
+  remainder = az_span_copy_u8(remainder, '2');
+  remainder = az_span_copy_u8(remainder, '2');
+  remainder = az_span_copy_u8(remainder, '2');
+  remainder = az_span_copy_u8(remainder, '.');
+  remainder = az_span_copy_u8(remainder, '5');
+  remainder = az_span_copy_u8(remainder, '6');
+  remainder = az_span_copy_u8(remainder, '8');
+  remainder = az_span_copy_u8(remainder, '1');
+  double number = -1222.5681;
+
+  uint8_t convertion_buff[11];
+  az_span conv_span = AZ_SPAN_FROM_BUFFER(convertion_buff);
+
+  double result = 0;
+  assert_return_code(az_span_atod(buff_span, &conv_span, &result), AZ_OK);
+
+  assert_true(number - result < 0.00001);
+}
+
+static void az_span_atod_test_possitive(void** state)
+{
+  (void)state;
+  uint8_t buff[10];
+  az_span buff_span = AZ_SPAN_FROM_BUFFER(buff);
+  az_span remainder = { 0 };
+  remainder = az_span_copy_u8(buff_span, '9');
+  remainder = az_span_copy_u8(remainder, '1');
+  remainder = az_span_copy_u8(remainder, '2');
+  remainder = az_span_copy_u8(remainder, '2');
+  remainder = az_span_copy_u8(remainder, '2');
+  remainder = az_span_copy_u8(remainder, '.');
+  remainder = az_span_copy_u8(remainder, '5');
+  remainder = az_span_copy_u8(remainder, '6');
+  remainder = az_span_copy_u8(remainder, '8');
+  remainder = az_span_copy_u8(remainder, '1');
+  double number = 91222.5681;
+
+  uint8_t convertion_buff[11];
+  az_span conv_span = AZ_SPAN_FROM_BUFFER(convertion_buff);
+
+  double result = 0;
+  assert_return_code(az_span_atod(buff_span, &conv_span, &result), AZ_OK);
+
+  assert_true(number - result < 0.00001);
+}
+
+static void az_span_atod_test_no_extra_buffer(void** state)
+{
+  (void)state;
+  // this will be zero terminated
+  az_span buff_span = AZ_SPAN_FROM_STR("-1222.568");
+  double number = -1222.568;
+
+  double result = 0;
+  assert_return_code(az_span_atod(buff_span, NULL, &result), AZ_OK);
+
+  assert_true(number - result < 0.00001);
+}
+
 int test_az_span()
 {
   const struct CMUnitTest tests[] = {
@@ -789,6 +856,9 @@ int test_az_span()
     cmocka_unit_test(az_span_u32toa_zero_succeeds),
     cmocka_unit_test(az_span_u32toa_max_uint_succeeds),
     cmocka_unit_test(az_span_u32toa_overflow_fails),
+    cmocka_unit_test(az_span_atod_test),
+    cmocka_unit_test(az_span_atod_test_no_extra_buffer),
+    cmocka_unit_test(az_span_atod_test_possitive),
   };
   return cmocka_run_group_tests_name("az_core_span", tests, NULL, NULL);
 }

--- a/sdk/core/core/test/cmocka/test_az_span.c
+++ b/sdk/core/core/test/cmocka/test_az_span.c
@@ -778,7 +778,7 @@ static void az_span_atod_test(void** state)
   assert_true(number - result < 0.00001);
 }
 
-static void az_span_atod_test_possitive(void** state)
+static void az_span_atod_test_positive(void** state)
 {
   (void)state;
   uint8_t buff[10];
@@ -883,7 +883,7 @@ int test_az_span()
     cmocka_unit_test(az_span_u32toa_overflow_fails),
     cmocka_unit_test(az_span_atod_test),
     cmocka_unit_test(az_span_atod_test_no_extra_buffer),
-    cmocka_unit_test(az_span_atod_test_possitive),
+    cmocka_unit_test(az_span_atod_test_positive),
     cmocka_unit_test(az_span_atod_test_not_enough_space),
   };
   return cmocka_run_group_tests_name("az_core_span", tests, NULL, NULL);


### PR DESCRIPTION
some progress for: https://github.com/Azure/azure-sdk-for-c/issues/598

Adding az_span_atod on top of atof from standar library.

we talked in the past about it is not a good idea to implement a double to char* parser ourself and how best thing is to use the standard library

This function wrapper is an approach that allows customers 2 ways of usage
-  spans with an invalid character after all digits to be converted. So we just call atof directly from az_span_ptr(). Customer set NULL for the converting buffer.
-  spans without with only digits to be converted. In this case we ask for an extra span pointer pointing to a buffer where we first copy the content, then attach a \0 and then we call atof()