### PR TITLE
Add brief keyword to make sure the description shows up in docs and remove repeated type names

### DIFF
--- a/sdk/core/core/inc/az_context.h
+++ b/sdk/core/core/inc/az_context.h
@@ -25,8 +25,9 @@
 typedef struct az_context az_context;
 
 /**
- * @brief An az_context value is a node in a tree that represents expiration times and key/value
- * pairs. The root node in the tree (ultimate parent) is az_context_app which is a context for the
+ * @brief A context is a node within a tree that represents expiration times and key/value
+ * pairs.
+ * @details The root node in the tree (ultimate parent) is #az_context_app which is a context for the
  * entire application. Each new node is a child of some parent.
  */
 struct az_context

--- a/sdk/core/core/inc/az_credentials.h
+++ b/sdk/core/core/inc/az_credentials.h
@@ -80,7 +80,7 @@ typedef struct
 } _az_credential;
 
 /**
- * @brief az_credential_client_secret is used by an Azure SDK client to authenticate with its
+ * @brief This structure is used by Azure SDK clients to authenticate with the
  * Azure service using a tenant ID, client ID and client secret.
  */
 typedef struct

--- a/sdk/core/core/inc/az_http.h
+++ b/sdk/core/core/inc/az_http.h
@@ -128,7 +128,7 @@ typedef enum
 } _az_http_response_kind;
 
 /**
- * @brief Represents an HTTP response.
+ * @brief Allows you to parse an HTTP response's status line, headers, and body.
  *
  * @details Users create an instance of this and pass it in to an Azure service client's operation
  * function. The function initializes the az_http_response and application code can query the

--- a/sdk/core/core/inc/az_http.h
+++ b/sdk/core/core/inc/az_http.h
@@ -108,8 +108,9 @@ typedef enum
 /**
  * @brief Allows you to customize the retry policy used by SDK clients whenever they performs an I/O
  * operation.
- * @details Applications should acquire an initialized instance of this struct and then modify any
- * fields you desire before passing a pointer to this struct when initializing the specific client.
+ * @details Client libraries should acquire an initialized instance of this struct and then modify
+ * any fields necessary before passing a pointer to this struct when initializing the specific
+ * client.
  */
 typedef struct
 {

--- a/sdk/core/core/inc/az_http.h
+++ b/sdk/core/core/inc/az_http.h
@@ -106,11 +106,10 @@ typedef enum
 } az_http_status_code;
 
 /**
- * @brief An az_http_policy_retry_options instance allows you to customize the retry policy
- * used by an XxxClient type whenever it performs an I/O operation. Applications should
- * acquire an initialized instance of this struct by calling az_http_policy_retry_options_default
- * first and then modify any fields you desire before passing a pointer to this struct
- * when initializing the XxxClient.
+ * @brief Allows you to customize the retry policy used by SDK clients whenever they performs an I/O
+ * operation.
+ * @details Applications should acquire an initialized instance of this struct and then modify any
+ * fields you desire before passing a pointer to this struct when initializing the specific client.
  */
 typedef struct
 {
@@ -129,12 +128,12 @@ typedef enum
 } _az_http_response_kind;
 
 /**
- * @brief az_http_response represents an HTTP response.
+ * @brief Represents an HTTP response.
  *
- * Users create an instance of this and pass it in to an Azure service client's operation function.
- * The function initializes the az_http_response and application code can query the response after
- * the operation completes by calling the az_http_response_get_status_line,
- * az_http_response_get_next_header and az_http_response_get_body functions.
+ * @details Users create an instance of this and pass it in to an Azure service client's operation
+ * function. The function initializes the az_http_response and application code can query the
+ * response after the operation completes by calling the #az_http_response_get_status_line,
+ * #az_http_response_get_next_header and #az_http_response_get_body functions.
  *
  */
 typedef struct
@@ -177,8 +176,8 @@ AZ_NODISCARD AZ_INLINE az_result az_http_response_init(az_http_response* respons
 }
 
 /**
- * @brief az_http_response_status_line represents the result of making an HTTP request.
- * An application obtains this initialed structured by calling az_http_response_get_status_line.
+ * @brief Represents the result of making an HTTP request.
+ * An application obtains this initialized structure by calling #az_http_response_get_status_line.
  *
  * @see https://tools.ietf.org/html/rfc7230#section-3.1.2
  */

--- a/sdk/core/core/inc/az_json.h
+++ b/sdk/core/core/inc/az_json.h
@@ -58,7 +58,7 @@ typedef struct
 } _az_json_bit_stack;
 
 /**
- * @brief An az_json_token instance represents a JSON token. The kind field indicates the kind of
+ * @brief Represents a JSON token. The kind field indicates the kind of
  * token and based on the kind, you can access the corresponding field.
  */
 typedef struct
@@ -439,7 +439,7 @@ AZ_NODISCARD az_result az_json_builder_append_end_array(az_json_builder* json_bu
 typedef uint64_t _az_json_stack;
 
 /**
- * @brief An az_json_parser returns the JSON tokens contained within a JSON buffer.
+ * @brief Returns the JSON tokens contained within a JSON buffer.
  */
 typedef struct
 {
@@ -451,7 +451,7 @@ typedef struct
 } az_json_parser;
 
 /**
- * @brief An az_json_token_member represents a JSON element's name and value.
+ * @brief Represents a JSON element's name and value.
  */
 typedef struct
 {

--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -26,8 +26,8 @@
 #include <_az_cfg_prefix.h>
 
 /**
- * @brief A span is a "view" over a byte buffer that represents a contiguous region of memory. It contains
- * a pointer to the start of the byte buffer and the buffer's size.
+ * @brief Represents a "view" over a byte buffer that represents a contiguous region of memory. It
+ * contains a pointer to the start of the byte buffer and the buffer's size.
  */
 typedef struct
 {

--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -26,7 +26,7 @@
 #include <_az_cfg_prefix.h>
 
 /**
- * A span is a "view" over a byte buffer that represents a contiguous region of memory. It contains
+ * @brief A span is a "view" over a byte buffer that represents a contiguous region of memory. It contains
  * a pointer to the start of the byte buffer and the buffer's size.
  */
 typedef struct
@@ -389,7 +389,7 @@ AZ_NODISCARD az_result az_span_dtoa(az_span destination, double source, az_span*
 /******************************  SPAN PAIR  */
 
 /**
- * An #az_pair represents a key/value pair of #az_span instances.
+ * @brief Represents a key/value pair of #az_span instances.
  * This is typically used for HTTP query parameters and headers.
  */
 typedef struct


### PR DESCRIPTION
My goal with this PR was to improve the `Data Structures` docs page.
1) Remove redundant/unnecessary links and info
2) Keep the `@brief` short (1-2 short sentences at most). Move the rest to `@details`.
3) Make sure that each typedef has a `@brief`.

**Before:**
![image](https://user-images.githubusercontent.com/6527137/81617209-dc171100-9399-11ea-987f-e0d8e291da17.png)

**After:**
![image](https://user-images.githubusercontent.com/6527137/81617115-aeca6300-9399-11ea-8f17-a626cce19e10.png)

cc @danieljurek 