### PR TITLE
Update CMakeLists for use as submodule

### DIFF
--- a/sdk/iot/core/CMakeLists.txt
+++ b/sdk/iot/core/CMakeLists.txt
@@ -25,6 +25,6 @@ add_library (az::iot::core ALIAS ${TARGET_NAME})
 
 # set coverage excluding for az_core. Don't show coverage outside iot
 set(COV_EXCLUDE
-    ${CMAKE_SOURCE_DIR}/sdk/core/core/inc/*
-    ${CMAKE_SOURCE_DIR}/sdk/core/core/internal/*)
+    ${az_SOURCE_DIR}/sdk/core/core/inc/*
+    ${az_SOURCE_DIR}/sdk/core/core/internal/*)
 include(CreateCodeCoverageTargets)

--- a/sdk/iot/hub/CMakeLists.txt
+++ b/sdk/iot/hub/CMakeLists.txt
@@ -31,6 +31,6 @@ add_library (az::iot::hub ALIAS ${TARGET_NAME})
 
 # set coverage excluding for az_core. Don't show coverage outside iot
 set(COV_EXCLUDE
-    ${CMAKE_SOURCE_DIR}/sdk/core/core/inc/*
-    ${CMAKE_SOURCE_DIR}/sdk/core/core/internal/*)
+    ${az_SOURCE_DIR}/sdk/core/core/inc/*
+    ${az_SOURCE_DIR}/sdk/core/core/internal/*)
 include(CreateCodeCoverageTargets)

--- a/sdk/iot/pnp/CMakeLists.txt
+++ b/sdk/iot/pnp/CMakeLists.txt
@@ -19,7 +19,10 @@ add_library (
 
 target_include_directories (${TARGET_NAME} PUBLIC inc)
 target_include_directories (${TARGET_NAME} PRIVATE src)
-target_include_directories (${TARGET_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/sdk/iot/core/inc ${CMAKE_SOURCE_DIR}/sdk/iot/hub/inc)
+target_include_directories (${TARGET_NAME} PRIVATE 
+  ${az_SOURCE_DIR}/sdk/iot/core/inc
+  ${az_SOURCE_DIR}/sdk/iot/hub/inc
+)
 
 # TODO: Follow up with team about the linking/including strategy for SDK-clients on top of az_core
 target_link_libraries(${TARGET_NAME} PRIVATE az_core az_iot_hub)
@@ -28,8 +31,8 @@ add_library (az::iot::pnp ALIAS ${TARGET_NAME})
 
 # set coverage excluding for az_core and az_iot_hub. Don't show coverage outside pnp
 set(COV_EXCLUDE
-    ${CMAKE_SOURCE_DIR}/sdk/core/core/inc/*
-    ${CMAKE_SOURCE_DIR}/sdk/core/core/internal/*
-    ${CMAKE_SOURCE_DIR}/sdk/iot/hub/inc/*
-    ${CMAKE_SOURCE_DIR}/sdk/iot/core/inc/*)
+    ${az_SOURCE_DIR}/sdk/core/core/inc/*
+    ${az_SOURCE_DIR}/sdk/core/core/internal/*
+    ${az_SOURCE_DIR}/sdk/iot/hub/inc/*
+    ${az_SOURCE_DIR}/sdk/iot/core/inc/*)
 include(CreateCodeCoverageTargets)

--- a/sdk/iot/provisioning/CMakeLists.txt
+++ b/sdk/iot/provisioning/CMakeLists.txt
@@ -27,6 +27,6 @@ add_library (az::iot::provisioning ALIAS ${TARGET_NAME})
 
 # set coverage excluding for az_core. Don't show coverage outside iot
 set(COV_EXCLUDE
-    ${CMAKE_SOURCE_DIR}/sdk/core/core/inc/*
-    ${CMAKE_SOURCE_DIR}/sdk/core/core/internal/*)
+    ${az_SOURCE_DIR}/sdk/core/core/inc/*
+    ${az_SOURCE_DIR}/sdk/core/core/internal/*)
 include(CreateCodeCoverageTargets)

--- a/sdk/samples/keyvault/keyvault/CMakeLists.txt
+++ b/sdk/samples/keyvault/keyvault/CMakeLists.txt
@@ -19,9 +19,15 @@ add_library (
 target_include_directories (${TARGET_NAME} PUBLIC inc)
 target_include_directories (${TARGET_NAME} PRIVATE src)
 
-target_include_directories (${TARGET_NAME} PRIVATE $<BUILD_INTERFACE:${az_SOURCE_DIR}/sdk/core/core/inc> $<INSTALL_INTERFACE:include/az_core>)
+target_include_directories (${TARGET_NAME} PUBLIC 
+  $<BUILD_INTERFACE:${az_SOURCE_DIR}/sdk/core/core/inc>
+  $<INSTALL_INTERFACE:include/az_core>
+)
 # include internal headers
-target_include_directories(${TARGET_NAME} PRIVATE $<BUILD_INTERFACE:${az_SOURCE_DIR}/sdk/core/core/internal> $<INSTALL_INTERFACE:include/az_core_internal>)
+target_include_directories(${TARGET_NAME} PUBLIC
+  $<BUILD_INTERFACE:${az_SOURCE_DIR}/sdk/core/core/internal>
+  $<INSTALL_INTERFACE:include/az_core_internal>
+)
 
 # make sure that users can consume the project as a library.
 add_library (az::keyvault ALIAS ${TARGET_NAME})

--- a/sdk/samples/keyvault/keyvault/CMakeLists.txt
+++ b/sdk/samples/keyvault/keyvault/CMakeLists.txt
@@ -19,15 +19,15 @@ add_library (
 target_include_directories (${TARGET_NAME} PUBLIC inc)
 target_include_directories (${TARGET_NAME} PRIVATE src)
 
-target_include_directories (${TARGET_NAME} PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/sdk/core/core/inc> $<INSTALL_INTERFACE:include/az_core>)
+target_include_directories (${TARGET_NAME} PRIVATE $<BUILD_INTERFACE:${az_SOURCE_DIR}/sdk/core/core/inc> $<INSTALL_INTERFACE:include/az_core>)
 # include internal headers
-target_include_directories(${TARGET_NAME} PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/sdk/core/core/internal> $<INSTALL_INTERFACE:include/az_core_internal>)
+target_include_directories(${TARGET_NAME} PRIVATE $<BUILD_INTERFACE:${az_SOURCE_DIR}/sdk/core/core/internal> $<INSTALL_INTERFACE:include/az_core_internal>)
 
 # make sure that users can consume the project as a library.
 add_library (az::keyvault ALIAS ${TARGET_NAME})
 
 # set coverage excluding for az_core. Don't show coverage outside keyvault
 set(COV_EXCLUDE
-    ${CMAKE_SOURCE_DIR}/sdk/core/core/inc/*
-    ${CMAKE_SOURCE_DIR}/sdk/core/core/internal/*)
+    ${az_SOURCE_DIR}/sdk/core/core/inc/*
+    ${az_SOURCE_DIR}/sdk/core/core/internal/*)
 include(CreateCodeCoverageTargets)

--- a/sdk/storage/blobs/CMakeLists.txt
+++ b/sdk/storage/blobs/CMakeLists.txt
@@ -17,15 +17,15 @@ add_library (
 
 target_include_directories (${TARGET_NAME} PUBLIC inc)
 
-target_include_directories (${TARGET_NAME} PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/sdk/core/core/inc> $<INSTALL_INTERFACE:include/az_core>)
+target_include_directories (${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${az_core_SOURCE_DIR}/inc> $<INSTALL_INTERFACE:include/az_core>)
 # include internal headers
-target_include_directories(${TARGET_NAME} PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/sdk/core/core/internal> $<INSTALL_INTERFACE:include/az_core_internal>)
+target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${az_core_SOURCE_DIR}/internal> $<INSTALL_INTERFACE:include/az_core_internal>)
 
 # make sure that users can consume the project as a library.
 add_library (az::storage::blobs ALIAS ${TARGET_NAME})
 
 # set coverage excluding for az_core. Don't show coverage outside storage blobs
 set(COV_EXCLUDE
-    ${CMAKE_SOURCE_DIR}/sdk/core/core/inc/*
-    ${CMAKE_SOURCE_DIR}/sdk/core/core/internal/*)
+    ${az_SOURCE_DIR}/sdk/core/core/inc/*
+    ${az_SOURCE_DIR}/sdk/core/core/internal/*)
 include(CreateCodeCoverageTargets)

--- a/sdk/storage/blobs/CMakeLists.txt
+++ b/sdk/storage/blobs/CMakeLists.txt
@@ -17,10 +17,15 @@ add_library (
 
 target_include_directories (${TARGET_NAME} PUBLIC inc)
 
-target_include_directories (${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${az_core_SOURCE_DIR}/inc> $<INSTALL_INTERFACE:include/az_core>)
+target_include_directories (${TARGET_NAME} PUBLIC
+  $<BUILD_INTERFACE:${az_SOURCE_DIR}/sdk/core/core/inc>
+  $<INSTALL_INTERFACE:include/az_core>
+)
 # include internal headers
-target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${az_core_SOURCE_DIR}/internal> $<INSTALL_INTERFACE:include/az_core_internal>)
-
+target_include_directories(${TARGET_NAME} PUBLIC
+  $<BUILD_INTERFACE:${az_SOURCE_DIR}/sdk/core/core/internal>
+  $<INSTALL_INTERFACE:include/az_core_internal>
+)
 # make sure that users can consume the project as a library.
 add_library (az::storage::blobs ALIAS ${TARGET_NAME})
 


### PR DESCRIPTION
[`CMAKE_SOURCE_DIR`](https://cmake.org/cmake/help/latest/variable/CMAKE_SOURCE_DIR.html) refers to the top level of the source tree which could be a user's project using us as a submodule.

Instead, we can use [`<PROJECT-NAME>_SOURCE_DIR`](https://cmake.org/cmake/help/latest/variable/PROJECT-NAME_SOURCE_DIR.html) to find the top level of this project.

Additionally, some previous target includes were being made `PRIVATE` which need to be public for include files to resolve for someone using them. Core already does this:
https://github.com/Azure/azure-sdk-for-c/blob/3011f16b299e5aaf5a752d36918c0bfc48444269/sdk/core/core/CMakeLists.txt#L67-L72
I have updated those.