### PR TITLE
Update c2d parse for NO_MATCH case and allow props to init with AZ_SPAN_NULL

### DIFF
--- a/sdk/iot/hub/src/az_iot_hub_client.c
+++ b/sdk/iot/hub/src/az_iot_hub_client.c
@@ -146,7 +146,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_init(
     int32_t written_length)
 {
   _az_PRECONDITION_NOT_NULL(properties);
-  _az_PRECONDITION_VALID_SPAN(buffer, 0, false);
+  _az_PRECONDITION_VALID_SPAN(buffer, 0, true);
   _az_PRECONDITION(written_length >= 0);
 
   properties->_internal.properties_buffer = buffer;

--- a/sdk/iot/hub/src/az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_c2d.c
@@ -60,9 +60,16 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
 
   az_span token;
   token = az_span_token(received_topic, c2d_topic_suffix, &received_topic);
-  token = az_span_token(received_topic, c2d_topic_suffix, &received_topic);
-  AZ_RETURN_IF_FAILED(
-      az_iot_hub_client_properties_init(&out_request->properties, token, az_span_size(token)));
+  if (az_span_ptr(received_topic) != NULL)
+  {
+    token = az_span_token(received_topic, c2d_topic_suffix, &received_topic);
+    AZ_RETURN_IF_FAILED(
+        az_iot_hub_client_properties_init(&out_request->properties, token, az_span_size(token)));
+  }
+  else
+  {
+    return AZ_ERROR_IOT_TOPIC_NO_MATCH;
+  }
 
   return AZ_OK;
 }

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
@@ -175,15 +175,6 @@ static void test_az_iot_hub_client_properties_init_NULL_props_fails(void** state
   assert_precondition_checked(az_iot_hub_client_properties_init(NULL, test_span, 0));
 }
 
-static void test_az_iot_hub_client_properties_init_NULL_buffer_fails(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client_properties props;
-
-  assert_precondition_checked(az_iot_hub_client_properties_init(&props, AZ_SPAN_NULL, 0));
-}
-
 static void test_az_iot_hub_client_properties_append_get_NULL_props_fails(void** state)
 {
   (void)state;
@@ -511,6 +502,18 @@ static void test_az_iot_hub_client_properties_append_succeed(void** state)
       TEST_SPAN_BUFFER_SIZE);
 }
 
