### PR TITLE
IoT Core, Provisioning state APIs implementations

### DIFF
--- a/sdk/core/core/inc/_az_cfg.h
+++ b/sdk/core/core/inc/_az_cfg.h
@@ -6,7 +6,7 @@
  *
  * @brief Disable warnings.
  *
- * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.

--- a/sdk/core/core/inc/_az_cfg_prefix.h
+++ b/sdk/core/core/inc/_az_cfg_prefix.h
@@ -6,7 +6,7 @@
  *
  * @brief Open "extern C" and save warnings state.
  *
- * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.

--- a/sdk/core/core/inc/_az_cfg_suffix.h
+++ b/sdk/core/core/inc/_az_cfg_suffix.h
@@ -6,7 +6,7 @@
  *
  * @brief Close "extern C" and restore warnings state.
  *
- * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.

--- a/sdk/core/core/inc/az_config.h
+++ b/sdk/core/core/inc/az_config.h
@@ -8,7 +8,7 @@
  * Typically, these constants are correct as is but depending on how your application
  * uses an Azure service, the constants may need increasing.
  *
- * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.

--- a/sdk/core/core/inc/az_context.h
+++ b/sdk/core/core/inc/az_context.h
@@ -6,7 +6,7 @@
  *
  * @brief Context for cancelling long running operations.
  *
- * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.

--- a/sdk/core/core/inc/az_credentials.h
+++ b/sdk/core/core/inc/az_credentials.h
@@ -6,7 +6,7 @@
  *
  * @brief Credentials used for authentication with many (not all) Azure SDK client libraries.
  *
- * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.

--- a/sdk/core/core/inc/az_http.h
+++ b/sdk/core/core/inc/az_http.h
@@ -7,7 +7,7 @@
  * @brief This header defines the types and functions your application uses
  *        to leverage HTTP request and response functionality.
  *
- * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.

--- a/sdk/core/core/inc/az_http_transport.h
+++ b/sdk/core/core/inc/az_http_transport.h
@@ -6,7 +6,7 @@
  *
  * @brief Utilities to be used by HTTP transport policy implementations.
  *
- * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.

--- a/sdk/core/core/inc/az_json.h
+++ b/sdk/core/core/inc/az_json.h
@@ -7,7 +7,7 @@
  * @brief This header defines the types and functions your application uses
  *        to build or parse JSON objects.
  *
- * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.

--- a/sdk/core/core/inc/az_log.h
+++ b/sdk/core/core/inc/az_log.h
@@ -7,7 +7,7 @@
  * @brief This header defines the types and functions your application uses
  *        to be notified of Azure SDK client library log messages.
  *
- * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.

--- a/sdk/core/core/inc/az_precondition.h
+++ b/sdk/core/core/inc/az_precondition.h
@@ -28,7 +28,7 @@
  *        precondition checking will be excluding making the binary code smaller and faster. We
  *        recommend doing this before you ship your code.
  *
- * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.

--- a/sdk/core/core/inc/az_result.h
+++ b/sdk/core/core/inc/az_result.h
@@ -6,7 +6,7 @@
  *
  * @brief az_result and facilities definition
  *
- * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.

--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -7,7 +7,7 @@
  * @brief An #az_span represents a contiguous byte buffer and is used for string manipulations,
  * HTTP requests/responses, building/parsing JSON payloads, and more.
  *
- * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.

--- a/sdk/core/core/inc/az_version.h
+++ b/sdk/core/core/inc/az_version.h
@@ -6,7 +6,7 @@
  *
  * @brief Provides version information.
  *
- * NOTE: You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.

--- a/sdk/iot/core/inc/az_iot_core.h
+++ b/sdk/iot/core/inc/az_iot_core.h
@@ -21,12 +21,16 @@
 /**
  * @brief Azure IoT service MQTT connection properties.
  *
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * prefixed with an underscore ('_') directly in your application code. These symbols
+ * are part of Azure SDK's internal implementation; we do not document these symbols
+ * and they are subject to change in future versions of the SDK which would break your code.
  */
+
 enum
 {
-  AZ_CLIENT_DEFAULT_MQTT_CONNECT_PORT = 8883,
-  AZ_CLIENT_DEFAULT_MQTT_CONNECT_CLEAN_SESSION = 0x20,
-  AZ_CLIENT_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS = 240
+  AZ_IOT_DEFAULT_MQTT_CONNECT_PORT = 8883,
+  AZ_IOT_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS = 240
 };
 
 /**
@@ -59,34 +63,27 @@ typedef enum
 } az_iot_status;
 
 /**
- * @brief Get the #az_iot_status from an int.
- *
- * @param[in] status_int The int with the status number.
- * @param[out] status The #az_iot_status* with the status enum.
- * @return The #az_result with the result of the get operation.
- *  @retval #AZ_OK If the int is an #az_iot_status enum. `status` will be set to the according
- * enum.
- *  @retval #AZ_ERROR_ITEM_NOT_FOUND If the int is NOT an #az_iot_status enum.
- */
-
-AZ_NODISCARD az_result az_iot_get_status_from_uint32(uint32_t status_int, az_iot_status* status);
-
-/**
  * @brief Checks if the status indicates a successful operation.
  *
  * @param[in] status The #az_iot_status to verify.
- * @return True if the status indicates success. False otherwise.
+ * @return `true` if the status indicates success. `false` otherwise.
  */
-AZ_NODISCARD bool az_iot_is_success_status(az_iot_status status);
+AZ_INLINE bool az_iot_is_success_status(az_iot_status status)
+{
+  return status < AZ_IOT_STATUS_BAD_REQUEST;
+}
 
 /**
  * @brief Checks if the status indicates a retriable error occurred during the
  *        operation.
  *
  * @param[in] status The #az_iot_status to verify.
- * @return True if the operation should be retried. False otherwise.
+ * @return `true` if the operation should be retried. `false` otherwise.
  */
-AZ_NODISCARD bool az_iot_is_retriable_status(az_iot_status status);
+AZ_INLINE bool az_iot_is_retriable_status(az_iot_status status)
+{
+  return ((status == AZ_IOT_STATUS_THROTTLED) || (status == AZ_IOT_STATUS_SERVER_ERROR));
+}
 
 /**
  * @brief Calculates the recommended delay before retrying an operation that failed.
@@ -94,7 +91,7 @@ AZ_NODISCARD bool az_iot_is_retriable_status(az_iot_status status);
  * @param[in] operation_msec The time it took, in milliseconds, to perform the operation that
  *                           failed.
  * @param[in] attempt The number of failed retry attempts.
- * @param[in] retry_delay_msec The minimum time, in milliseconds, to wait before a retry.
+ * @param[in] min_retry_delay_msec The minimum time, in milliseconds, to wait before a retry.
  * @param[in] max_retry_delay_msec The maximum time, in milliseconds, to wait before a retry.
  * @param[in] random_msec A random value between 0 and the maximum allowed jitter, in milliseconds.
  * @return The recommended delay in milliseconds.
@@ -102,12 +99,12 @@ AZ_NODISCARD bool az_iot_is_retriable_status(az_iot_status status);
 AZ_NODISCARD int32_t az_iot_retry_calc_delay(
     int32_t operation_msec,
     int16_t attempt,
-    int32_t retry_delay_msec,
+    int32_t min_retry_delay_msec,
     int32_t max_retry_delay_msec,
     int32_t random_msec);
 
 /**
- * @brief az_span_token is a string tokenizer for az_span.
+ * @brief _az_span_token is a string tokenizer for az_span.
  *
  * @param[in] source The #az_span with the content to be searched on. It must be a non-empty
  * #az_span.
@@ -120,7 +117,7 @@ AZ_NODISCARD int32_t az_iot_retry_calc_delay(
  * occurrence of (but not including the) `delimiter`, or the end of `source` if `delimiter` is not
  * found. If `source` is empty, AZ_SPAN_NULL is returned instead.
  */
-AZ_NODISCARD az_span az_span_token(az_span source, az_span delimiter, az_span* out_remainder);
+AZ_NODISCARD az_span _az_span_token(az_span source, az_span delimiter, az_span* out_remainder);
 
 /**
  * @brief _az_iot_u32toa_size gives the length, in bytes, of the string that would represent the given number.

--- a/sdk/iot/core/inc/az_iot_core.h
+++ b/sdk/iot/core/inc/az_iot_core.h
@@ -5,6 +5,11 @@
  * @file az_iot_core.h
  *
  * @brief Azure IoT common definitions.
+ *
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * prefixed with an underscore ('_') directly in your application code. These symbols
+ * are part of Azure SDK's internal implementation; we do not document these symbols
+ * and they are subject to change in future versions of the SDK which would break your code.
  */
 
 #ifndef _az_IOT_CORE_H
@@ -17,15 +22,6 @@
 #include <stdint.h>
 
 #include <_az_cfg_prefix.h>
