### PR TITLE
Make sure to avoid passing null ptr to memcmp within az_span_is_content_equal.

### DIFF
--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -195,8 +195,22 @@ AZ_NODISCARD az_span az_span_slice_to_end(az_span span, int32_t start_index);
  */
 AZ_NODISCARD AZ_INLINE bool az_span_is_content_equal(az_span span1, az_span span2)
 {
-  return az_span_size(span1) == az_span_size(span2)
-      && memcmp(az_span_ptr(span1), az_span_ptr(span2), (size_t)az_span_size(span1)) == 0;
+  int32_t span1_size = az_span_size(span1);
+  int32_t span2_size = az_span_size(span2);
+
+  // Make sure to avoid passing a null pointer to memcmp, which is considered undefined.
+  // We assume that if the size is non-zero, then the pointer can't be null.
+  if (span1_size == 0)
+  {
+    // Two empty spans are considered equal, even if their pointers are different.
+    return span2_size == 0;
+  }
+
+  // If span2_size == 0, then the first condition which compares sizes will be false, since we
+  // checked the size of span1 above. And due to short-circuiting we won't be calling memcmp anyway.
+  // Therefore, we don't need to check for that explicitly.
+  return span1_size == span2_size
+      && memcmp(az_span_ptr(span1), az_span_ptr(span2), (size_t)span1_size) == 0;
 }
 
 /**

--- a/sdk/core/core/test/cmocka/test_az_span.c
+++ b/sdk/core/core/test/cmocka/test_az_span.c
@@ -98,20 +98,29 @@ static void test_az_span_is_content_equal(void** state)
   az_span a = AZ_SPAN_FROM_STR("one");
   az_span b = AZ_SPAN_FROM_STR("One");
   az_span c = AZ_SPAN_FROM_STR("one1");
+  az_span d = AZ_SPAN_FROM_STR("done"); // d contains a
 
   assert_false(az_span_is_content_equal(a, b));
   assert_false(az_span_is_content_equal(b, a));
   assert_false(az_span_is_content_equal(a, c));
   assert_false(az_span_is_content_equal(c, a));
+  assert_false(az_span_is_content_equal(a, d));
+  assert_false(az_span_is_content_equal(d, a));
 
   assert_true(az_span_is_content_equal(a, AZ_SPAN_FROM_STR("one")));
-
-  assert_false(az_span_is_content_equal(a, AZ_SPAN_NULL));
-  assert_false(az_span_is_content_equal(AZ_SPAN_NULL, a));
-  assert_true(az_span_is_content_equal(AZ_SPAN_NULL, AZ_SPAN_NULL));
   assert_true(az_span_is_content_equal(a, a));
 
+  // Comparing subsets
+  assert_true(az_span_is_content_equal(a, az_span_slice_to_end(d, 1)));
+  assert_true(az_span_is_content_equal(az_span_slice_to_end(d, 1), a));
+
+  // Comparing empty to non-empty
+  assert_false(az_span_is_content_equal(a, AZ_SPAN_NULL));
+  assert_false(az_span_is_content_equal(AZ_SPAN_NULL, a));
+
   // Empty spans are equal
+  assert_true(az_span_is_content_equal(AZ_SPAN_NULL, AZ_SPAN_NULL));
+
   assert_true(az_span_is_content_equal(az_span_slice_to_end(a, 3), AZ_SPAN_NULL));
   assert_true(az_span_is_content_equal(az_span_slice_to_end(a, 3), az_span_slice_to_end(b, 3)));
 

--- a/sdk/core/core/test/cmocka/test_az_span.c
+++ b/sdk/core/core/test/cmocka/test_az_span.c
@@ -91,6 +91,35 @@ static void az_span_to_lower_test(void** state)
   assert_false(az_span_is_content_equal_ignoring_case(a, d));
 }
 
+static void test_az_span_is_content_equal(void** state)
+{
+  (void)state;
+
+  az_span a = AZ_SPAN_FROM_STR("one");
+  az_span b = AZ_SPAN_FROM_STR("One");
+  az_span c = AZ_SPAN_FROM_STR("one1");
+
+  assert_false(az_span_is_content_equal(a, b));
+  assert_false(az_span_is_content_equal(b, a));
+  assert_false(az_span_is_content_equal(a, c));
+  assert_false(az_span_is_content_equal(c, a));
+
+  assert_true(az_span_is_content_equal(a, AZ_SPAN_FROM_STR("one")));
+
+  assert_false(az_span_is_content_equal(a, AZ_SPAN_NULL));
+  assert_false(az_span_is_content_equal(AZ_SPAN_NULL, a));
+  assert_true(az_span_is_content_equal(AZ_SPAN_NULL, AZ_SPAN_NULL));
+  assert_true(az_span_is_content_equal(a, a));
+
+  // Empty spans are equal
+  assert_true(az_span_is_content_equal(az_span_slice_to_end(a, 3), AZ_SPAN_NULL));
+  assert_true(az_span_is_content_equal(az_span_slice_to_end(a, 3), az_span_slice_to_end(b, 3)));
+
+  assert_true(az_span_is_content_equal(AZ_SPAN_FROM_STR(""), AZ_SPAN_FROM_STR("")));
+  assert_true(az_span_is_content_equal(AZ_SPAN_FROM_STR(""), AZ_SPAN_NULL));
+  assert_true(az_span_is_content_equal(AZ_SPAN_FROM_STR(""), az_span_slice_to_end(a, 3)));
+}
+
 static void az_span_atou64_return_errors(void** state)
 {
   (void)state;
@@ -1015,6 +1044,7 @@ int test_az_span()
     cmocka_unit_test(az_single_char_ascii_lower_test),
     cmocka_unit_test(az_span_to_lower_test),
     cmocka_unit_test(az_span_to_str_test),
+    cmocka_unit_test(test_az_span_is_content_equal),
     cmocka_unit_test(az_span_find_beginning_success),
     cmocka_unit_test(az_span_find_middle_success),
     cmocka_unit_test(az_span_find_end_success),


### PR DESCRIPTION
@vhvb1989 detected that using the SDK APIs within a sample app give a warning when compiling with gcc (`-O1` compiler flags). We now avoid passing a null pointer to `memcmp`.

Here is the compiler warning we want to avoid (shared by @vhvb1989)
```text
/home/vagrant/workspace/azure-sdk-for-c/sdk/samples/keyvault/keyvault/src/az_keyvault_client.c: In function ‘_az_keyvault_keys_key_create_build_json_body’:
/home/vagrant/workspace/azure-sdk-for-c/sdk/core/core/inc/az_span.h:199:10: error: argument 2 null where non-null expected [-Werror=nonnull]
       && memcmp(az_span_ptr(span1), az_span_ptr(span2), (size_t)az_span_size(span1)) == 0;
```