### PR TITLE
Fix up doxyfile based on the recent iot/core to iot/common directory rename.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -814,7 +814,7 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = ./sdk/core/core/inc \
-                         ./sdk/iot/core/inc \
+                         ./sdk/iot/common/inc \
                          ./sdk/iot/hub/inc \
                          ./sdk/iot/provisioning/inc \
                          ./README.md


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-for-c/pull/674

Fyi @ewertons 

@danieljurek do you know how the fact that the input wasn't set to the right directory name would impact running `doxygen Doxyfile` at the root of the repo?