### PR TITLE
Log all classifications via single-item array

### DIFF
--- a/sdk/core/core/inc/_az_cfg.h
+++ b/sdk/core/core/inc/_az_cfg.h
@@ -60,7 +60,6 @@
 
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #pragma clang diagnostic ignored "-Wmissing-braces"
-#pragma clang diagnostic ignored "-Wswitch-bool"
 
 #endif // __clang__
 

--- a/sdk/core/core/src/az_log.c
+++ b/sdk/core/core/src/az_log.c
@@ -40,7 +40,7 @@ static bool _az_log_write_engine(bool log_it, az_log_classification classificati
 {
   // Copy the volatile fields to local variables so that they don't change within this function
   az_log_message_fn const callback = _az_log_message_callback;
-  az_log_classification const* const classifications = _az_log_classifications;
+  az_log_classification const* classifications = _az_log_classifications;
 
   if (callback == NULL)
   {
@@ -48,27 +48,25 @@ static bool _az_log_write_engine(bool log_it, az_log_classification classificati
     return false;
   }
 
-  // If the user hasn't registered any classifications, then we log everything.
-  bool const log_everything = (classifications == NULL);
-  switch (log_everything)
+  az_log_classification current_classification[2] = { classification, AZ_LOG_END_OF_LIST };
+  if (classifications == NULL)
   {
-    case false:
-      for (az_log_classification const* cls = classifications; *cls != AZ_LOG_END_OF_LIST; ++cls)
-      {
-        // If this message's classification is in the customer-provided list, we should log it.
-        if (*cls == classification)
-        {
-          _az_FALLTHROUGH;
-          case true:
-            if (log_it)
-            {
-              callback(classification, message);
-            }
+    // If the user hasn't registered any classifications, then we log everything.
+    classifications = current_classification;
+  }
 
-            return true;
-        }
+  for (az_log_classification const* cls = classifications; *cls != AZ_LOG_END_OF_LIST; ++cls)
+  {
+    // If this message's classification is in the customer-provided list, we should log it.
+    if (*cls == classification)
+    {
+      if (log_it)
+      {
+        callback(classification, message);
       }
-  };
+      return true;
+    }
+  }
 
   // This message's classification is not in the customer-provided list; we should not log it.
   return false;


### PR DESCRIPTION
Jeffrey, doing this the way you proposed, with the one exception that we can't create array inside the scope of `if()` assign it's pointer, and use that pointer in an outer scope.
If you think it is more clear, I can apply this. I don't think it is more readable, and it is not the most direct way to emulate with the single-item array, although I agree there is some elegance in that solution. Honestly I can understand it all, no matter how it is written.
I'd either write a separate logic for the if statement, that conditionally invokes the callback and returns true (https://github.com/Azure/azure-sdk-for-c/pull/698), or I'd use the JMP method (https://github.com/Azure/azure-sdk-for-c/pull/696), which generates less code. Up to you, you are the author, I'll do as you suggest. I personally prefer JMP :)