### PR TITLE
Efficient job usage for CI pipelines

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -8,13 +8,13 @@ resources:
       type: git
       name: internal/azure-sdk-build-tools
 
-trigger:
-  branches:
-    include:
-      - master
-      - feature/*
-      - release/*
-      - hotfix/*
+# This pipeline does not need to run on merge. It is primarily used for building
+# release assets.
+trigger: none
+
+# This pipeline does not need to run on PR. The c - client - ci pipeline handles
+# validating
+pr: none
 
 stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/iot/ci.yml
+++ b/sdk/iot/ci.yml
@@ -10,13 +10,13 @@ resources:
       type: git
       name: internal/azure-sdk-build-tools
 
-trigger:
-  branches:
-    include:
-      - master
-      - feature/*
-      - release/*
-      - hotfix/*
+# This pipeline does not need to run on merge. It is primarily used for building
+# release assets.
+trigger: none
+
+# This pipeline does not need to run on PR. The c - client - ci pipeline handles
+# validating
+pr: none
 
 stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -10,13 +10,13 @@ resources:
       type: git
       name: internal/azure-sdk-build-tools
 
-trigger:
-  branches:
-    include:
-      - master
-      - feature/*
-      - release/*
-      - hotfix/*
+# This pipeline does not need to run on merge. It is primarily used for building
+# release assets.
+trigger: none
+
+# This pipeline does not need to run on PR. The c - client - ci pipeline handles
+# validating
+pr: none
 
 stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
Disable execution of unified pipelines because the same validation is already being done in `c - client - ci` 