### PR TITLE
Samples: remove internal headers

### DIFF
--- a/sdk/core/core/inc/az_span.h
+++ b/sdk/core/core/inc/az_span.h
@@ -55,9 +55,38 @@ AZ_NODISCARD AZ_INLINE int32_t az_span_size(az_span span) { return span._interna
 /********************************  CONSTRUCTORS */
 
 /**
+ * @brief Returns an #az_span over a byte buffer.
+ *
+ * @param[in] ptr The memory address of the 1st byte in the byte buffer.
+ * @param[in] size The number of total bytes in the byte buffer.
+ * @return The "view" over the byte buffer.
+ */
+// Note: If you are modifying this method, make sure to modify the non-inline version in the
+// az_span.c file as well, and the _az_ version right below.
+#ifdef AZ_NO_PRECONDITION_CHECKING
+AZ_NODISCARD AZ_INLINE az_span az_span_init(uint8_t* ptr, int32_t size)
+{
+  return (az_span){ ._internal = { .ptr = ptr, .size = size } };
+}
+#else
+AZ_NODISCARD az_span az_span_init(uint8_t* ptr, int32_t size);
+#endif // AZ_NO_PRECONDITION_CHECKING
+
+// Same function as above, only for use in AZ_SPAN_FROM_BUFFER macro.
+// So that the users don't get warnings in their code when they use the macro:
+// C4221: nonstandard extension: 'ptr': cannot be initialized using address of automatic variable
+// C4204: nonstandard extension: non-constant aggregate initializer
+AZ_NODISCARD AZ_INLINE az_span _az_span_init(uint8_t* ptr, int32_t size)
+{
+  return (az_span){ ._internal = { .ptr = ptr, .size = size } };
+}
+
+/**
  * @brief Returns an empty #az_span.
  *
  */
+// When updating this macro, also update AZ_PAIR_NULL, which should be using this macro, but can't
+// due to warnings, and so it is using an expansion of this macro instead.
 #define AZ_SPAN_NULL \
   (az_span) \
   { \
@@ -124,31 +153,8 @@ AZ_NODISCARD AZ_INLINE int32_t az_span_size(az_span span) { return span._interna
  */
 // Force a division by 0 that gets detected by compilers for anything that isn't a byte array.
 #define AZ_SPAN_FROM_BUFFER(BYTE_BUFFER) \
-  (az_span) \
-  { \
-    ._internal = { \
-      .ptr = (uint8_t*)BYTE_BUFFER, \
-      .size = (sizeof(BYTE_BUFFER) / (_az_IS_BYTE_ARRAY(BYTE_BUFFER) ? 1 : 0)), \
-    }, \
-  }
-
-/**
- * @brief Returns an #az_span over a byte buffer.
- *
- * @param[in] ptr The memory address of the 1st byte in the byte buffer.
- * @param[in] size The number of total bytes in the byte buffer.
- * @return The "view" over the byte buffer.
- */
-#ifdef AZ_NO_PRECONDITION_CHECKING
-// Note: If you are modifying this method, make sure to modify the non-inline version in the
-// az_span.c file as well.
-AZ_NODISCARD AZ_INLINE az_span az_span_init(uint8_t* ptr, int32_t size)
-{
-  return (az_span){ ._internal = { .ptr = ptr, .size = size, }, };
-}
-#else
-AZ_NODISCARD az_span az_span_init(uint8_t* ptr, int32_t size);
-#endif // AZ_NO_PRECONDITION_CHECKING
+  _az_span_init( \
+      (uint8_t*)BYTE_BUFFER, (sizeof(BYTE_BUFFER) / (_az_IS_BYTE_ARRAY(BYTE_BUFFER) ? 1 : 0)))
 
 /**
  * @brief Returns an #az_span from a 0-terminated array of bytes (chars).
@@ -401,7 +407,12 @@ typedef struct
  *
  */
 #define AZ_PAIR_NULL \
-  (az_pair) { .key = AZ_SPAN_NULL, .value = AZ_SPAN_NULL }
+  (az_pair) \
+  { \
+    .key = { ._internal = { .ptr = NULL, .size = 0 } }, \
+    .value \
+        = {._internal = { .ptr = NULL, .size = 0 } } \
+  }
 
 /**
  * @brief Returns an #az_pair with its key and value fields initialized to the specified key and

--- a/sdk/core/core/src/az_span.c
+++ b/sdk/core/core/src/az_span.c
@@ -31,7 +31,7 @@ AZ_NODISCARD az_span az_span_init(uint8_t* ptr, int32_t size)
   //   size == 0
   _az_PRECONDITION((ptr != NULL && size >= 0) || (ptr + (uint32_t)size == 0));
 
-  return (az_span){ ._internal = { .ptr = ptr, .size = size, }, };
+  return (az_span){ ._internal = { .ptr = ptr, .size = size } };
 }
 #endif // AZ_NO_PRECONDITION_CHECKING
 
@@ -584,7 +584,7 @@ AZ_NODISCARD static az_span _az_span_trim_side(az_span source, az_span_trim_side
   if (side == RIGHT)
   {
     increment = -1; // Set increment to be decremental for moving ptr
-    source_ptr += (source_size - 1); // Set initial position to the end
+    source_ptr += ((size_t)source_size - 1); // Set initial position to the end
   }
 
   // loop source, just to make sure staying within the size range

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -56,7 +56,7 @@
 #define CLIENT_SECRET_ENV "AZURE_CLIENT_SECRET"
 #define URI_ENV "AZURE_KEYVAULT_URL"
 
-#define TEST_FAIL_ON_ERROR(result, message) \
+#define RETURN_IF_FAILED(result, message) \
   do \
   { \
     if (az_failed(result)) \
@@ -83,7 +83,7 @@ int main()
       az_span_from_str(getenv(CLIENT_ID_ENV)),
       az_span_from_str(getenv(CLIENT_SECRET_ENV)));
 
-  TEST_FAIL_ON_ERROR(creds_retcode, "Failed to init credential");
+  RETURN_IF_FAILED(creds_retcode, "Failed to init credential");
 
   /************ 2) Creates keyvault client    ****************/
   az_keyvault_keys_client client = { 0 };
@@ -94,7 +94,7 @@ int main()
   az_result const operation_result = az_keyvault_keys_client_init(
       &client, az_span_from_str(getenv(URI_ENV)), &credential, &options);
 
-  TEST_FAIL_ON_ERROR(operation_result, "Failed to init keys client");
+  RETURN_IF_FAILED(operation_result, "Failed to init keys client");
 
   /******* 3) Create a buffer for response (will be reused for all requests)   *****/
   uint8_t response_buffer[1024 * 4];
@@ -102,7 +102,7 @@ int main()
   az_http_response http_response = { 0 };
   az_result const init_http_response_result = az_http_response_init(&http_response, response_span);
 
-  TEST_FAIL_ON_ERROR(init_http_response_result, "Failed to init http response");
+  RETURN_IF_FAILED(init_http_response_result, "Failed to init http response");
 
   /****************** 4) CREATE KEY with options******************************/
   az_keyvault_create_key_options key_options = az_keyvault_create_key_options_default();
@@ -133,7 +133,7 @@ int main()
     return 0;
   }
 
-  TEST_FAIL_ON_ERROR(create_result, "Failed to create key");
+  RETURN_IF_FAILED(create_result, "Failed to create key");
 
   printf("Key created result: \n%s", response_buffer);
 
@@ -141,7 +141,7 @@ int main()
   az_result get_key_result = az_keyvault_keys_key_get(
       &client, &az_context_app, key_name_for_test, AZ_SPAN_NULL, &http_response);
 
-  TEST_FAIL_ON_ERROR(get_key_result, "Failed to get key");
+  RETURN_IF_FAILED(get_key_result, "Failed to get key");
 
   printf("\n\n*********************************\nGet Key result: \n%s", response_buffer);
 
@@ -185,7 +185,7 @@ int main()
       NULL,
       &http_response);
 
-  TEST_FAIL_ON_ERROR(create_version_result, "Failed to create key version");
+  RETURN_IF_FAILED(create_version_result, "Failed to create key version");
 
   printf(
       "\n\n*********************************\nKey new version created result: \n%s",
@@ -197,7 +197,7 @@ int main()
   az_result const get_key_prev_ver_result = az_keyvault_keys_key_get(
       &client, &az_context_app, key_name_for_test, version, &http_response);
 
-  TEST_FAIL_ON_ERROR(get_key_prev_ver_result, "Failed to get previous version of the key");
+  RETURN_IF_FAILED(get_key_prev_ver_result, "Failed to get previous version of the key");
 
   printf("\n\n*********************************\nGet Key previous Ver: \n%s", response_buffer);
 
@@ -205,7 +205,7 @@ int main()
   az_result const delete_key_result
       = az_keyvault_keys_key_delete(&client, &az_context_app, key_name_for_test, &http_response);
 
-  TEST_FAIL_ON_ERROR(delete_key_result, "Failed to delete key");
+  RETURN_IF_FAILED(delete_key_result, "Failed to delete key");
 
   printf("\n\n*********************************\nDELETED Key: \n %s", response_buffer);
 
@@ -213,7 +213,7 @@ int main()
   az_result get_key_again_result = az_keyvault_keys_key_get(
       &client, &az_context_app, key_name_for_test, AZ_SPAN_NULL, &http_response);
 
-  TEST_FAIL_ON_ERROR(get_key_again_result, "Failed to get key");
+  RETURN_IF_FAILED(get_key_again_result, "Failed to get key");
 
   printf(
       "\n\n*********************************\nGet Key again after DELETE result: \n%s\n",

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -77,13 +77,13 @@ int main()
   az_credential_client_secret credential = { 0 };
 
   // init the credential struct
-  az_result const creds_retcode = az_credential_client_secret_init(
+  az_result const credential_init_result = az_credential_client_secret_init(
       &credential,
       az_span_from_str(getenv(TENANT_ID_ENV)),
       az_span_from_str(getenv(CLIENT_ID_ENV)),
       az_span_from_str(getenv(CLIENT_SECRET_ENV)));
 
-  RETURN_IF_FAILED(creds_retcode, "Failed to init credential");
+  RETURN_IF_FAILED(credential_init_result, "Failed to init credential");
 
   /************ 2) Creates keyvault client    ****************/
   az_keyvault_keys_client client = { 0 };
@@ -91,18 +91,18 @@ int main()
 
   // URL will be copied to client's internal buffer. So we don't need to keep the content of URL
   // buffer immutable  on client's side
-  az_result const operation_result = az_keyvault_keys_client_init(
+  az_result const client_init_result = az_keyvault_keys_client_init(
       &client, az_span_from_str(getenv(URI_ENV)), &credential, &options);
 
-  RETURN_IF_FAILED(operation_result, "Failed to init keys client");
+  RETURN_IF_FAILED(client_init_result, "Failed to init keys client");
 
   /******* 3) Create a buffer for response (will be reused for all requests)   *****/
   uint8_t response_buffer[1024 * 4];
   az_span response_span = AZ_SPAN_FROM_BUFFER(response_buffer);
   az_http_response http_response = { 0 };
-  az_result const init_http_response_result = az_http_response_init(&http_response, response_span);
+  az_result const http_response_init_result = az_http_response_init(&http_response, response_span);
 
-  RETURN_IF_FAILED(init_http_response_result, "Failed to init http response");
+  RETURN_IF_FAILED(http_response_init_result, "Failed to init http response");
 
   /****************** 4) CREATE KEY with options******************************/
   az_keyvault_create_key_options key_options = az_keyvault_create_key_options_default();
@@ -116,7 +116,7 @@ int main()
                                   AZ_PAIR_NULL };
 
   // 5) This is the actual call to keyvault service
-  az_result const create_result = az_keyvault_keys_key_create(
+  az_result const key_create_result = az_keyvault_keys_key_create(
       &client,
       &az_context_app,
       key_name_for_test,
@@ -125,7 +125,7 @@ int main()
       &http_response);
 
   // validate sample running with no_op http client
-  if (create_result == AZ_ERROR_NOT_IMPLEMENTED)
+  if (key_create_result == AZ_ERROR_NOT_IMPLEMENTED)
   {
     printf("Running sample with no_op HTTP implementation.\nRecompile az_core with an HTTP client "
            "implementation like CURL to see sample sending network requests.\n\n"
@@ -133,43 +133,43 @@ int main()
     return 1;
   }
 
-  RETURN_IF_FAILED(create_result, "Failed to create key");
+  RETURN_IF_FAILED(key_create_result, "Failed to create key");
 
   printf("Key created result: \n%s", response_buffer);
 
   /****************** 6) GET KEY latest ver ******************************/
-  az_result get_key_result = az_keyvault_keys_key_get(
+  az_result const key_get_result = az_keyvault_keys_key_get(
       &client, &az_context_app, key_name_for_test, AZ_SPAN_NULL, &http_response);
 
-  RETURN_IF_FAILED(get_key_result, "Failed to get key");
+  RETURN_IF_FAILED(key_get_result, "Failed to get key");
 
   printf("\n\n*********************************\nGet Key result: \n%s", response_buffer);
 
   /****************** 7) get key version from response ****/
   // version is still at http_response. Let's copy it to a new buffer
-  uint8_t copy_version_buf[40];
-  az_span copy_version_builder = AZ_SPAN_FROM_BUFFER(copy_version_buf);
+  uint8_t version_copy_buffer[40] = { 0 };
+  az_span version_copy_span = AZ_SPAN_FROM_BUFFER(version_copy_buffer);
   // version span will be pointing to http_response, so it will change as soon as http response is
   // reused. We just need to get it and then copy it to copy_version_builder to keep it
   az_span version = get_key_version(&http_response);
   {
     // make sure that the size of new buffer can hold the version on runtime
-    int32_t version_buffer_len = az_span_size(copy_version_builder);
+    int32_t version_buffer_len = az_span_size(version_copy_span);
     int32_t version_len = az_span_size(version);
     if (version_buffer_len < az_span_size(version))
     {
       printf(
-          "Version length is greater (%d) than the buffer used to copy it (%d). Use a larger "
-          "buffer",
+          "Version length is greater (%d) than the buffer used to copy it (%d). "
+          "Use larger buffer.",
           version_len,
           version_buffer_len);
       return 1; // Error, terminate proccess with non 0 as error.
     }
     else
     {
-      az_span_copy(copy_version_builder, version);
+      az_span_copy(version_copy_span, version);
       // now let version point to the copy_version_builder and with the right size
-      version = az_span_slice(copy_version_builder, 0, version_len);
+      version = az_span_slice(version_copy_span, 0, version_len);
     }
   }
 
@@ -177,7 +177,7 @@ int main()
   // We previously created a key and saved its version locally
   // We are not re-using same http response to create a new version for same already created key
   // After that, we can get previous version by using the copy of version we got before.
-  az_result const create_version_result = az_keyvault_keys_key_create(
+  az_result const version_create_result = az_keyvault_keys_key_create(
       &client,
       &az_context_app,
       key_name_for_test,
@@ -185,7 +185,7 @@ int main()
       NULL,
       &http_response);
 
-  RETURN_IF_FAILED(create_version_result, "Failed to create key version");
+  RETURN_IF_FAILED(version_create_result, "Failed to create key version");
 
   printf(
       "\n\n*********************************\nKey new version created result: \n%s",
@@ -194,26 +194,26 @@ int main()
   /****************** 9) GET KEY previous ver ******************************/
   // Here we use the version we recorded previously as parameter
   // Getting a key with NULL parameter for version will return latest version
-  az_result const get_key_prev_ver_result = az_keyvault_keys_key_get(
+  az_result const key_get_prev_ver_result = az_keyvault_keys_key_get(
       &client, &az_context_app, key_name_for_test, version, &http_response);
 
-  RETURN_IF_FAILED(get_key_prev_ver_result, "Failed to get previous version of the key");
+  RETURN_IF_FAILED(key_get_prev_ver_result, "Failed to get previous version of the key");
 
   printf("\n\n*********************************\nGet Key previous Ver: \n%s", response_buffer);
 
   /****************** 10) DELETE KEY ******************************/
-  az_result const delete_key_result
+  az_result const key_delete_result
       = az_keyvault_keys_key_delete(&client, &az_context_app, key_name_for_test, &http_response);
 
-  RETURN_IF_FAILED(delete_key_result, "Failed to delete key");
+  RETURN_IF_FAILED(key_delete_result, "Failed to delete key");
 
   printf("\n\n*********************************\nDELETED Key: \n %s", response_buffer);
 
   /****************** 11) GET KEY (should return failed response ) ******************************/
-  az_result get_key_again_result = az_keyvault_keys_key_get(
+  az_result const key_get_again_result = az_keyvault_keys_key_get(
       &client, &az_context_app, key_name_for_test, AZ_SPAN_NULL, &http_response);
 
-  RETURN_IF_FAILED(get_key_again_result, "Failed to get key");
+  RETURN_IF_FAILED(key_get_again_result, "Failed to get key");
 
   printf(
       "\n\n*********************************\nGet Key again after DELETE result: \n%s\n",
@@ -253,12 +253,11 @@ az_span get_key_version(az_http_response* response)
     return AZ_SPAN_NULL;
   }
   // calculate version
-  int32_t kid_length = az_span_size(k);
+  int32_t const kid_length = az_span_size(k);
   az_span version = { 0 };
 
   for (int32_t index = kid_length; index > 0; --index)
   {
-
     if (az_span_ptr(k)[index] == '/')
     {
       version = az_span_slice_to_end(k, index + 1);

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -79,7 +79,7 @@ az_span const key_name_for_test = AZ_SPAN_LITERAL_FROM_STR("test-new-key");
 int main()
 {
   /************* 1) create secret id credentials for request   ***********/
-  az_credential_client_secret credential = { 0 };
+  az_credential_client_secret credential = { { 0 } };
 
   // init the credential struct
   az_result const credential_init_result = az_credential_client_secret_init(
@@ -91,7 +91,7 @@ int main()
   RETURN_IF_FAILED(credential_init_result, "Failed to init credential");
 
   /************ 2) Creates keyvault client    ****************/
-  az_keyvault_keys_client client = { 0 };
+  az_keyvault_keys_client client = { { 0 } };
   az_keyvault_keys_client_options options = az_keyvault_keys_client_options_default();
 
   // URL will be copied to client's internal buffer. So we don't need to keep the content of URL
@@ -104,7 +104,7 @@ int main()
   /******* 3) Create a buffer for response (will be reused for all requests)   *****/
   uint8_t response_buffer[1024 * 4];
   az_span response_span = AZ_SPAN_FROM_BUFFER(response_buffer);
-  az_http_response http_response = { 0 };
+  az_http_response http_response = { { 0 } };
   az_result const http_response_init_result = az_http_response_init(&http_response, response_span);
 
   RETURN_IF_FAILED(http_response_init_result, "Failed to init http response");
@@ -113,13 +113,13 @@ int main()
   az_keyvault_create_key_options key_options = az_keyvault_create_key_options_default();
 
   // override options values
-  az_span operations[2] = { 0 };
+  az_span operations[2] = { { 0 } };
   operations[0] = az_keyvault_key_operation_sign();
   operations[1] = AZ_SPAN_NULL;
   key_options.operations = operations;
 
   // buffer for tags   ->  adding tags
-  az_pair tags[3] = { 0 };
+  az_pair tags[3] = { { 0 } };
   tags[0] = az_pair_from_str("aKey", "aValue");
   tags[1] = az_pair_from_str("bKey", "bValue");
   tags[2] = AZ_PAIR_NULL;

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -105,7 +105,7 @@ int main()
   TEST_FAIL_ON_ERROR(init_http_response_result, "Failed to init http response");
 
   /****************** 4) CREATE KEY with options******************************/
-  az_keyvault_create_key_options key_options = { 0 };
+  az_keyvault_create_key_options key_options = az_keyvault_create_key_options_default();
 
   // override options values
   key_options.operations = (az_span[]){ az_keyvault_key_operation_sign(), AZ_SPAN_NULL };

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -43,7 +43,6 @@
 #include <az_context.h>
 #include <az_credentials.h>
 #include <az_http.h>
-#include <az_http_internal.h>
 #include <az_json.h>
 #include <az_keyvault.h>
 
@@ -68,8 +67,6 @@
       return 1; \
     } \
   } while (0)
-
-int exit_code = 0;
 
 az_span get_key_version(az_http_response* response);
 az_span const key_name_for_test = AZ_SPAN_LITERAL_FROM_STR("test-new-key");
@@ -166,7 +163,7 @@ int main()
           "buffer",
           version_len,
           version_buffer_len);
-      return exit_code + 1; // Error, terminate proccess with non 0 as error.
+      return 1; // Error, terminate proccess with non 0 as error.
     }
     else
     {
@@ -222,7 +219,7 @@ int main()
       "\n\n*********************************\nGet Key again after DELETE result: \n%s\n",
       response_buffer);
 
-  return exit_code;
+  return 0;
 }
 
 az_span get_key_version(az_http_response* response)

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -136,7 +136,7 @@ int main()
 
   RETURN_IF_FAILED(key_create_result, "Failed to create key");
 
-  printf("Key created result: \n%s", response_buffer);
+  printf("Key created: \n%s", response_buffer);
 
   /****************** 6) GET KEY latest ver ******************************/
   az_result const key_get_result = az_keyvault_keys_key_get(
@@ -144,7 +144,7 @@ int main()
 
   RETURN_IF_FAILED(key_get_result, "Failed to get key");
 
-  printf("\n\n*********************************\nGet Key result: \n%s", response_buffer);
+  printf("\n\n*********************************\nGet key: \n%s", response_buffer);
 
   /****************** 7) get key version from response ****/
   // version is still at http_response. Let's copy it to a new buffer
@@ -164,6 +164,7 @@ int main()
           "Use larger buffer.",
           version_len,
           version_buffer_len);
+
       return 1; // Error, terminate proccess with non 0 as error.
     }
     else
@@ -189,7 +190,7 @@ int main()
   RETURN_IF_FAILED(version_create_result, "Failed to create key version");
 
   printf(
-      "\n\n*********************************\nKey new version created result: \n%s",
+      "\n\n*********************************\nKey new version created: \n%s",
       response_buffer);
 
   /****************** 9) GET KEY previous ver ******************************/
@@ -217,7 +218,7 @@ int main()
   RETURN_IF_FAILED(key_get_again_result, "Failed to get key");
 
   printf(
-      "\n\n*********************************\nGet Key again after DELETE result: \n%s\n",
+      "\n\n*********************************\nGet Key again after DELETE: \n%s\n",
       response_buffer);
 
   return 0;

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -130,7 +130,7 @@ int main()
     printf("Running sample with no_op HTTP implementation.\nRecompile az_core with an HTTP client "
            "implementation like CURL to see sample sending network requests.\n\n"
            "i.e. cmake -DTRANSPORT_CURL=ON ..\n\n");
-    return 0;
+    return 1;
   }
 
   RETURN_IF_FAILED(create_result, "Failed to create key");

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -130,7 +130,8 @@ int main()
     printf("Running sample with no_op HTTP implementation.\nRecompile az_core with an HTTP client "
            "implementation like CURL to see sample sending network requests.\n\n"
            "i.e. cmake -DTRANSPORT_CURL=ON ..\n\n");
-    return 1;
+
+    return 255;
   }
 
   RETURN_IF_FAILED(key_create_result, "Failed to create key");

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -74,12 +74,12 @@ az_span const key_name_for_test = AZ_SPAN_LITERAL_FROM_STR("test-new-key");
 #pragma warning(disable : 4996)
 // "Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified"
 #pragma warning(disable : 5045)
-#endif
+#endif // _MSC_VER
 
 int main()
 {
   /************* 1) create secret id credentials for request   ***********/
-  az_credential_client_secret credential = { { 0 } };
+  az_credential_client_secret credential;
 
   // init the credential struct
   az_result const credential_init_result = az_credential_client_secret_init(
@@ -91,7 +91,7 @@ int main()
   RETURN_IF_FAILED(credential_init_result, "Failed to init credential");
 
   /************ 2) Creates keyvault client    ****************/
-  az_keyvault_keys_client client = { { 0 } };
+  az_keyvault_keys_client client;
   az_keyvault_keys_client_options options = az_keyvault_keys_client_options_default();
 
   // URL will be copied to client's internal buffer. So we don't need to keep the content of URL
@@ -104,7 +104,7 @@ int main()
   /******* 3) Create a buffer for response (will be reused for all requests)   *****/
   uint8_t response_buffer[1024 * 4];
   az_span response_span = AZ_SPAN_FROM_BUFFER(response_buffer);
-  az_http_response http_response = { { 0 } };
+  az_http_response http_response;
   az_result const http_response_init_result = az_http_response_init(&http_response, response_span);
 
   RETURN_IF_FAILED(http_response_init_result, "Failed to init http response");
@@ -113,13 +113,13 @@ int main()
   az_keyvault_create_key_options key_options = az_keyvault_create_key_options_default();
 
   // override options values
-  az_span operations[2] = { { 0 } };
+  az_span operations[2];
   operations[0] = az_keyvault_key_operation_sign();
   operations[1] = AZ_SPAN_NULL;
   key_options.operations = operations;
 
   // buffer for tags   ->  adding tags
-  az_pair tags[3] = { { 0 } };
+  az_pair tags[3];
   tags[0] = az_pair_from_str("aKey", "aValue");
   tags[1] = az_pair_from_str("bKey", "bValue");
   tags[2] = AZ_PAIR_NULL;
@@ -233,9 +233,9 @@ int main()
 
 az_span get_key_version(az_http_response* response)
 {
-  az_span body = { 0 };
+  az_span body;
 
-  az_http_response_status_line status_line = { 0 };
+  az_http_response_status_line status_line ;
   az_result r = az_http_response_get_status_line(response, &status_line);
   if (az_failed(r))
   {
@@ -255,7 +255,7 @@ az_span get_key_version(az_http_response* response)
     return AZ_SPAN_NULL;
   }
 
-  az_span k = { 0 };
+  az_span k;
   r = az_json_token_get_string(&value, &k);
   if (az_failed(r))
   {
@@ -263,7 +263,7 @@ az_span get_key_version(az_http_response* response)
   }
   // calculate version
   int32_t const kid_length = az_span_size(k);
-  az_span version = { 0 };
+  az_span version = AZ_SPAN_NULL;
 
   for (int32_t index = kid_length; index > 0; --index)
   {

--- a/sdk/storage/blobs/samples/src/blobs_client_example.c
+++ b/sdk/storage/blobs/samples/src/blobs_client_example.c
@@ -90,7 +90,7 @@ int main()
     printf("Running sample with no_op HTTP implementation.\nRecompile az_core with an HTTP client "
            "implementation like CURL to see sample sending network requests.\n\n"
            "i.e. cmake -DTRANSPORT_CURL=ON ..\n\n");
-    return 0;
+    return 1;
   }
 
   RETURN_IF_FAILED(create_result, "Failed to create blob");

--- a/sdk/storage/blobs/samples/src/blobs_client_example.c
+++ b/sdk/storage/blobs/samples/src/blobs_client_example.c
@@ -67,7 +67,7 @@ int main()
 
   // 1) Init client.
   // Example expects AZURE_STORAGE_URL in env to be a URL w/ SAS token
-  az_storage_blobs_blob_client client = { { 0 } };
+  az_storage_blobs_blob_client client;
   az_storage_blobs_blob_client_options options = az_storage_blobs_blob_client_options_default();
 
   az_result const client_init_result = az_storage_blobs_blob_client_init(
@@ -77,7 +77,7 @@ int main()
 
   /******* 2) Create a buffer for response (will be reused for all requests)   *****/
   uint8_t response_buffer[1024 * 4] = { 0 };
-  az_http_response http_response = { 0 };
+  az_http_response http_response;
   az_result const http_response_init_result
       = az_http_response_init(&http_response, AZ_SPAN_FROM_BUFFER(response_buffer));
 
@@ -101,7 +101,7 @@ int main()
   RETURN_IF_FAILED(blob_upload_result, "Failed to upload blob");
 
   // 4) get response and parse it
-  az_http_response_status_line status_line = { 0 };
+  az_http_response_status_line status_line;
 
   az_result const status_line_get_result
       = az_http_response_get_status_line(&http_response, &status_line);
@@ -118,7 +118,7 @@ int main()
   // loop all headers from response
   while (true)
   {
-    az_pair header = { 0 };
+    az_pair header;
     az_result const header_get_result = az_http_response_get_next_header(&http_response, &header);
     if (header_get_result == AZ_ERROR_ITEM_NOT_FOUND)
     {

--- a/sdk/storage/blobs/samples/src/blobs_client_example.c
+++ b/sdk/storage/blobs/samples/src/blobs_client_example.c
@@ -30,7 +30,7 @@
 
 #define URI_ENV "AZURE_STORAGE_URL"
 
-#define TEST_FAIL_ON_ERROR(result, message) \
+#define RETURN_IF_FAILED(result, message) \
   do \
   { \
     if (az_failed(result)) \
@@ -69,7 +69,7 @@ int main()
   az_result const operation_result = az_storage_blobs_blob_client_init(
       &client, az_span_from_str(getenv(URI_ENV)), AZ_CREDENTIAL_ANONYMOUS, &options);
 
-  TEST_FAIL_ON_ERROR(operation_result, "Failed to init blob client");
+  RETURN_IF_FAILED(operation_result, "Failed to init blob client");
 
   /******* 2) Create a buffer for response (will be reused for all requests)   *****/
   uint8_t response_buffer[1024 * 4] = { 0 };
@@ -77,7 +77,7 @@ int main()
   az_result const init_http_response_result
       = az_http_response_init(&http_response, AZ_SPAN_FROM_BUFFER(response_buffer));
 
-  TEST_FAIL_ON_ERROR(init_http_response_result, "Failed to init http response");
+  RETURN_IF_FAILED(init_http_response_result, "Failed to init http response");
 
   // 3) upload content
   printf("Uploading blob...\n");
@@ -93,11 +93,11 @@ int main()
     return 0;
   }
 
-  TEST_FAIL_ON_ERROR(create_result, "Failed to create blob");
+  RETURN_IF_FAILED(create_result, "Failed to create blob");
 
   // 4) get response and parse it
   az_http_response_status_line status_line = { 0 };
-  TEST_FAIL_ON_ERROR(
+  RETURN_IF_FAILED(
       az_http_response_get_status_line(&http_response, &status_line), "Failed to get status code");
   printf("Status Code: %d\n", status_line.status_code);
   printf(

--- a/sdk/storage/blobs/samples/src/blobs_client_example.c
+++ b/sdk/storage/blobs/samples/src/blobs_client_example.c
@@ -26,8 +26,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <_az_cfg.h>
-
 #define URI_ENV "AZURE_STORAGE_URL"
 
 #define RETURN_IF_FAILED(result, message) \
@@ -43,6 +41,11 @@
   } while (0)
 
 static az_span content_to_upload = AZ_SPAN_LITERAL_FROM_STR("Some test content");
+
+#ifdef _MSC_VER
+// "'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead."
+#pragma warning(disable : 4996)
+#endif
 
 // Uncomment below code to enable logging (and the first lines of main function)
 /*

--- a/sdk/storage/blobs/samples/src/blobs_client_example.c
+++ b/sdk/storage/blobs/samples/src/blobs_client_example.c
@@ -91,7 +91,8 @@ int main()
     printf("Running sample with no_op HTTP implementation.\nRecompile az_core with an HTTP client "
            "implementation like CURL to see sample sending network requests.\n\n"
            "i.e. cmake -DTRANSPORT_CURL=ON ..\n\n");
-    return 1;
+
+    return 255;
   }
 
   RETURN_IF_FAILED(blob_upload_result, "Failed to upload blob");

--- a/sdk/storage/blobs/samples/src/blobs_client_example.c
+++ b/sdk/storage/blobs/samples/src/blobs_client_example.c
@@ -20,9 +20,6 @@
 #include <az_context.h>
 #include <az_credentials.h>
 #include <az_http.h>
-#include <az_http_internal.h>
-#include <az_http_transport.h>
-#include <az_json.h>
 #include <az_log.h>
 #include <az_storage_blobs.h>
 
@@ -45,7 +42,6 @@
     } \
   } while (0)
 
-int exit_code = 0;
 static az_span content_to_upload = AZ_SPAN_LITERAL_FROM_STR("Some test content");
 
 // Uncomment below code to enable logging (and the first lines of main function)
@@ -122,5 +118,5 @@ int main()
         az_span_ptr(header.value));
   }
 
-  return exit_code;
+  return 0;
 }

--- a/sdk/storage/blobs/samples/src/blobs_client_example.c
+++ b/sdk/storage/blobs/samples/src/blobs_client_example.c
@@ -67,7 +67,7 @@ int main()
 
   // 1) Init client.
   // Example expects AZURE_STORAGE_URL in env to be a URL w/ SAS token
-  az_storage_blobs_blob_client client = { 0 };
+  az_storage_blobs_blob_client client = { { 0 } };
   az_storage_blobs_blob_client_options options = az_storage_blobs_blob_client_options_default();
 
   az_result const client_init_result = az_storage_blobs_blob_client_init(


### PR DESCRIPTION
Samples:
* remove `#include http_internal.h`
* init `az_keyvault_create_key_options` properly (`az_keyvault_create_key_options_default()`)
* remove unused headers (json in storage sample)
* remove unused/almost unused exit_code - that's an unnecessary complication if we don't use it.


We need to ask someone more knowledgeable in CMake to help us to fix our CMake files, so that even if you `#include <az_http_internal.h>` in sample.c, it won't find that header and won't compile.


Also, what do you think of `TEST_FAIL_ON_ERROR` macro? I am not touching it in this PR.
* Why is the name `TEST`? I think `EXIT_ON_ERROR` would be a better name.
* Is it a neccessary concept for users to bring their attention to and to understand?
In addition to some natural extra concept understanding, it has `do { ... } while(0)`, which is also a useful technique to use in our library code, but in a sample? Well, if I am a beginner, I see do-while-0, and I have questions already.
Do we want our users to replicate exactly that approach in their code? Why not use `if (failed()) { printf(); return 1; }`?


I have left all this feedback at a time in the PR, and in Teams. If you disagree with my proposal, it is fine, but if you strongly agree, then please let me know how I can bring more attention to these comments next time, block the PR?

If having `TEST_FAIL_ON_ERROR` is rather necessary for us in order to test that samples do not fail in CI/CD, we still can have sample code written as
```
if (az_failed(...))
{
    printf(...);
    exit 1;
}
```
and we should be able to test it in CI/CD.
First, we can analyze the exit code, it is only non-0 when something failed (and also if code was compiled with az_nohttp, and I think that we should return non-0 in that case too).
Second, another option would be to define a macro in only in our CI/CD, and name it exactly as the function, `az_failed(x)` and in that macro, if the result is faulty, do something extra that we need in CI/CD.

Update: here is the proposal to remove `TEST_FAIL_ON_ERROR_MACRO`: https://github.com/Azure/azure-sdk-for-c/pull/758