+static void test_az_iot_hub_client_properties_append_empty_buffer_fail(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client_properties props;
+  assert_int_equal(az_iot_hub_client_properties_init(&props, AZ_SPAN_NULL, 0), AZ_OK);
+
+  assert_int_equal(
+      az_iot_hub_client_properties_append(&props, test_key_one, test_value_one),
+      AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+}
+
 static void test_az_iot_hub_client_properties_append_small_buffer_fail(void** state)
 {
   (void)state;
@@ -646,6 +649,19 @@ static void test_az_iot_hub_client_properties_find_name_value_same_succeed(void*
   assert_int_equal(az_iot_hub_client_properties_find(&props, test_key, &out_value), AZ_OK);
   assert_memory_equal(
       az_span_ptr(out_value), az_span_ptr(test_value_two), (size_t)az_span_size(test_value_two));
+}
+
+static void test_az_iot_hub_client_properties_find_empty_buffer_fail(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client_properties props;
+
+  assert_int_equal(
+      az_iot_hub_client_properties_init(&props, AZ_SPAN_NULL, 0), AZ_OK);
+
+  az_span out_value;
+  assert_int_equal(az_iot_hub_client_properties_find(&props, test_key_one, &out_value), AZ_ERROR_ITEM_NOT_FOUND);
 }
 
 static void test_az_iot_hub_client_properties_find_fail(void** state)
@@ -822,10 +838,8 @@ static void test_az_iot_hub_client_properties_next_empty_succeed(void** state)
 {
   (void)state;
 
-  uint8_t empty_prop_buf[8] = { 0 };
-  az_span test_span = az_span_init(empty_prop_buf, _az_COUNTOF(empty_prop_buf));
   az_iot_hub_client_properties props;
-  assert_int_equal(az_iot_hub_client_properties_init(&props, test_span, 0), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_init(&props, AZ_SPAN_NULL, 0), AZ_OK);
 
   az_pair pair_out;
 
@@ -850,7 +864,6 @@ int test_iot_hub_client()
     cmocka_unit_test(test_az_iot_hub_client_get_client_id_NULL_input_span_fails),
     cmocka_unit_test(test_az_iot_hub_client_get_client_id_NULL_output_span_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_init_NULL_props_fails),
-    cmocka_unit_test(test_az_iot_hub_client_properties_init_NULL_buffer_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_append_get_NULL_props_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_append_NULL_name_span_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_append_NULL_value_span_fails),
@@ -874,6 +887,7 @@ int test_iot_hub_client()
     cmocka_unit_test(test_az_iot_hub_client_properties_init_succeed),
     cmocka_unit_test(test_az_iot_hub_client_properties_init_user_set_params_succeed),
     cmocka_unit_test(test_az_iot_hub_client_properties_append_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_properties_append_empty_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_properties_append_small_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_properties_append_twice_succeed),
     cmocka_unit_test(test_az_iot_hub_client_properties_append_twice_small_buffer_fail),
@@ -882,6 +896,7 @@ int test_iot_hub_client()
     cmocka_unit_test(test_az_iot_hub_client_properties_find_end_succeed),
     cmocka_unit_test(test_az_iot_hub_client_properties_find_substring_succeed),
     cmocka_unit_test(test_az_iot_hub_client_properties_find_name_value_same_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_properties_find_empty_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_properties_find_fail),
     cmocka_unit_test(test_az_iot_hub_client_properties_find_substring_fail),
     cmocka_unit_test(test_az_iot_hub_client_properties_find_substring_suffix_fail),

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
@@ -212,7 +212,7 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_no_props_succeed(voi
       AZ_OK);
 }
 
-static void test_az_iot_hub_client_c2d_parse_received_topic_fail(void** state)
+static void test_az_iot_hub_client_c2d_parse_received_topic_reject(void** state)
 {
   (void)state;
 
@@ -230,7 +230,7 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_fail(void** state)
       AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
-static void test_az_iot_hub_client_c2d_parse_received_topic_malformed_fail(void** state)
+static void test_az_iot_hub_client_c2d_parse_received_topic_malformed_reject(void** state)
 {
   (void)state;
 
@@ -266,8 +266,8 @@ int test_iot_hub_c2d()
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_url_decoded_succeed),
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_url_encoded_succeed),
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_no_props_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_fail),
-    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_malformed_fail),
+    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_reject),
+    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_malformed_reject),
   };
   return cmocka_run_group_tests_name("az_iot_hub_c2d", tests, NULL, NULL);
 }

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
@@ -26,10 +26,10 @@
 static const az_span test_device_hostname = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_HOSTNAME_STR);
 static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_ID_STR);
 static char g_test_correct_subscribe_topic[] = "devices/my_device/messages/devicebound/#";
