### PR TITLE
Rename BUILD_PRECONDITIONS and other cmake options to be more concise and fix cmocka typos.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,19 +6,19 @@ cmake_minimum_required (VERSION 3.10)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake-modules")
 
 option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
-option(BUILD_CURL_TRANSPORT "Build internal http transport implementation with CURL for HTTP Pipeline" OFF)
+option(TRANSPORT_CURL "Build internal http transport implementation with CURL for HTTP Pipeline" OFF)
 option(UNIT_TESTING "Build unit test projects" OFF)
-option(UNIT_TESTING_MOCK_ENABLED "wrap PAL functions with mock implementation for tests" OFF)
+option(UNIT_TESTING_MOCKS "wrap PAL functions with mock implementation for tests" OFF)
 option(BUILD_PAHO_TRANSPORT "Build IoT Samples with Paho MQTT support" OFF)
-option(BUILD_WITH_PRECONDITIONS "Build SDK with preconditions enabled" ON)
+option(PRECONDITIONS "Build SDK with preconditions enabled" ON)
 
 # disable preconditions when it's set to OFF
-if (NOT BUILD_WITH_PRECONDITIONS)
+if (NOT PRECONDITIONS)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DAZ_NO_PRECONDITION_CHECKING")
 endif()
 
 # enable mock functions with link option -ld
-if(UNIT_TESTING_MOCK_ENABLED)
+if(UNIT_TESTING_MOCKS)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_az_MOCK_ENABLED")
 endif()
 
@@ -50,7 +50,7 @@ add_subdirectory(sdk/core/core)
 add_subdirectory(sdk/platform/http_client/nohttp)
 # Adding transport implementation for curl
 # Users can still build Core and SDK client without depending on a HTTP transport implementation
