### PR TITLE
Improve multithreaded logging

### DIFF
--- a/sdk/core/core/inc/_az_cfg.h
+++ b/sdk/core/core/inc/_az_cfg.h
@@ -60,7 +60,6 @@
 
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #pragma clang diagnostic ignored "-Wmissing-braces"
-#pragma clang diagnostic ignored "-Wswitch-bool"
 
 #endif // __clang__
 

--- a/sdk/core/core/inc/_az_cfg.h
+++ b/sdk/core/core/inc/_az_cfg.h
@@ -60,6 +60,7 @@
 
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #pragma clang diagnostic ignored "-Wmissing-braces"
+#pragma clang diagnostic ignored "-Wswitch-bool"
 
 #endif // __clang__
 

--- a/sdk/core/core/src/az_log.c
+++ b/sdk/core/core/src/az_log.c
@@ -40,7 +40,7 @@ static bool _az_log_write_engine(bool log_it, az_log_classification classificati
 {
   // Copy the volatile fields to local variables so that they don't change within this function
   az_log_message_fn const callback = _az_log_message_callback;
-  az_log_classification const* const classifications = _az_log_classifications;
+  az_log_classification const* classifications = _az_log_classifications;
 
   if (callback == NULL)
   {
@@ -48,27 +48,25 @@ static bool _az_log_write_engine(bool log_it, az_log_classification classificati
     return false;
   }
 
-  // If the user hasn't registered any classifications, then we log everything.
-  bool const log_everything = (classifications == NULL);
-  switch (log_everything)
+  az_log_classification current_classification[2] = { classification, AZ_LOG_END_OF_LIST };
+  if (classifications == NULL)
   {
-    case false:
-      for (az_log_classification const* cls = classifications; *cls != AZ_LOG_END_OF_LIST; ++cls)
-      {
-        // If this message's classification is in the customer-provided list, we should log it.
-        if (*cls == classification)
-        {
-          _az_FALLTHROUGH;
-          case true:
-            if (log_it)
-            {
-              callback(classification, message);
-            }
+    // If the user hasn't registered any classifications, then we log everything.
+    classifications = current_classification;
+  }
 
-            return true;
-        }
+  for (az_log_classification const* cls = classifications; *cls != AZ_LOG_END_OF_LIST; ++cls)
+  {
+    // If this message's classification is in the customer-provided list, we should log it.
+    if (*cls == classification)
+    {
+      if (log_it)
+      {
+        callback(classification, message);
       }
-  };
+      return true;
+    }
+  }
 
   // This message's classification is not in the customer-provided list; we should not log it.
   return false;

--- a/sdk/core/core/src/az_log.c
+++ b/sdk/core/core/src/az_log.c
@@ -47,11 +47,12 @@ static bool _az_log_write_engine(bool log_it, az_log_classification classificati
     return false;
   }
 
-  az_log_classification current_classification[2] = { classification, AZ_LOG_END_OF_LIST };
   if (classifications == NULL)
   {
     // If the user hasn't registered any classifications, then we log everything.
-    classifications = current_classification;
+    classifications
+        = &classification; // We don't need AZ_LOG_END_OF_LIST to be there, as very first comparison
+                           // is going to succeed and return from the function.
   }
 
   for (az_log_classification const* cls = classifications; *cls != AZ_LOG_END_OF_LIST; ++cls)
@@ -63,6 +64,7 @@ static bool _az_log_write_engine(bool log_it, az_log_classification classificati
       {
         callback(classification, message);
       }
+
       return true;
     }
   }

--- a/sdk/core/core/src/az_log.c
+++ b/sdk/core/core/src/az_log.c
@@ -31,8 +31,7 @@ void az_log_set_callback(az_log_message_fn az_log_message_callback)
 // _az_log_should_write & _az_log_write.
 //
 // If log_it is false, then the function returns true or false indicating whether the message
-// should be logged (without actually logging it). if log_it is false, then the function returns
-// true or false indicating whether the message should be logged (without actually logging it).
+// should be logged (without actually logging it).
 //
 // If log_it is true, then the function logs the message (if it should) and returns true or
 // false indicating whether it was logged.


### PR DESCRIPTION
I added this code per Jeffrey's request.

It is Jeffrey's code with my only addition of switch/case on `log_everything` to jump right inside the loop code without actually looping and creating a temporary array on the stack.

Existing logging tests are enough to ensure its correctness (but not to test race conditions).

Regarding race conditions, I have one question to Jeffrey, and I myself will ask him in the comments for this PR.