-static const az_span test_URL_DECODED_topic = AZ_SPAN_LITERAL_FROM_STR(
+static const az_span test_url_decoded_topic = AZ_SPAN_LITERAL_FROM_STR(
     "devices/useragent_c/messages/devicebound/$.mid=79eadb01-bd0d-472d-bd35-ccb76e70eab8&$.to=/"
     "devices/useragent_c/messages/deviceBound&abc=123");
-static const az_span test_URL_ENCODED_topic
+static const az_span test_url_encoded_topic
     = AZ_SPAN_LITERAL_FROM_STR("devices/useragent_c/messages/devicebound/"
                                "%24.to=%2Fdevices%2Fuseragent_c%2Fmessages%2FdeviceBound&abc=123&"
                                "ghi=%2Fsome%2Fthing&jkl=%2Fsome%2Fthing%2F%3Fbla%3Dbla");
@@ -80,7 +80,7 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_NULL_out_request_fai
   assert_true(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
-  az_span received_topic = test_URL_DECODED_topic;
+  az_span received_topic = test_url_decoded_topic;
 
   assert_precondition_checked(
       az_iot_hub_client_c2d_parse_received_topic(&client, received_topic, NULL));
@@ -144,7 +144,7 @@ static void test_az_iot_hub_client_c2d_get_subscribe_topic_filter_small_buffer_f
       == AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
 }
 
-static void test_az_iot_hub_client_c2d_parse_received_topic_URL_DECODED_succeed(void** state)
+static void test_az_iot_hub_client_c2d_parse_received_topic_url_decoded_succeed(void** state)
 {
   (void)state;
 
@@ -153,7 +153,7 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_URL_DECODED_succeed(
   assert_true(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
-  az_span received_topic = test_URL_DECODED_topic;
+  az_span received_topic = test_url_decoded_topic;
 
   az_iot_hub_client_c2d_request out_request;
 
@@ -176,7 +176,7 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_URL_DECODED_succeed(
   assert_true(az_span_is_content_equal(pair.value, AZ_SPAN_FROM_STR("123")));
 }
 
-static void test_az_iot_hub_client_c2d_parse_received_topic_URL_ENCODED_succeed(void** state)
+static void test_az_iot_hub_client_c2d_parse_received_topic_url_encoded_succeed(void** state)
 {
   (void)state;
 
@@ -185,7 +185,7 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_URL_ENCODED_succeed(
   assert_true(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
-  az_span received_topic = test_URL_ENCODED_topic;
+  az_span received_topic = test_url_encoded_topic;
 
   az_iot_hub_client_c2d_request out_request;
 
@@ -231,7 +231,7 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_fail(void** state)
       AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
-static void test_az_iot_hub_client_c2d_parse_received_topic_MALFORMED_fail(void** state)
+static void test_az_iot_hub_client_c2d_parse_received_topic_malformed_fail(void** state)
 {
   (void)state;
 
@@ -265,10 +265,10 @@ int test_iot_hub_c2d()
 #endif // NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_c2d_get_subscribe_topic_filter_succeed),
     cmocka_unit_test(test_az_iot_hub_client_c2d_get_subscribe_topic_filter_small_buffer_fail),
-    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_URL_DECODED_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_URL_ENCODED_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_url_decoded_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_url_encoded_succeed),
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_fail),
-    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_MALFORMED_fail),
+    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_malformed_fail),
   };
   return cmocka_run_group_tests_name("az_iot_hub_c2d", tests, NULL, NULL);
 }

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
@@ -26,6 +26,8 @@
 static const az_span test_device_hostname = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_HOSTNAME_STR);
 static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_ID_STR);
 static char g_test_correct_subscribe_topic[] = "devices/my_device/messages/devicebound/#";
+static const az_span test_url_no_props
+    = AZ_SPAN_LITERAL_FROM_STR("devices/useragent_c/messages/devicebound/");
 static const az_span test_url_decoded_topic = AZ_SPAN_LITERAL_FROM_STR(
     "devices/useragent_c/messages/devicebound/$.mid=79eadb01-bd0d-472d-bd35-ccb76e70eab8&$.to=/"
     "devices/useragent_c/messages/deviceBound&abc=123");
@@ -84,24 +86,6 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_NULL_out_request_fai
 
   assert_precondition_checked(
       az_iot_hub_client_c2d_parse_received_topic(&client, received_topic, NULL));
-}
-
-// Note: c2d messages ALWAYS contain properties (at least $.to).
-static void test_az_iot_hub_client_c2d_parse_received_topic_no_properties_fail(void** state)
-{
-  (void)state;
-
-  az_iot_hub_client client;
-  az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  assert_true(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
-
-  az_span received_topic = AZ_SPAN_FROM_STR("devices/useragent_c/messages/devicebound/");
-
-  az_iot_hub_client_c2d_request out_request;
-
-  assert_precondition_checked(
-      az_iot_hub_client_c2d_parse_received_topic(&client, received_topic, &out_request));
 }
 
 #endif // NO_PRECONDITION_CHECKING
@@ -163,13 +147,13 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_url_decoded_succeed(
   az_pair pair;
   assert_int_equal(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("$.mid")));
-  assert_true(az_span_is_content_equal(pair.value,
-  AZ_SPAN_FROM_STR("79eadb01-bd0d-472d-bd35-ccb76e70eab8")));
+  assert_true(az_span_is_content_equal(
+      pair.value, AZ_SPAN_FROM_STR("79eadb01-bd0d-472d-bd35-ccb76e70eab8")));
 
   assert_int_equal(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("$.to")));