-if(BUILD_CURL_TRANSPORT)
+if(TRANSPORT_CURL)
   add_subdirectory(sdk/platform/http_client/curl)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,10 @@ option(BUILD_CURL_TRANSPORT "Build internal http transport implementation with C
 option(UNIT_TESTING "Build unit test projects" OFF)
 option(UNIT_TESTING_MOCK_ENABLED "wrap PAL functions with mock implementation for tests" OFF)
 option(BUILD_PAHO_TRANSPORT "Build IoT Samples with Paho MQTT support" OFF)
-option(BUILD_PRECONDITIONS "Build SDK with preconditions enabled" ON)
+option(BUILD_WITH_PRECONDITIONS "Build SDK with preconditions enabled" ON)
 
 # disable preconditions when it's set to OFF
-if (NOT BUILD_PRECONDITIONS)
+if (NOT BUILD_WITH_PRECONDITIONS)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DAZ_NO_PRECONDITION_CHECKING")
 endif()
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,10 +97,10 @@ Some test uses linker option ld to wrap functions and mock the implementation fo
 
 In order to run this tests, GCC is required (or any compiler that supports -ld linker flag).
 
-To enable building project and linking with this option, as well as adding tests using mocked functions, add option `-DUNIT_TESTING_MOCK_ENABLED=ON` next to `-DUNIT_TESTING=ON` to cmake cache generation (see below example)
+To enable building project and linking with this option, as well as adding tests using mocked functions, add option `-DUNIT_TESTING_MOCKS=ON` next to `-DUNIT_TESTING=ON` to cmake cache generation (see below example)
 
 ```cmake
-cmake -DUNIT_TESTING=ON -DUNIT_TESTING_MOCK_ENABLED=ON ..
+cmake -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON ..
 ```
 
 ## Build Docs

--- a/README.md
+++ b/README.md
@@ -116,17 +116,17 @@ The following compiler options are available for adding/removing project feature
 <td>OFF</td>
 </tr>
 <tr>
-<td>UNIT_TESTING_MOCK_ENABLED</td>
+<td>UNIT_TESTING_MOCKS</td>
 <td>This option works only with GCC. It uses -ld option from linker to mock functions during unit test. This is used to test platform or HTTP functions by mocking the return values.</td>
 <td>OFF</td>
 </tr>
 <tr>
-<td>BUILD_PRECONDITIONS</td>
+<td>PRECONDITIONS</td>
 <td>Turning this option ON would remove all method contracts. This us typically for shipping libraries for production to make it as much optimized as possible.</td>
 <td>ON</td>
 </tr>
 <tr>
-<td>BUILD_CURL_TRANSPORT</td>
+<td>TRANSPORT_CURL</td>
 <td>This option requires Libcurl dependency to be available. It generates an HTTP stack with libcurl for az_http to be able to send requests thru the wire. This library would replace the no_http.</td>
 <td>OFF</td>
 </tr>
@@ -150,7 +150,7 @@ The following compiler options are available for adding/removing project feature
 Running sample with no_op HTTP implementation.
 Recompile az_core with an HTTP client implementation like CURL to see sample sending network requests.
 
-i.e. cmake -DBUILD_CURL_TRANSPORT=ON ..
+i.e. cmake -DTRANSPORT_CURL=ON ..
 ```
 
 ## Running Samples

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -9,11 +9,11 @@ jobs:
     matrix:
       # Build with no dependencies at all (No samples) - PRECONDITIONS ON
       # WARNINGS_AS_ERRORS          ON
-      # BUILD_CURL_TRANSPORT        OFF
+      # TRANSPORT_CURL              OFF
       # UNIT_TESTING                OFF
-      # UNIT_TESTING_MOCK_ENABLED   OFF
+      # UNIT_TESTING_MOCKS          OFF
       # BUILD_PAHO_TRANSPORT        OFF
-      # BUILD_WITH_PRECONDITIONS    ON
+      # PRECONDITIONS               ON
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
       Linux_x64:
         vm.image: 'ubuntu-18.04'
@@ -38,84 +38,84 @@ jobs:
 
       # Build with sample dependencies [curl for transport] - PRECONDITIONS ON
       # WARNINGS_AS_ERRORS          ON
-      # BUILD_CURL_TRANSPORT        ON
+      # TRANSPORT_CURL              ON
       # UNIT_TESTING                OFF
-      # UNIT_TESTING_MOCK_ENABLED   OFF
+      # UNIT_TESTING_MOCKS          OFF
       # BUILD_PAHO_TRANSPORT        ON
-      # BUILD_WITH_PRECONDITIONS    ON
+      # PRECONDITIONS               ON
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
       Linux_x64_with_samples:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: 'curl[ssl] paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX'
+        build.args: ' -DTRANSPORT_CURL=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX'
       Win_x86_with_samples:
         vm.image: 'windows-2019'
         vcpkg.deps: 'curl[winssl] paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32'
+        build.args: ' -DTRANSPORT_CURL=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32'
       Win_x64_with_samples:
         vm.image: 'windows-2019'
         vcpkg.deps: 'curl[winssl] paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32'
+        build.args: ' -DTRANSPORT_CURL=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32'
       MacOS_x64_with_samples:
         vm.image: 'macOS-10.15'
         vcpkg.deps: 'curl[ssl] paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX'
+        build.args: ' -DTRANSPORT_CURL=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX'
 
       # Build with sample dependencies and unit testing [curl for transport and cmocka]  - PRECONDITIONS ON
       # WARNINGS_AS_ERRORS          ON
-      # BUILD_CURL_TRANSPORT        ON
+      # TRANSPORT_CURL              ON
       # UNIT_TESTING                ON
-      # UNIT_TESTING_MOCK_ENABLED   OFF
+      # UNIT_TESTING_MOCKS          OFF
       # BUILD_PAHO_TRANSPORT        ON
-      # BUILD_WITH_PRECONDITIONS    ON
+      # PRECONDITIONS               ON
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
       Linux_x64_with_samples_and_unit_test:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
+        build.args: ' -DTRANSPORT_CURL=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
       Win_x86_with_samples_and_unit_test:
         vm.image: 'windows-2019'
         vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
+        build.args: ' -DTRANSPORT_CURL=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
       Win_x64_with_samples_and_unit_test:
         vm.image: 'windows-2019'
         vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
+        build.args: ' -DTRANSPORT_CURL=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
       MacOS_x64_with_samples_and_unit_test:
         vm.image: 'macOS-10.15'
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        build.args: ' -DBUILD_CURL_TRANSPORT=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
+        build.args: ' -DTRANSPORT_CURL=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
 
       # Build with unit testing only. No samples [cmocka] - PRECONDITIONS ON
       # WARNINGS_AS_ERRORS          ON
-      # BUILD_CURL_TRANSPORT        OFF
+      # TRANSPORT_CURL              OFF
       # UNIT_TESTING                ON
-      # UNIT_TESTING_MOCK_ENABLED   ON
+      # UNIT_TESTING_MOCKS          ON
       # BUILD_PAHO_TRANSPORT        OFF
-      # BUILD_WITH_PRECONDITIONS    ON
+      # PRECONDITIONS               ON
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
       Linux_x64_with_unit_test:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         # This is the only platform where we run mocking functions and generate CodeCoverage
-        build.args: ' -DUNIT_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING_MOCK_ENABLED=ON'
+        build.args: ' -DUNIT_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING_MOCKS=ON'
         AZ_SDK_CODE_COV: 1
       Win_x86_with_unit_test:
         vm.image: 'windows-2019'
@@ -139,36 +139,36 @@ jobs:
 
       # Build with unit testing only. No samples [cmocka] - PRECONDITIONS OFF
       # WARNINGS_AS_ERRORS          ON
-      # BUILD_CURL_TRANSPORT        OFF
+      # TRANSPORT_CURL              OFF
       # UNIT_TESTING                ON
-      # UNIT_TESTING_MOCK_ENABLED   OFF
+      # UNIT_TESTING_MOCKS          OFF
       # BUILD_PAHO_TRANSPORT        OFF
-      # BUILD_WITH_PRECONDITIONS    OFF
+      # PRECONDITIONS               OFF
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
       Linux_x64_with_unit_test_no_preconditions:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DUNIT_TESTING=ON -DBUILD_WITH_PRECONDITIONS=OFF'
+        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
       Win_x86_with_unit_test_no_preconditions:
         vm.image: 'windows-2019'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DUNIT_TESTING=ON -DBUILD_WITH_PRECONDITIONS=OFF'
+        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
       Win_x64_with_unit_test_no_preconditions:
         vm.image: 'windows-2019'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DUNIT_TESTING=ON -DBUILD_WITH_PRECONDITIONS=OFF'
+        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
       MacOS_x64_with_unit_test_no_preconditions:
         vm.image: 'macOS-10.15'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        build.args: ' -DUNIT_TESTING=ON -DBUILD_WITH_PRECONDITIONS=OFF'
+        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
   pool:
     vmImage: $(vm.image)
   variables:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -13,7 +13,7 @@ jobs:
       # UNIT_TESTING                OFF
       # UNIT_TESTING_MOCK_ENABLED   OFF
       # BUILD_PAHO_TRANSPORT        OFF
-      # BUILD_PRECONDITIONS         ON
+      # BUILD_WITH_PRECONDITIONS    ON
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
       Linux_x64:
         vm.image: 'ubuntu-18.04'
@@ -42,7 +42,7 @@ jobs:
       # UNIT_TESTING                OFF
       # UNIT_TESTING_MOCK_ENABLED   OFF
       # BUILD_PAHO_TRANSPORT        ON
-      # BUILD_PRECONDITIONS         ON
+      # BUILD_WITH_PRECONDITIONS    ON
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
       Linux_x64_with_samples:
         vm.image: 'ubuntu-18.04'
@@ -69,13 +69,13 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
         build.args: ' -DBUILD_CURL_TRANSPORT=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX'
 
-      # Build with sample dependencies and unit testing [curl for transport and cmoka]  - PRECONDITIONS ON
+      # Build with sample dependencies and unit testing [curl for transport and cmocka]  - PRECONDITIONS ON
       # WARNINGS_AS_ERRORS          ON
       # BUILD_CURL_TRANSPORT        ON
       # UNIT_TESTING                ON
       # UNIT_TESTING_MOCK_ENABLED   OFF
       # BUILD_PAHO_TRANSPORT        ON
-      # BUILD_PRECONDITIONS         ON
+      # BUILD_WITH_PRECONDITIONS    ON
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
       Linux_x64_with_samples_and_unit_test:
         vm.image: 'ubuntu-18.04'
@@ -102,13 +102,13 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
         build.args: ' -DBUILD_CURL_TRANSPORT=ON -DBUILD_PAHO_TRANSPORT=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
 
-      # Build with unit testing only. No samples [cmoka] - PRECONDITIONS ON
+      # Build with unit testing only. No samples [cmocka] - PRECONDITIONS ON
       # WARNINGS_AS_ERRORS          ON
       # BUILD_CURL_TRANSPORT        OFF
       # UNIT_TESTING                ON
       # UNIT_TESTING_MOCK_ENABLED   ON
       # BUILD_PAHO_TRANSPORT        OFF
-      # BUILD_PRECONDITIONS         ON
+      # BUILD_WITH_PRECONDITIONS    ON
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
       Linux_x64_with_unit_test:
         vm.image: 'ubuntu-18.04'
@@ -137,38 +137,38 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
         build.args: ' -DUNIT_TESTING=ON'
 
-      # Build with unit testing only. No samples [cmoka] - PRECONDITIONS OFF
+      # Build with unit testing only. No samples [cmocka] - PRECONDITIONS OFF
       # WARNINGS_AS_ERRORS          ON
       # BUILD_CURL_TRANSPORT        OFF
       # UNIT_TESTING                ON
       # UNIT_TESTING_MOCK_ENABLED   OFF
       # BUILD_PAHO_TRANSPORT        OFF
-      # BUILD_PRECONDITIONS         OFF
+      # BUILD_WITH_PRECONDITIONS    OFF
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
       Linux_x64_with_unit_test_no_preconditions:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DUNIT_TESTING=ON -DBUILD_PRECONDITIONS=OFF'
+        build.args: ' -DUNIT_TESTING=ON -DBUILD_WITH_PRECONDITIONS=OFF'
       Win_x86_with_unit_test_no_preconditions:
         vm.image: 'windows-2019'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DUNIT_TESTING=ON -DBUILD_PRECONDITIONS=OFF'
+        build.args: ' -DUNIT_TESTING=ON -DBUILD_WITH_PRECONDITIONS=OFF'
       Win_x64_with_unit_test_no_preconditions:
         vm.image: 'windows-2019'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DUNIT_TESTING=ON -DBUILD_PRECONDITIONS=OFF'
+        build.args: ' -DUNIT_TESTING=ON -DBUILD_WITH_PRECONDITIONS=OFF'
       MacOS_x64_with_unit_test_no_preconditions:
         vm.image: 'macOS-10.15'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        build.args: ' -DUNIT_TESTING=ON -DBUILD_PRECONDITIONS=OFF'
+        build.args: ' -DUNIT_TESTING=ON -DBUILD_WITH_PRECONDITIONS=OFF'
   pool:
     vmImage: $(vm.image)
   variables:

--- a/sdk/core/core/README.md
+++ b/sdk/core/core/README.md
@@ -122,7 +122,7 @@ The public SDK functions validate the arguments passed to them to ensure that th
 
 To override the default behavior, implement a function matching the `az_precondition_failed_fn` function signature and then, in your application's initialization (before calling any Azure SDK function), call `az_precondition_failed_set_callback` passing it the address of your function. Now, when any Azure SDK function detects a precondition failure, it will invoke your callback instead. You might override the callback to attach a debugger or perhaps to reboot the device rather than allowing it to continue running with unpredictable behavior.
 
-Also, if you define the `AZ_NO_PRECONDITION_CHECKING` symbol when compiling the SDK code (or adding option -DBUILD_WITH_PRECONDITIONS=OFF with cmake), all of the Azure SDK precondition checking will be excluded, making the binary code smaller and faster. We recommend doing this before you ship your code.
+Also, if you define the `AZ_NO_PRECONDITION_CHECKING` symbol when compiling the SDK code (or adding option -DPRECONDITIONS=OFF with cmake), all of the Azure SDK precondition checking will be excluded, making the binary code smaller and faster. We recommend doing this before you ship your code.
 
 ### Canceling an Operation
 

--- a/sdk/core/core/README.md
+++ b/sdk/core/core/README.md
@@ -122,7 +122,7 @@ The public SDK functions validate the arguments passed to them to ensure that th
 
 To override the default behavior, implement a function matching the `az_precondition_failed_fn` function signature and then, in your application's initialization (before calling any Azure SDK function), call `az_precondition_failed_set_callback` passing it the address of your function. Now, when any Azure SDK function detects a precondition failure, it will invoke your callback instead. You might override the callback to attach a debugger or perhaps to reboot the device rather than allowing it to continue running with unpredictable behavior.
 
-Also, if you define the `AZ_NO_PRECONDITION_CHECKING` symbol when compiling the SDK code (or adding option -DBUILD_PRECONDITIONS=OFF with cmake), all of the Azure SDK precondition checking will be excluded, making the binary code smaller and faster. We recommend doing this before you ship your code.
+Also, if you define the `AZ_NO_PRECONDITION_CHECKING` symbol when compiling the SDK code (or adding option -DBUILD_WITH_PRECONDITIONS=OFF with cmake), all of the Azure SDK precondition checking will be excluded, making the binary code smaller and faster. We recommend doing this before you ship your code.
 
 ### Canceling an Operation
 

--- a/sdk/core/core/inc/az_precondition.h
+++ b/sdk/core/core/inc/az_precondition.h
@@ -24,7 +24,7 @@
  *        unpredictable behavior.
  *
  *        Also, if you define the AZ_NO_PRECONDITION_CHECKING symbol when compiling the SDK
- *        code (or adding option -DBUILD_PRECONDITIONS=OFF with cmake), all of the Azure SDK
+ *        code (or adding option -DBUILD_WITH_PRECONDITIONS=OFF with cmake), all of the Azure SDK
  *        precondition checking will be excluding making the binary code smaller and faster. We
  *        recommend doing this before you ship your code.
  *

--- a/sdk/core/core/inc/az_precondition.h
+++ b/sdk/core/core/inc/az_precondition.h
@@ -24,7 +24,7 @@
  *        unpredictable behavior.
  *
  *        Also, if you define the AZ_NO_PRECONDITION_CHECKING symbol when compiling the SDK
- *        code (or adding option -DBUILD_WITH_PRECONDITIONS=OFF with cmake), all of the Azure SDK
+ *        code (or adding option -DPRECONDITIONS=OFF with cmake), all of the Azure SDK
  *        precondition checking will be excluding making the binary code smaller and faster. We
  *        recommend doing this before you ship your code.
  *

--- a/sdk/core/core/internal/az_precondition_internal.h
+++ b/sdk/core/core/internal/az_precondition_internal.h
@@ -24,7 +24,7 @@
  *        unpredictable behavior.
  *
  *        Also, if you define the AZ_NO_PRECONDITION_CHECKING symbol when compiling the SDK
- *        code (or adding option -DBUILD_PRECONDITIONS=OFF with cmake), all of the Azure SDK
+ *        code (or adding option -DBUILD_WITH_PRECONDITIONS=OFF with cmake), all of the Azure SDK
  *        precondition checking will be excluding making the binary code smaller and faster. We
  *        recommend doing this before you ship your code.
  */

--- a/sdk/core/core/internal/az_precondition_internal.h
+++ b/sdk/core/core/internal/az_precondition_internal.h
@@ -24,7 +24,7 @@
  *        unpredictable behavior.
  *
  *        Also, if you define the AZ_NO_PRECONDITION_CHECKING symbol when compiling the SDK
- *        code (or adding option -DBUILD_WITH_PRECONDITIONS=OFF with cmake), all of the Azure SDK
+ *        code (or adding option -DPRECONDITIONS=OFF with cmake), all of the Azure SDK
  *        precondition checking will be excluding making the binary code smaller and faster. We
  *        recommend doing this before you ship your code.
  */

--- a/sdk/core/core/test/cmocka/CMakeLists.txt
+++ b/sdk/core/core/test/cmocka/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_C_STANDARD 99)
 include(AddTestCMocka)
 
 # -ld link option is only available for gcc
-if(UNIT_TESTING_MOCK_ENABLED)
+if(UNIT_TESTING_MOCKS)
     set(WRAP_FUNCTIONS "-Wl,--wrap=az_platform_clock_msec -Wl,--wrap=az_http_client_send_request")
 else()
     set(WRAP_FUNCTIONS "")

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -132,7 +132,7 @@ int main()
   {
     printf("Running sample with no_op HTTP implementation.\nRecompile az_core with an HTTP client "
            "implementation like CURL to see sample sending network requests.\n\n"
-           "i.e. cmake -DBUILD_CURL_TRANSPORT=ON ..\n\n");
+           "i.e. cmake -DTRANSPORT_CURL=ON ..\n\n");
     return 0;
   }
 

--- a/sdk/storage/blobs/samples/src/blobs_client_example.c
+++ b/sdk/storage/blobs/samples/src/blobs_client_example.c
@@ -93,7 +93,7 @@ int main()
   {
     printf("Running sample with no_op HTTP implementation.\nRecompile az_core with an HTTP client "
            "implementation like CURL to see sample sending network requests.\n\n"
-           "i.e. cmake -DBUILD_CURL_TRANSPORT=ON ..\n\n");
+           "i.e. cmake -DTRANSPORT_CURL=ON ..\n\n");
     return 0;
   }
 


### PR DESCRIPTION
Follow up to address feedback from https://github.com/Azure/azure-sdk-for-c/pull/582
- https://github.com/Azure/azure-sdk-for-c/pull/582#discussion_r409166562
- https://github.com/Azure/azure-sdk-for-c/pull/582#discussion_r409167111

cc @vhvb1989 