-
-/**
- * @brief Azure IoT service MQTT connection properties.
- *
- * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
- * prefixed with an underscore ('_') directly in your application code. These symbols
- * are part of Azure SDK's internal implementation; we do not document these symbols
- * and they are subject to change in future versions of the SDK which would break your code.
- */
 
 enum
 {
@@ -68,7 +64,7 @@ typedef enum
  * @param[in] status The #az_iot_status to verify.
  * @return `true` if the status indicates success. `false` otherwise.
  */
-AZ_INLINE bool az_iot_is_success_status(az_iot_status status)
+AZ_NODISCARD AZ_INLINE bool az_iot_is_success_status(az_iot_status status)
 {
   return status < AZ_IOT_STATUS_BAD_REQUEST;
 }
@@ -80,7 +76,7 @@ AZ_INLINE bool az_iot_is_success_status(az_iot_status status)
  * @param[in] status The #az_iot_status to verify.
  * @return `true` if the operation should be retried. `false` otherwise.
  */
-AZ_INLINE bool az_iot_is_retriable_status(az_iot_status status)
+AZ_NODISCARD AZ_INLINE bool az_iot_is_retriable_status(az_iot_status status)
 {
   return ((status == AZ_IOT_STATUS_THROTTLED) || (status == AZ_IOT_STATUS_SERVER_ERROR));
 }
@@ -104,7 +100,7 @@ AZ_NODISCARD int32_t az_iot_retry_calc_delay(
     int32_t random_msec);
 
 /**
- * @brief _az_span_token is a string tokenizer for az_span.
+ * @brief String tokenizer for #az_span.
  *
  * @param[in] source The #az_span with the content to be searched on. It must be a non-empty
  * #az_span.
@@ -120,7 +116,7 @@ AZ_NODISCARD int32_t az_iot_retry_calc_delay(
 AZ_NODISCARD az_span _az_span_token(az_span source, az_span delimiter, az_span* out_remainder);
 
 /**
- * @brief _az_iot_u32toa_size gives the length, in bytes, of the string that would represent the given number.
+ * @brief Gives the length, in bytes, of the string that would represent the given number.
  *
  * @param[in] number The number whose length, as a string, is to be evaluated.
  * @return The length (not considering null terminator) of the string that would represent the given

--- a/sdk/iot/core/src/az_iot_core.c
+++ b/sdk/iot/core/src/az_iot_core.c
@@ -19,11 +19,11 @@ AZ_NODISCARD int32_t az_iot_retry_calc_delay(
     int32_t max_retry_delay_msec,
     int32_t random_msec)
 {
-  AZ_PRECONDITION_RANGE(0, operation_msec, INT32_MAX - 1);
-  AZ_PRECONDITION_RANGE(0, attempt, INT16_MAX - 1);
-  AZ_PRECONDITION_RANGE(0, min_retry_delay_msec, INT32_MAX - 1);
-  AZ_PRECONDITION_RANGE(0, max_retry_delay_msec, INT32_MAX - 1);
-  AZ_PRECONDITION_RANGE(0, random_msec, INT32_MAX - 1);
+  _az_PRECONDITION_RANGE(0, operation_msec, INT32_MAX - 1);
+  _az_PRECONDITION_RANGE(0, attempt, INT16_MAX - 1);
+  _az_PRECONDITION_RANGE(0, min_retry_delay_msec, INT32_MAX - 1);
+  _az_PRECONDITION_RANGE(0, max_retry_delay_msec, INT32_MAX - 1);
+  _az_PRECONDITION_RANGE(0, random_msec, INT32_MAX - 1);
 
   int32_t delay = _az_retry_calc_delay(attempt, min_retry_delay_msec, max_retry_delay_msec);
   

--- a/sdk/iot/core/src/az_iot_core.c
+++ b/sdk/iot/core/src/az_iot_core.c
@@ -8,74 +8,41 @@
 #include <az_result.h>
 #include <az_span.h>
 
+#include <az_retry_internal.h>
+
 #include <_az_cfg.h>
 
-AZ_NODISCARD az_result az_iot_get_status_from_uint32(uint32_t status_int, az_iot_status* status)
+AZ_NODISCARD int32_t az_iot_retry_calc_delay(
+    int32_t operation_msec,
+    int16_t attempt,
+    int32_t min_retry_delay_msec,
+    int32_t max_retry_delay_msec,
+    int32_t random_msec)
 {
-  switch (status_int)
+  AZ_PRECONDITION_RANGE(0, operation_msec, INT32_MAX - 1);
+  AZ_PRECONDITION_RANGE(0, attempt, INT16_MAX - 1);
+  AZ_PRECONDITION_RANGE(0, min_retry_delay_msec, INT32_MAX - 1);
+  AZ_PRECONDITION_RANGE(0, max_retry_delay_msec, INT32_MAX - 1);
+  AZ_PRECONDITION_RANGE(0, random_msec, INT32_MAX - 1);
+
+  int32_t delay = _az_retry_calc_delay(attempt, min_retry_delay_msec, max_retry_delay_msec);
+  
+  if (delay < 0) 
   {
-    case AZ_IOT_STATUS_OK:
-      *status = AZ_IOT_STATUS_OK;
-      break;
-    case AZ_IOT_STATUS_ACCEPTED:
-      *status = AZ_IOT_STATUS_ACCEPTED;
-      break;
-    case AZ_IOT_STATUS_NO_CONTENT:
-      *status = AZ_IOT_STATUS_NO_CONTENT;
-      break;
-    case AZ_IOT_STATUS_BAD_REQUEST:
-      *status = AZ_IOT_STATUS_BAD_REQUEST;
-      break;
-    case AZ_IOT_STATUS_UNAUTHORIZED:
-      *status = AZ_IOT_STATUS_UNAUTHORIZED;
-      break;
-    case AZ_IOT_STATUS_FORBIDDEN:
-      *status = AZ_IOT_STATUS_FORBIDDEN;
-      break;
-    case AZ_IOT_STATUS_NOT_FOUND:
-      *status = AZ_IOT_STATUS_NOT_FOUND;
-      break;
-    case AZ_IOT_STATUS_NOT_ALLOWED:
-      *status = AZ_IOT_STATUS_NOT_ALLOWED;
-      break;
-    case AZ_IOT_STATUS_NOT_CONFLICT:
-      *status = AZ_IOT_STATUS_NOT_CONFLICT;
-      break;
-    case AZ_IOT_STATUS_PRECONDITION_FAILED:
-      *status = AZ_IOT_STATUS_PRECONDITION_FAILED;
-      break;
-    case AZ_IOT_STATUS_REQUEST_TOO_LARGE:
-      *status = AZ_IOT_STATUS_REQUEST_TOO_LARGE;
-      break;
-    case AZ_IOT_STATUS_UNSUPPORTED_TYPE:
-      *status = AZ_IOT_STATUS_UNSUPPORTED_TYPE;
-      break;
-    case AZ_IOT_STATUS_THROTTLED:
-      *status = AZ_IOT_STATUS_THROTTLED;
-      break;
-    case AZ_IOT_STATUS_CLIENT_CLOSED:
-      *status = AZ_IOT_STATUS_CLIENT_CLOSED;
-      break;
-    case AZ_IOT_STATUS_SERVER_ERROR:
-      *status = AZ_IOT_STATUS_SERVER_ERROR;
-      break;
-    case AZ_IOT_STATUS_BAD_GATEWAY:
-      *status = AZ_IOT_STATUS_BAD_GATEWAY;
-      break;
-    case AZ_IOT_STATUS_SERVICE_UNAVAILABLE:
-      *status = AZ_IOT_STATUS_SERVICE_UNAVAILABLE;
-      break;
-    case AZ_IOT_STATUS_TIMEOUT:
-      *status = AZ_IOT_STATUS_TIMEOUT;
-      break;
-    default:
-      return AZ_ERROR_ITEM_NOT_FOUND;
+    delay = max_retry_delay_msec;
   }
 
-  return AZ_OK;
+  if (max_retry_delay_msec - delay > random_msec)
+  {
+    delay += random_msec;
+  }
+
+  delay -= operation_msec;
+
+  return delay > 0 ? delay : 0;
 }
 
-AZ_NODISCARD az_span az_span_token(az_span source, az_span delimiter, az_span* out_remainder)
+AZ_NODISCARD az_span _az_span_token(az_span source, az_span delimiter, az_span* out_remainder)
 {
   _az_PRECONDITION_VALID_SPAN(delimiter, 1, false);
   _az_PRECONDITION_NOT_NULL(out_remainder);

--- a/sdk/iot/core/tests/cmocka/test_az_iot_core.c
+++ b/sdk/iot/core/tests/cmocka/test_az_iot_core.c
@@ -16,16 +16,15 @@
 #include <az_test_precondition.h>
 #include <cmocka.h>
 
-static void az_span_token_success(void** state)
+static void test_az_span_token_success()
 {
-  (void)state;
   az_span span = AZ_SPAN_FROM_STR("abcdefgabcdefgabcdefg");
   az_span delim = AZ_SPAN_FROM_STR("abc");
   az_span token;
   az_span out_span;
 
   // token: ""
-  token = az_span_token(span, delim, &out_span);
+  token = _az_span_token(span, delim, &out_span);
   assert_non_null(az_span_ptr(token));
   assert_true(az_span_size(token) == 0);
   assert_true(az_span_ptr(out_span) == (az_span_ptr(span) + az_span_size(delim)));
@@ -34,7 +33,7 @@ static void az_span_token_success(void** state)
   // token: "defg" (span+3)
   span = out_span;
 
-  token = az_span_token(span, delim, &out_span);
+  token = _az_span_token(span, delim, &out_span);
   assert_true(az_span_ptr(token) == az_span_ptr(span));
   assert_int_equal(az_span_size(token), 4);
   assert_true(
@@ -45,7 +44,7 @@ static void az_span_token_success(void** state)
   // token: "defg" (span+10)
   span = out_span;
 
-  token = az_span_token(span, delim, &out_span);
+  token = _az_span_token(span, delim, &out_span);
   assert_true(az_span_ptr(token) == az_span_ptr(span));
   assert_int_equal(az_span_size(token), 4);
   assert_true(
@@ -56,7 +55,7 @@ static void az_span_token_success(void** state)
   // token: "defg" (span+17)
   span = out_span;
 
-  token = az_span_token(span, delim, &out_span);
+  token = _az_span_token(span, delim, &out_span);
   assert_true(az_span_ptr(token) == az_span_ptr(span));
   assert_int_equal(az_span_size(token), 4);
   assert_true(az_span_ptr(out_span) == NULL);
@@ -65,76 +64,12 @@ static void az_span_token_success(void** state)
   // Out_span is empty.
   span = out_span;
 
-  token = az_span_token(span, delim, &out_span);
+  token = _az_span_token(span, delim, &out_span);
   assert_true(az_span_is_content_equal(token, AZ_SPAN_NULL));
 }
 
-static void test_az_iot_get_status_from_uint32(void** state)
+static void test_az_iot_u32toa_size_success()
 {
-  (void)state;
-
-  az_iot_status status;
-
-  assert_int_equal(az_iot_get_status_from_uint32(200, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_OK, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(202, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_ACCEPTED, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(204, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_NO_CONTENT, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(400, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_BAD_REQUEST, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(401, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_UNAUTHORIZED, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(403, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_FORBIDDEN, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(404, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_NOT_FOUND, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(405, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_NOT_ALLOWED, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(409, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_NOT_CONFLICT, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(412, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_PRECONDITION_FAILED, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(413, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_REQUEST_TOO_LARGE, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(415, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_UNSUPPORTED_TYPE, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(429, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_THROTTLED, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(499, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_CLIENT_CLOSED, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(500, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_SERVER_ERROR, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(502, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_BAD_GATEWAY, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(503, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_SERVICE_UNAVAILABLE, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(504, &status), AZ_OK);
-  assert_int_equal(AZ_IOT_STATUS_TIMEOUT, status);
-
-  assert_int_equal(az_iot_get_status_from_uint32(999, &status), AZ_ERROR_ITEM_NOT_FOUND);
-}
-
-static void _az_iot_u32toa_size_success(void** state)
-{
-  (void)state;
   assert_int_equal(_az_iot_u32toa_size(0), 1);
   assert_int_equal(_az_iot_u32toa_size(9), 1);
   assert_int_equal(_az_iot_u32toa_size(10), 2);
@@ -145,7 +80,7 @@ static void _az_iot_u32toa_size_success(void** state)
   assert_int_equal(_az_iot_u32toa_size(1999), 4);
   assert_int_equal(_az_iot_u32toa_size(10000), 5);
   assert_int_equal(_az_iot_u32toa_size(19999), 5);
-  assert_int_equal(_az_iot_u32toa_size(100000), 6);  
+  assert_int_equal(_az_iot_u32toa_size(100000), 6);
   assert_int_equal(_az_iot_u32toa_size(199999), 6);
   assert_int_equal(_az_iot_u32toa_size(1000000), 7);
   assert_int_equal(_az_iot_u32toa_size(1999999), 7);
@@ -157,13 +92,65 @@ static void _az_iot_u32toa_size_success(void** state)
   assert_int_equal(_az_iot_u32toa_size(4294967295), 10);
 }
 
+static void test_az_iot_is_success_status_translate_success()
+{
+  assert_true(az_iot_is_success_status(AZ_IOT_STATUS_OK));
+  assert_true(az_iot_is_success_status(AZ_IOT_STATUS_NO_CONTENT));
+  assert_true(az_iot_is_success_status(0));
+  assert_true(az_iot_is_success_status(350));
+
+  assert_false(az_iot_is_success_status(AZ_IOT_STATUS_BAD_REQUEST));
+  assert_false(az_iot_is_success_status(AZ_IOT_STATUS_TIMEOUT));
+  assert_false(az_iot_is_success_status(600));
+}
+
+static void test_az_iot_is_retriable_status_translate_success()
+{
+  assert_true(az_iot_is_retriable_status(AZ_IOT_STATUS_THROTTLED));
+  assert_true(az_iot_is_retriable_status(AZ_IOT_STATUS_SERVER_ERROR));
+
+  assert_false(az_iot_is_retriable_status(AZ_IOT_STATUS_OK));
+  assert_false(az_iot_is_retriable_status(AZ_IOT_STATUS_UNAUTHORIZED));
+}
+
+static void test_az_iot_retry_calc_delay_common_timings_success()
+{
+  assert_int_equal(2229, az_iot_retry_calc_delay(5, 1, 500, 100000, 1234));
+  assert_int_equal(321, az_iot_retry_calc_delay(5000, 1, 500, 100000, 4321));
+
+  // Operation already took more than the back-off interval.
+  assert_int_equal(0, az_iot_retry_calc_delay(10000, 1, 500, 100000, 4321));
+
+  // Max retry exceeded.
+  assert_int_equal(9995, az_iot_retry_calc_delay(5, 5, 500, 10000, 4321));
+}
+
+static void test_az_iot_retry_calc_delay_overflow_time_success()
+{
+  assert_int_equal(
+      0,
+      az_iot_retry_calc_delay(
+          INT32_MAX - 1, INT16_MAX - 1, INT32_MAX - 1, INT32_MAX - 1, INT32_MAX - 1));
+
+  assert_int_equal(
+      INT32_MAX - 1,
+      az_iot_retry_calc_delay(0, INT16_MAX - 1, INT32_MAX - 1, INT32_MAX - 1, INT32_MAX - 1));
+}
+
+#ifdef _MSC_VER
+// warning C4113: 'void (__cdecl *)()' differs in parameter lists from 'CMUnitTestFunction'
+#pragma warning(disable : 4113)
+#endif
 
 int test_az_iot_core()
 {
   const struct CMUnitTest tests[] = {
-    cmocka_unit_test(az_span_token_success),
-    cmocka_unit_test(test_az_iot_get_status_from_uint32),
-    cmocka_unit_test(_az_iot_u32toa_size_success)
+    cmocka_unit_test(test_az_span_token_success),
+    cmocka_unit_test(test_az_iot_u32toa_size_success),
+    cmocka_unit_test(test_az_iot_is_success_status_translate_success),
+    cmocka_unit_test(test_az_iot_is_retriable_status_translate_success),
+    cmocka_unit_test(test_az_iot_retry_calc_delay_common_timings_success),
+    cmocka_unit_test(test_az_iot_retry_calc_delay_overflow_time_success),
   };
   return cmocka_run_group_tests_name("az_iot_core", tests, NULL, NULL);
 }

--- a/sdk/iot/doc/mqtt_state_machine.md
+++ b/sdk/iot/doc/mqtt_state_machine.md
@@ -75,7 +75,7 @@ Recommended defaults:
 
 #### MQTT Clean Session
 
-We recommend to always use Clean Session false when connecting to IoT Hub.
+We recommend to always use [Clean Session](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718030) false when connecting to IoT Hub.
 Connecting with Clean Session true will remove all enqueued C2D messages.
 
 ### Subscribe to topics

--- a/sdk/iot/doc/mqtt_state_machine.md
+++ b/sdk/iot/doc/mqtt_state_machine.md
@@ -61,7 +61,7 @@ if(az_failed(az_iot_hub_client_sas_get_signature(client, unix_time + 3600, signa
     // error.
 }
 
-// Base64Encode the HMAC256 of the az_span_ptr(signature)/az_span_len(signature) with the Shared Access Key.
+// Application will Base64Encode the HMAC256 of the az_span_ptr(signature) containing az_span_size(signature) bytes with the Shared Access Key.
 
 if(az_failed(az_iot_hub_client_sas_get_password(client, base64_hmac_sha256_signature, NULL, password, password_size, &password_length)))
 {
@@ -92,7 +92,7 @@ if(az_failed(az_iot_hub_client_c2d_get_subscribe_topic_filter(client, topic, top
 }
 ```
 
-_Note:_ If the MQTT stack allows, it is recommended to subscribe prior to connecting.
+__Note:__ If the MQTT stack allows, it is recommended to subscribe prior to connecting.
 
 ### Sending APIs
 

--- a/sdk/iot/doc/mqtt_state_machine.md
+++ b/sdk/iot/doc/mqtt_state_machine.md
@@ -25,11 +25,11 @@ For more information about Azure IoT services using MQTT see [this article](http
 
 ### IoT Hub
 
-![iot_hub_flow](https://www.plantuml.com/plantuml/png/0/dLTTRzis57tNhxXlJOTvAuAbG8qYgE84SzQayM8L650K12tTM4GaKYMff5wn_pvI7vRZYgBbF1W1UUwvXuVKvUK7fQdKPPu5WNfalA2Ivc36DCAF0CpV1OqVrrAKF9c9JCZtxyF5ulmSpE_DzIoChky-zSEMqVtdMMIGD_G9UO8o-C-ag8XZYo2nI1XVDrdgYUNbHn8khlT6BiCe97SNVrtD8kXuTq0xMiZixl8A6f4suokuvam7Ntxv2fF9ET1_2HEQfEMAn1b3hWapqrDOHk5z5FJFGczSgL0IJdCaQzI1PxwVWYMEs7gY2YgAZCLKCy59_arhunhd61l5_vozUGUp2WzXgTCf55IfPo4JO0emB_IciTl5iRN9c7HNs6cQmJ9SWXQFo66D76KLDHsM-DESeeeejkPKbx9U_hJYfKPcS0XyR-5fJkFJixT1pvXRGEk6m-9zI7qwN4wzD9TsBlLOt2hRSJV237FKSXCuC_GVJjq6ag9SPKobH8k2nOsdMrg8AOSLWZbp2Jp_Ba2LAnLBjh8Vc1P0-GQgmD-2SJbwJMbWTc6pqyknIufF4zBAmoRL0ykq-LhwTseue5_Y5cz5tg9EHQB62ithi75Y_K5UmMvIYQeGNE4H6nKzCpxwy9cOBkSe6muDzPjnXEI2wZWzGgylpYisS4yEwJNKF-zeC0RisVxZPDLs72pC0VUN497dWaDde-FIwZItXNLeMJqv9SR8dj3KpTk_emWojkgI9e4hRQEqg-OENClUzaS_mAwDPjdAD4QGc1gxDcXJZbFAampbjEfVt6s9hNeDPzAuQNepPUNVDyEm-7nnSxsSGuvAqJLMZ2EOXikU8paN6WmZICoC3uaZvo39OBLn9cqeFOdTB3QhjRjcixWjLNEHZRNFlMtVIbJsWhP6nUOCG4jGvUYkfEbHzhbtRITrFT2JtHkx_-tKi_MntMcwdPZjfr9bSw8yXyzrqxKELXVQw3FWlUQCSzNH-FCg0Y5X4KQpUUTV_PuG4SpB5TJXKzUZOGeJQCTJeRHz2WnX4tnYCPg-El0-9dQehI3RZ4Qs6LN1ORtu14hElXFDUXNjTyOMVq4LlltZP7uRpYRBUMZQsvCjwQ-mJAd498nZKuS-ukRrwo0OsyfEUZQcaA90gHcgRTNrdTsTvw4FQtCs_rhJ3u5NMtXKVtPWCX-5TQ4SS6Et-WnQyR9C-SmVrOhiBNLik-1roXlD7aXUJJ-XLARkkErw-UKF6hPV9Ap8PgVqfi038tpBUW5lDliGw7Qbho3i2YumRZhN1se-os3WPMioeJGCvFlPctT4orAPEv588VHmr9T6JXKMsxFoOB7ujVUTRYCUSGCdETtOf-epqwcfi-RTEb_UceBn0NbIvjd_ "iot_hub_flow")
+![iot_hub_flow](https://www.plantuml.com/plantuml/svg/0/dLTjRzis4FxENt7VbWnpLmHBWHf5KCK9vgp9uiOgCA0e15gwM4GaKYMff5wn_pvIBvRjY7fnFXY1U7VFmuV7uzr7fQdKUPeGefuOpwYaAPXl6k4d0VDtISEdjHGvZsOY4VB31s-nkBW0ytjxC_Fyc_k_sysM_iENcMyiR-apyWWb-Sz05853Qn648c9yNQ6K2ykhJu6tk3duSkNvNd1_-TVrp8ScxexH3fTWTdzr3HL9Y_WBt72coTTVly5aSW7qtu097SJvAWWJXbm7p2nFOUbx3pvfNuLMlpNg85Se0qvJ93thxX0rJaHwreiGMPQma6ecU91-rsPLS8wXuV_F-TltC2jimSjrF8MCAlKYP0HC0QQPtbJYks9iHJEItMTscIQmz9QWnHDoM2D7MNXD1p5zPQAeAimKMtEgSuamBS9JmvOCCJ_OVvpIyEpy7MdvrasW5eRqcvGfun9iNsFQYDMYTCriHsGV4qnHomrn8hHdhAuTIwxvAc4g3hJ8M6WuRSD2I3ci44mIHl3okm2LhrGesShUEYs0yWqKJc_8E8nMKIeJkx7PsTNOBOLdKNdQ5KKieO97bcXJESOwj5FSsbgITwXZ4QcnHDFIRHpPVgTUmkwW4bKckC8Z3if_ONnqyXcVVSp1CWnrxHVZ2CePrM5y1Dy-lrwonBtOnJSIOPxMfNNlMCbeZvv4E8vW8ymWTWxp_c8YqbHmQ0Hrl68Dvxh4Tcsh1LDYYEpPlaftdtqV4hPgG2FYWgsODdNTOLT7hzkdds3tHfDaPVecY4orNHjhKvXZogC4vRHeRznTYwr_fbSpzwYA76qVW8Vg0oo-NDxUBEUGeb9qZKN44P6w2w03d0iD9Y98J8mEaGEpCqXdpZb1gv0zmEue5jNANKQpTjjGrPCsLZxNiKdydgEoxOCLAZGv0BLhWT4yJjEZv7EVsWvq-Q45lTVtyEwKgsNQxlJaJfljLIdGd5QToUT-yse5YwTjT0xqFdX6kI8r_hpsGKXOUFvitkXNZXl2Xtc-Wj9zwfeffZ21-diib7PC4LlR29zPY7PEC1Ysq_Hjfwd8i4PxKZQc0Vx8MDd51vW9Kv0rQuKzR8HjX4kgyDqV9_CxRpPPpZtJpPvi8Nw3PKmbHbuOccBp2JUdfmEZFk6cdA38s4Ptqd9OcHGPIirGRIjnNpxlJ9HzjXQp-hTzO7jjxjfQVoOF1EiBOLN8EzJOhKYTKkoNhZxnn_Se1_iTsqSSkhlskt-TEtTyUFCjG2MrtcGuqAFZ15-RLwSrnFGPfJBts9O3hwcYmBXfIX-fkOQaOt0rI2XDXE37-TltWPQvCWzT88NGtLvVApg5MsWF-z7QuhVMCRowtt2IqesTH5-OZatnD6FfV7btIiX7v56U9ly3 "iot_hub_flow")
 
 ### Device Provisioning Service
 
-![iot_provisioning_flow](https://www.plantuml.com/plantuml/png/0/fLTXRzCy4FwUNt5yeaCK8VI2z5OmaNMJjXVshYn1GaB8SfDhQfROmNRA2kA_SqwJDkhI9ktsePFivvwxUto-SzuRoxKjijJpp9sGETSy0rgp2ByzeByp7jqbMXKo7gjKwRTl_Sdaz1Jez-FLs0-lRlvlXmNXxUTnICYFV84oHktz8HSbSUGGB5Ana4dbPRKHd7zW_kHgQ-NS3trsS_RVnJY43My3r8Y5ZM_EBw0Aqdby2bTIME_hisym79u2_yM4iYpNQY6CK98YO54gK5ec23U28FHlGwy3raLL6DHCyWnPWjRh2-mCC2vH8_Zo-kM_m0ixh_JaUPwAY5k2i-o7jIIjb1ZPjGxTfANh7JHEn9lSBVCK0Zy0g-vGGe8ITOaUzN6mDpN33JCYaTmM6giidQSooOFijlAOPpnwzVgDrxBM8wIS6_DJwRZh6BUnU-Mar6fio_dLmTL7Hze7nTH4MapHsqdPKJaQ4s4ibPgfgPXLkOZOJAHkkIEz7kRj6Q_nkmfr3TYKwcv8cmUD4Oe5agRNdy8GKZ65jK7inBkjOjzBt5Ezl9YcmiohvFkAzi2gNQiAjakfQdjJ5pjmjI1rd_uD94AfpUJp6LIxSTayU_J46by5d_DbgdXC_xN1qKDQc6cLmLHJVz0mY59LnA0qNCG9dfGkZtJL-uGqcbn9WuzsvhGPWLGMckQKQ4ggKs5rycy5r21r1rSOUFSEg0jGxwfEus2svj775DTom_rammq38QEqA4SjQgsqEMbCpeSSTNsL8JtOxJW7Acwcycegi5KmBRUc8zr-BFjlKJdv9ysZMv6FEaVx28QGf6hAKqRFbbm9sfWhOzsKxcLC0yz457ylyEfegrH5sR7St0lTX3NUWHDpk9hC3EzpKL4MKjmpAoXqxzZhiEAbzKSnL2lhldL8jJSUVGVPER-hyZdSJkEF0erxlXnZQ_MIyLavTWutRbH4ATOZEOISAPrrFzJQg5wy6Aux2PiNqrutOHTHZ0iHuH6AEkFlXbAfY-W8-xBtkMyEFDuwGsDuilygRJy5tN6SSODl_XbSNllZON3fq_DkiBwwpo6OSusn7qN4_W6N9oTx-NisnwqIfhRYRrebK4z3FUFaqTlpIgNBWtf1OjpJzmQpkY1bOgQLilkjlbQXbcOHQYjc3elVlBQHjNLTMfx23dE7InXaP43FjP_2peK4Bk4ok2QrtbEVfW_Olm00 "iot_provisioning_flow")
+![iot_provisioning_flow](https://www.plantuml.com/plantuml/svg/0/hLTHRziu37xNhz3RaiCo70xRW0L3CJSjq6xhDTTum81X41IBSOJOaYV9MRFX_lient6onedjP7q82fFyI7waAEgTTTouF4q8iGkfCcvuIl6R0_gJKFoxvD4YDZfNOgGJRTw-3SRZYmkAlnzlHq5uU_zllTeaVFWq2b7p8r-24c38_-YY08wy1ekqa2eklQm5awiFB1ZVFlbo5OG1kxzyVpqAwHPtHsad5ZQwlxgcPP3UupDwgwGZN_xwIWU32yf_CAaTounUIYkrmWXOb4XGZadK6z9963o4f46j2Ie6nt8BXYcU0cchs0Pr4uIWG_hvrTzlAC_TlAILPraY8-xGYgNV72fhfI1o5HsjiOj03g1vIkyp_vadT19CgDCBK3G61QRG7dRmSpHVossXRsMikCiDOCxUOP5o9xidwSnJ7ltpwZMf-TOof8nR-rqRGJhe7cKLKwimzwkv2MvJI2p199_QoCWfa8EG3Ura89RMOUyLN6tWcDEPZDXC9YWYvvdNPrpf7chRIg7AzzaHdLeV1YAGIzymT_-58Ktab5OMmjFtK4PFcf1R4f3bqqJQ-JfzSf9LVIQbof-4BCavH7-9i6ss0teRZZStma-Al1PqZpzTqb8gYZ7TOlhYnMDXWodADk9Ae62LQ2w6-z1qPdHAfmRdZw6zAD6veDhGQn53lt1xXhlMnJTWCwqi_167dgSXLThHNGXCEC4AODys-DWBgXtfEYidD_ELpYrfbyjJioPdM_r8fra2hf6pVOiTbYeXhOGzcqSHMEkxOCPbWgE_VwAFtMuNIF_gDuzI-GB5IBFTMKFsRJP7g8XXJzh0rxSSpAhajcR6DEHrtFhuh2dMfl5k1wv1XurxqP0EQ9peAKyOxdoPbYYOQ-kQzg3AM0fc8oIwbVAwtylooMAk-_qWz0k99HqtYy5waM7mcCaICbVoaJc9ePDpJlOQk-5UQ8LI_b-Dv2wZO6TpxcJd_PPpeRFTzd19SOxrgVuDE3m4VEO55d0l4YU1x7GPIlBa-46eGtdnOa1nlSDsmzhEyschGt48IC1IHd02fTuOZ5c_lKvo3O_El-K4EnEci4vnVFBu300iIhJmskTGuSytzbUQaIxBl6-CIsxXzSlUpLqm6ank0bpGUzL0UKudSsv01CM5z05M_NvN-0Mirkz7SlgOtpk4E2A3xTZ7YmnvcN6CaHnvcU000BD40X_nnOcivyYcO4PhTzpgInbaOHQ1SNBcTU4hgRjUVpkkjM-paXNQIz405_JlqitnAkQAtapk-eIymzxCq-GN "iot_provisioning_flow")
 
 ## Porting the IoT Clients
 
@@ -47,7 +47,7 @@ Optionally, the IoT services support MQTT tunneling over WebSocket Secure which 
 ### Connecting
 
 The application code is required to initialize the TLS and MQTT stacks.
-Two authentication schemes are currently supported: _X509 Client Certificate Authentication_ and _Shared Access Signature_ authentication. 
+Two authentication schemes are currently supported: _X509 Client Certificate Authentication_ and _Shared Access Signature_ authentication.
 
 When X509 client authentication is used, the MQTT password field should be an empty string.
 
@@ -61,13 +61,22 @@ if(az_failed(az_iot_hub_client_sas_get_signature(client, unix_time + 3600, signa
     // error.
 }
 
-// Base64Encode the HMAC256 of the az_span_ptr(signature) with the Shared Access Key.
+// Base64Encode the HMAC256 of the az_span_ptr(signature)/az_span_len(signature) with the Shared Access Key.
 
 if(az_failed(az_iot_hub_client_sas_get_password(client, base64_hmac_sha256_signature, NULL, password, password_size, &password_length)))
 {
     // error.
 }
 ```
+
+Recommended defaults:
+    - MQTT Keep-Alive Interval:  `AZ_IOT_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS`
+    - MQTT Clean Session: false.
+
+#### MQTT Clean Session
+
+We recommend to always use Clean Session false when connecting to IoT Hub.
+Connecting with Clean Session true will remove all enqueued C2D messages.
 
 ### Subscribe to topics
 
@@ -77,13 +86,13 @@ _Example:_
 
 ```C
 
-if(az_failed(az_iot_hub_client_c2d_get_subscribe_topic_filter(client, mqtt_topic_filter, &mqtt_topic_filter))
+if(az_failed(az_iot_hub_client_c2d_get_subscribe_topic_filter(client, topic, topic_size, NULL))
 {
     // error.
 }
-
-// Use az_span_ptr(mqtt_topic_filter) and az_span_len(mqtt_topic_filter).
 ```
+
+_Note:_ If the MQTT stack allows, it is recommended to subscribe prior to connecting.
 
 ### Sending APIs
 
@@ -93,13 +102,13 @@ The application is responsible for filling in the MQTT payload with the format e
 _Example:_
 
 ```C
-if(az_failed(az_iot_hub_client_telemetry_get_publish_topic(client, NULL, mqtt_topic, &mqtt_topic)))
+if(az_failed(az_iot_hub_client_telemetry_get_publish_topic(client, NULL, topic, topic_size, NULL)))
 {
     // error.
 }
-
-// Use az_span_ptr(mqtt_topic) and az_span_len(mqtt_topic) to create an MQTT Publish message.
 ```
+
+__Note:__ To limit overheads, when publishing, it is recommended to serialize as many MQTT messages within the same TLS record. This feature may not be available on all MQTT/TLS/Sockets stacks.
 
 ### Receiving APIs
 
@@ -145,6 +154,8 @@ _Example:_
         }
     }
 ```
+
+__Important:__ C2D messages are not enqueued until the device establishes the first MQTT session (connects for the first time to IoT Hub). The C2D message queue is preserved (according to the per-message time-to-live) as long as the device connects with Clean Session `false`.
 
 ### Retrying Operations
 
@@ -229,7 +240,7 @@ else
 
 Combining the functions above we recommend the following flow:
 
-![iot_retry_flow](https://www.plantuml.com/plantuml/png/0/bLN1QiCm3BtxAtGR3F83PPHsWR50QKkQdSO8Rk9cfguTRAVGZVtxx2u9JQEaQmuvw3tvINeMdXbBjQqEWfWzboNLz00kP1by4t3VCytsXLQLp4Cbb7vwcg_Nqocu_o8AvqcqMkAqJHA_XObZBkYHoPnfdFOoZnQEjD9K5epy4FB--051C8L89UbQgoCtN4akYpHc1JVMdVDNtI0ETOc4FC0b0M9cDQTRmO1fhRGXmqVu0Zg8RdBJ7UMYqgokOfpKj4V6QNsvZ8gi4auWpPcW9p86zhDfMTPvI94js8m9HszuC5RG10AWNobNzjpgwOp_en6VTqu8wCvhNFktL39ePmVtk2VhKcuwY19n5r5gNpfMNYKDDSkPj9mAW-dsMO3QW_3ky6aWss_S1AG2PJ_TzB8M9ZTcxD7NQfkkIgQfTGntpARACcRChXAT3Y-MjfjniQmEm7Uqc-6LVMJ8K1HhFKJHziphlKDYBVTwopgnfgrE41yQ9ZAsGlMaa6t0vpHs-GVnpho6h_hm_PWuAuEoWGYPkJV0FJA_ "iot_retry_flow")
+![iot_retry_flow](https://www.plantuml.com/plantuml/svg/0/bPNDQkCm4CVlUegvBHIy3n1AQ3RBie7G13TxMefHd6agwaf6abEwfUzUsObSoHedsnnya7xpd-_enbYkRVDSCVCaPCqrVmPtP17U6BZV3ru-xRLgv6wkAgMlhsVhzNGAxhjSp6URnUgMnkus-P_vnf5BVa2vGqrZlsQBfODMciizidV6_bxTGvPDOQtLGHYXf91xTWmeF08Vo1lhX8z4ZdjXBEhY9nv4YHxgY6-nVOvM2xwj451hfKt7UES3dT15A59eBr8yS54r6dr2dS4mcc5QgNbdTXv9LKfUbKtbOYjsMF7NL6C0f0gyhWDR8iyU20jA4rJzO09j7fT3cq3cI5ChQV1xPvBn1tkQdKk6_5yXbEqgzjhT1pbH4t2hPDQN5_wlO_Ba8EqQKJKIZYRaCfw6aAlMKp7Nk4Df1Q_CcF-KXD7-4UoN6ZbYtoxK1AG2PHzHGzbVitTWB6f7Yo_KflZTR9t9NLEMQ0mxhRw_-DpwpvpTUR6gKNFhbA8C_Jf713lDGYj7_Wd4Ujx-NDV9-wZH9D5hKnjCdFSyjQ_HULY4w28jHzHImkcvpGegIImJNSTB6pJA9FKStvVZrEMOrNx0sfV5pz1menowsbek94Xy2KRK3T-DUxdSq_W1 "iot_retry_flow")
 
 When devices are using IoT Hub without Provisioning Service, we recommend attempting to rotate the IoT Credentials (SAS Token or X509 Certificate) on authentication issues.
 

--- a/sdk/iot/doc/resources/iot_hub_flow.puml
+++ b/sdk/iot/doc/resources/iot_hub_flow.puml
@@ -83,11 +83,10 @@ state application_mqtt_receive <<APP>> {
 az_iot_hub_client_init : - iot_hub_hostname
 az_iot_hub_client_init : - device_id
 
-az_iot_hub_client_get_user_name : - iot_hub
-
 ' SAS Tokens
-az_iot_hub_client_sas_get_signature : - unix_time
+az_iot_hub_client_sas_get_signature : - token_expiration_epoch_time
 az_iot_hub_client_sas_get_password: - Base64(HMAC-SHA256(signature, SharedAccessKey))
+az_iot_hub_client_sas_get_password: - key_name
 
 az_iot_hub_client_telemetry_get_publish_topic : - az_iot_hub_client_properties
 
@@ -104,7 +103,6 @@ az_iot_hub_client_c2d_request : - az_iot_hub_client_properties
 az_iot_hub_client_twin_document_get_publish_topic : - request_id
 
 az_iot_hub_client_twin_patch_get_publish_topic : - request_id
-az_iot_hub_client_twin_patch_get_publish_topic : - if_match_version
 
 state az_iot_hub_client_twin_response <<STRUCT>>
 az_iot_hub_client_twin_response : - response_type

--- a/sdk/iot/doc/resources/iot_provisioning_flow.puml
+++ b/sdk/iot/doc/resources/iot_provisioning_flow.puml
@@ -14,26 +14,27 @@ state color_coding {
 ' Init
 [*] --> az_iot_provisioning_client_init: START
 az_iot_provisioning_client_init --> az_iot_provisioning_client_get_user_name
-az_iot_provisioning_client_get_user_name --> az_iot_provisioning_get_client_id : X509 auth
+az_iot_provisioning_client_get_user_name --> az_iot_provisioning_client_get_client_id : X509 auth
 state application_mqtt_connect <<APP>>
-az_iot_provisioning_get_client_id --> application_mqtt_connect
+az_iot_provisioning_client_get_client_id --> application_mqtt_connect
 
 ' Optional SAS token generation:
-az_iot_provisioning_get_client_id -> az_iot_provisioning_client_get_sas_signature : SAS auth
-az_iot_provisioning_client_get_sas_signature -> application_hmac256
-application_hmac256 -> az_iot_provisioning_client_get_sas_password
-az_iot_provisioning_client_get_sas_password --> application_mqtt_connect : password
+az_iot_provisioning_client_get_client_id -> az_iot_provisioning_client_sas_get_signature : SAS auth
+az_iot_provisioning_client_sas_get_signature -> application_hmac256
+application_hmac256 -> az_iot_provisioning_client_sas_get_password
+az_iot_provisioning_client_sas_get_password --> application_mqtt_connect : password
 state application_hmac256 <<APP>>
 
 ' Subscribe
 application_mqtt_connect --> az_iot_provisioning_client_register_get_subscribe_topic_filter
 az_iot_provisioning_client_register_get_subscribe_topic_filter --> application_mqtt_subscribe
 state application_mqtt_subscribe <<APP>>
-application_mqtt_subscribe -> application_mqtt_receive : MQTT lib subscribed
+'application_mqtt_subscribe --> application_mqtt_receive : MQTT lib subscribed
 
 ' Register
 application_mqtt_subscribe --> az_iot_provisioning_client_register_get_publish_topic
 az_iot_provisioning_client_register_get_publish_topic --> application_mqtt_publish
+az_iot_provisioning_client_register_get_publish_topic --> application_mqtt_receive
 state application_mqtt_publish <<APP>>
 
 state application_mqtt_receive <<APP>> { 
@@ -42,8 +43,11 @@ state application_mqtt_receive <<APP>> {
     az_iot_provisioning_client_parse_received_topic_and_payload --> az_iot_provisioning_client_register_response
     az_iot_provisioning_client_parse_received_topic_and_payload --> [*] : not provisioning related
 
-    az_iot_provisioning_client_register_response --> [*] : status == assigned
-    az_iot_provisioning_client_register_response --> application_delay : status != assigned (including errors)
+    az_iot_provisioning_client_register_response --> az_iot_provisioning_client_parse_operation_status
+
+    az_iot_provisioning_client_parse_operation_status --> az_iot_provisioning_client_operation_complete
+    az_iot_provisioning_client_operation_complete --> [*] : operation complete (success or failure)
+    az_iot_provisioning_client_operation_complete --> application_delay : operation in progress
     state application_delay <<APP>>
     application_delay --> az_iot_provisioning_client_query_status_get_publish_topic
     az_iot_provisioning_client_query_status_get_publish_topic --> application_mqtt_publish
@@ -55,7 +59,7 @@ az_iot_provisioning_client_init : - id_scope
 az_iot_provisioning_client_init : - registration_id
 
 ' SAS Tokens
-az_iot_provisioning_client_get_sas_signature : - token_expiration_unix_time
+az_iot_provisioning_client_sas_get_signature : - token_expiration_unix_time
 
 az_iot_provisioning_client_parse_received_topic_and_payload : - topic
 az_iot_provisioning_client_parse_received_topic_and_payload : - payload
@@ -63,20 +67,21 @@ az_iot_provisioning_client_parse_received_topic_and_payload : - payload
 state az_iot_provisioning_client_register_response <<STRUCT>>
 az_iot_provisioning_client_register_response : - status
 az_iot_provisioning_client_register_response : - operation_id
+az_iot_provisioning_client_register_response : - operation_status
 az_iot_provisioning_client_register_response : - retry_after_seconds
-az_iot_provisioning_client_register_response : - registration_state
-az_iot_provisioning_client_register_response : - registration_information:
+az_iot_provisioning_client_register_response : - registration_result:
 az_iot_provisioning_client_register_response : ..- assigned_hub_hostname
 az_iot_provisioning_client_register_response : ..- device_id
-az_iot_provisioning_client_register_response : ..- status
+az_iot_provisioning_client_register_response : ..- error_code
 az_iot_provisioning_client_register_response : ..- extended_error_code
 az_iot_provisioning_client_register_response : ..- error_message
 az_iot_provisioning_client_register_response : ..- error_tracking_id
 az_iot_provisioning_client_register_response : ..- error_timestamp
 
-az_iot_provisioning_client_get_sas_password: - Base64(HMAC-SHA256(signature, SharedAccessKey))
+az_iot_provisioning_client_sas_get_password: - Base64(HMAC-SHA256(signature, SharedAccessKey))
+az_iot_provisioning_client_sas_get_password: - key_name
 
-az_iot_provisioning_client_query_status_get_publish_topic : - request_id
+az_iot_provisioning_client_query_status_get_publish_topic : - operation_id
 
 ' Application interfaces
 application_mqtt_connect : - server_x509_trusted_root

--- a/sdk/iot/doc/resources/iot_retry_flow.puml
+++ b/sdk/iot/doc/resources/iot_retry_flow.puml
@@ -5,42 +5,52 @@ skinparam state {
     BackgroundColor<<FAIL>> Orange
 }
 
-[*] --> IoT_Provisioning_Register
-state IoT_Provisioning_Register <<APP>>
+[*] --> Provisioning
+state Provisioning <<APP>> {
 
-' Provisioning Retriable errors
-IoT_Provisioning_Register --> Provisioning_retriable_failure
-state Provisioning_retriable_failure<<FAIL>>
-Provisioning_retriable_failure --> Provisioning_calculate_delay
-Provisioning_calculate_delay --> Provisioning_app_delay
-state Provisioning_app_delay<<APP>>
-Provisioning_app_delay --> IoT_Provisioning_Register
-Provisioning_calculate_delay: - az_iot_retry_calc_delay
-Provisioning_calculate_delay: - retry-after
+    state Register_Device <<APP>>
+    ' Provisioning Retriable errors
+    [*] --> Register_Device
 
-' Provisioning Non-retriable 
-IoT_Provisioning_Register --> Provisioning_not_retriable_failure
-state Provisioning_not_retriable_failure<<FAIL>>
-Provisioning_not_retriable_failure --> Provisioning_Rotate_Credentials
-state Provisioning_Rotate_Credentials <<APP>>
-Provisioning_Rotate_Credentials --> IoT_Provisioning_Register
-Provisioning_Rotate_Credentials --> [*] : no other credential
+    state Provisioning_retriable_failure<<FAIL>>
+    Register_Device --> Provisioning_retriable_failure
+    Provisioning_retriable_failure --> Provisioning_calculate_delay
+    Provisioning_calculate_delay --> Provisioning_app_delay
+    state Provisioning_app_delay<<APP>>
+    Provisioning_app_delay --> Register_Device : retry
+    Provisioning_calculate_delay: - response.retry-after
+    Provisioning_calculate_delay: - az_iot_retry_calc_delay
+    
+    ' Provisioning Non-retriable 
+    Register_Device --> Provisioning_not_retriable_failure
+    state Provisioning_not_retriable_failure<<FAIL>>
+    Provisioning_not_retriable_failure --> Provisioning_Rotate_Credentials
+    state Provisioning_Rotate_Credentials <<APP>>
+    Provisioning_Rotate_Credentials --> Register_Device : retry
+    Provisioning_Rotate_Credentials --> [*] : no other credential
+} 
 
-IoT_Provisioning_Register --> IoT_Hub_Operation : Successful Provisioning
-state IoT_Hub_Operation <<APP>>
+Provisioning --> IoT_Hub : Success
 
-' Hub Retriable errors
-IoT_Hub_Operation --> Hub_retriable_failure
-state Hub_retriable_failure<<FAIL>>
-Hub_retriable_failure --> Hub_calculate_delay
-Hub_calculate_delay --> Hub_app_delay
-state Hub_app_delay<<APP>>
-Hub_app_delay --> IoT_Hub_Operation
-Hub_calculate_delay: - az_iot_retry_calc_delay
+state IoT_Hub <<APP>> {
+    state Hub_Operation <<APP>>
+    [*] --> Hub_Operation
 
-' Hub Non-retriable 
-IoT_Hub_Operation --> Hub_not_retriable_failure
-state Hub_not_retriable_failure<<FAIL>>
-Hub_not_retriable_failure --> IoT_Provisioning_Register : Re-provision
+    ' Hub Retriable errors
+    Hub_Operation --> Hub_retriable_failure
+    state Hub_retriable_failure<<FAIL>>
+    Hub_retriable_failure --> Hub_calculate_delay
+    Hub_calculate_delay --> Hub_app_delay
+    state Hub_app_delay<<APP>>
+    Hub_app_delay --> Hub_Operation : retry
+    Hub_calculate_delay: - az_iot_retry_calc_delay
+
+    ' Hub Non-retriable 
+    Hub_Operation --> Hub_not_retriable_failure
+    state Hub_not_retriable_failure<<FAIL>>
+    Hub_not_retriable_failure --> [*] : Re-provision
+}
+
+IoT_Hub --> Provisioning : Obtain new credentials
 
 @enduml

--- a/sdk/iot/hub/inc/az_iot_hub_client.h
+++ b/sdk/iot/hub/inc/az_iot_hub_client.h
@@ -5,8 +5,13 @@
  * @file az_iot_hub_client.h
  *
  * @brief definition for the Azure IoT Hub client.
- * @note The IoT Hub MQTT protocol is described at 
+ * @remark The IoT Hub MQTT protocol is described at 
  * https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support
+ * 
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * prefixed with an underscore ('_') directly in your application code. These symbols
+ * are part of Azure SDK's internal implementation; we do not document these symbols
+ * and they are subject to change in future versions of the SDK which would break your code.
  */
 
 #ifndef _az_IOT_HUB_CLIENT_H
@@ -141,7 +146,7 @@ AZ_NODISCARD az_result az_iot_hub_client_get_client_id(
  * @details The application must obtain a valid clear-text signature using this API, sign it using
  *          HMAC-SHA256 using the Shared Access Key as password then Base64 encode the result.
  *
- * @note More information available at
+ * @remark More information available at
  * https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#security-tokens
  * 
  * @param[in] client The #az_iot_hub_client to use for this call.
@@ -158,7 +163,7 @@ AZ_NODISCARD az_result az_iot_hub_client_sas_get_signature(
 
 /**
  * @brief Gets the MQTT password.
- * @note The MQTT password must be an empty string if X509 Client certificates are used. Use this
+ * @remark The MQTT password must be an empty string if X509 Client certificates are used. Use this
  *       API only when authenticating with SAS tokens.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
@@ -261,7 +266,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_append(
 
 /**
  * @brief Finds the value of a property.
- * @note This will return the first value of the property with the given name if multiple properties
+ * @remark This will return the first value of the property with the given name if multiple properties
  *       with the same key exist.
  *
  * @param[in] properties The #az_iot_hub_client_properties to use for this call
@@ -292,8 +297,8 @@ az_iot_hub_client_properties_next(az_iot_hub_client_properties* properties, az_p
 
 /**
  * @brief Gets the MQTT topic that must be used for device to cloud telemetry messages.
- * @note Telemetry MQTT Publish messages must have QoS At Least Once (1).
- * @note This topic can also be used to set the MQTT Will message in the Connect message.
+ * @remark Telemetry MQTT Publish messages must have QoS At Least Once (1).
+ * @remark This topic can also be used to set the MQTT Will message in the Connect message.
  *
  * Should the user want a null terminated topic string, they may allocate a buffer large enough
  * to fit the topic plus a null terminator. They must set the last byte themselves or zero
@@ -327,7 +332,7 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
 
 /**
  * @brief Gets the MQTT topic filter to subscribe to cloud to device requests.
- * @note C2D MQTT Publish messages will have QoS At Least Once (1).
+ * @remark C2D MQTT Publish messages will have QoS At Least Once (1).
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[out] mqtt_topic_filter A buffer with sufficient capacity to hold the MQTT topic filter.
@@ -467,7 +472,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_response_get_subscribe_topic_filte
 
 /**
  * @brief Gets the MQTT topic filter to subscribe to twin desired property changes.
- * @note The payload will contain only changes made to the desired properties.
+ * @remark The payload will contain only changes made to the desired properties.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[out] mqtt_topic_filter A buffer with sufficient capacity to hold the MQTT topic filter.
@@ -506,7 +511,7 @@ typedef struct az_iot_hub_client_twin_response
   az_span
       request_id; /**< Request ID matches the ID specified when issuing a Get or Patch command. */
   az_span version; /**< The Twin object version.
-                    * @note This is only returned when
+                    * @remark This is only returned when
                     * response_type==AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES
                     * or
                     * response_type==AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES. */
@@ -529,7 +534,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
 
 /**
  * @brief Gets the MQTT topic that must be used to submit a Twin GET request.
- * @note The payload of the MQTT publish message should be empty.
+ * @remark The payload of the MQTT publish message should be empty.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] request_id The request id.
@@ -550,8 +555,8 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_document_get_publish_topic(
 
 /**
  * @brief Gets the MQTT topic that must be used to submit a Twin PATCH request.
- * @note The payload of the MQTT publish message should contain a JSON document
- *       formatted according to the Twin specification.
+ * @remark The payload of the MQTT publish message should contain a JSON document
+ *         formatted according to the Twin specification.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] request_id The request id.

--- a/sdk/iot/hub/inc/az_iot_hub_client.h
+++ b/sdk/iot/hub/inc/az_iot_hub_client.h
@@ -366,7 +366,7 @@ typedef struct az_iot_hub_client_c2d_request
  * @param[out] out_request If the message is a C2D request, this will contain the
  *                         #az_iot_hub_client_c2d_request
  * @return #az_result
- *         - #AZ_ERROR_IOT_TOPIC_NO_MATCH if the topic is not matching the expected format.
+ *         - `AZ_ERROR_IOT_TOPIC_NO_MATCH` if the topic is not matching the expected format.
  */
 AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
     az_iot_hub_client const* client,
@@ -416,7 +416,7 @@ typedef struct az_iot_hub_client_method_request
  * @param[out] out_request If the message is a method request, this will contain the
  *                         #az_iot_hub_client_method_request.
  * @return #az_result
- *         - #AZ_ERROR_IOT_TOPIC_NO_MATCH if the topic is not matching the expected format.
+ *         - `AZ_ERROR_IOT_TOPIC_NO_MATCH` if the topic is not matching the expected format.
  */
 AZ_NODISCARD az_result az_iot_hub_client_methods_parse_received_topic(
     az_iot_hub_client const* client,
@@ -525,7 +525,7 @@ typedef struct az_iot_hub_client_twin_response
  * @param[out] out_twin_response If the message is twin-operation related, this will contain the
  *                         #az_iot_hub_client_twin_response.
  * @return #az_result
- *         - #AZ_ERROR_IOT_TOPIC_NO_MATCH if the topic is not matching the expected format.
+ *         - `AZ_ERROR_IOT_TOPIC_NO_MATCH` if the topic is not matching the expected format.
  */
 AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
     az_iot_hub_client const* client,

--- a/sdk/iot/hub/src/az_iot_hub_client.c
+++ b/sdk/iot/hub/src/az_iot_hub_client.c
@@ -206,16 +206,16 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_find(
 
   while (az_span_size(remaining) != 0)
   {
-    az_span delim_span = az_span_token(remaining, hub_client_param_equals_span, &remaining);
+    az_span delim_span = _az_span_token(remaining, hub_client_param_equals_span, &remaining);
     if (az_span_is_content_equal(delim_span, name))
     {
-      *out_value = az_span_token(remaining, hub_client_param_separator_span, &remaining);
+      *out_value = _az_span_token(remaining, hub_client_param_separator_span, &remaining);
       return AZ_OK;
     }
     else
     {
       az_span value;
-      value = az_span_token(remaining, hub_client_param_separator_span, &remaining);
+      value = _az_span_token(remaining, hub_client_param_separator_span, &remaining);
       (void)value;
     }
   }
@@ -241,8 +241,8 @@ az_iot_hub_client_properties_next(az_iot_hub_client_properties* properties, az_p
   az_span remainder;
   az_span prop_span = az_span_slice(properties->_internal.properties_buffer, index, prop_length);
 
-  out->key = az_span_token(prop_span, hub_client_param_equals_span, &remainder);
-  out->value = az_span_token(remainder, hub_client_param_separator_span, &remainder);
+  out->key = _az_span_token(prop_span, hub_client_param_equals_span, &remainder);
+  out->value = _az_span_token(remainder, hub_client_param_separator_span, &remainder);
   if (az_span_size(remainder) == 0)
   {
     properties->_internal.current_property_index = (uint32_t)prop_length;

--- a/sdk/iot/hub/src/az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_c2d.c
@@ -59,10 +59,10 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
   (void)client;
 
   az_span token;
-  token = az_span_token(received_topic, c2d_topic_suffix, &received_topic);
+  token = _az_span_token(received_topic, c2d_topic_suffix, &received_topic);
   if (az_span_ptr(received_topic) != NULL)
   {
-    token = az_span_token(received_topic, c2d_topic_suffix, &received_topic);
+    token = _az_span_token(received_topic, c2d_topic_suffix, &received_topic);
     AZ_RETURN_IF_FAILED(
         az_iot_hub_client_properties_init(&out_request->properties, token, az_span_size(token)));
   }

--- a/sdk/iot/hub/src/az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_twin.c
@@ -192,7 +192,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
     {
       // Is a res case
       az_span remainder;
-      az_span status_str = az_span_token(
+      az_span status_str = _az_span_token(
           az_span_slice(
               received_topic,
               twin_feature_index + az_span_size(az_iot_hub_twin_response_sub_topic),
@@ -203,7 +203,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
       // Get status and convert to enum
       uint32_t status_int;
       AZ_RETURN_IF_FAILED(az_span_atou32(status_str, &status_int));
-      AZ_RETURN_IF_FAILED(az_iot_get_status_from_uint32(status_int, &out_twin_response->status));
+      out_twin_response->status = (az_iot_status)status_int;
 
       // Get request id prop value
       az_iot_hub_client_properties props;

--- a/sdk/iot/pnp/inc/az_iot_pnp_client.h
+++ b/sdk/iot/pnp/inc/az_iot_pnp_client.h
@@ -154,8 +154,8 @@ AZ_NODISCARD AZ_INLINE az_result az_iot_pnp_client_get_sas_signature(
 
 /**
  * @brief Gets the MQTT password.
- * @note The MQTT password must be an empty string if X509 Client certificates are used. Use this
- *       API only when authenticating with SAS tokens.
+ * @remark The MQTT password must be an empty string if X509 Client certificates are used. Use this
+ *         API only when authenticating with SAS tokens.
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
  * @param[in] base64_hmac_sha256_signature The Base64 encoded value of the HMAC-SHA256(signature,
@@ -200,8 +200,8 @@ AZ_NODISCARD AZ_INLINE az_result az_iot_pnp_client_get_sas_password(
 
 /**
  * @brief Gets the MQTT topic that must be used for device to cloud telemetry messages.
- * @note Telemetry MQTT Publish messages must have QoS At Least Once (1).
- * @note This topic can also be used to set the MQTT Will message in the Connect message.
+ * @remark Telemetry MQTT Publish messages must have QoS At Least Once (1).
+ * @remark This topic can also be used to set the MQTT Will message in the Connect message.
  *
  * Should the user want a null terminated topic string, they may allocate a buffer large enough
  * to fit the topic plus a null terminator. They must set the last byte themselves or zero

--- a/sdk/iot/provisioning/inc/az_iot_provisioning_client.h
+++ b/sdk/iot/provisioning/inc/az_iot_provisioning_client.h
@@ -159,7 +159,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_sas_get_signature(
  * @param[in] client The #az_iot_provisioning_client to use for this call.
  * @param[in] base64_hmac_sha256_signature The Base64 encoded value of the HMAC-SHA256(signature,
  *                                         SharedAccessKey). The signature is obtained by using
- *                                         #az_iot_hub_client_sas_signature_get.
+ *                                         #az_iot_provisioning_client_sas_get_signature.
  * @param[in] token_expiration_epoch_time The time, in seconds, from 1/1/1970.
  * @param[in] key_name The Shared Access Key Name (Policy Name). This is optional. For security
  *                     reasons we recommend using one key per device instead of using a global
@@ -259,7 +259,7 @@ typedef struct az_iot_provisioning_client_register_response
  * @param[out] out_response If the message is register-operation related, this will contain the
  *                          #az_iot_provisioning_client_register_response.
  * @return #az_result
- *         - #AZ_ERROR_IOT_TOPIC_NO_MATCH if the topic is not matching the expected format.
+ *         - `AZ_ERROR_IOT_TOPIC_NO_MATCH` if the topic is not matching the expected format.
  */
 AZ_NODISCARD az_result az_iot_provisioning_client_parse_received_topic_and_payload(
     az_iot_provisioning_client const* client,

--- a/sdk/iot/provisioning/inc/az_iot_provisioning_client.h
+++ b/sdk/iot/provisioning/inc/az_iot_provisioning_client.h
@@ -292,7 +292,6 @@ typedef enum
  * @param[out] out_operation_status The registration operation status.
  * @return #az_result
  *         - #AZ_ERROR_PARSER_UNEXPECTED_CHAR if the string contains an unexpected value.
- *         @remark See #az_iot_provisioning_client_register_response for acceptable values.
  */
 AZ_NODISCARD az_result az_iot_provisioning_client_parse_operation_status(
     az_iot_provisioning_client_register_response* response,

--- a/sdk/iot/provisioning/samples/src/paho_iot_provisioning_example.c
+++ b/sdk/iot/provisioning/samples/src/paho_iot_provisioning_example.c
@@ -347,7 +347,7 @@ static int get_operation_status()
     MQTTClient_freeMessage(&message);
     MQTTClient_free(topic);
   }
-  
+
   return 0;
 }
 

--- a/sdk/iot/provisioning/samples/src/paho_iot_provisioning_example.c
+++ b/sdk/iot/provisioning/samples/src/paho_iot_provisioning_example.c
@@ -145,6 +145,8 @@ static int connect_device()
 
   MQTTClient_SSLOptions mqtt_ssl_options = MQTTClient_SSLOptions_initializer;
   MQTTClient_connectOptions mqtt_connect_options = MQTTClient_connectOptions_initializer;
+  mqtt_connect_options.cleansession = false;
+  mqtt_connect_options.keepAliveInterval = AZ_IOT_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS;
 
   char username[128];
   if ((rc = az_iot_provisioning_client_get_user_name(
@@ -280,7 +282,17 @@ static int get_operation_status()
       return rc;
     }
 
-    if (az_span_is_content_equal(response.registration_state, AZ_SPAN_FROM_STR("assigning")))
+    az_iot_provisioning_client_operation_status operation_status;
+    if (az_failed(
+            rc = az_iot_provisioning_client_parse_operation_status(&response, &operation_status)))
+    {
+      printf("Failed to parse operation_status, return code %d\n", rc);
+      return rc;
+    }
+
+    is_operation_complete = az_iot_provisioning_client_operation_complete(operation_status);
+
+    if (!is_operation_complete)
     {
       if (az_failed(
               rc = az_iot_provisioning_client_query_status_get_publish_topic(
@@ -300,42 +312,42 @@ static int get_operation_status()
         return rc;
       }
     }
-    else if (az_span_is_content_equal(response.registration_state, AZ_SPAN_FROM_STR("assigned")))
+    else
     {
-      printf("SUCCESS - Device provisioned:\n");
-      printf("\tHub Hostname: ");
-      print_az_span(response.registration_information.assigned_hub_hostname);
-      printf("\tDevice Id: ");
-      print_az_span(response.registration_information.device_id);
-      is_operation_complete = true;
-    }
-    else // unassigned, failed or disabled states
-    {
-      printf("ERROR - Device Provisioning failed:\n");
-      printf("\tRegistration state: ");
-      print_az_span(response.registration_state);
-      printf("\tLast operation status: %d\n", response.status);
-      printf("\tOperation ID: ");
-      print_az_span(response.operation_id);
-      printf("\tError code: %u\n", response.registration_information.extended_error_code);
-      printf("\tError message: ");
-      print_az_span(response.registration_information.error_message);
-      printf("\tError timestamp: ");
-      print_az_span(response.registration_information.error_timestamp);
-      printf("\tError tracking ID: ");
-      print_az_span(response.registration_information.error_tracking_id);
-      if (response.retry_after_seconds > 0)
+      if (operation_status == AZ_IOT_PROVISIONING_STATUS_ASSIGNED)
       {
-        printf("\tRetry-after: %u seconds.", response.retry_after_seconds);
+        printf("SUCCESS - Device provisioned:\n");
+        printf("\tHub Hostname: ");
+        print_az_span(response.registration_result.assigned_hub_hostname);
+        printf("\tDevice Id: ");
+        print_az_span(response.registration_result.device_id);
       }
-
-      is_operation_complete = true;
+      else // unassigned, failed or disabled states
+      {
+        printf("ERROR - Device Provisioning failed:\n");
+        printf("\tRegistration state: ");
+        print_az_span(response.operation_status);
+        printf("\tLast operation status: %d\n", response.status);
+        printf("\tOperation ID: ");
+        print_az_span(response.operation_id);
+        printf("\tError code: %u\n", response.registration_result.extended_error_code);
+        printf("\tError message: ");
+        print_az_span(response.registration_result.error_message);
+        printf("\tError timestamp: ");
+        print_az_span(response.registration_result.error_timestamp);
+        printf("\tError tracking ID: ");
+        print_az_span(response.registration_result.error_tracking_id);
+        if (response.retry_after_seconds > 0)
+        {
+          printf("\tRetry-after: %u seconds.", response.retry_after_seconds);
+        }
+      }
     }
 
     MQTTClient_freeMessage(&message);
     MQTTClient_free(topic);
   }
-
+  
   return 0;
 }
 

--- a/sdk/iot/provisioning/tests/cmocka/test_az_iot_provisioning_client_parser.c
+++ b/sdk/iot/provisioning/tests/cmocka/test_az_iot_provisioning_client_parser.c
@@ -25,6 +25,7 @@
 #define TEST_STATUS_ASSIGNED "assigned"
 #define TEST_STATUS_FAILED "failed"
 #define TEST_STATUS_DISABLED "disabled"
+#define TEST_STATUS_UNASSIGNED "unassigned"
 
 #define TEST_ERROR_MESSAGE_INVALID_CERT "Invalid certificate."
 #define TEST_ERROR_MESSAGE_ALLOCATION "Custom allocation failed with status code: 400"
@@ -52,9 +53,7 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_assigning_state
   assert_memory_equal(
       az_span_ptr(response.operation_id), TEST_OPERATION_ID, strlen(TEST_OPERATION_ID));
   assert_memory_equal(
-      az_span_ptr(response.registration_state),
-      TEST_STATUS_ASSIGNING,
-      strlen(TEST_STATUS_ASSIGNING));
+      az_span_ptr(response.operation_status), TEST_STATUS_ASSIGNING, strlen(TEST_STATUS_ASSIGNING));
 }
 
 static void
@@ -68,8 +67,8 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_topic_not_match
   az_iot_provisioning_client_register_response response = { .status = AZ_IOT_STATUS_FORBIDDEN,
                                                             .retry_after_seconds = 0xBAADC0DE,
                                                             .operation_id = AZ_SPAN_NULL,
-                                                            .registration_state = AZ_SPAN_NULL,
-                                                            .registration_information = { 0 } };
+                                                            .operation_status = AZ_SPAN_NULL,
+                                                            .registration_result = { 0 } };
 
   az_result ret = az_iot_provisioning_client_parse_received_topic_and_payload(
       &client, received_topic, received_payload, &response);
@@ -103,9 +102,7 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_parse_assigning
   assert_memory_equal(
       az_span_ptr(response.operation_id), TEST_OPERATION_ID, strlen(TEST_OPERATION_ID));
   assert_memory_equal(
-      az_span_ptr(response.registration_state),
-      TEST_STATUS_ASSIGNING,
-      strlen(TEST_STATUS_ASSIGNING));
+      az_span_ptr(response.operation_status), TEST_STATUS_ASSIGNING, strlen(TEST_STATUS_ASSIGNING));
 }
 
 static void
@@ -140,19 +137,17 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_assigned_state_
   assert_memory_equal(
       az_span_ptr(response.operation_id), TEST_OPERATION_ID, strlen(TEST_OPERATION_ID));
   assert_memory_equal(
-      az_span_ptr(response.registration_state), TEST_STATUS_ASSIGNED, strlen(TEST_STATUS_ASSIGNED));
+      az_span_ptr(response.operation_status), TEST_STATUS_ASSIGNED, strlen(TEST_STATUS_ASSIGNED));
   assert_memory_equal(
-      az_span_ptr(response.registration_information.assigned_hub_hostname),
+      az_span_ptr(response.registration_result.assigned_hub_hostname),
       TEST_HUB_HOSTNAME,
       strlen(TEST_HUB_HOSTNAME));
   assert_memory_equal(
-      az_span_ptr(response.registration_information.device_id),
-      TEST_DEVICE_ID,
-      strlen(TEST_DEVICE_ID));
+      az_span_ptr(response.registration_result.device_id), TEST_DEVICE_ID, strlen(TEST_DEVICE_ID));
 
-  assert_int_equal(200, response.registration_information.status);
-  assert_int_equal(0, response.registration_information.extended_error_code);
-  assert_int_equal(0, az_span_size(response.registration_information.error_message));
+  assert_int_equal(0, response.registration_result.error_code);
+  assert_int_equal(0, response.registration_result.extended_error_code);
+  assert_int_equal(0, az_span_size(response.registration_result.error_message));
 }
 
 static void
@@ -177,24 +172,24 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_invalid_certifi
   // From payload
   assert_int_equal(0, az_span_size(response.operation_id));
   assert_memory_equal(
-      az_span_ptr(response.registration_state), TEST_STATUS_FAILED, strlen(TEST_STATUS_FAILED));
+      az_span_ptr(response.operation_status), TEST_STATUS_FAILED, strlen(TEST_STATUS_FAILED));
 
-  assert_int_equal(0, az_span_size(response.registration_information.assigned_hub_hostname));
-  assert_int_equal(0, az_span_size(response.registration_information.device_id));
+  assert_int_equal(0, az_span_size(response.registration_result.assigned_hub_hostname));
+  assert_int_equal(0, az_span_size(response.registration_result.device_id));
 
-  assert_int_equal(AZ_IOT_STATUS_UNAUTHORIZED, response.registration_information.status);
-  assert_int_equal(401002, response.registration_information.extended_error_code);
+  assert_int_equal(AZ_IOT_STATUS_UNAUTHORIZED, response.registration_result.error_code);
+  assert_int_equal(401002, response.registration_result.extended_error_code);
 
   assert_memory_equal(
-      az_span_ptr(response.registration_information.error_message),
+      az_span_ptr(response.registration_result.error_message),
       TEST_ERROR_MESSAGE_INVALID_CERT,
       strlen(TEST_ERROR_MESSAGE_INVALID_CERT));
   assert_memory_equal(
-      az_span_ptr(response.registration_information.error_timestamp),
+      az_span_ptr(response.registration_result.error_timestamp),
       TEST_ERROR_TIMESTAMP,
       strlen(TEST_ERROR_TIMESTAMP));
   assert_memory_equal(
-      az_span_ptr(response.registration_information.error_tracking_id),
+      az_span_ptr(response.registration_result.error_tracking_id),
       TEST_ERROR_TRACKING_ID,
       strlen(TEST_ERROR_TRACKING_ID));
 }
@@ -220,7 +215,7 @@ static void test_az_iot_provisioning_client_parse_received_topic_payload_disable
   // From payload
   assert_int_equal(0, az_span_size(response.operation_id));
   assert_memory_equal(
-      az_span_ptr(response.registration_state), TEST_STATUS_DISABLED, strlen(TEST_STATUS_DISABLED));
+      az_span_ptr(response.operation_status), TEST_STATUS_DISABLED, strlen(TEST_STATUS_DISABLED));
 }
 
 static void
@@ -252,24 +247,24 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_allocation_erro
   assert_memory_equal(
       az_span_ptr(response.operation_id), TEST_OPERATION_ID, strlen(TEST_OPERATION_ID));
   assert_memory_equal(
-      az_span_ptr(response.registration_state), TEST_STATUS_FAILED, strlen(TEST_STATUS_FAILED));
+      az_span_ptr(response.operation_status), TEST_STATUS_FAILED, strlen(TEST_STATUS_FAILED));
 
-  assert_int_equal(0, az_span_size(response.registration_information.assigned_hub_hostname));
-  assert_int_equal(0, az_span_size(response.registration_information.device_id));
+  assert_int_equal(0, az_span_size(response.registration_result.assigned_hub_hostname));
+  assert_int_equal(0, az_span_size(response.registration_result.device_id));
 
-  assert_int_equal(AZ_IOT_STATUS_BAD_REQUEST, response.registration_information.status);
-  assert_int_equal(400207, response.registration_information.extended_error_code);
+  assert_int_equal(AZ_IOT_STATUS_BAD_REQUEST, response.registration_result.error_code);
+  assert_int_equal(400207, response.registration_result.extended_error_code);
 
   assert_memory_equal(
-      az_span_ptr(response.registration_information.error_message),
+      az_span_ptr(response.registration_result.error_message),
       TEST_ERROR_MESSAGE_ALLOCATION,
       strlen(TEST_ERROR_MESSAGE_ALLOCATION));
   assert_memory_equal(
-      az_span_ptr(response.registration_information.error_timestamp),
+      az_span_ptr(response.registration_result.error_timestamp),
       TEST_ERROR_TIMESTAMP,
       strlen(TEST_ERROR_TIMESTAMP));
 
-  assert_int_equal(0, az_span_size(response.registration_information.error_tracking_id));
+  assert_int_equal(0, az_span_size(response.registration_result.error_tracking_id));
 }
 
 static void
