### PR TITLE
Prefix build macros, internal prefix for precondition checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,12 @@ option(BUILD_PRECONDITIONS "Build SDK with preconditions enabled" ON)
 
 #enable mock functions with link option -ld
 if (NOT BUILD_PRECONDITIONS)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNO_PRECONDITION_CHECKING")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DAZ_NO_PRECONDITION_CHECKING")
 endif()
 
 #enable mock functions with link option -ld
 if(UNIT_TESTING_MOCK_ENABLED)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMOCK_ENABLED")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_az_MOCK_ENABLED")
 endif()
 
 if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ option(BUILD_PRECONDITIONS "Build SDK with preconditions enabled" ON)
 
 #enable mock functions with link option -ld
 if (NOT BUILD_PRECONDITIONS)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DAZ_NO_PRECONDITION_CHECKING")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DAZ_NO_PRECONDITION_CHECKING") 
 endif()
 
 #enable mock functions with link option -ld
@@ -90,4 +90,3 @@ if (UNIT_TESTING)
     add_subdirectory(sdk/samples/keyvault/keyvault/test/cmocka)
   endif()
 endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ option(BUILD_PRECONDITIONS "Build SDK with preconditions enabled" ON)
 
 #enable mock functions with link option -ld
 if (NOT BUILD_PRECONDITIONS)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DAZ_NO_PRECONDITION_CHECKING") 
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DAZ_NO_PRECONDITION_CHECKING")
 endif()
 
 #enable mock functions with link option -ld

--- a/sdk/core/core/README.md
+++ b/sdk/core/core/README.md
@@ -126,7 +126,7 @@ The public SDK functions validate the arguments passed to them to ensure that th
 
 To override the default behavior, implement a function matching the `az_precondition_failed_fn` function signature and then, in your application's initialization (before calling any Azure SDK function), call `az_precondition_failed_set_callback` passing it the address of your function. Now, when any Azure SDK function detects a precondition failure, it will invoke your callback instead. You might override the callback to attach a debugger or perhaps to reboot the device rather than allowing it to continue running with unpredictable behavior.
 
-Also, if you define the `NO_PRECONDITION_CHECKING` symbol when compiling the SDK code (or adding option -DBUILD_PRECONDITIONS=OFF with cmake), all of the Azure SDK precondition checking will be excluded, making the binary code smaller and faster. We recommend doing this before you ship your code.
+Also, if you define the `AZ_NO_PRECONDITION_CHECKING` symbol when compiling the SDK code (or adding option -DBUILD_PRECONDITIONS=OFF with cmake), all of the Azure SDK precondition checking will be excluded, making the binary code smaller and faster. We recommend doing this before you ship your code.
 
 ### Canceling an Operation
 

--- a/sdk/core/core/inc/_az_cfg.h
+++ b/sdk/core/core/inc/_az_cfg.h
@@ -35,11 +35,11 @@
 // specified
 #pragma warning(disable : 5045)
 
-// warning C6011: Dereferencing NULL pointer. Using AZ_PRECONDITION_NOT_NULL
+// warning C6011: Dereferencing NULL pointer. Using _az_PRECONDITION_NOT_NULL
 #pragma warning(disable : 6011)
 
 // warning C6387: 'str' could be '0':  this does not adhere to the specification for the function
-// 'strlen' Using AZ_PRECONDITION_NOT_NULL
+// 'strlen' Using _az_PRECONDITION_NOT_NULL
 #pragma warning(disable : 6387)
 
 // Treat warnings as errors:

--- a/sdk/core/core/inc/az_precondition.h
+++ b/sdk/core/core/inc/az_precondition.h
@@ -23,7 +23,7 @@
  *        perhaps to reboot the device rather than allowing it to continue running with
  *        unpredictable behavior.
  *
- *        Also, if you define the NO_PRECONDITION_CHECKING symbol when compiling the SDK
+ *        Also, if you define the AZ_NO_PRECONDITION_CHECKING symbol when compiling the SDK
  *        code (or adding option -DBUILD_PRECONDITIONS=OFF with cmake), all of the Azure SDK
  *        precondition checking will be excluding making the binary code smaller and faster. We
  *        recommend doing this before you ship your code.