-  assert_true(az_span_is_content_equal(pair.value,
-  AZ_SPAN_FROM_STR("/devices/useragent_c/messages/deviceBound")));
+  assert_true(az_span_is_content_equal(
+      pair.value, AZ_SPAN_FROM_STR("/devices/useragent_c/messages/deviceBound")));
 
   assert_int_equal(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("abc")));
@@ -195,9 +179,9 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_url_encoded_succeed(
   az_pair pair;
   assert_int_equal(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("%24.to")));
-  assert_true(az_span_is_content_equal(pair.value,
-  AZ_SPAN_FROM_STR("%2Fdevices%2Fuseragent_c%2Fmessages%2FdeviceBound")));
-  
+  assert_true(az_span_is_content_equal(
+      pair.value, AZ_SPAN_FROM_STR("%2Fdevices%2Fuseragent_c%2Fmessages%2FdeviceBound")));
+
   assert_int_equal(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("abc")));
   assert_true(az_span_is_content_equal(pair.value, AZ_SPAN_FROM_STR("123")));
@@ -208,8 +192,24 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_url_encoded_succeed(
 
   assert_int_equal(az_iot_hub_client_properties_next(&out_request.properties, &pair), AZ_OK);
   assert_true(az_span_is_content_equal(pair.key, AZ_SPAN_FROM_STR("jkl")));
-  assert_true(az_span_is_content_equal(pair.value,
-  AZ_SPAN_FROM_STR("%2Fsome%2Fthing%2F%3Fbla%3Dbla")));
+  assert_true(
+      az_span_is_content_equal(pair.value, AZ_SPAN_FROM_STR("%2Fsome%2Fthing%2F%3Fbla%3Dbla")));
+}
+
+static void test_az_iot_hub_client_c2d_parse_received_topic_no_props_succeed(void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  assert_true(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
+
+  az_iot_hub_client_c2d_request out_request;
+
+  assert_int_equal(
+      az_iot_hub_client_c2d_parse_received_topic(&client, test_url_no_props, &out_request),
+      AZ_OK);
 }
 
 static void test_az_iot_hub_client_c2d_parse_received_topic_fail(void** state)
@@ -226,8 +226,7 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_fail(void** state)
   az_iot_hub_client_c2d_request out_request;
 
   assert_int_equal(
-      az_iot_hub_client_c2d_parse_received_topic(
-          &client, received_topic, &out_request),
+      az_iot_hub_client_c2d_parse_received_topic(&client, received_topic, &out_request),
       AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
@@ -261,12 +260,12 @@ int test_iot_hub_c2d()
     cmocka_unit_test(
         test_az_iot_hub_client_c2d_parse_received_topic_AZ_SPAN_NULL_received_topic_fail),
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_NULL_out_request_fail),
-    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_no_properties_fail),
 #endif // NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_c2d_get_subscribe_topic_filter_succeed),
     cmocka_unit_test(test_az_iot_hub_client_c2d_get_subscribe_topic_filter_small_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_url_decoded_succeed),
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_url_encoded_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_no_props_succeed),
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_fail),
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_malformed_fail),
   };

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
@@ -86,7 +86,7 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_NULL_out_request_fai
       az_iot_hub_client_c2d_parse_received_topic(&client, received_topic, NULL));
 }
 
-// Note: c2d messages ALWAYS contain propeties (at least $.to).
+// Note: c2d messages ALWAYS contain properties (at least $.to).
 static void test_az_iot_hub_client_c2d_parse_received_topic_no_properties_fail(void** state)
 {
   (void)state;


### PR DESCRIPTION
This also updates C2D unit tests to use `assert_int_equal` instead of `assert_return_code` since we get false failures on some `az_result` return values.

EDIT: Updated the PR to allow for properties to be initialized with an `AZ_SPAN_NULL` or an empty buffer. The reason being in cases when a response/message comes in from the service which don't have properties, we should be able to communicate to the developer that the topic was successfully parsed but that it came with no properties. 

Therefore, if `az_iot_hub_client_properties_init` is called with an `az_span` with size 0 and pointer equal to `NULL` or otherwise, we should allow it. All the other property functionality will work with this as they check to make sure the required size is enough in the case that it appends. And in the case for finding a property or getting the `next` property, there are no properties to find so either `AZ_ERROR_ITEM_NOT_FOUND` is returned in `find` or `AZ_ERROR_EOF` in the `next` case.