### PR TITLE
Add min_size check to az_span_is_valid()

### DIFF
--- a/sdk/core/core/internal/az_precondition_internal.h
+++ b/sdk/core/core/internal/az_precondition_internal.h
@@ -63,6 +63,11 @@ az_precondition_failed_fn az_precondition_failed_get_callback();
 
 AZ_NODISCARD AZ_INLINE bool az_span_is_valid(az_span span, int32_t min_size, bool null_is_valid)
 {
+  if (min_size < 0)
+  {
+    return false;
+  }
+
   uint8_t* ptr = az_span_ptr(span);
   int32_t const span_size = az_span_size(span);
 


### PR DESCRIPTION
Regardless of what you think of the url_encode()'s precondition requiring `dest_size >= src_size + 2`, I think we should check min_size parameter in span validation. It can be an integer overflow when adding several span lenghts, it can be an error in your math expression, it can be bad input data.

Passing -5 as min_size is an unsatisfiable condition, so we should return false. You never want to meaningfully say "a span should be of size -5 or greater". It is an error, and we want to warn you. If we ignore it, we could be masking errors - you think your preconditions work, butin reality they are effectively no-ops.

And if you are concerned about perf/code size impact, az_span_check_is_valid() is an inline function. If you pass an integer literal `5` there, the compiler should be able to figure out that it can throw that `if()` code away. Plus, az_span_check_is_valid() only impacts the code compiled with preconditions enabled, which is already not as fast as possible code as it can be, and we should rather being consistent in preferring correctness over performance.