### PR TITLE
Remove the "getting started" section from the az_core README.

### DIFF
--- a/sdk/core/core/README.md
+++ b/sdk/core/core/README.md
@@ -4,10 +4,6 @@ Azure Core Library for Embedded C (`az_core`) provides shared primitives, abstra
 
 The library allows client libraries to expose common functionality in a consistent fashion.  Once you learn how to use these APIs in one client library, you will know how to use them in other client libraries.
 
-## Getting Started
-
-TODO
-
 ## Porting the Azure SDK to Another Platform
 
 The `Azure Core` library requires you to implement a few functions to provide platform-specific features such as a clock, a thread sleep, a mutual-exclusive thread synchronization lock, and an HTTP stack. By default, `Azure Core` ships with no-op versions of these functions, all of which return `AZ_RESULT_NOT_IMPLEMENTED`. The no-op versions allow the Azure SDK to compile successfully so you can verify that your build tool chain is working properly; however, failures occur if you execute the code.


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/723

If we want to add this back in the future, we'd want to include details on how to build and consume azure core (if we distributed packages, rather than libraries and shipping sources). 

Currently, the steps to build is identical to what's in the root of the repo, so removing that section.