### PR TITLE
Add subdirectory only for specified platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,9 +67,13 @@ add_subdirectory(sdk/iot/hub)
 add_subdirectory(sdk/iot/provisioning)
 
 # PAL
-add_subdirectory(sdk/platform/noplatform)
-add_subdirectory(sdk/platform/posix)
-add_subdirectory(sdk/platform/win32)
+if(AZ_PLATFORM_IMPL STREQUAL "POSIX")
+  add_subdirectory(sdk/platform/posix)
+elseif(AZ_PLATFORM_IMPL STREQUAL "WIN32")
+  add_subdirectory(sdk/platform/win32)
+else()
+  add_subdirectory(sdk/platform/noplatform)
+endif()
 
 # User can disable samples generation by setting env variable AZ_SDK_C_NO_SAMPLES
 if(NOT DEFINED ENV{AZ_SDK_C_NO_SAMPLES})

--- a/sdk/platform/posix/CMakeLists.txt
+++ b/sdk/platform/posix/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-if (NOT WIN32)
-
 cmake_minimum_required (VERSION 3.10)
 
 project(az_posix LANGUAGES C)
@@ -15,5 +13,3 @@ target_link_libraries(az_posix PRIVATE az_core)
 target_sources(az_posix PRIVATE src/az_posix.c)
 
 target_include_directories(az_posix PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>)
-
-endif()

--- a/sdk/platform/win32/CMakeLists.txt
+++ b/sdk/platform/win32/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-if(WIN32)
-
 cmake_minimum_required (VERSION 3.10)
 
 project (az_win32 LANGUAGES C)
@@ -15,5 +13,3 @@ target_link_libraries(az_win32 PRIVATE az_core)
 target_sources(az_win32 PRIVATE src/az_win32.c)
 
 target_include_directories(az_win32 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>)
-
-endif()


### PR DESCRIPTION
@TiejunMS was using our SDK with arm-gcc and the way the current platform structure is set up in CMake causes POSIX code to get built even if `no_platform` is selected. It currently gets built
`if (!WIN32)` which in arm-gcc with `no_platform` selected renders true.

I think this change helps to only pull in code for that platform which was specified.