### PR TITLE
Require min version of libcurl

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,8 @@ Thank you for your interest in contributing to Azure SDK for C.
 - C compiler: [MSVC](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019), [gcc](https://gcc.gnu.org/) or [clang](https://clang.llvm.org/) are recommended
 - [git](https://git-scm.com/downloads) to clone our Azure SDK repository with the desired tag
 - [cmocka](https://cmocka.org/) for building and running unit tests. By default, building unit tests is disabled, so, unless you want to add unit tests or run then, you don't need to install this. See how `vcpkg` can be used to install dependencies, [below](#VCPKG).
-- [curl](https://curl.haxx.se/download.html) which is used as an http stack, and is required for building and running service samples (keyvault and storage). You don't need to install curl if you are not building samples.
+- [libcurl](https://curl.haxx.se/download.html) which is used as an http stack, and is required for building and running service samples (keyvault and storage). You don't need to install libcurl if you are not building samples. The minimum required version of libcurl is 7.1.
+See how `vcpkg` can be used to install dependencies, [below](#VCPKG).
 - [doxygen](http://www.doxygen.nl/download.html) if you need to generate and view documentation.
 
 ### Development Environment

--- a/sdk/platform/http_client/curl/CMakeLists.txt
+++ b/sdk/platform/http_client/curl/CMakeLists.txt
@@ -8,9 +8,10 @@ cmake_minimum_required (VERSION 3.10)
 project (az_curl LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
-find_package(CURL CONFIG)
+set(CURL_MIN_REQUIRED_VERSION 7.1) #Min curl version to support CURLOPT_HTTPHEADER option
+find_package(CURL ${CURL_MIN_REQUIRED_VERSION} CONFIG) 
 if(NOT CURL_FOUND)
-  find_package(CURL REQUIRED)
+  find_package(CURL ${CURL_MIN_REQUIRED_VERSION} REQUIRED)
 endif()
 
 add_library (


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-c/issues/90

Simple change to request a min version of libcurl