### PR TITLE
Add missing doc strings

### DIFF
--- a/sdk/core/core/inc/az_credentials.h
+++ b/sdk/core/core/inc/az_credentials.h
@@ -104,8 +104,9 @@ typedef struct
  * @param tenant_id an Azure tenant ID
  * @param client_id an Azure client ID
  * @param client_secret an Azure client secret
- * @return AZ_OK = Successfull initialization <br>
- * Other value = Initialization failed
+ * @retval An #az_result value indicating the result of the operation:
+ *         - #AZ_OK if successful
+ *         - Other value = Initialization failed
  */
 AZ_NODISCARD az_result az_credential_client_secret_init(
     az_credential_client_secret* self,

--- a/sdk/core/core/inc/az_credentials.h
+++ b/sdk/core/core/inc/az_credentials.h
@@ -106,7 +106,7 @@ typedef struct
  * @param client_secret an Azure client secret
  * @retval An #az_result value indicating the result of the operation:
  *         - #AZ_OK if successful
- *         - Other value = Initialization failed
+ *         - Other error code if initialization failed
  */
 AZ_NODISCARD az_result az_credential_client_secret_init(
     az_credential_client_secret* self,

--- a/sdk/core/core/inc/az_credentials.h
+++ b/sdk/core/core/inc/az_credentials.h
@@ -104,7 +104,7 @@ typedef struct
  * @param tenant_id an Azure tenant ID
  * @param client_id an Azure client ID
  * @param client_secret an Azure client secret
- * @retval An #az_result value indicating the result of the operation:
+ * @return An #az_result value indicating the result of the operation:
  *         - #AZ_OK if successful
  *         - Other error code if initialization failed
  */

--- a/sdk/platform/http_client/nohttp/src/az_nohttp.c
+++ b/sdk/platform/http_client/nohttp/src/az_nohttp.c
@@ -8,7 +8,7 @@
 /**
  * @brief Provides no HTTP support.
  *
- * @param p_request an internal http builder with data to build and send http request
+ * @param p_request An internal HTTP builder with data to build and send HTTP request.
  * @param p_response A pre-allocated buffer where the HTTP response will be written.
  * @retval An #az_result value indicating the result of the operation:
  *         - #AZ_OK if successful

--- a/sdk/platform/http_client/nohttp/src/az_nohttp.c
+++ b/sdk/platform/http_client/nohttp/src/az_nohttp.c
@@ -9,7 +9,7 @@
  * @brief Provides no HTTP support.
  *
  * @param p_request an internal http builder with data to build and send http request
- * @param p_response pre-allocated buffer where http response will be written
+ * @param p_response A pre-allocated buffer where the HTTP response will be written.
  * @retval An #az_result value indicating the result of the operation:
  *         - #AZ_OK if successful
  */

--- a/sdk/platform/http_client/nohttp/src/az_nohttp.c
+++ b/sdk/platform/http_client/nohttp/src/az_nohttp.c
@@ -6,7 +6,7 @@
 #include <_az_cfg.h>
 
 /**
- * @brief Provides no http support.
+ * @brief Provides no HTTP support.
  *
  * @param p_request an internal http builder with data to build and send http request
  * @param p_response pre-allocated buffer where http response will be written

--- a/sdk/platform/http_client/nohttp/src/az_nohttp.c
+++ b/sdk/platform/http_client/nohttp/src/az_nohttp.c
@@ -5,6 +5,14 @@
 
 #include <_az_cfg.h>
 
+/**
+ * @brief Provides no http support.
+ *
+ * @param p_request an internal http builder with data to build and send http request
+ * @param p_response pre-allocated buffer where http response will be written
+ * @retval An #az_result value indicating the result of the operation:
+ *         - #AZ_OK if successful
+ */
 AZ_NODISCARD az_result
 az_http_client_send_request(_az_http_request* p_request, az_http_response* p_response)
 {

--- a/sdk/platform/noplatform/inc/az_platform_impl.h
+++ b/sdk/platform/noplatform/inc/az_platform_impl.h
@@ -6,6 +6,10 @@
 
 #include <_az_cfg_prefix.h>
 
+/**
+ * @brief A platform specific abstraction for a mutex.
+ *
+ */
 struct az_platform_mtx
 {
   struct

--- a/sdk/platform/posix/inc/az_platform_impl.h
+++ b/sdk/platform/posix/inc/az_platform_impl.h
@@ -8,6 +8,10 @@
 
 #include <_az_cfg_prefix.h>
 
+/**
+ * @brief A platform specific abstraction for a mutex.
+ *
+ */
 struct az_platform_mtx
 {
   struct

--- a/sdk/platform/win32/inc/az_platform_impl.h
+++ b/sdk/platform/win32/inc/az_platform_impl.h
@@ -28,6 +28,10 @@
 
 #include <_az_cfg_prefix.h>
 
+/**
+ * @brief A platform specific abstraction for a mutex.
+ *
+ */
 struct az_platform_mtx
 {
   struct


### PR DESCRIPTION
Fixes a some of the places where doc strings are missing.  Does not address all the platform headers