### PR TITLE
Update to use add_compile_definitions instead of C_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,17 +15,17 @@ option(LOGGING "Build SDK with logging support" ON)
 
 # disable preconditions when it's set to OFF
 if (NOT PRECONDITIONS)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DAZ_NO_PRECONDITION_CHECKING")
+  add_compile_definitions(AZ_NO_PRECONDITION_CHECKING)
 endif()
 
 if (NOT LOGGING)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DAZ_NO_LOGGING")
+  add_compile_definitions(AZ_NO_LOGGING)
 endif()
 
 
 # enable mock functions with link option -ld
 if(UNIT_TESTING_MOCKS)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_az_MOCK_ENABLED")
+  add_compile_definitions(_az_MOCK_ENABLED)
 endif()
 
 if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)


### PR DESCRIPTION
Discussion here on another PR:
https://github.com/Azure/azure-sdk-for-c/pull/763#discussion_r424842003

We should try to avoid mucking with C_FLAGS if we can and use the CMake primitives to modify the compilation.