@@ -308,7 +303,7 @@ test_az_iot_provisioning_client_received_topic_and_payload_parse_operationid_not
 }
 
 static void
-test_az_iot_provisioning_client_received_topic_and_payload_parse_registration_state_not_found_fails()
+test_az_iot_provisioning_client_received_topic_and_payload_parse_operation_status_not_found_fails()
 {
   az_iot_provisioning_client client;
   az_span received_topic = AZ_SPAN_FROM_STR("$dps/registrations/res/200/?$rid=1");
@@ -346,7 +341,7 @@ test_az_iot_provisioning_client_received_topic_and_payload_parse_error_code_not_
 }
 
 static void
-test_az_iot_provisioning_client_received_topic_and_payload_parse_invalid_registration_state_fails()
+test_az_iot_provisioning_client_received_topic_and_payload_parse_invalid_operation_status_fails()
 {
   az_iot_provisioning_client client;
   az_span received_topic = AZ_SPAN_FROM_STR("$dps/registrations/res/200/?$rid=1");
@@ -358,6 +353,117 @@ test_az_iot_provisioning_client_received_topic_and_payload_parse_invalid_registr
   az_result ret = az_iot_provisioning_client_parse_received_topic_and_payload(
       &client, received_topic, received_payload, &response);
   assert_int_equal(AZ_ERROR_PARSER_UNEXPECTED_CHAR, ret);
+}
+
+static void test_az_iot_provisioning_client_received_topic_and_payload_parse_invalid_result_json_fails()
+{
+  az_iot_provisioning_client client;
+  az_span received_topic = AZ_SPAN_FROM_STR("$dps/registrations/res/200/?$rid=1");
+  az_span received_payload
+      = AZ_SPAN_FROM_STR("{\"operationId\":\"" TEST_OPERATION_ID
+                         /*"\",\"status\":\"" TEST_STATUS_FAILED */ "\",\"registrationState\":{"
+                         "\"registrationId\":\"" TEST_REGISTRATION_ID "\",");
+
+  az_iot_provisioning_client_register_response response;
+  az_result ret = az_iot_provisioning_client_parse_received_topic_and_payload(
+      &client, received_topic, received_payload, &response);
+  assert_int_equal(AZ_ERROR_ITEM_NOT_FOUND, ret);
+}
+
+static void test_az_iot_provisioning_client_received_topic_and_payload_parse_hub_not_found_fails()
+{
+  az_iot_provisioning_client client;
+  az_span received_topic = AZ_SPAN_FROM_STR("$dps/registrations/res/200/?$rid=1");
+  az_span received_payload
+      = AZ_SPAN_FROM_STR("{\"operationId\":\"" TEST_OPERATION_ID
+                         "\",\"status\":\"" TEST_STATUS_ASSIGNED "\",\"registrationState\":{"
+                         "\"x509\":{},"
+                         "\"registrationId\":\"" TEST_REGISTRATION_ID "\","
+                         "\"createdDateTimeUtc\":\"2020-04-10T03:11:13.0276997Z\","
+                         "\"deviceId\":\"" TEST_DEVICE_ID "\","
+                         "\"status\":\"" TEST_STATUS_ASSIGNED "\","
+                         "\"substatus\":\"initialAssignment\","
+                         "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
+                         "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
+                         "\"payload\":{\"hello\":\"world\",\"arr\":[1,2,3,4,5,6],\"num\":123}}}");
+
+  az_iot_provisioning_client_register_response response;
+  az_result ret = az_iot_provisioning_client_parse_received_topic_and_payload(
+      &client, received_topic, received_payload, &response);
+  assert_int_equal(AZ_ERROR_ITEM_NOT_FOUND, ret);
+}
+
+static void test_az_iot_provisioning_client_received_topic_and_payload_parse_device_not_found_fails()
+{
+  az_iot_provisioning_client client;
+  az_span received_topic = AZ_SPAN_FROM_STR("$dps/registrations/res/200/?$rid=1");
+  az_span received_payload
+      = AZ_SPAN_FROM_STR("{\"operationId\":\"" TEST_OPERATION_ID
+                         "\",\"status\":\"" TEST_STATUS_ASSIGNED "\",\"registrationState\":{"
+                         "\"x509\":{},"
+                         "\"registrationId\":\"" TEST_REGISTRATION_ID "\","
+                         "\"createdDateTimeUtc\":\"2020-04-10T03:11:13.0276997Z\","
+                         "\"assignedHub\":\"" TEST_HUB_HOSTNAME "\","
+                         "\"status\":\"" TEST_STATUS_ASSIGNED "\","
+                         "\"substatus\":\"initialAssignment\","
+                         "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
+                         "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
+                         "\"payload\":{\"hello\":\"world\",\"arr\":[1,2,3,4,5,6],\"num\":123}}}");
+
+  az_iot_provisioning_client_register_response response;
+  az_result ret = az_iot_provisioning_client_parse_received_topic_and_payload(
+      &client, received_topic, received_payload, &response);
+  assert_int_equal(AZ_ERROR_ITEM_NOT_FOUND, ret);
+}
+
+static void test_az_iot_provisioning_client_parse_operation_status_translate_succeed()
+{
+  az_iot_provisioning_client_register_response response = { .status = AZ_IOT_STATUS_FORBIDDEN,
+                                                            .retry_after_seconds = 0xBAADC0DE,
+                                                            .operation_id = AZ_SPAN_NULL,
+                                                            .operation_status = AZ_SPAN_NULL,
+                                                            .registration_result = { 0 } };
+
+  az_iot_provisioning_client_operation_status operation_status = 0xBAADC0DE;
+
+  assert_true(
+      az_failed(az_iot_provisioning_client_parse_operation_status(&response, &operation_status)));
+  assert_int_equal((uint32_t)0xBAADC0DE, (uint32_t)operation_status);
+
+  response.operation_status = AZ_SPAN_FROM_STR(TEST_STATUS_UNASSIGNED);
+  assert_true(az_succeeded(
+      az_iot_provisioning_client_parse_operation_status(&response, &operation_status)));
+  assert_int_equal(AZ_IOT_PROVISIONING_STATUS_UNASSIGNED, operation_status);
+
+  response.operation_status = AZ_SPAN_FROM_STR(TEST_STATUS_ASSIGNING);
+  assert_true(az_succeeded(
+      az_iot_provisioning_client_parse_operation_status(&response, &operation_status)));
+  assert_int_equal(AZ_IOT_PROVISIONING_STATUS_ASSIGNING, operation_status);
+
+  response.operation_status = AZ_SPAN_FROM_STR(TEST_STATUS_ASSIGNED);
+  assert_true(az_succeeded(
+      az_iot_provisioning_client_parse_operation_status(&response, &operation_status)));
+  assert_int_equal(AZ_IOT_PROVISIONING_STATUS_ASSIGNED, operation_status);
+
+  response.operation_status = AZ_SPAN_FROM_STR(TEST_STATUS_FAILED);
+  assert_true(az_succeeded(
+      az_iot_provisioning_client_parse_operation_status(&response, &operation_status)));
+  assert_int_equal(AZ_IOT_PROVISIONING_STATUS_FAILED, operation_status);
+
+  response.operation_status = AZ_SPAN_FROM_STR(TEST_STATUS_DISABLED);
+  assert_true(az_succeeded(
+      az_iot_provisioning_client_parse_operation_status(&response, &operation_status)));
+  assert_int_equal(AZ_IOT_PROVISIONING_STATUS_DISABLED, operation_status);
+}
+
+static void test_az_iot_provisioning_client_operation_complete_translate_succeed()
+{
+  assert_false(
+      az_iot_provisioning_client_operation_complete(AZ_IOT_PROVISIONING_STATUS_UNASSIGNED));
+  assert_false(az_iot_provisioning_client_operation_complete(AZ_IOT_PROVISIONING_STATUS_ASSIGNING));
+  assert_true(az_iot_provisioning_client_operation_complete(AZ_IOT_PROVISIONING_STATUS_ASSIGNED));
+  assert_true(az_iot_provisioning_client_operation_complete(AZ_IOT_PROVISIONING_STATUS_FAILED));
+  assert_true(az_iot_provisioning_client_operation_complete(AZ_IOT_PROVISIONING_STATUS_DISABLED));
 }
 
 #ifdef _MSC_VER
