### PR TITLE
Proposal: Remove second parameter from az_span_is_valid()

### DIFF
--- a/sdk/core/core/internal/az_precondition_internal.h
+++ b/sdk/core/core/internal/az_precondition_internal.h
@@ -61,33 +61,16 @@ az_precondition_failed_fn az_precondition_failed_get_callback();
 #define AZ_PRECONDITION_NOT_NULL(arg) AZ_PRECONDITION((arg != NULL))
 #define AZ_PRECONDITION_IS_NULL(arg) AZ_PRECONDITION((arg == NULL))
 
-AZ_NODISCARD AZ_INLINE bool az_span_is_valid(az_span span, int32_t min_size, bool null_is_valid)
+AZ_NODISCARD AZ_INLINE bool az_span_is_valid(az_span span, int32_t min_size)
 {
-  uint8_t* ptr = az_span_ptr(span);
+  uint8_t* const ptr = az_span_ptr(span);
   int32_t const span_size = az_span_size(span);
 
-  bool result = false;
-
-  /* Span is valid if:
-     The size is greater than or equal to a user defined minimum value AND one of the
-     following:
-        - If null_is_valid is true and the pointer in the span is null, the size must also be 0.
-        - In the case of the pointer not being NULL, the size is greater than or equal to zero.
-  */
-  if (null_is_valid)
-  {
-    result = ptr == NULL ? span_size == 0 : span_size >= 0;
-  }
-  else
-  {
-    result = ptr != NULL && span_size >= 0;
-  }
-
-  return result && min_size <= span_size;
+  return span_size >= 0 && (span_size == 0 || ptr != NULL) && span_size >= min_size;
 }
 
-#define AZ_PRECONDITION_VALID_SPAN(span, min_size, null_is_valid) \
-  AZ_PRECONDITION(az_span_is_valid(span, min_size, null_is_valid))
+#define AZ_PRECONDITION_VALID_SPAN(span, min_size) \
+  AZ_PRECONDITION(az_span_is_valid(span, min_size))
 
 #include <_az_cfg_suffix.h>
 

