### PR TITLE
Update properties to correctly copy

### DIFF
--- a/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
@@ -39,7 +39,7 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
   }
   if (properties != NULL)
   {
-    required_length += az_span_size(properties->_internal.properties_buffer);
+    required_length += properties->_internal.properties_written;
   }
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_span, required_length + (int32_t)sizeof(null_terminator));
@@ -57,7 +57,10 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
 
   if (properties != NULL)
   {
-    remainder = az_span_copy(remainder, properties->_internal.properties_buffer);
+    remainder = az_span_copy(
+        remainder,
+        az_span_slice(
+            properties->_internal.properties_buffer, 0, properties->_internal.properties_written));
   }
 
   az_span_copy_u8(remainder, null_terminator);

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -75,8 +75,8 @@ static void test_az_iot_hub_client_telemetry_get_publish_topic_NULL_out_mqtt_top
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  assert_precondition_checked(
-      az_iot_hub_client_telemetry_get_publish_topic(&client, NULL, test_buf, 0, &test_length));
+  assert_precondition_checked(az_iot_hub_client_telemetry_get_publish_topic(
+      &client, NULL, test_buf, 0, &test_length));
 }
 
 #endif // NO_PRECONDITION_CHECKING


### PR DESCRIPTION
Properties, when appended to telemetry, were being copied over up to the end of the span, not up to where they were written. This now works for the case when a property buffer is initialized and appended to but not filled.