@@ -387,11 +493,19 @@ int test_az_iot_provisioning_client_parser()
     cmocka_unit_test(
         test_az_iot_provisioning_client_received_topic_and_payload_parse_operationid_not_found_fails),
     cmocka_unit_test(
-        test_az_iot_provisioning_client_received_topic_and_payload_parse_registration_state_not_found_fails),
+        test_az_iot_provisioning_client_received_topic_and_payload_parse_operation_status_not_found_fails),
     cmocka_unit_test(
         test_az_iot_provisioning_client_received_topic_and_payload_parse_error_code_not_found_fails),
     cmocka_unit_test(
-        test_az_iot_provisioning_client_received_topic_and_payload_parse_invalid_registration_state_fails),
+        test_az_iot_provisioning_client_received_topic_and_payload_parse_invalid_operation_status_fails),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_received_topic_and_payload_parse_invalid_result_json_fails),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_received_topic_and_payload_parse_hub_not_found_fails),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_received_topic_and_payload_parse_device_not_found_fails),
+    cmocka_unit_test(test_az_iot_provisioning_client_parse_operation_status_translate_succeed),
+    cmocka_unit_test(test_az_iot_provisioning_client_operation_complete_translate_succeed),
   };
 
   return cmocka_run_group_tests_name("az_iot_provisioning_client_parser", tests, NULL, NULL);


### PR DESCRIPTION
- Implementations for az_iot_core state and retry public APIs + UT.
- Adding operation_state parsing APIs + UT + updated sample.
- Clarifying naming for Provisioning APIs (breaking API change).
- Removing some az_iot_core functions from the public API surface.
- Fixing Provisioning invalid JSON parsing bug + UT.

Doc:
- Updating PUML (switching to svg rendering).
- Changing from @note to @remark for non-important items (leaving @note for paragraphs that _must_ be understood, @remarks for clarifications).