### PR TITLE
Standardize on Embedded C name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Azure SDK for C Contributing Guide
+# Azure SDK for Embedded C Contributing Guide
 
-Thank you for your interest in contributing to Azure SDK for C.
+Thank you for your interest in contributing to Azure SDK for Embedded C.
 
 - For reporting bugs, requesting features, or asking for support, please file an issue in the [issues](https://github.com/Azure/azure-sdk-for-c/issues) section of the project.
 
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to Azure SDK for C.
 
 - To make code changes, or contribute something new, please follow the [GitHub Forks / Pull requests model](https://help.github.com/articles/fork-a-repo/): Fork the repo, make the change and propose it back by submitting a pull request.
 
-- Refer to the [wiki](https://github.com/Azure/azure-sdk-for-c/wiki) to learn about how Azure SDK for C generates lint checker, doxygen, and code coverage reports.
+- Refer to the [wiki](https://github.com/Azure/azure-sdk-for-c/wiki) to learn about how Azure SDK for Embedded C generates lint checker, doxygen, and code coverage reports.
 
 ## Pull Requests
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -20,8 +20,8 @@ General Public License.
 
 ------------------------------------------------------------------------------
 
-Azure SDK for C uses third-party libraries or other resources that may be
-distributed under licenses different than the Azure SDK for C software.
+Azure SDK for Embedded C uses third-party libraries or other resources that may be
+distributed under licenses different than the Azure SDK for Embedded C software.
 
 In the event that we accidentally failed to list a required notice, please
 bring it to our attention. Post an issue or email us:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/c/c%20-%20client%20-%20ci?branchName=master)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=722&branchName=master)
 
-The Azure SDK for C is designed to allow small embedded (IoT) devices to communicate with Azure services. Since we expect our client library code to run on microcontrollers, which have very limited amounts of flash and RAM, and have slower CPUs, our C SDK does things very differently than the SDKs we offer for other languages.
+The Azure SDK for Embedded C is designed to allow small embedded (IoT) devices to communicate with Azure services. Since we expect our client library code to run on microcontrollers, which have very limited amounts of flash and RAM, and have slower CPUs, our C SDK does things very differently than the SDKs we offer for other languages.
 
 With this in mind, there are many tenants or principles that we follow in order to properly address this target audience:
 
@@ -132,4 +132,4 @@ Security issues and bugs should be reported privately, via email, to the Microso
 
 ### License
 
-Azure SDK for C is licensed under the [MIT](LICENSE) license.
+Azure SDK for Embedded C is licensed under the [MIT](LICENSE) license.

--- a/sdk/core/core/README.md
+++ b/sdk/core/core/README.md
@@ -1,6 +1,6 @@
-# Azure SDK Core Library for C
+# Azure SDK Core Library for Embedded C
 
-Azure Core library for C (`az_core`) provides shared primitives, abstractions, and helpers for modern Azure SDK client libraries written in the C programming language. These libraries follow the Azure SDK Design Guidelines for Embedded C.
+Azure Core Library for Embedded C (`az_core`) provides shared primitives, abstractions, and helpers for modern Azure SDK client libraries written in the C programming language. These libraries follow the Azure SDK Design Guidelines for Embedded C.
 
 The library allows client libraries to expose common functionality in a consistent fashion.  Once you learn how to use these APIs in one client library, you will know how to use them in other client libraries.
 

--- a/sdk/core/core/samples/README.md
+++ b/sdk/core/core/samples/README.md
@@ -7,7 +7,7 @@ products:
 urlFragment: core-samples
 ---
 
-# Azure Core Samples client library for C
+# Azure Core Samples client Library for Embedded C
 This document explains samples and how to use them.
 
 ## Key concepts

--- a/sdk/iot/README.md
+++ b/sdk/iot/README.md
@@ -149,7 +149,7 @@ Many people all over the world have helped make this project better.  You'll wan
 * [What are some good first issues for new contributors to the repo?](https://github.com/azure/azure-sdk-for-c/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)
 * [How to build and test your change](CONTRIBUTING.md#developer-guide)
 * [How you can make a change happen!](CONTRIBUTING.md#pull-requests)
-* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for C wiki][azure_sdk_for_c_wiki].
+* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for Embedded C wiki][azure_sdk_for_c_wiki].
 
 ### Community
 

--- a/sdk/platform/http_client/curl/README.md
+++ b/sdk/platform/http_client/curl/README.md
@@ -71,7 +71,7 @@ Many people all over the world have helped make this project better.  You'll wan
 * [What are some good first issues for new contributors to the repo?](https://github.com/azure/azure-sdk-for-c/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)
 * [How to build and test your change][azure_sdk_for_c_contributing_developer_guide]
 * [How you can make a change happen!][azure_sdk_for_c_contributing_pull_requests]
-* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for C wiki](https://github.com/azure/azure-sdk-for-c/wiki).
+* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for Embedded C wiki](https://github.com/azure/azure-sdk-for-c/wiki).
 
 ### Community
 
@@ -83,7 +83,7 @@ Security issues and bugs should be reported privately, via email, to the Microso
 
 ### License
 
-Azure SDK for C is licensed under the [MIT](LICENSE) license.
+Azure SDK for Embedded C is licensed under the [MIT](LICENSE) license.
 
 <!-- LINKS -->
 [azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md

--- a/sdk/platform/http_client/nohttp/README.md
+++ b/sdk/platform/http_client/nohttp/README.md
@@ -71,7 +71,7 @@ Many people all over the world have helped make this project better.  You'll wan
 * [What are some good first issues for new contributors to the repo?](https://github.com/azure/azure-sdk-for-c/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)
 * [How to build and test your change][azure_sdk_for_c_contributing_developer_guide]
 * [How you can make a change happen!][azure_sdk_for_c_contributing_pull_requests]
-* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for C wiki](https://github.com/azure/azure-sdk-for-c/wiki).
+* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for Embedded C wiki](https://github.com/azure/azure-sdk-for-c/wiki).
 
 ### Community
 
@@ -83,7 +83,7 @@ Security issues and bugs should be reported privately, via email, to the Microso
 
 ### License
 
-Azure SDK for C is licensed under the [MIT](LICENSE) license.
+Azure SDK for Embedded C is licensed under the [MIT](LICENSE) license.
 
 <!-- LINKS -->
 [azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md

--- a/sdk/platform/noplatform/README.md
+++ b/sdk/platform/noplatform/README.md
@@ -69,7 +69,7 @@ Many people all over the world have helped make this project better.  You'll wan
 * [What are some good first issues for new contributors to the repo?](https://github.com/azure/azure-sdk-for-c/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)
 * [How to build and test your change][azure_sdk_for_c_contributing_developer_guide]
 * [How you can make a change happen!][azure_sdk_for_c_contributing_pull_requests]
-* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for C wiki](https://github.com/azure/azure-sdk-for-c/wiki).
+* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for Embedded C wiki](https://github.com/azure/azure-sdk-for-c/wiki).
 
 ### Community
 
@@ -81,7 +81,7 @@ Security issues and bugs should be reported privately, via email, to the Microso
 
 ### License
 
-Azure SDK for C is licensed under the [MIT](LICENSE) license.
+Azure SDK for Embedded C is licensed under the [MIT](LICENSE) license.
 
 <!-- LINKS -->
 [azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md

--- a/sdk/platform/posix/README.md
+++ b/sdk/platform/posix/README.md
@@ -69,7 +69,7 @@ Many people all over the world have helped make this project better.  You'll wan
 * [What are some good first issues for new contributors to the repo?](https://github.com/azure/azure-sdk-for-c/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)
 * [How to build and test your change][azure_sdk_for_c_contributing_developer_guide]
 * [How you can make a change happen!][azure_sdk_for_c_contributing_pull_requests]
-* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for C wiki](https://github.com/azure/azure-sdk-for-c/wiki).
+* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for Embedded C wiki](https://github.com/azure/azure-sdk-for-c/wiki).
 
 ### Community
 
@@ -81,7 +81,7 @@ Security issues and bugs should be reported privately, via email, to the Microso
 
 ### License
 
-Azure SDK for C is licensed under the [MIT](LICENSE) license.
+Azure SDK for Embedded C is licensed under the [MIT](LICENSE) license.
 
 <!-- LINKS -->
 [azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md

--- a/sdk/platform/win32/README.md
+++ b/sdk/platform/win32/README.md
@@ -69,7 +69,7 @@ Many people all over the world have helped make this project better.  You'll wan
 * [What are some good first issues for new contributors to the repo?](https://github.com/azure/azure-sdk-for-c/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)
 * [How to build and test your change][azure_sdk_for_c_contributing_developer_guide]
 * [How you can make a change happen!][azure_sdk_for_c_contributing_pull_requests]
-* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for C wiki](https://github.com/azure/azure-sdk-for-c/wiki).
+* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for Embedded C wiki](https://github.com/azure/azure-sdk-for-c/wiki).
 
 ### Community
 
@@ -81,7 +81,7 @@ Security issues and bugs should be reported privately, via email, to the Microso
 
 ### License
 
-Azure SDK for C is licensed under the [MIT](LICENSE) license.
+Azure SDK for Embedded C is licensed under the [MIT](LICENSE) license.
 
 <!-- LINKS -->
 [azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md

--- a/sdk/samples/keyvault/keyvault/README.md
+++ b/sdk/samples/keyvault/keyvault/README.md
@@ -1,4 +1,4 @@
-# Azure SDK KeyVault Keys Library for C
+# Azure SDK KeyVault Keys Library for Embedded C
 
 Azure KeyVault Keys library (`az_keyvault_keys`) provides abstractions, and helpers for communicating with Azure KeyVault in the C programming language. This library follows the Azure SDK Design Guidelines for Embedded C.
 
@@ -81,7 +81,7 @@ Many people all over the world have helped make this project better.  You'll wan
 * [What are some good first issues for new contributors to the repo?](https://github.com/azure/azure-sdk-for-c/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)
 * [How to build and test your change][azure_sdk_for_c_contributing_developer_guide]
 * [How you can make a change happen!][azure_sdk_for_c_contributing_pull_requests]
-* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for C wiki](https://github.com/azure/azure-sdk-for-c/wiki).
+* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for Embedded C wiki](https://github.com/azure/azure-sdk-for-c/wiki).
 
 ### Community
 
@@ -93,7 +93,7 @@ Security issues and bugs should be reported privately, via email, to the Microso
 
 ### License
 
-Azure SDK for C is licensed under the [MIT](LICENSE) license.
+Azure SDK for Embedded C is licensed under the [MIT](LICENSE) license.
 
 <!-- LINKS -->
 [azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md

--- a/sdk/samples/keyvault/keyvault/samples/README.md
+++ b/sdk/samples/keyvault/keyvault/samples/README.md
@@ -9,7 +9,7 @@ products:
 urlFragment: keyvault-keys-samples
 ---
 
-# Azure KeyVault Keys Samples client library for C
+# Azure KeyVault Keys Samples client Library for Embedded C
 This document explains samples and how to use them.
 
 ## Key concepts

--- a/sdk/storage/blobs/README.md
+++ b/sdk/storage/blobs/README.md
@@ -1,8 +1,8 @@
-# Azure SDK Storage Blobs Library for C
+# Azure SDK Storage Blobs Library for Embedded C
 
 Azure Storage Blobs library (`az_storage_blobs`) provides abstractions, and helpers for communicating with Azure Storage Blobs in the C programming language. This library follows the Azure SDK Design Guidelines for Embedded C.
 
-Use the Azure SDK Storage Blobs library for C to work with Azure Storage Blobs.
+Use the Azure SDK Storage Blobs Library for Embedded C to work with Azure Storage Blobs.
 
 * Upload blobs
 * Create and modify blob metadata
@@ -74,7 +74,7 @@ Many people all over the world have helped make this project better.  You'll wan
 * [What are some good first issues for new contributors to the repo?](https://github.com/azure/azure-sdk-for-c/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)
 * [How to build and test your change][azure_sdk_for_c_contributing_developer_guide]
 * [How you can make a change happen!][azure_sdk_for_c_contributing_pull_requests]
-* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for C wiki](https://github.com/azure/azure-sdk-for-c/wiki).
+* Frequently Asked Questions (FAQ) and Conceptual Topics in the detailed [Azure SDK for Embedded C wiki](https://github.com/azure/azure-sdk-for-c/wiki).
 
 ### Community
 
@@ -86,7 +86,7 @@ Security issues and bugs should be reported privately, via email, to the Microso
 
 ### License
 
-Azure SDK for C is licensed under the [MIT](LICENSE) license.
+Azure SDK for Embedded C is licensed under the [MIT](LICENSE) license.
 
 <!-- LINKS -->
 [azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md

--- a/sdk/storage/blobs/samples/README.md
+++ b/sdk/storage/blobs/samples/README.md
@@ -5,11 +5,11 @@ languages:
 products:
   - azure
   - azure-storage
-  - azure-blob-storage
+  - azure-storage-blobs
 urlFragment: storage-blob-samples
 ---
 
-# Azure Storage Blob Samples client library for C
+# Azure Storage Blob Samples client Library for Embedded C
 This document explains samples and how to use them.
 
 ## Key concepts


### PR DESCRIPTION
Fixes readme files to use a consistent name throughout.  

For this review please only focus on the "Embedded C" name change.  Yes I know there are other issues in the readme's.  You can call out other issues if you see them, but do not block the review on changes unrelated to the name change.  

Issues called out that are unrelated to the name change will be addressed in subsequent PRs.