--- a/sdk/core/core/src/az_http_request.c
+++ b/sdk/core/core/src/az_http_request.c
@@ -29,9 +29,9 @@ AZ_NODISCARD az_result az_http_request_init(
     az_span body)
 {
   AZ_PRECONDITION_NOT_NULL(p_request);
-  AZ_PRECONDITION_VALID_SPAN(method, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(url, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(headers_buffer, 0, false);
+  AZ_PRECONDITION_VALID_SPAN(method, 1);
+  AZ_PRECONDITION_VALID_SPAN(url, 1);
+  AZ_PRECONDITION_VALID_SPAN(headers_buffer, 0);
 
   int32_t query_start = 0;
   az_result url_with_query = _az_span_scan_until(
@@ -100,8 +100,8 @@ AZ_NODISCARD az_result
 az_http_request_set_query_parameter(_az_http_request* p_request, az_span name, az_span value)
 {
   AZ_PRECONDITION_NOT_NULL(p_request);
-  AZ_PRECONDITION_VALID_SPAN(name, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(value, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(name, 1);
+  AZ_PRECONDITION_VALID_SPAN(value, 1);
 
   // name or value can't be empty
   AZ_PRECONDITION(az_span_size(name) > 0 && az_span_size(value) > 0);
@@ -147,7 +147,7 @@ AZ_NODISCARD az_result
 az_http_request_append_header(_az_http_request* p_request, az_span key, az_span value)
 {
   AZ_PRECONDITION_NOT_NULL(p_request);
-  AZ_PRECONDITION_VALID_SPAN(key, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(key, 1);
 
   az_span headers = p_request->_internal.headers;
 

--- a/sdk/core/core/src/az_span.c
+++ b/sdk/core/core/src/az_span.c
@@ -52,7 +52,7 @@ AZ_NODISCARD az_span az_span_from_str(char* str)
 
 AZ_NODISCARD az_span az_span_slice(az_span span, int32_t start_index, int32_t end_index)
 {
-  AZ_PRECONDITION_VALID_SPAN(span, 0, true);
+  AZ_PRECONDITION_VALID_SPAN(span, 0);
 
   // The following set of preconditions validate that:
   //    0 <= end_index <= span.size
@@ -99,7 +99,7 @@ AZ_NODISCARD bool az_span_is_content_equal_ignoring_case(az_span span1, az_span 
 
 AZ_NODISCARD az_result az_span_atou64(az_span span, uint64_t* out_number)
 {
-  AZ_PRECONDITION_VALID_SPAN(span, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(span, 1);
   AZ_PRECONDITION_NOT_NULL(out_number);
 
   int32_t self_size = az_span_size(span);
@@ -127,7 +127,7 @@ AZ_NODISCARD az_result az_span_atou64(az_span span, uint64_t* out_number)
 
 AZ_NODISCARD az_result az_span_atou32(az_span span, uint32_t* out_number)
 {
-  AZ_PRECONDITION_VALID_SPAN(span, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(span, 1);
   AZ_PRECONDITION_NOT_NULL(out_number);
 
   int32_t self_size = az_span_size(span);
@@ -231,9 +231,9 @@ AZ_NODISCARD int32_t az_span_find(az_span source, az_span target)
 
 az_span az_span_copy(az_span destination, az_span source)
 {
+  AZ_PRECONDITION_VALID_SPAN(source, 0);
   int32_t src_size = az_span_size(source);
-
-  AZ_PRECONDITION_VALID_SPAN(destination, src_size, false);
+  AZ_PRECONDITION_VALID_SPAN(destination, src_size);
 
   if (src_size == 0)
   {
@@ -256,7 +256,7 @@ az_span az_span_copy(az_span destination, az_span source)
 
 az_span az_span_copy_u8(az_span destination, uint8_t byte)
 {
-  AZ_PRECONDITION_VALID_SPAN(destination, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(destination, 1);
 
   // Even though the contract of the method is that the destination must be at least 1 byte large,
   // no-op if it is empty to avoid memory corruption.
@@ -279,7 +279,7 @@ void az_span_to_str(char* destination, int32_t destination_max_size, az_span sou
   // Implementations of memmove generally do the right thing when number of bytes to move is 0, even
   // if the ptr is null, but given the behavior is documented to be undefined, we disallow it as a
   // precondition.
-  AZ_PRECONDITION_VALID_SPAN(source, 0, false);
+  AZ_PRECONDITION_VALID_SPAN(source, 0);
 
   int32_t size_to_write = az_span_size(source);
 
@@ -371,7 +371,7 @@ _az_span_replace(az_span self, int32_t current_size, int32_t start, int32_t end,
 
 AZ_NODISCARD az_result az_span_dtoa(az_span destination, double source, az_span* out_span)
 {
-  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
+  AZ_PRECONDITION_VALID_SPAN(destination, 0);
   AZ_PRECONDITION_NOT_NULL(out_span);
 
   // Verify to make sure that the destination has at least one byte up front (for either a digit or
@@ -478,7 +478,7 @@ static AZ_NODISCARD az_result _az_span_builder_append_uint64(az_span* self, uint
 
 AZ_NODISCARD az_result az_span_u64toa(az_span destination, uint64_t source, az_span* out_span)
 {
-  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
+  AZ_PRECONDITION_VALID_SPAN(destination, 0);
   AZ_PRECONDITION_NOT_NULL(out_span);
   *out_span = destination;
 
@@ -487,7 +487,7 @@ AZ_NODISCARD az_result az_span_u64toa(az_span destination, uint64_t source, az_s
 
 AZ_NODISCARD az_result az_span_i64toa(az_span destination, int64_t source, az_span* out_span)
 {
-  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
+  AZ_PRECONDITION_VALID_SPAN(destination, 0);
   AZ_PRECONDITION_NOT_NULL(out_span);
 
   if (source < 0)
@@ -543,14 +543,14 @@ _az_span_builder_append_u32toa(az_span self, uint32_t n, az_span* out_span)
 
 AZ_NODISCARD az_result az_span_u32toa(az_span destination, uint32_t source, az_span* out_span)
 {
-  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
+  AZ_PRECONDITION_VALID_SPAN(destination, 0);
   AZ_PRECONDITION_NOT_NULL(out_span);
   return _az_span_builder_append_u32toa(destination, source, out_span);
 }
 
 AZ_NODISCARD az_result az_span_i32toa(az_span destination, int32_t source, az_span* out_span)
 {
-  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
+  AZ_PRECONDITION_VALID_SPAN(destination, 0);
   AZ_PRECONDITION_NOT_NULL(out_span);
 
   *out_span = destination;

--- a/sdk/iot/core/src/az_iot_core.c
+++ b/sdk/iot/core/src/az_iot_core.c
@@ -77,7 +77,7 @@ AZ_NODISCARD az_result az_iot_get_status_from_uint32(uint32_t status_int, az_iot
 
 AZ_NODISCARD az_span az_span_token(az_span source, az_span delimiter, az_span* out_remainder)
 {
-  AZ_PRECONDITION_VALID_SPAN(delimiter, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(delimiter, 1);
   AZ_PRECONDITION_NOT_NULL(out_remainder);
 
   if (az_span_size(source) == 0)

--- a/sdk/iot/hub/src/az_iot_hub_client.c
+++ b/sdk/iot/hub/src/az_iot_hub_client.c
@@ -32,8 +32,8 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
     az_iot_hub_client_options const* options)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(iot_hub_hostname, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(device_id, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(iot_hub_hostname, 1);
+  AZ_PRECONDITION_VALID_SPAN(device_id, 1);
 
   client->_internal.iot_hub_hostname = iot_hub_hostname;
   client->_internal.device_id = device_id;
@@ -146,7 +146,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_init(
     int32_t written_length)
 {
   AZ_PRECONDITION_NOT_NULL(properties);
-  AZ_PRECONDITION_VALID_SPAN(buffer, 0, false);
+  AZ_PRECONDITION_VALID_SPAN(buffer, 0);
   AZ_PRECONDITION(written_length >= 0);
 
   properties->_internal.properties_buffer = buffer;
@@ -162,8 +162,8 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_append(
     az_span value)
 {
   AZ_PRECONDITION_NOT_NULL(properties);
-  AZ_PRECONDITION_VALID_SPAN(name, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(value, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(name, 1);
+  AZ_PRECONDITION_VALID_SPAN(value, 1);
 
   int32_t prop_length = properties->_internal.properties_written;
 
@@ -198,7 +198,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_find(
     az_span* out_value)
 {
   AZ_PRECONDITION_NOT_NULL(properties);
-  AZ_PRECONDITION_VALID_SPAN(name, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(name, 1);
   AZ_PRECONDITION_NOT_NULL(out_value);
 
   az_span remaining = az_span_slice(

--- a/sdk/iot/hub/src/az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_c2d.c
@@ -54,7 +54,7 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
     az_iot_hub_client_c2d_request* out_request)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(received_topic, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(received_topic, 1);
   AZ_PRECONDITION_NOT_NULL(out_request);
   (void)client;
 

--- a/sdk/iot/hub/src/az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_methods.c
@@ -61,7 +61,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_parse_received_topic(
     az_iot_hub_client_method_request* out_request)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(received_topic, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(received_topic, 1);
   AZ_PRECONDITION_NOT_NULL(out_request);
 
   (void)client;
@@ -113,7 +113,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_response_get_publish_topic(
     size_t* out_mqtt_topic_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(request_id, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(request_id, 1);
   AZ_PRECONDITION(status == 200 || status == 404 || status == 504);
   AZ_PRECONDITION_NOT_NULL(mqtt_topic);
   AZ_PRECONDITION(mqtt_topic_size);

--- a/sdk/iot/hub/src/az_iot_hub_client_sas.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_sas.c
@@ -37,7 +37,7 @@ AZ_NODISCARD az_result az_iot_hub_client_sas_get_signature(
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION(token_expiration_epoch_time > 0);
-  AZ_PRECONDITION_VALID_SPAN(signature, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(signature, 1);
   AZ_PRECONDITION_NOT_NULL(out_signature);
 
   int32_t required_size = az_span_size(client->_internal.iot_hub_hostname)
@@ -86,7 +86,7 @@ AZ_NODISCARD az_result az_iot_hub_client_sas_get_password(
     size_t* out_mqtt_password_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(base64_hmac_sha256_signature, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(base64_hmac_sha256_signature, 1);
   AZ_PRECONDITION(token_expiration_epoch_time > 0);
   AZ_PRECONDITION_NOT_NULL(mqtt_password);
   AZ_PRECONDITION(mqtt_password_size > 0);

--- a/sdk/iot/hub/src/az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_twin.c
@@ -99,7 +99,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_document_get_publish_topic(
     size_t* out_mqtt_topic_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(request_id, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(request_id, 1);
   AZ_PRECONDITION_NOT_NULL(mqtt_topic);
   AZ_PRECONDITION(mqtt_topic_size > 0);
   (void)client;
@@ -137,7 +137,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_patch_get_publish_topic(
     size_t* out_mqtt_topic_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(request_id, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(request_id, 1);
   AZ_PRECONDITION_NOT_NULL(mqtt_topic);
   AZ_PRECONDITION(mqtt_topic_size > 0);
   (void)client;
@@ -173,7 +173,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
     az_iot_hub_client_twin_response* out_twin_response)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(received_topic, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(received_topic, 1);
   AZ_PRECONDITION_NOT_NULL(out_twin_response);
   (void)client;
 

--- a/sdk/iot/pnp/src/az_iot_pnp_client.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client.c
@@ -36,9 +36,9 @@ AZ_NODISCARD az_result az_iot_pnp_client_init(
     az_iot_pnp_client_options const* options)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(iot_hub_hostname, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(device_id, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(root_interface_name, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(iot_hub_hostname, 1);
+  AZ_PRECONDITION_VALID_SPAN(device_id, 1);
+  AZ_PRECONDITION_VALID_SPAN(root_interface_name, 1);
 
   az_iot_hub_client_options hub_options = az_iot_hub_client_options_default();
   hub_options.user_agent = (options != NULL) ? options->user_agent : AZ_SPAN_NULL;

--- a/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
@@ -57,7 +57,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
     size_t* out_mqtt_topic_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(component_name, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(component_name, 1);
   AZ_PRECONDITION_NOT_NULL(mqtt_topic);
   AZ_PRECONDITION(mqtt_topic_size > 0);
   AZ_PRECONDITION_IS_NULL(reserved);

--- a/sdk/iot/provisioning/src/az_iot_provisioning_client.c
+++ b/sdk/iot/provisioning/src/az_iot_provisioning_client.c
@@ -41,9 +41,9 @@ AZ_NODISCARD az_result az_iot_provisioning_client_init(
     az_iot_provisioning_client_options const* options)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(global_device_endpoint, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(id_scope, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(registration_id, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(global_device_endpoint, 1);
+  AZ_PRECONDITION_VALID_SPAN(id_scope, 1);
+  AZ_PRECONDITION_VALID_SPAN(registration_id, 1);
 
   client->_internal.global_device_endpoint = global_device_endpoint;
   client->_internal.id_scope = id_scope;
@@ -218,7 +218,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_query_status_get_publish_topic
   AZ_PRECONDITION(mqtt_topic_size > 0);
 
   AZ_PRECONDITION_NOT_NULL(register_response);
-  AZ_PRECONDITION_VALID_SPAN(register_response->operation_id, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(register_response->operation_id, 1);
 
   az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   az_span str_dps_registrations = _az_iot_provisioning_get_str_dps_registrations();
@@ -450,8 +450,8 @@ AZ_NODISCARD az_result az_iot_provisioning_client_parse_received_topic_and_paylo
   (void)client;
 
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(received_topic, 0, false);
-  AZ_PRECONDITION_VALID_SPAN(received_payload, 0, false);
+  AZ_PRECONDITION_VALID_SPAN(received_topic, 0);
+  AZ_PRECONDITION_VALID_SPAN(received_payload, 0);
   AZ_PRECONDITION_NOT_NULL(out_response);
 
   int32_t idx = az_span_find(received_topic, str_dps_registrations_res);

--- a/sdk/iot/provisioning/src/az_iot_provisioning_client_sas.c
+++ b/sdk/iot/provisioning/src/az_iot_provisioning_client_sas.c
@@ -35,7 +35,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_sas_get_signature(
 {
   AZ_PRECONDITION_NOT_NULL(client);
   AZ_PRECONDITION(token_expiration_epoch_time > 0);
-  AZ_PRECONDITION_VALID_SPAN(signature, 0, false);
+  AZ_PRECONDITION_VALID_SPAN(signature, 0);
   AZ_PRECONDITION_NOT_NULL(out_signature);
 
   // Produces the following signature:
@@ -75,7 +75,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_sas_get_password(
     size_t* out_mqtt_password_length)
 {
   AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(base64_hmac_sha256_signature, 1, false);
+  AZ_PRECONDITION_VALID_SPAN(base64_hmac_sha256_signature, 1);
   AZ_PRECONDITION(token_expiration_epoch_time > 0);
   AZ_PRECONDITION_NOT_NULL(mqtt_password);
   AZ_PRECONDITION(mqtt_password_size > 0);


### PR DESCRIPTION
Why do we want to allow a function to accept `az_span x = AZ_SPAN_FROM_STR("")`, but not accept `az_span x = { 0 }`? Why do you want your code to even care whether the ptr is null, if the size is 0? Is it worth to carry that extra boolean parameter around?

I think the following:
```
(az_span) { .ptr = nonnull, .size = 0 } - valid span, given that you are fine with its size
(az_span) { .ptr = NULL, .size = 0 } - also valid span, given that you are fine with its size
(az_span) { .ptr = nonnull, .size = 5 } - valid span, given that you are fine with its size
(az_span) { .ptr = any, .size = -5 } - never a valid span
(az_span) { .ptr = NULL, .size = 5 } - not a valid span for our SDK*
```

If you agree with the above, you can see that the validity of span is an input of only one parameter: `size`. Depending on the size, `is_null_allowed = (size != 0)`.

`*` - I know that on embedded devices, 0x00000000 may be valid, for firmware updates, for example. 3 questions then:
1. Do we see it being realistic that it is our code that writes to address 0x00000000, and not some customer's code memcpy()?
2. If it is realistic, then how can we ever assume that 0x00000000 is not a valid value for a span anywhere in our code? The az_span_copy() proably should allow { .ptr = NULL, .size = 5 } then.
But, how can you be sure that the span you created can make to that final az_span_copy() call, given that az_span_copy()  is probably is going to be called from az_curl_http_response_handler(), and in order for the span to make it to az_curl_http_response_handler(), it needs to make it through the pipeline code and az_http_response_init(), which probably do not think that NULLptr span is fine.
I think that in preconditions, we should either allow (az_span) { NULL, 5 }, or disallow it then (null check could be an ifdef). But I don't think we need it now, so we should disallow this types of spans. 
3. If you say, yes, we only want the az_span_copy() to be able to accept spans like { NULL, 5 }. Then can we write a custom precondition check for just that one place, and not require us to pass `false` in 99% else of our code?