### PR TITLE
Update dropdown generation code

### DIFF
--- a/eng/docs/api/assets/header.html
+++ b/eng/docs/api/assets/header.html
@@ -34,8 +34,10 @@ function currentVersion() {
 }
 
 function currentPackage() {
-  // Filled in by Doxygen template
-  return "$projectname";
+  // C docs are generated as a monolith, the correct path is:
+  // https://azuresdkdocs.blob.core.windows.net/$web/c/docs/{version}/index.html
+  // This sets the "docs" piece of the URL path
+  return "docs";
 }
 
 function httpGetAsync(targetUrl, callback) {


### PR DESCRIPTION
Right now docs don't generate the proper dropdown URLs because we're using the `$projectname` variable from Doxygen (which is "Azure SDK for Embedded C"). This would normally be the package name but since docs are released as a single entity we use "docs" as the "package" component of the path. 