--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -139,7 +139,7 @@ AZ_NODISCARD AZ_INLINE int32_t az_span_size(az_span span) { return span._interna
  * @param[in] size The number of total bytes in the byte buffer.
  * @return The "view" over the byte buffer.
  */
-#ifdef NO_PRECONDITION_CHECKING
+#ifdef AZ_NO_PRECONDITION_CHECKING
 // Note: If you are modifying this method, make sure to modify the non-inline version in the
 // az_span.c file as well.
 AZ_NODISCARD AZ_INLINE az_span az_span_init(uint8_t* ptr, int32_t size)
@@ -148,7 +148,7 @@ AZ_NODISCARD AZ_INLINE az_span az_span_init(uint8_t* ptr, int32_t size)
 }
 #else
 AZ_NODISCARD az_span az_span_init(uint8_t* ptr, int32_t size);
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
 /**
  * @brief Returns an #az_span from a 0-terminated array of bytes (chars).

--- a/sdk/core/core/internal/az_precondition_internal.h
+++ b/sdk/core/core/internal/az_precondition_internal.h
@@ -23,7 +23,7 @@
  *        perhaps to reboot the device rather than allowing it to continue running with
  *        unpredictable behavior.
  *
- *        Also, if you define the NO_PRECONDITION_CHECKING symbol when compiling the SDK
+ *        Also, if you define the AZ_NO_PRECONDITION_CHECKING symbol when compiling the SDK
  *        code (or adding option -DBUILD_PRECONDITIONS=OFF with cmake), all of the Azure SDK
  *        precondition checking will be excluding making the binary code smaller and faster. We
  *        recommend doing this before you ship your code.
@@ -43,7 +43,7 @@
 
 az_precondition_failed_fn az_precondition_failed_get_callback();
 
-#ifdef NO_PRECONDITION_CHECKING
+#ifdef AZ_NO_PRECONDITION_CHECKING
 #define AZ_PRECONDITION(condition)
 #else
 #define AZ_PRECONDITION(condition) \
@@ -54,7 +54,7 @@ az_precondition_failed_fn az_precondition_failed_get_callback();
       az_precondition_failed_get_callback()(); \
     } \
   } while (0)
-#endif
+#endif // AZ_NO_PRECONDITION_CHECKING
 
 #define AZ_PRECONDITION_RANGE(low, arg, max) AZ_PRECONDITION((low <= arg && arg <= max))
 

--- a/sdk/core/core/internal/az_precondition_internal.h
+++ b/sdk/core/core/internal/az_precondition_internal.h
@@ -44,9 +44,9 @@
 az_precondition_failed_fn az_precondition_failed_get_callback();
 
 #ifdef AZ_NO_PRECONDITION_CHECKING
-#define AZ_PRECONDITION(condition)
+#define _az_PRECONDITION(condition)
 #else
-#define AZ_PRECONDITION(condition) \
+#define _az_PRECONDITION(condition) \
   do \
   { \
     if (!(condition)) \
@@ -56,10 +56,10 @@ az_precondition_failed_fn az_precondition_failed_get_callback();
   } while (0)
 #endif // AZ_NO_PRECONDITION_CHECKING
 
-#define AZ_PRECONDITION_RANGE(low, arg, max) AZ_PRECONDITION((low <= arg && arg <= max))
+#define _az_PRECONDITION_RANGE(low, arg, max) _az_PRECONDITION((low <= arg && arg <= max))
 
-#define AZ_PRECONDITION_NOT_NULL(arg) AZ_PRECONDITION((arg != NULL))
-#define AZ_PRECONDITION_IS_NULL(arg) AZ_PRECONDITION((arg == NULL))
+#define _az_PRECONDITION_NOT_NULL(arg) _az_PRECONDITION((arg != NULL))
+#define _az_PRECONDITION_IS_NULL(arg) _az_PRECONDITION((arg == NULL))
 
 AZ_NODISCARD AZ_INLINE bool az_span_is_valid(az_span span, int32_t min_size, bool null_is_valid)
 {
@@ -91,8 +91,8 @@ AZ_NODISCARD AZ_INLINE bool az_span_is_valid(az_span span, int32_t min_size, boo
   return result && min_size <= span_size;
 }
 
-#define AZ_PRECONDITION_VALID_SPAN(span, min_size, null_is_valid) \
-  AZ_PRECONDITION(az_span_is_valid(span, min_size, null_is_valid))
+#define _az_PRECONDITION_VALID_SPAN(span, min_size, null_is_valid) \
+  _az_PRECONDITION(az_span_is_valid(span, min_size, null_is_valid))
 
 #include <_az_cfg_suffix.h>
 

--- a/sdk/core/core/internal/az_span_internal.h
+++ b/sdk/core/core/internal/az_span_internal.h
@@ -18,7 +18,7 @@ AZ_INLINE AZ_NODISCARD int32_t _az_span_diff(az_span sliced_span, az_span origin
 
   // The passed in span parameters cannot be any two arbitrary spans.
   // This validates the span parameters are valid and one is a sub-slice of another.
-  AZ_PRECONDITION(answer == (int32_t)(az_span_ptr(sliced_span) - az_span_ptr(original_span)));
+  _az_PRECONDITION(answer == (int32_t)(az_span_ptr(sliced_span) - az_span_ptr(original_span)));
   return answer;
 }
 

--- a/sdk/core/core/src/az_http_pipeline.c
+++ b/sdk/core/core/src/az_http_pipeline.c
@@ -12,9 +12,9 @@ AZ_NODISCARD az_result az_http_pipeline_process(
     _az_http_request* p_request,
     az_http_response* p_response)
 {
-  AZ_PRECONDITION_NOT_NULL(p_request);
-  AZ_PRECONDITION_NOT_NULL(p_response);
-  AZ_PRECONDITION_NOT_NULL(pipeline);
+  _az_PRECONDITION_NOT_NULL(p_request);
+  _az_PRECONDITION_NOT_NULL(p_response);
+  _az_PRECONDITION_NOT_NULL(pipeline);
 
   return pipeline->_internal.p_policies[0]._internal.process(
       &(pipeline->_internal.p_policies[1]),

--- a/sdk/core/core/src/az_http_policy_logging.c
+++ b/sdk/core/core/src/az_http_policy_logging.c
@@ -28,7 +28,7 @@ static az_span _az_http_policy_logging_copy_lengthy_value(az_span ref_log_msg, a
   // The caller should validate that ref_log_msg is large enough to contain the value az_span
   // This means, ref_log_msg must have available at least _az_LOG_LENGTHY_VALUE_MAX_LENGTH (i.e. 50)
   // bytes or as much as the size of the value az_span, whichever is smaller.
-  AZ_PRECONDITION(
+  _az_PRECONDITION(
       az_span_size(ref_log_msg) >= _az_LOG_LENGTHY_VALUE_MAX_LENGTH
       || az_span_size(ref_log_msg) >= value_size);
 
@@ -47,7 +47,7 @@ static az_span _az_http_policy_logging_copy_lengthy_value(az_span ref_log_msg, a
       = ((_az_LOG_LENGTHY_VALUE_MAX_LENGTH / 2) + (_az_LOG_LENGTHY_VALUE_MAX_LENGTH % 2)) // 23
       - (ellipsis_len / 2);
 
-  AZ_PRECONDITION((first + last + ellipsis_len) == _az_LOG_LENGTHY_VALUE_MAX_LENGTH);
+  _az_PRECONDITION((first + last + ellipsis_len) == _az_LOG_LENGTHY_VALUE_MAX_LENGTH);
 
   ref_log_msg = az_span_copy(ref_log_msg, az_span_slice(value, 0, first));
   ref_log_msg = az_span_copy(ref_log_msg, ellipsis);

--- a/sdk/core/core/src/az_http_private.h
+++ b/sdk/core/core/src/az_http_private.h
@@ -26,7 +26,7 @@
  */
 AZ_NODISCARD AZ_INLINE az_result _az_http_request_mark_retry_headers_start(_az_http_request* p_hrb)
 {
-  AZ_PRECONDITION_NOT_NULL(p_hrb);
+  _az_PRECONDITION_NOT_NULL(p_hrb);
   p_hrb->_internal.retry_headers_start_byte_offset
       = p_hrb->_internal.headers_length * (int32_t)sizeof(az_pair);
   return AZ_OK;
@@ -34,7 +34,7 @@ AZ_NODISCARD AZ_INLINE az_result _az_http_request_mark_retry_headers_start(_az_h
 
 AZ_NODISCARD AZ_INLINE az_result _az_http_request_remove_retry_headers(_az_http_request* p_hrb)
 {
-  AZ_PRECONDITION_NOT_NULL(p_hrb);
+  _az_PRECONDITION_NOT_NULL(p_hrb);
   p_hrb->_internal.headers_length
       = p_hrb->_internal.retry_headers_start_byte_offset / (int32_t)sizeof(az_pair);
   return AZ_OK;

--- a/sdk/core/core/src/az_http_request.c
+++ b/sdk/core/core/src/az_http_request.c
@@ -28,10 +28,10 @@ AZ_NODISCARD az_result az_http_request_init(
     az_span headers_buffer,
     az_span body)
 {
-  AZ_PRECONDITION_NOT_NULL(p_request);
-  AZ_PRECONDITION_VALID_SPAN(method, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(url, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(headers_buffer, 0, false);
+  _az_PRECONDITION_NOT_NULL(p_request);
+  _az_PRECONDITION_VALID_SPAN(method, 1, false);
+  _az_PRECONDITION_VALID_SPAN(url, 1, false);
+  _az_PRECONDITION_VALID_SPAN(headers_buffer, 0, false);
 
   int32_t query_start = 0;
   az_result url_with_query = _az_span_scan_until(
@@ -61,7 +61,7 @@ AZ_NODISCARD az_result az_http_request_init(
 
 AZ_NODISCARD az_result az_http_request_append_path(_az_http_request* p_request, az_span path)
 {
-  AZ_PRECONDITION_NOT_NULL(p_request);
+  _az_PRECONDITION_NOT_NULL(p_request);
 
   // get the query starting point.
   bool url_with_question_mark = p_request->_internal.query_start > 0;
@@ -99,12 +99,12 @@ AZ_NODISCARD az_result az_http_request_append_path(_az_http_request* p_request, 
 AZ_NODISCARD az_result
 az_http_request_set_query_parameter(_az_http_request* p_request, az_span name, az_span value)
 {
-  AZ_PRECONDITION_NOT_NULL(p_request);
-  AZ_PRECONDITION_VALID_SPAN(name, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(value, 1, false);
+  _az_PRECONDITION_NOT_NULL(p_request);
+  _az_PRECONDITION_VALID_SPAN(name, 1, false);
+  _az_PRECONDITION_VALID_SPAN(value, 1, false);
 
   // name or value can't be empty
-  AZ_PRECONDITION(az_span_size(name) > 0 && az_span_size(value) > 0);
+  _az_PRECONDITION(az_span_size(name) > 0 && az_span_size(value) > 0);
 
   int32_t required_length = az_span_size(name) + az_span_size(value) + 2;
 
@@ -146,8 +146,8 @@ az_http_request_set_query_parameter(_az_http_request* p_request, az_span name, a
 AZ_NODISCARD az_result
 az_http_request_append_header(_az_http_request* p_request, az_span key, az_span value)
 {
-  AZ_PRECONDITION_NOT_NULL(p_request);
-  AZ_PRECONDITION_VALID_SPAN(key, 1, false);
+  _az_PRECONDITION_NOT_NULL(p_request);
+  _az_PRECONDITION_VALID_SPAN(key, 1, false);
 
   az_span headers = p_request->_internal.headers;
 
@@ -167,8 +167,8 @@ az_http_request_append_header(_az_http_request* p_request, az_span key, az_span 
 AZ_NODISCARD az_result
 az_http_request_get_header(_az_http_request const* request, int32_t index, az_pair* out_header)
 {
-  AZ_PRECONDITION_NOT_NULL(request);
-  AZ_PRECONDITION_NOT_NULL(out_header);
+  _az_PRECONDITION_NOT_NULL(request);
+  _az_PRECONDITION_NOT_NULL(out_header);
 
   if (index >= _az_http_request_headers_count(request))
   {

--- a/sdk/core/core/src/az_http_response.c
+++ b/sdk/core/core/src/az_http_response.c
@@ -112,8 +112,8 @@ AZ_NODISCARD az_result az_http_response_get_status_line(
     az_http_response* response,
     az_http_response_status_line* out_status_line)
 {
-  AZ_PRECONDITION_NOT_NULL(response);
-  AZ_PRECONDITION_NOT_NULL(out_status_line);
+  _az_PRECONDITION_NOT_NULL(response);
+  _az_PRECONDITION_NOT_NULL(out_status_line);
 
   // Restart parser to the beggining
   response->_internal.parser.remaining = response->_internal.http_response;
@@ -131,8 +131,8 @@ AZ_NODISCARD az_result az_http_response_get_status_line(
 AZ_NODISCARD az_result
 az_http_response_get_next_header(az_http_response* response, az_pair* out_header)
 {
-  AZ_PRECONDITION_NOT_NULL(response);
-  AZ_PRECONDITION_NOT_NULL(out_header);
+  _az_PRECONDITION_NOT_NULL(response);
+  _az_PRECONDITION_NOT_NULL(out_header);
   az_span* reader = &response->_internal.parser.remaining;
   {
     _az_http_response_kind const kind = response->_internal.parser.next_kind;
@@ -225,8 +225,8 @@ az_http_response_get_next_header(az_http_response* response, az_pair* out_header
 
 AZ_NODISCARD az_result az_http_response_get_body(az_http_response* response, az_span* out_body)
 {
-  AZ_PRECONDITION_NOT_NULL(response);
-  AZ_PRECONDITION_NOT_NULL(out_body);
+  _az_PRECONDITION_NOT_NULL(response);
+  _az_PRECONDITION_NOT_NULL(out_body);
 
   // Make sure get body works no matter where is the current parsing. Allow users to call get body
   // directly and ignore headers and status line

--- a/sdk/core/core/src/az_json_builder.c
+++ b/sdk/core/core/src/az_json_builder.c
@@ -16,7 +16,7 @@ static AZ_NODISCARD az_span _get_remaining_span(az_json_builder* json_builder)
 
 AZ_NODISCARD static az_result az_json_builder_append_str(az_json_builder* self, az_span value)
 {
-  AZ_PRECONDITION_NOT_NULL(self);
+  _az_PRECONDITION_NOT_NULL(self);
 
   az_span remaining_json = _get_remaining_span(self);
 
@@ -34,7 +34,7 @@ AZ_NODISCARD static az_result az_json_builder_append_str(az_json_builder* self, 
 
 static AZ_NODISCARD az_result _az_json_builder_write_span(az_json_builder* self, az_span value)
 {
-  AZ_PRECONDITION_NOT_NULL(self);
+  _az_PRECONDITION_NOT_NULL(self);
 
   az_span remaining_json = _get_remaining_span(self);
 
@@ -90,7 +90,7 @@ static AZ_NODISCARD az_result _az_json_builder_write_span(az_json_builder* self,
 AZ_NODISCARD az_result
 az_json_builder_append_token(az_json_builder* json_builder, az_json_token token)
 {
-  AZ_PRECONDITION_NOT_NULL(json_builder);
+  _az_PRECONDITION_NOT_NULL(json_builder);
   az_span remaining_json = _get_remaining_span(json_builder);
 
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remaining_json, 1);
@@ -181,7 +181,7 @@ az_json_builder_append_token(az_json_builder* json_builder, az_json_token token)
 
 AZ_NODISCARD static az_result az_json_builder_write_comma(az_json_builder* self)
 {
-  AZ_PRECONDITION_NOT_NULL(self);
+  _az_PRECONDITION_NOT_NULL(self);
 
   if (self->_internal.need_comma)
   {
@@ -196,7 +196,7 @@ AZ_NODISCARD static az_result az_json_builder_write_comma(az_json_builder* self)
 AZ_NODISCARD az_result
 az_json_builder_append_object(az_json_builder* json_builder, az_span name, az_json_token token)
 {
-  AZ_PRECONDITION_NOT_NULL(json_builder);
+  _az_PRECONDITION_NOT_NULL(json_builder);
 
   AZ_RETURN_IF_FAILED(az_json_builder_write_comma(json_builder));
   AZ_RETURN_IF_FAILED(az_json_builder_append_str(json_builder, name));
@@ -213,7 +213,7 @@ az_json_builder_append_object(az_json_builder* json_builder, az_span name, az_js
 AZ_NODISCARD az_result
 az_json_builder_append_array_item(az_json_builder* json_builder, az_json_token token)
 {
-  AZ_PRECONDITION_NOT_NULL(json_builder);
+  _az_PRECONDITION_NOT_NULL(json_builder);
 
   AZ_RETURN_IF_FAILED(az_json_builder_write_comma(json_builder));
   AZ_RETURN_IF_FAILED(az_json_builder_append_token(json_builder, token));

--- a/sdk/core/core/src/az_json_parser.c
+++ b/sdk/core/core/src/az_json_parser.c
@@ -412,8 +412,8 @@ AZ_NODISCARD static az_result az_json_parser_get_value_space(
 AZ_NODISCARD az_result
 az_json_parser_parse_token(az_json_parser* json_parser, az_json_token* out_token)
 {
-  AZ_PRECONDITION_NOT_NULL(json_parser);
-  AZ_PRECONDITION_NOT_NULL(out_token);
+  _az_PRECONDITION_NOT_NULL(json_parser);
+  _az_PRECONDITION_NOT_NULL(out_token);
 
   if (!az_json_parser_stack_is_empty(json_parser))
   {
@@ -507,8 +507,8 @@ AZ_NODISCARD az_result az_json_parser_parse_token_member(
     az_json_parser* json_parser,
     az_json_token_member* out_token_member)
 {
-  AZ_PRECONDITION_NOT_NULL(json_parser);
-  AZ_PRECONDITION_NOT_NULL(out_token_member);
+  _az_PRECONDITION_NOT_NULL(json_parser);
+  _az_PRECONDITION_NOT_NULL(out_token_member);
 
   az_span* p_reader = &json_parser->_internal.reader;
   AZ_RETURN_IF_FAILED(az_json_parser_check_item_begin(json_parser, AZ_JSON_STACK_OBJECT));
@@ -524,8 +524,8 @@ AZ_NODISCARD az_result az_json_parser_parse_token_member(
 AZ_NODISCARD az_result
 az_json_parser_parse_array_item(az_json_parser* json_parser, az_json_token* out_token)
 {
-  AZ_PRECONDITION_NOT_NULL(json_parser);
-  AZ_PRECONDITION_NOT_NULL(out_token);
+  _az_PRECONDITION_NOT_NULL(json_parser);
+  _az_PRECONDITION_NOT_NULL(out_token);
 
   AZ_RETURN_IF_FAILED(az_json_parser_check_item_begin(json_parser, AZ_JSON_STACK_ARRAY));
   AZ_RETURN_IF_FAILED(az_json_parser_get_value_space(json_parser, out_token));
@@ -534,7 +534,7 @@ az_json_parser_parse_array_item(az_json_parser* json_parser, az_json_token* out_
 
 AZ_NODISCARD az_result az_json_parser_done(az_json_parser* json_parser)
 {
-  AZ_PRECONDITION_NOT_NULL(json_parser);
+  _az_PRECONDITION_NOT_NULL(json_parser);
 
   if (az_span_size(json_parser->_internal.reader) > 0
       || !az_json_parser_stack_is_empty(json_parser))
@@ -547,7 +547,7 @@ AZ_NODISCARD az_result az_json_parser_done(az_json_parser* json_parser)
 AZ_NODISCARD az_result
 az_json_parser_skip_children(az_json_parser* json_parser, az_json_token token)
 {
-  AZ_PRECONDITION_NOT_NULL(json_parser);
+  _az_PRECONDITION_NOT_NULL(json_parser);
 
   switch (token.kind)
   {

--- a/sdk/core/core/src/az_json_pointer.c
+++ b/sdk/core/core/src/az_json_pointer.c
@@ -10,7 +10,7 @@
 
 static AZ_NODISCARD az_result _az_span_reader_read_json_pointer_char(az_span* self, uint32_t* out)
 {
-  AZ_PRECONDITION_NOT_NULL(self);
+  _az_PRECONDITION_NOT_NULL(self);
   int32_t reader_current_length = az_span_size(*self);
 
   // check for EOF
@@ -208,7 +208,7 @@ AZ_NODISCARD static az_result az_json_parser_get_by_pointer_token(
 AZ_NODISCARD az_result
 az_json_parse_by_pointer(az_span json_buffer, az_span json_pointer, az_json_token* out_token)
 {
-  AZ_PRECONDITION_NOT_NULL(out_token);
+  _az_PRECONDITION_NOT_NULL(out_token);
 
   az_json_parser json_parser = { 0 };
   AZ_RETURN_IF_FAILED(az_json_parser_init(&json_parser, json_buffer));

--- a/sdk/core/core/src/az_json_token.c
+++ b/sdk/core/core/src/az_json_token.c
@@ -9,7 +9,7 @@
 AZ_NODISCARD az_result az_json_token_get_boolean(az_json_token const*  token, bool* out_value)
 {
 
-  AZ_PRECONDITION_NOT_NULL(out_value);
+  _az_PRECONDITION_NOT_NULL(out_value);
 
   if (token->kind != AZ_JSON_TOKEN_BOOLEAN)
   {
@@ -23,7 +23,7 @@ AZ_NODISCARD az_result az_json_token_get_boolean(az_json_token const*  token, bo
 AZ_NODISCARD az_result az_json_token_get_string(az_json_token const*  token, az_span* out_value)
 {
 
-  AZ_PRECONDITION_NOT_NULL(out_value);
+  _az_PRECONDITION_NOT_NULL(out_value);
 
   if (token->kind != AZ_JSON_TOKEN_STRING)
   {
@@ -37,7 +37,7 @@ AZ_NODISCARD az_result az_json_token_get_string(az_json_token const*  token, az_
 AZ_NODISCARD az_result az_json_token_get_number(az_json_token const* token, double* out_value)
 {
 
-  AZ_PRECONDITION_NOT_NULL(out_value);
+  _az_PRECONDITION_NOT_NULL(out_value);
 
   if (token->kind != AZ_JSON_TOKEN_NUMBER)
   {

--- a/sdk/core/core/src/az_span.c
+++ b/sdk/core/core/src/az_span.c
@@ -27,7 +27,7 @@ AZ_NODISCARD az_span az_span_init(uint8_t* ptr, int32_t size)
   //   size >= 0
   // Otherwise, if ptr is null, then:
   //   size == 0
-  AZ_PRECONDITION((ptr != NULL && size >= 0) || (ptr + (uint32_t)size == 0));
+  _az_PRECONDITION((ptr != NULL && size >= 0) || (ptr + (uint32_t)size == 0));
 
   return (az_span){ ._internal = { .ptr = ptr, .size = size, }, };
 }
@@ -35,7 +35,7 @@ AZ_NODISCARD az_span az_span_init(uint8_t* ptr, int32_t size)
 
 AZ_NODISCARD az_span az_span_from_str(char* str)
 {
-  AZ_PRECONDITION_NOT_NULL(str);
+  _az_PRECONDITION_NOT_NULL(str);
 
   // Avoid passing in null pointer to strlen to avoid memory access violation.
   if (str == NULL)
@@ -45,21 +45,21 @@ AZ_NODISCARD az_span az_span_from_str(char* str)
 
   int32_t const length = (int32_t)strlen(str);
 
-  AZ_PRECONDITION(length >= 0);
+  _az_PRECONDITION(length >= 0);
 
   return az_span_init((uint8_t*)str, length);
 }
 
 AZ_NODISCARD az_span az_span_slice(az_span span, int32_t start_index, int32_t end_index)
 {
-  AZ_PRECONDITION_VALID_SPAN(span, 0, true);
+  _az_PRECONDITION_VALID_SPAN(span, 0, true);
 
   // The following set of preconditions validate that:
   //    0 <= end_index <= span.size
   // And
   //    0 <= start_index <= end_index
-  AZ_PRECONDITION_RANGE(0, end_index, az_span_size(span));
-  AZ_PRECONDITION((uint32_t)start_index <= (uint32_t)end_index);
+  _az_PRECONDITION_RANGE(0, end_index, az_span_size(span));
+  _az_PRECONDITION((uint32_t)start_index <= (uint32_t)end_index);
 
   return az_span_init(az_span_ptr(span) + start_index, end_index - start_index);
 }
@@ -99,8 +99,8 @@ AZ_NODISCARD bool az_span_is_content_equal_ignoring_case(az_span span1, az_span 
 
 AZ_NODISCARD az_result az_span_atou64(az_span span, uint64_t* out_number)
 {
-  AZ_PRECONDITION_VALID_SPAN(span, 1, false);
-  AZ_PRECONDITION_NOT_NULL(out_number);
+  _az_PRECONDITION_VALID_SPAN(span, 1, false);
+  _az_PRECONDITION_NOT_NULL(out_number);
 
   int32_t self_size = az_span_size(span);
   uint64_t value = 0;
@@ -127,8 +127,8 @@ AZ_NODISCARD az_result az_span_atou64(az_span span, uint64_t* out_number)
 
 AZ_NODISCARD az_result az_span_atou32(az_span span, uint32_t* out_number)
 {
-  AZ_PRECONDITION_VALID_SPAN(span, 1, false);
-  AZ_PRECONDITION_NOT_NULL(out_number);
+  _az_PRECONDITION_VALID_SPAN(span, 1, false);
+  _az_PRECONDITION_NOT_NULL(out_number);
 
   int32_t self_size = az_span_size(span);
   uint32_t value = 0;
@@ -233,7 +233,7 @@ az_span az_span_copy(az_span destination, az_span source)
 {
   int32_t src_size = az_span_size(source);
 
-  AZ_PRECONDITION_VALID_SPAN(destination, src_size, false);
+  _az_PRECONDITION_VALID_SPAN(destination, src_size, false);
 
   if (src_size == 0)
   {
@@ -256,7 +256,7 @@ az_span az_span_copy(az_span destination, az_span source)
 
 az_span az_span_copy_u8(az_span destination, uint8_t byte)
 {
-  AZ_PRECONDITION_VALID_SPAN(destination, 1, false);
+  _az_PRECONDITION_VALID_SPAN(destination, 1, false);
 
   // Even though the contract of the method is that the destination must be at least 1 byte large,
   // no-op if it is empty to avoid memory corruption.
@@ -273,17 +273,17 @@ az_span az_span_copy_u8(az_span destination, uint8_t byte)
 
 void az_span_to_str(char* destination, int32_t destination_max_size, az_span source)
 {
-  AZ_PRECONDITION_NOT_NULL(destination);
-  AZ_PRECONDITION(destination_max_size > 0);
+  _az_PRECONDITION_NOT_NULL(destination);
+  _az_PRECONDITION(destination_max_size > 0);
 
   // Implementations of memmove generally do the right thing when number of bytes to move is 0, even
   // if the ptr is null, but given the behavior is documented to be undefined, we disallow it as a
   // precondition.
-  AZ_PRECONDITION_VALID_SPAN(source, 0, false);
+  _az_PRECONDITION_VALID_SPAN(source, 0, false);
 
   int32_t size_to_write = az_span_size(source);
 
-  AZ_PRECONDITION(size_to_write < destination_max_size);
+  _az_PRECONDITION(size_to_write < destination_max_size);
 
   // Even though the contract of this method is that the destination_max_size must be larger than
   // source to be able to copy all of the source to the char buffer including an extra null
@@ -302,7 +302,7 @@ void az_span_to_str(char* destination, int32_t destination_max_size, az_span sou
     }
   }
 
-  AZ_PRECONDITION(size_to_write >= 0);
+  _az_PRECONDITION(size_to_write >= 0);
 
   memmove((void*)destination, (void const*)az_span_ptr(source), (size_t)size_to_write);
   destination[size_to_write] = 0;
@@ -371,8 +371,8 @@ _az_span_replace(az_span self, int32_t current_size, int32_t start, int32_t end,
 
 AZ_NODISCARD az_result az_span_dtoa(az_span destination, double source, az_span* out_span)
 {
-  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
-  AZ_PRECONDITION_NOT_NULL(out_span);
+  _az_PRECONDITION_VALID_SPAN(destination, 0, false);
+  _az_PRECONDITION_NOT_NULL(out_span);
 
   // Verify to make sure that the destination has at least one byte up front (for either a digit or
   // the sign), since that's is common across all branches.
@@ -478,8 +478,8 @@ static AZ_NODISCARD az_result _az_span_builder_append_uint64(az_span* self, uint
 
 AZ_NODISCARD az_result az_span_u64toa(az_span destination, uint64_t source, az_span* out_span)
 {
-  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
-  AZ_PRECONDITION_NOT_NULL(out_span);
+  _az_PRECONDITION_VALID_SPAN(destination, 0, false);
+  _az_PRECONDITION_NOT_NULL(out_span);
   *out_span = destination;
 
   return _az_span_builder_append_uint64(out_span, source);
@@ -487,8 +487,8 @@ AZ_NODISCARD az_result az_span_u64toa(az_span destination, uint64_t source, az_s
 
 AZ_NODISCARD az_result az_span_i64toa(az_span destination, int64_t source, az_span* out_span)
 {
-  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
-  AZ_PRECONDITION_NOT_NULL(out_span);
+  _az_PRECONDITION_VALID_SPAN(destination, 0, false);
+  _az_PRECONDITION_NOT_NULL(out_span);
 
   if (source < 0)
   {
@@ -543,15 +543,15 @@ _az_span_builder_append_u32toa(az_span self, uint32_t n, az_span* out_span)
 
 AZ_NODISCARD az_result az_span_u32toa(az_span destination, uint32_t source, az_span* out_span)
 {
-  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
-  AZ_PRECONDITION_NOT_NULL(out_span);
+  _az_PRECONDITION_VALID_SPAN(destination, 0, false);
+  _az_PRECONDITION_NOT_NULL(out_span);
   return _az_span_builder_append_u32toa(destination, source, out_span);
 }
 
 AZ_NODISCARD az_result az_span_i32toa(az_span destination, int32_t source, az_span* out_span)
 {
-  AZ_PRECONDITION_VALID_SPAN(destination, 0, false);
-  AZ_PRECONDITION_NOT_NULL(out_span);
+  _az_PRECONDITION_VALID_SPAN(destination, 0, false);
+  _az_PRECONDITION_NOT_NULL(out_span);
 
   *out_span = destination;
 

--- a/sdk/core/core/src/az_span.c
+++ b/sdk/core/core/src/az_span.c
@@ -18,7 +18,7 @@ enum
   _az_ASCII_LOWER_DIF = 'a' - 'A',
 };
 
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
 // Note: If you are modifying this method, make sure to modify the inline version in the az_span.h
 // file as well.
 AZ_NODISCARD az_span az_span_init(uint8_t* ptr, int32_t size)
@@ -31,7 +31,7 @@ AZ_NODISCARD az_span az_span_init(uint8_t* ptr, int32_t size)
 
   return (az_span){ ._internal = { .ptr = ptr, .size = size, }, };
 }
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
 AZ_NODISCARD az_span az_span_from_str(char* str)
 {

--- a/sdk/core/core/test/cmocka/test_az_aad.c
+++ b/sdk/core/core/test/cmocka/test_az_aad.c
@@ -46,7 +46,7 @@ az_result __wrap_az_http_client_send_request(
   return AZ_OK;
 }
 
-#ifdef MOCK_ENABLED
+#ifdef _az_MOCK_ENABLED
 static void test_az_token_expired(void** state)
 {
   (void)state;
@@ -89,7 +89,7 @@ static void test_az_aad_request_token(void** state)
   assert_return_code(_az_aad_request_token(&r, &t), AZ_OK);
   assert_string_equal(t._internal.token, "Bearer fakeToken");
 }
-#endif // MOCK_ENABLED
+#endif // _az_MOCK_ENABLED
 
 static void test_az_aad_build_body(void** state)
 {
@@ -119,10 +119,10 @@ static void test_az_aad_build_url(void** state)
 int test_az_add()
 {
   const struct CMUnitTest tests[] = {
-#ifdef MOCK_ENABLED
+#ifdef _az_MOCK_ENABLED
     cmocka_unit_test(test_az_token_expired),
     cmocka_unit_test(test_az_aad_request_token),
-#endif // MOCK_ENABLED
+#endif // _az_MOCK_ENABLED
     cmocka_unit_test(test_az_aad_build_body),
     cmocka_unit_test(test_az_aad_build_url),
   };

--- a/sdk/core/core/test/cmocka/test_az_policy.c
+++ b/sdk/core/core/test/cmocka/test_az_policy.c
@@ -16,7 +16,7 @@
 
 #include <_az_cfg.h>
 
-#ifdef MOCK_ENABLED
+#ifdef _az_MOCK_ENABLED
 az_result test_policy_transport_retry_response(
     _az_http_policy* p_policies,
     void* p_options,
@@ -38,7 +38,7 @@ void test_az_http_pipeline_policy_credential(void** state);
 void test_az_http_pipeline_policy_retry(void** state);
 void test_az_http_pipeline_policy_retry_with_header(void** state);
 void test_az_http_pipeline_policy_retry_with_header_2(void** state);
-#endif // MOCK_ENABLED
+#endif // _az_MOCK_ENABLED
 
 static az_result test_policy_transport(
     _az_http_policy* p_policies,
@@ -173,7 +173,7 @@ void test_az_http_pipeline_policy_uniquerequestid(void** state)
   assert_return_code(az_http_pipeline_policy_uniquerequestid(policies, NULL, &hrb, NULL), AZ_OK);
 }
 
-#ifdef MOCK_ENABLED
+#ifdef _az_MOCK_ENABLED
 
 const az_span retry_response = AZ_SPAN_LITERAL_FROM_STR("HTTP/1.1 408 Request Timeout\r\n"
                                                         "Content-Type: text/html; charset=UTF-8\r\n"
@@ -409,17 +409,17 @@ void test_az_http_pipeline_policy_retry_with_header_2(void** state)
       az_http_pipeline_policy_retry(policies, &retry_options, &hrb, &response), AZ_OK);
 }
 
-#endif // MOCK_ENABLED
+#endif // _az_MOCK_ENABLED
 
 int test_az_policy()
 {
   const struct CMUnitTest tests[] = {
-#ifdef MOCK_ENABLED
+#ifdef _az_MOCK_ENABLED
     cmocka_unit_test(test_az_http_pipeline_policy_credential),
     cmocka_unit_test(test_az_http_pipeline_policy_retry),
     cmocka_unit_test(test_az_http_pipeline_policy_retry_with_header),
     cmocka_unit_test(test_az_http_pipeline_policy_retry_with_header_2),
-#endif // MOCK_ENABLED
+#endif // _az_MOCK_ENABLED
     cmocka_unit_test(test_az_http_pipeline_policy_apiversion),
     cmocka_unit_test(test_az_http_pipeline_policy_uniquerequestid),
     cmocka_unit_test(test_az_http_pipeline_policy_telemetry),

--- a/sdk/iot/core/src/az_iot_core.c
+++ b/sdk/iot/core/src/az_iot_core.c
@@ -77,8 +77,8 @@ AZ_NODISCARD az_result az_iot_get_status_from_uint32(uint32_t status_int, az_iot
 
 AZ_NODISCARD az_span az_span_token(az_span source, az_span delimiter, az_span* out_remainder)
 {
-  AZ_PRECONDITION_VALID_SPAN(delimiter, 1, false);
-  AZ_PRECONDITION_NOT_NULL(out_remainder);
+  _az_PRECONDITION_VALID_SPAN(delimiter, 1, false);
+  _az_PRECONDITION_NOT_NULL(out_remainder);
 
   if (az_span_size(source) == 0)
   {

--- a/sdk/iot/hub/src/az_iot_hub_client.c
+++ b/sdk/iot/hub/src/az_iot_hub_client.c
@@ -31,9 +31,9 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
     az_span device_id,
     az_iot_hub_client_options const* options)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(iot_hub_hostname, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(device_id, 1, false);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_VALID_SPAN(iot_hub_hostname, 1, false);
+  _az_PRECONDITION_VALID_SPAN(device_id, 1, false);
 
   client->_internal.iot_hub_hostname = iot_hub_hostname;
   client->_internal.device_id = device_id;
@@ -48,9 +48,9 @@ AZ_NODISCARD az_result az_iot_hub_client_get_user_name(
     size_t mqtt_user_name_size,
     size_t* out_mqtt_user_name_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_NOT_NULL(mqtt_user_name);
-  AZ_PRECONDITION(mqtt_user_name_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(mqtt_user_name);
+  _az_PRECONDITION(mqtt_user_name_size > 0);
 
   const az_span* const module_id = &(client->_internal.options.module_id);
   const az_span* const user_agent = &(client->_internal.options.user_agent);
@@ -106,9 +106,9 @@ AZ_NODISCARD az_result az_iot_hub_client_get_client_id(
     size_t mqtt_client_id_size,
     size_t* out_mqtt_client_id_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_NOT_NULL(mqtt_client_id);
-  AZ_PRECONDITION(mqtt_client_id_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(mqtt_client_id);
+  _az_PRECONDITION(mqtt_client_id_size > 0);
 
   az_span mqtt_client_id_span = az_span_init((uint8_t*)mqtt_client_id, (int32_t)mqtt_client_id_size);
   const az_span* const module_id = &(client->_internal.options.module_id);
@@ -145,9 +145,9 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_init(
     az_span buffer,
     int32_t written_length)
 {
-  AZ_PRECONDITION_NOT_NULL(properties);
-  AZ_PRECONDITION_VALID_SPAN(buffer, 0, false);
-  AZ_PRECONDITION(written_length >= 0);
+  _az_PRECONDITION_NOT_NULL(properties);
+  _az_PRECONDITION_VALID_SPAN(buffer, 0, false);
+  _az_PRECONDITION(written_length >= 0);
 
   properties->_internal.properties_buffer = buffer;
   properties->_internal.properties_written = written_length;
@@ -161,9 +161,9 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_append(
     az_span name,
     az_span value)
 {
-  AZ_PRECONDITION_NOT_NULL(properties);
-  AZ_PRECONDITION_VALID_SPAN(name, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(value, 1, false);
+  _az_PRECONDITION_NOT_NULL(properties);
+  _az_PRECONDITION_VALID_SPAN(name, 1, false);
+  _az_PRECONDITION_VALID_SPAN(value, 1, false);
 
   int32_t prop_length = properties->_internal.properties_written;
 
@@ -197,9 +197,9 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_find(
     az_span name,
     az_span* out_value)
 {
-  AZ_PRECONDITION_NOT_NULL(properties);
-  AZ_PRECONDITION_VALID_SPAN(name, 1, false);
-  AZ_PRECONDITION_NOT_NULL(out_value);
+  _az_PRECONDITION_NOT_NULL(properties);
+  _az_PRECONDITION_VALID_SPAN(name, 1, false);
+  _az_PRECONDITION_NOT_NULL(out_value);
 
   az_span remaining = az_span_slice(
       properties->_internal.properties_buffer, 0, properties->_internal.properties_written);
@@ -226,8 +226,8 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_find(
 AZ_NODISCARD az_result
 az_iot_hub_client_properties_next(az_iot_hub_client_properties* properties, az_pair* out)
 {
-  AZ_PRECONDITION_NOT_NULL(properties);
-  AZ_PRECONDITION_NOT_NULL(out);
+  _az_PRECONDITION_NOT_NULL(properties);
+  _az_PRECONDITION_NOT_NULL(out);
 
   int32_t index = (int32_t)properties->_internal.current_property_index;
   int32_t prop_length = properties->_internal.properties_written;

--- a/sdk/iot/hub/src/az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_c2d.c
@@ -21,9 +21,9 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_get_subscribe_topic_filter(
     size_t mqtt_topic_filter_size,
     size_t* out_mqtt_topic_filter_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_NOT_NULL(mqtt_topic_filter);
-  AZ_PRECONDITION(mqtt_topic_filter_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(mqtt_topic_filter);
+  _az_PRECONDITION(mqtt_topic_filter_size > 0);
 
   az_span mqtt_topic_filter_span
       = az_span_init((uint8_t*)mqtt_topic_filter, (int32_t)mqtt_topic_filter_size);
@@ -53,9 +53,9 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
     az_span received_topic,
     az_iot_hub_client_c2d_request* out_request)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(received_topic, 1, false);
-  AZ_PRECONDITION_NOT_NULL(out_request);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_VALID_SPAN(received_topic, 1, false);
+  _az_PRECONDITION_NOT_NULL(out_request);
   (void)client;
 
   az_span token;

--- a/sdk/iot/hub/src/az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_methods.c
@@ -26,9 +26,9 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_get_subscribe_topic_filter(
     size_t mqtt_topic_filter_size,
     size_t* out_mqtt_topic_filter_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_NOT_NULL(mqtt_topic_filter);
-  AZ_PRECONDITION(mqtt_topic_filter_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(mqtt_topic_filter);
+  _az_PRECONDITION(mqtt_topic_filter_size > 0);
 
   (void)client;
 
@@ -60,9 +60,9 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_parse_received_topic(
     az_span received_topic,
     az_iot_hub_client_method_request* out_request)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(received_topic, 1, false);
-  AZ_PRECONDITION_NOT_NULL(out_request);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_VALID_SPAN(received_topic, 1, false);
+  _az_PRECONDITION_NOT_NULL(out_request);
 
   (void)client;
 
@@ -112,11 +112,11 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_response_get_publish_topic(
     size_t mqtt_topic_size,
     size_t* out_mqtt_topic_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(request_id, 1, false);
-  AZ_PRECONDITION(status == 200 || status == 404 || status == 504);
-  AZ_PRECONDITION_NOT_NULL(mqtt_topic);
-  AZ_PRECONDITION(mqtt_topic_size);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_VALID_SPAN(request_id, 1, false);
+  _az_PRECONDITION(status == 200 || status == 404 || status == 504);
+  _az_PRECONDITION_NOT_NULL(mqtt_topic);
+  _az_PRECONDITION(mqtt_topic_size);
 
   (void)client;
 

--- a/sdk/iot/hub/src/az_iot_hub_client_sas.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_sas.c
@@ -35,10 +35,10 @@ AZ_NODISCARD az_result az_iot_hub_client_sas_get_signature(
     az_span signature,
     az_span* out_signature)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION(token_expiration_epoch_time > 0);
-  AZ_PRECONDITION_VALID_SPAN(signature, 1, false);
-  AZ_PRECONDITION_NOT_NULL(out_signature);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION(token_expiration_epoch_time > 0);
+  _az_PRECONDITION_VALID_SPAN(signature, 1, false);
+  _az_PRECONDITION_NOT_NULL(out_signature);
 
   int32_t required_size = az_span_size(client->_internal.iot_hub_hostname)
       + az_span_size(devices_string)
@@ -85,11 +85,11 @@ AZ_NODISCARD az_result az_iot_hub_client_sas_get_password(
     size_t mqtt_password_size,
     size_t* out_mqtt_password_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(base64_hmac_sha256_signature, 1, false);
-  AZ_PRECONDITION(token_expiration_epoch_time > 0);
-  AZ_PRECONDITION_NOT_NULL(mqtt_password);
-  AZ_PRECONDITION(mqtt_password_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_VALID_SPAN(base64_hmac_sha256_signature, 1, false);
+  _az_PRECONDITION(token_expiration_epoch_time > 0);
+  _az_PRECONDITION_NOT_NULL(mqtt_password);
+  _az_PRECONDITION(mqtt_password_size > 0);
 
   // Concatenates: "SharedAccessSignature sr=" scope "&sig=" sig  "&se=" expiration_time_secs
   //               plus, if key_name size > 0, "&skn=" key_name

--- a/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_telemetry.c
@@ -23,9 +23,9 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
     size_t mqtt_topic_size,
     size_t* out_mqtt_topic_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_NOT_NULL(mqtt_topic);
-  AZ_PRECONDITION(mqtt_topic_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(mqtt_topic);
+  _az_PRECONDITION(mqtt_topic_size > 0);
 
   const az_span* const module_id = &(client->_internal.options.module_id);
 

--- a/sdk/iot/hub/src/az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_twin.c
@@ -31,9 +31,9 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_response_get_subscribe_topic_filte
     size_t mqtt_topic_filter_size,
     size_t* out_mqtt_topic_filter_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_NOT_NULL(mqtt_topic_filter);
-  AZ_PRECONDITION(mqtt_topic_filter_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(mqtt_topic_filter);
+  _az_PRECONDITION(mqtt_topic_filter_size > 0);
   (void)client;
 
   az_span mqtt_topic_filter_span
@@ -64,9 +64,9 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_patch_get_subscribe_topic_filter(
     size_t mqtt_topic_filter_size,
     size_t* out_mqtt_topic_filter_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_NOT_NULL(mqtt_topic_filter);
-  AZ_PRECONDITION(mqtt_topic_filter_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(mqtt_topic_filter);
+  _az_PRECONDITION(mqtt_topic_filter_size > 0);
   (void)client;
 
   az_span mqtt_topic_filter_span
@@ -98,10 +98,10 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_document_get_publish_topic(
     size_t mqtt_topic_size,
     size_t* out_mqtt_topic_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(request_id, 1, false);
-  AZ_PRECONDITION_NOT_NULL(mqtt_topic);
-  AZ_PRECONDITION(mqtt_topic_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_VALID_SPAN(request_id, 1, false);
+  _az_PRECONDITION_NOT_NULL(mqtt_topic);
+  _az_PRECONDITION(mqtt_topic_size > 0);
   (void)client;
 
   az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
@@ -136,10 +136,10 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_patch_get_publish_topic(
     size_t mqtt_topic_size,
     size_t* out_mqtt_topic_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(request_id, 1, false);
-  AZ_PRECONDITION_NOT_NULL(mqtt_topic);
-  AZ_PRECONDITION(mqtt_topic_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_VALID_SPAN(request_id, 1, false);
+  _az_PRECONDITION_NOT_NULL(mqtt_topic);
+  _az_PRECONDITION(mqtt_topic_size > 0);
   (void)client;
 
   az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
@@ -172,9 +172,9 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
     az_span received_topic,
     az_iot_hub_client_twin_response* out_twin_response)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(received_topic, 1, false);
-  AZ_PRECONDITION_NOT_NULL(out_twin_response);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_VALID_SPAN(received_topic, 1, false);
+  _az_PRECONDITION_NOT_NULL(out_twin_response);
   (void)client;
 
   az_result result;

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client.c
@@ -63,7 +63,7 @@ static const az_span test_value_three = AZ_SPAN_LITERAL_FROM_STR(TEST_VALUE_THRE
 static const char test_correct_one_key_value[] = "key_one=value_one";
 static const char test_correct_two_key_value[] = "key_one=value_one&key_two=value_two";
 
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
 enable_precondition_check_tests()
 
 static void test_az_iot_hub_client_init_NULL_client_fails(void** state)
@@ -259,7 +259,7 @@ static void test_az_iot_hub_client_properties_next_NULL_out_fail(void** state)
   assert_precondition_checked(az_iot_hub_client_properties_next(&props, NULL));
 }
 
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
 static void test_az_iot_hub_client_get_default_options_succeed(void** state)
 {
@@ -834,12 +834,12 @@ static void test_az_iot_hub_client_properties_next_empty_succeed(void** state)
 
 int test_iot_hub_client()
 {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
   const struct CMUnitTest tests[] = {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_init_NULL_client_fails),
     cmocka_unit_test(test_az_iot_hub_client_init_NULL_device_id_fails),
     cmocka_unit_test(test_az_iot_hub_client_init_NULL_hub_hostname_id_fails),
@@ -859,7 +859,7 @@ int test_iot_hub_client()
     cmocka_unit_test(test_az_iot_hub_client_properties_find_NULL_value_fail),
     cmocka_unit_test(test_az_iot_hub_client_properties_next_NULL_props_fail),
     cmocka_unit_test(test_az_iot_hub_client_properties_next_NULL_out_fail),
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_get_default_options_succeed),
     cmocka_unit_test(test_az_iot_hub_client_init_succeed),
     cmocka_unit_test(test_az_iot_hub_client_init_custom_options_succeed),

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_c2d.c
@@ -34,7 +34,7 @@ static const az_span test_URL_ENCODED_topic
                                "%24.to=%2Fdevices%2Fuseragent_c%2Fmessages%2FdeviceBound&abc=123&"
                                "ghi=%2Fsome%2Fthing&jkl=%2Fsome%2Fthing%2F%3Fbla%3Dbla");
 
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
 enable_precondition_check_tests()
 
 static void test_az_iot_hub_client_c2d_parse_received_topic_NULL_client_fail(void** state)
@@ -119,7 +119,7 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_MALFORMED_fail(void*
       az_iot_hub_client_c2d_parse_received_topic(&client, received_topic, &out_request));
 }
 
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
 static void test_az_iot_hub_client_c2d_get_subscribe_topic_filter_succeed(void** state)
 {
@@ -229,19 +229,19 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_URL_ENCODED_succeed(
 
 int test_iot_hub_c2d()
 {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
   const struct CMUnitTest tests[] = {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_NULL_client_fail),
     cmocka_unit_test(
         test_az_iot_hub_client_c2d_parse_received_topic_AZ_SPAN_NULL_received_topic_fail),
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_NULL_out_request_fail),
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_no_properties_fail),
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_MALFORMED_fail),
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_c2d_get_subscribe_topic_filter_succeed),
     cmocka_unit_test(test_az_iot_hub_client_c2d_get_subscribe_topic_filter_small_buffer_fail),
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_URL_DECODED_succeed),

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_methods.c
@@ -27,7 +27,7 @@ static const az_span test_device_hostname = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE
 static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_ID_STR);
 static uint8_t g_expected_methods_subscribe_topic[] = "$iothub/methods/POST/#";
 
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
 enable_precondition_check_tests()
 
 static void test_az_iot_hub_client_methods_get_subscribe_topic_filter_NULL_client_fail(void** state)
@@ -213,7 +213,7 @@ static void test_az_iot_hub_client_methods_parse_received_topic_NULL_out_request
       az_iot_hub_client_methods_parse_received_topic(&client, received_topic, NULL));
 }
 
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
 static void test_az_iot_hub_client_methods_get_subscribe_topic_filter_succeed(void** state)
 {
@@ -447,12 +447,12 @@ static void test_az_iot_hub_client_methods_parse_received_topic_response_topic_f
 
 int test_iot_hub_methods()
 {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
   const struct CMUnitTest tests[] = {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_methods_get_subscribe_topic_filter_NULL_client_fail),
     cmocka_unit_test(test_az_iot_hub_client_methods_get_subscribe_topic_filter_NULL_out_topic_fail),
     cmocka_unit_test(test_az_iot_hub_client_methods_get_subscribe_topic_filter_empty_topic_fail),
@@ -469,7 +469,7 @@ int test_iot_hub_methods()
     cmocka_unit_test(
         test_az_iot_hub_client_methods_parse_received_topic_AZ_SPAN_NULL_received_topic_fail),
     cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_NULL_out_request_fail),
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_methods_get_subscribe_topic_filter_succeed),
     cmocka_unit_test(
         test_az_iot_hub_client_methods_get_subscribe_topic_filter_INSUFFICIENT_BUFFER_fail),

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_sas.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_sas.c
@@ -32,7 +32,7 @@ static const az_span test_module_id = AZ_SPAN_LITERAL_FROM_STR(TEST_MODULE_ID_ST
 static const uint32_t test_sas_expiry_time_secs = 1578941692;
 static const az_span test_signature = AZ_SPAN_LITERAL_FROM_STR(TEST_SIG);
 
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
 enable_precondition_check_tests()
 
 static void az_iot_hub_client_sas_get_signature_NULL_signature_fails(void** state)
@@ -113,7 +113,7 @@ static void az_iot_hub_client_sas_get_password_empty_password_buffer_span_fails(
       &client, test_signature, test_sas_expiry_time_secs, key_name, password, 0, &length));
 }
 
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
 static void az_iot_hub_client_sas_get_signature_device_succeeds(void** state)
 {
@@ -367,19 +367,19 @@ static void az_iot_hub_client_sas_get_signature_module_signature_overflow_fails(
 
 int test_iot_sas_token()
 {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
   const struct CMUnitTest tests[] = {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(az_iot_hub_client_sas_get_signature_NULL_signature_fails),
     cmocka_unit_test(az_iot_hub_client_sas_get_signature_NULL_signature_span_fails),
     cmocka_unit_test(az_iot_hub_client_sas_get_signature_NULL_client_fails),
     cmocka_unit_test(az_iot_hub_client_sas_get_password_EMPTY_signature_fails),
     cmocka_unit_test(az_iot_hub_client_sas_get_password_NULL_password_span_fails),
     cmocka_unit_test(az_iot_hub_client_sas_get_password_empty_password_buffer_span_fails),
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(az_iot_hub_client_sas_get_signature_device_succeeds),
     cmocka_unit_test(az_iot_hub_client_sas_get_password_device_no_out_length_succeeds),
     cmocka_unit_test(az_iot_hub_client_sas_get_signature_module_succeeds),

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_telemetry.c
@@ -35,7 +35,7 @@ static const char g_test_correct_topic_no_options_with_props[]
 static const char g_test_correct_topic_with_options_module_id_with_props[]
     = "devices/my_device/modules/my_module_id/messages/events/key=value&key_two=value2";
 
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
 enable_precondition_check_tests()
 
 static void test_az_iot_hub_client_telemetry_get_publish_topic_NULL_client_fails(void** state)
@@ -79,7 +79,7 @@ static void test_az_iot_hub_client_telemetry_get_publish_topic_NULL_out_mqtt_top
       &client, NULL, test_buf, 0, &test_length));
 }
 
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
 static void test_az_iot_hub_client_telemetry_get_publish_topic_no_options_no_props_succeed(
     void** state)
@@ -321,16 +321,16 @@ test_az_iot_hub_client_telemetry_get_publish_topic_with_options_module_id_with_p
 
 int test_iot_hub_telemetry()
 {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
   const struct CMUnitTest tests[] = {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_telemetry_get_publish_topic_NULL_client_fails),
     cmocka_unit_test(test_az_iot_hub_client_telemetry_get_publish_topic_NULL_mqtt_topic_fails),
     cmocka_unit_test(test_az_iot_hub_client_telemetry_get_publish_topic_NULL_out_mqtt_topic_fails),
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(
         test_az_iot_hub_client_telemetry_get_publish_topic_no_options_no_props_succeed),
     cmocka_unit_test(

--- a/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/tests/cmocka/test_az_iot_hub_client_twin.c
@@ -41,7 +41,7 @@ static const char test_correct_twin_path_subscribe_topic[]
 static const char test_correct_twin_patch_pub_topic[]
     = "$iothub/twin/PATCH/properties/reported/?$rid=id_one";
 
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
 enable_precondition_check_tests()
 
     static void test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_null_client_fails(
@@ -292,7 +292,7 @@ static void test_az_iot_hub_client_twin_parse_received_topic_NULL_response_fails
       &client, test_twin_received_topic_desired_success, NULL));
 }
 
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
 static void test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_succeed(void** state)
 {
@@ -532,12 +532,12 @@ static void test_az_iot_hub_client_twin_parse_received_topic_not_found_prefix_fa
 
 int test_az_iot_hub_client_twin()
 {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
   const struct CMUnitTest tests[] = {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(
         test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_null_client_fails),
     cmocka_unit_test(
@@ -560,7 +560,7 @@ int test_az_iot_hub_client_twin()
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_NULL_client_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_NULL_rec_topic_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_NULL_response_fails),
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_succeed),
     cmocka_unit_test(
         test_az_iot_hub_client_twin_response_get_subscribe_topic_filter_small_buffer_fails),

--- a/sdk/iot/pnp/src/az_iot_pnp_client.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client.c
@@ -35,10 +35,10 @@ AZ_NODISCARD az_result az_iot_pnp_client_init(
     az_span root_interface_name,
     az_iot_pnp_client_options const* options)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(iot_hub_hostname, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(device_id, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(root_interface_name, 1, false);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_VALID_SPAN(iot_hub_hostname, 1, false);
+  _az_PRECONDITION_VALID_SPAN(device_id, 1, false);
+  _az_PRECONDITION_VALID_SPAN(root_interface_name, 1, false);
 
   az_iot_hub_client_options hub_options = az_iot_hub_client_options_default();
   hub_options.user_agent = (options != NULL) ? options->user_agent : AZ_SPAN_NULL;
@@ -58,9 +58,9 @@ AZ_NODISCARD az_result az_iot_pnp_client_get_user_name(
     size_t mqtt_user_name_size,
     size_t* out_mqtt_user_name_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_NOT_NULL(mqtt_user_name);
-  AZ_PRECONDITION(mqtt_user_name_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(mqtt_user_name);
+  _az_PRECONDITION(mqtt_user_name_size > 0);
 
   size_t hub_user_name_length;
 

--- a/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/src/az_iot_pnp_client_telemetry.c
@@ -56,11 +56,11 @@ AZ_NODISCARD az_result az_iot_pnp_client_telemetry_get_publish_topic(
     size_t mqtt_topic_size,
     size_t* out_mqtt_topic_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(component_name, 1, false);
-  AZ_PRECONDITION_NOT_NULL(mqtt_topic);
-  AZ_PRECONDITION(mqtt_topic_size > 0);
-  AZ_PRECONDITION_IS_NULL(reserved);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_VALID_SPAN(component_name, 1, false);
+  _az_PRECONDITION_NOT_NULL(mqtt_topic);
+  _az_PRECONDITION(mqtt_topic_size > 0);
+  _az_PRECONDITION_IS_NULL(reserved);
   (void)reserved;
 
   size_t hub_topic_length;

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client.c
@@ -41,7 +41,7 @@ static const char test_correct_pnp_user_name_with_user_agent[]
     = "myiothub.azure-devices.net/my_device/?api-version=2018-06-30&" TEST_USER_AGENT
       "&digital-twin-model-id=" TEST_ROOT_INTERFACE_NAME;
 
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
 enable_precondition_check_tests()
 
 static void test_az_iot_pnp_client_init_NULL_client_fails(void** state)
@@ -79,7 +79,7 @@ static void test_az_iot_pnp_client_init_empty_root_interface_name_fails(void** s
       az_iot_pnp_client_init(&client, test_device_hostname, test_device_id, AZ_SPAN_NULL, NULL));
 }
 
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
 static void test_az_iot_pnp_client_get_default_options_succeed(void** state)
 {
@@ -222,17 +222,17 @@ static void test_az_iot_pnp_client_get_user_name_user_options_small_buffer_fail(
 
 int test_iot_pnp_client()
 {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
   const struct CMUnitTest tests[] = {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_pnp_client_init_NULL_client_fails),
     cmocka_unit_test(test_az_iot_pnp_client_init_empty_iot_hub_hostname_fails),
     cmocka_unit_test(test_az_iot_pnp_client_init_empty_device_id_fails),
     cmocka_unit_test(test_az_iot_pnp_client_init_empty_root_interface_name_fails),
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_pnp_client_get_default_options_succeed),
     cmocka_unit_test(test_az_iot_pnp_client_init_succeed),
     cmocka_unit_test(test_az_iot_pnp_client_init_custom_options_succeed),

--- a/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
+++ b/sdk/iot/pnp/tests/cmocka/test_az_iot_pnp_client_telemetry.c
@@ -44,7 +44,7 @@ static const char g_test_correct_pnp_topic_content_type_and_encoding[]
     = "devices/my_device/messages/events/%24.ifname=" TEST_COMPONENT_NAME
       "&%24.ct=" TEST_CONTENT_TYPE "&%24.ce=" TEST_CONTENT_ENCODING;
 
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
 enable_precondition_check_tests()
 
 static void test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_client_fails(void** state)
@@ -128,7 +128,7 @@ static void test_az_iot_pnp_client_telemetry_get_publish_topic_non_NULL_reserved
       &client, AZ_SPAN_NULL, (void*)0x1, mqtt_topic_buf, sizeof(mqtt_topic_buf), &mqtt_topic_length));
 }
 
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
 static void test_az_iot_pnp_client_telemetry_publish_topic_get_no_options_succeed(void** state)
 {
@@ -358,18 +358,18 @@ test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_and_encoding_wit
 
 int test_iot_pnp_telemetry()
 {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
   const struct CMUnitTest tests[] = {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_client_fails),
     cmocka_unit_test(test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_mqtt_topic_fails),
     cmocka_unit_test(test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_out_mqtt_topic_fails),
     cmocka_unit_test(test_az_iot_pnp_client_telemetry_get_publish_topic_NULL_component_name_fails),
     cmocka_unit_test(test_az_iot_pnp_client_telemetry_get_publish_topic_non_NULL_reserved_fails),
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_pnp_client_telemetry_publish_topic_get_no_options_succeed),
     cmocka_unit_test(test_az_iot_pnp_client_telemetry_publish_topic_get_content_type_succeed),
     cmocka_unit_test(test_az_iot_pnp_client_telemetry_publish_topic_get_content_encoding_succeed),

--- a/sdk/iot/provisioning/src/az_iot_provisioning_client.c
+++ b/sdk/iot/provisioning/src/az_iot_provisioning_client.c
@@ -40,10 +40,10 @@ AZ_NODISCARD az_result az_iot_provisioning_client_init(
     az_span registration_id,
     az_iot_provisioning_client_options const* options)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(global_device_endpoint, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(id_scope, 1, false);
-  AZ_PRECONDITION_VALID_SPAN(registration_id, 1, false);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_VALID_SPAN(global_device_endpoint, 1, false);
+  _az_PRECONDITION_VALID_SPAN(id_scope, 1, false);
+  _az_PRECONDITION_VALID_SPAN(registration_id, 1, false);
 
   client->_internal.global_device_endpoint = global_device_endpoint;
   client->_internal.id_scope = id_scope;
@@ -62,9 +62,9 @@ AZ_NODISCARD az_result az_iot_provisioning_client_get_user_name(
     size_t mqtt_user_name_size,
     size_t* out_mqtt_user_name_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_NOT_NULL(mqtt_user_name);
-  AZ_PRECONDITION(mqtt_user_name_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(mqtt_user_name);
+  _az_PRECONDITION(mqtt_user_name_size > 0);
 
   az_span provisioning_service_api_version
       = AZ_SPAN_LITERAL_FROM_STR("/api-version=" AZ_IOT_PROVISIONING_SERVICE_VERSION);
@@ -115,9 +115,9 @@ AZ_NODISCARD az_result az_iot_provisioning_client_get_client_id(
     size_t mqtt_client_id_size,
     size_t* out_mqtt_client_id_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_NOT_NULL(mqtt_client_id);
-  AZ_PRECONDITION(mqtt_client_id_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(mqtt_client_id);
+  _az_PRECONDITION(mqtt_client_id_size > 0);
 
   az_span mqtt_client_id_span
       = az_span_init((uint8_t*)mqtt_client_id, (int32_t)mqtt_client_id_size);
@@ -147,9 +147,9 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_get_subscribe_topic_f
 {
   (void)client;
 
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_NOT_NULL(mqtt_topic_filter);
-  AZ_PRECONDITION(mqtt_topic_filter_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(mqtt_topic_filter);
+  _az_PRECONDITION(mqtt_topic_filter_size > 0);
 
   az_span mqtt_topic_filter_span
       = az_span_init((uint8_t*)mqtt_topic_filter, (int32_t)mqtt_topic_filter_size);
@@ -179,9 +179,9 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_get_publish_topic(
 {
   (void)client;
 
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_NOT_NULL(mqtt_topic);
-  AZ_PRECONDITION(mqtt_topic_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(mqtt_topic);
+  _az_PRECONDITION(mqtt_topic_size > 0);
 
   az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   az_span str_dps_registrations = _az_iot_provisioning_get_str_dps_registrations();
@@ -213,12 +213,12 @@ AZ_NODISCARD az_result az_iot_provisioning_client_query_status_get_publish_topic
 {
   (void)client;
 
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_NOT_NULL(mqtt_topic);
-  AZ_PRECONDITION(mqtt_topic_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(mqtt_topic);
+  _az_PRECONDITION(mqtt_topic_size > 0);
 
-  AZ_PRECONDITION_NOT_NULL(register_response);
-  AZ_PRECONDITION_VALID_SPAN(register_response->operation_id, 1, false);
+  _az_PRECONDITION_NOT_NULL(register_response);
+  _az_PRECONDITION_VALID_SPAN(register_response->operation_id, 1, false);
 
   az_span mqtt_topic_span = az_span_init((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   az_span str_dps_registrations = _az_iot_provisioning_get_str_dps_registrations();
@@ -449,10 +449,10 @@ AZ_NODISCARD az_result az_iot_provisioning_client_parse_received_topic_and_paylo
 {
   (void)client;
 
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(received_topic, 0, false);
-  AZ_PRECONDITION_VALID_SPAN(received_payload, 0, false);
-  AZ_PRECONDITION_NOT_NULL(out_response);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_VALID_SPAN(received_topic, 0, false);
+  _az_PRECONDITION_VALID_SPAN(received_payload, 0, false);
+  _az_PRECONDITION_NOT_NULL(out_response);
 
   int32_t idx = az_span_find(received_topic, str_dps_registrations_res);
   if (idx != 0)

--- a/sdk/iot/provisioning/src/az_iot_provisioning_client_sas.c
+++ b/sdk/iot/provisioning/src/az_iot_provisioning_client_sas.c
@@ -33,10 +33,10 @@ AZ_NODISCARD az_result az_iot_provisioning_client_sas_get_signature(
     az_span signature,
     az_span* out_signature)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION(token_expiration_epoch_time > 0);
-  AZ_PRECONDITION_VALID_SPAN(signature, 0, false);
-  AZ_PRECONDITION_NOT_NULL(out_signature);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION(token_expiration_epoch_time > 0);
+  _az_PRECONDITION_VALID_SPAN(signature, 0, false);
+  _az_PRECONDITION_NOT_NULL(out_signature);
 
   // Produces the following signature:
   // url-encoded(<resource-string>)\n<expiration-time>
@@ -74,11 +74,11 @@ AZ_NODISCARD az_result az_iot_provisioning_client_sas_get_password(
     size_t mqtt_password_size,
     size_t* out_mqtt_password_length)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_VALID_SPAN(base64_hmac_sha256_signature, 1, false);
-  AZ_PRECONDITION(token_expiration_epoch_time > 0);
-  AZ_PRECONDITION_NOT_NULL(mqtt_password);
-  AZ_PRECONDITION(mqtt_password_size > 0);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_VALID_SPAN(base64_hmac_sha256_signature, 1, false);
+  _az_PRECONDITION(token_expiration_epoch_time > 0);
+  _az_PRECONDITION_NOT_NULL(mqtt_password);
+  _az_PRECONDITION(mqtt_password_size > 0);
 
   // Concatenates:
   // "SharedAccessSignature sr=<url-encoded(resource-string)>&sig=<signature>&se=<expiration-time>"

--- a/sdk/iot/provisioning/tests/cmocka/test_az_iot_provisioning_client_sas.c
+++ b/sdk/iot/provisioning/tests/cmocka/test_az_iot_provisioning_client_sas.c
@@ -33,7 +33,7 @@ static const az_span test_registration_id = AZ_SPAN_LITERAL_FROM_STR(TEST_REGIST
 static const uint32_t test_sas_expiry_time_secs = 1578941692;
 static const az_span test_signature = AZ_SPAN_LITERAL_FROM_STR(TEST_SIG);
 
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
 
 enable_precondition_check_tests()
 
@@ -118,7 +118,7 @@ static void az_iot_provisioning_client_sas_get_password_empty_password_buffer_fa
       &client, test_signature, test_sas_expiry_time_secs, key_name, password, 0, &length));
 }
 
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
 static void az_iot_provisioning_client_sas_get_signature_device_succeeds(void** state)
 {
@@ -218,19 +218,19 @@ static void az_iot_provisioning_client_sas_get_signature_device_signature_overfl
 
 int test_az_iot_provisioning_client_sas_token()
 {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
   setup_precondition_check_tests();
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
 
   const struct CMUnitTest tests[] = {
-#ifndef NO_PRECONDITION_CHECKING
+#ifndef AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(az_iot_provisioning_client_sas_get_signature_NULL_signature_fails),
     cmocka_unit_test(az_iot_provisioning_client_sas_get_signature_NULL_signature_span_fails),
     cmocka_unit_test(az_iot_provisioning_client_sas_get_signature_NULL_client_fails),
     cmocka_unit_test(az_iot_provisioning_client_sas_get_password_EMPTY_signature_fails),
     cmocka_unit_test(az_iot_provisioning_client_sas_get_password_NULL_password_span_fails),
     cmocka_unit_test(az_iot_provisioning_client_sas_get_password_empty_password_buffer_fails),
-#endif // NO_PRECONDITION_CHECKING
+#endif // AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(az_iot_provisioning_client_sas_get_signature_device_succeeds),
     cmocka_unit_test(az_iot_provisioning_client_sas_get_password_device_succeeds),
     cmocka_unit_test(az_iot_provisioning_client_sas_get_password_device_with_keyname_succeeds),

--- a/sdk/platform/http_client/curl/src/az_curl.c
+++ b/sdk/platform/http_client/curl/src/az_curl.c
@@ -14,7 +14,7 @@
 
 /*Copying AZ_CONTRACT on purpose from AZ_CORE because 3rd parties can define this and should not
  * depend on internal CORE headers */
-#define AZ_PRECONDITION(condition, error) \
+#define _az_PRECONDITION(condition, error) \
   do \
   { \
     if (!(condition)) \
@@ -23,11 +23,11 @@
     } \
   } while (0)
 
-#define AZ_PRECONDITION_NOT_NULL(arg) AZ_PRECONDITION((arg) != NULL, AZ_ERROR_ARG)
+#define _az_PRECONDITION_NOT_NULL(arg) _az_PRECONDITION((arg) != NULL, AZ_ERROR_ARG)
 
 static AZ_NODISCARD az_result _az_span_malloc(int32_t size, az_span* out)
 {
-  AZ_PRECONDITION_NOT_NULL(out);
+  _az_PRECONDITION_NOT_NULL(out);
 
   uint8_t* const p = (uint8_t*)malloc((size_t)size);
   if (p == NULL)
@@ -81,8 +81,8 @@ AZ_NODISCARD AZ_INLINE az_result _az_http_client_curl_init(CURL** out)
 
 AZ_NODISCARD AZ_INLINE az_result _az_http_client_curl_done(CURL** pp)
 {
-  AZ_PRECONDITION_NOT_NULL(pp);
-  AZ_PRECONDITION_NOT_NULL(*pp);
+  _az_PRECONDITION_NOT_NULL(pp);
+  _az_PRECONDITION_NOT_NULL(*pp);
 
   curl_easy_cleanup(*pp);
   *pp = NULL;
@@ -117,8 +117,8 @@ _az_span_append_header_to_buffer(az_span writable_buffer, az_pair header, az_spa
 static AZ_NODISCARD az_result
 _az_http_client_curl_slist_append(struct curl_slist** self, char const* str)
 {
-  AZ_PRECONDITION_NOT_NULL(self);
-  AZ_PRECONDITION_NOT_NULL(str);
+  _az_PRECONDITION_NOT_NULL(self);
+  _az_PRECONDITION_NOT_NULL(str);
 
   struct curl_slist* const p_list = curl_slist_append(*self, str);
   if (p_list == NULL)
@@ -146,7 +146,7 @@ static AZ_NODISCARD az_result _az_http_client_curl_add_header_to_curl_list(
     struct curl_slist** p_list,
     az_span separator)
 {
-  AZ_PRECONDITION_NOT_NULL(p_list);
+  _az_PRECONDITION_NOT_NULL(p_list);
 
   // allocate a buffer for header
   az_span writable_buffer;
@@ -201,8 +201,8 @@ static AZ_NODISCARD az_result _az_http_client_curl_add_header_to_curl_list(
 static AZ_NODISCARD az_result
 _az_http_client_curl_add_expect_header(CURL* p_curl, struct curl_slist** p_list)
 {
-  AZ_PRECONDITION_NOT_NULL(p_curl);
-  AZ_PRECONDITION_NOT_NULL(p_list);
+  _az_PRECONDITION_NOT_NULL(p_curl);
+  _az_PRECONDITION_NOT_NULL(p_list);
 
   // Append header to current custom headers list
   AZ_RETURN_IF_FAILED(_az_http_client_curl_slist_append(p_list, "Expect:"));
@@ -221,7 +221,7 @@ _az_http_client_curl_add_expect_header(CURL* p_curl, struct curl_slist** p_list)
 static AZ_NODISCARD az_result
 _az_http_client_curl_build_headers(_az_http_request* p_request, struct curl_slist** p_headers)
 {
-  AZ_PRECONDITION_NOT_NULL(p_request);
+  _az_PRECONDITION_NOT_NULL(p_request);
 
   az_pair header;
   for (int32_t offset = 0; offset < _az_http_request_headers_count(p_request); ++offset)
@@ -297,7 +297,7 @@ static size_t _az_http_client_curl_write_to_span(
  */
 static AZ_NODISCARD az_result _az_http_client_curl_send_get_request(CURL* p_curl)
 {
-  AZ_PRECONDITION_NOT_NULL(p_curl);
+  _az_PRECONDITION_NOT_NULL(p_curl);
 
   // send
   AZ_RETURN_IF_CURL_FAILED(curl_easy_perform(p_curl));
@@ -311,8 +311,8 @@ static AZ_NODISCARD az_result _az_http_client_curl_send_get_request(CURL* p_curl
 static AZ_NODISCARD az_result
 _az_http_client_curl_send_delete_request(CURL* p_curl, _az_http_request const* p_request)
 {
-  AZ_PRECONDITION_NOT_NULL(p_curl);
-  AZ_PRECONDITION_NOT_NULL(p_request);
+  _az_PRECONDITION_NOT_NULL(p_curl);
+  _az_PRECONDITION_NOT_NULL(p_request);
 
   AZ_RETURN_IF_FAILED(_az_http_client_curl_code_to_result(
       curl_easy_setopt(p_curl, CURLOPT_CUSTOMREQUEST, "DELETE")));
@@ -328,8 +328,8 @@ _az_http_client_curl_send_delete_request(CURL* p_curl, _az_http_request const* p
 static AZ_NODISCARD az_result
 _az_http_client_curl_send_post_request(CURL* p_curl, _az_http_request const* p_request)
 {
-  AZ_PRECONDITION_NOT_NULL(p_curl);
-  AZ_PRECONDITION_NOT_NULL(p_request);
+  _az_PRECONDITION_NOT_NULL(p_curl);
+  _az_PRECONDITION_NOT_NULL(p_request);
 
   // Method
   az_span body = { 0 };
@@ -412,8 +412,8 @@ static int32_t _az_http_client_curl_upload_read_callback(
 static AZ_NODISCARD az_result
 _az_http_client_curl_send_upload_request(CURL* p_curl, _az_http_request const* p_request)
 {
-  AZ_PRECONDITION_NOT_NULL(p_curl);
-  AZ_PRECONDITION_NOT_NULL(p_request);
+  _az_PRECONDITION_NOT_NULL(p_curl);
+  _az_PRECONDITION_NOT_NULL(p_request);
 
   az_span body = p_request->_internal.body;
 
@@ -448,8 +448,8 @@ static AZ_NODISCARD az_result _az_http_client_curl_setup_headers(
     struct curl_slist** p_list,
     _az_http_request* p_request)
 {
-  AZ_PRECONDITION_NOT_NULL(p_curl);
-  AZ_PRECONDITION_NOT_NULL(p_request);
+  _az_PRECONDITION_NOT_NULL(p_curl);
+  _az_PRECONDITION_NOT_NULL(p_request);
 
   if (_az_http_request_headers_count(p_request) == 0)
   {
@@ -475,8 +475,8 @@ static AZ_NODISCARD az_result _az_http_client_curl_setup_headers(
 static AZ_NODISCARD az_result
 _az_http_client_curl_setup_url(CURL* p_curl, _az_http_request const* p_request)
 {
-  AZ_PRECONDITION_NOT_NULL(p_curl);
-  AZ_PRECONDITION_NOT_NULL(p_request);
+  _az_PRECONDITION_NOT_NULL(p_curl);
+  _az_PRECONDITION_NOT_NULL(p_request);
 
   az_span writable_buffer;
   {
@@ -515,7 +515,7 @@ _az_http_client_curl_setup_url(CURL* p_curl, _az_http_request const* p_request)
 static AZ_NODISCARD az_result
 _az_http_client_curl_setup_response_redirect(CURL* p_curl, az_http_response* response)
 {
-  AZ_PRECONDITION_NOT_NULL(p_curl);
+  _az_PRECONDITION_NOT_NULL(p_curl);
 
   AZ_RETURN_IF_CURL_FAILED(
       curl_easy_setopt(p_curl, CURLOPT_HEADERFUNCTION, _az_http_client_curl_write_to_span));
@@ -545,8 +545,8 @@ static AZ_NODISCARD az_result _az_http_client_curl_send_request_impl_process(
     _az_http_request* p_request,
     az_http_response* response)
 {
-  AZ_PRECONDITION_NOT_NULL(p_curl);
-  AZ_PRECONDITION_NOT_NULL(p_request);
+  _az_PRECONDITION_NOT_NULL(p_curl);
+  _az_PRECONDITION_NOT_NULL(p_request);
 
   az_result result = AZ_ERROR_ARG;
 
@@ -609,8 +609,8 @@ static AZ_NODISCARD az_result _az_http_client_curl_send_request_impl_process(
 AZ_NODISCARD az_result
 az_http_client_send_request(_az_http_request* p_request, az_http_response* p_response)
 {
-  AZ_PRECONDITION_NOT_NULL(p_request);
-  AZ_PRECONDITION_NOT_NULL(p_response);
+  _az_PRECONDITION_NOT_NULL(p_request);
+  _az_PRECONDITION_NOT_NULL(p_response);
 
   CURL* p_curl = NULL;
 

--- a/sdk/samples/keyvault/keyvault/src/az_keyvault_client.c
+++ b/sdk/samples/keyvault/keyvault/src/az_keyvault_client.c
@@ -81,8 +81,8 @@ AZ_NODISCARD az_result az_keyvault_keys_client_init(
     void* credential,
     az_keyvault_keys_client_options* options)
 {
-  AZ_PRECONDITION_NOT_NULL(self);
-  AZ_PRECONDITION_NOT_NULL(options);
+  _az_PRECONDITION_NOT_NULL(self);
+  _az_PRECONDITION_NOT_NULL(options);
 
   _az_credential* const cred = (_az_credential*)credential;
 

--- a/sdk/storage/blobs/src/az_storage_blobs_blob_client.c
+++ b/sdk/storage/blobs/src/az_storage_blobs_blob_client.c
@@ -59,8 +59,8 @@ AZ_NODISCARD az_result az_storage_blobs_blob_client_init(
     void* credential,
     az_storage_blobs_blob_client_options* options)
 {
-  AZ_PRECONDITION_NOT_NULL(client);
-  AZ_PRECONDITION_NOT_NULL(options);
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(options);
 
   _az_credential* const cred = (_az_credential*)credential;
 


### PR DESCRIPTION
NO_PRECONDITION_CHECKING and BUILD_MOCK are not AZ_ prefixed. Therefore, we can less rely on the fact that they are not taken by something else in customer's build environment. We should add prefixes.

NO_PRECONDITION_CHECKING is part of public interface, it is documented. Therefore, it should be named AZ_NO_PRECONDITION_CHECKING.

BUILD_MOCK as a macro is not documented. Therefore, it should be at least _az_BUILD_MOCK.

Precondition checks are internal macros, therefore prefix is changed from `AZ_` to `_az_`.