### PR TITLE
Proposal: PLATFORM=(AUTO, WIN32, POSIX, NONE, <custom_lib>), HTTP_TRANSPORT=(NONE, CURL, <custom_lib>)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,14 @@ cmake_minimum_required (VERSION 3.10)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake-modules")
 
 option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
-option(TRANSPORT_CURL "Build internal http transport implementation with CURL for HTTP Pipeline" OFF)
 option(UNIT_TESTING "Build unit test projects" OFF)
 option(UNIT_TESTING_MOCKS "wrap PAL functions with mock implementation for tests" OFF)
 option(TRANSPORT_PAHO "Build IoT Samples with Paho MQTT support" OFF)
 option(PRECONDITIONS "Build SDK with preconditions enabled" ON)
 option(LOGGING "Build SDK with logging support" ON)
+set(PLATFORM "AUTO" CACHE STRING "Build SDK with the specific platform layer implementation")
+set(HTTP_TRANSPORT "NONE" CACHE STRING "Build with HTTP transport implementation")
+
 
 # disable preconditions when it's set to OFF
 if (NOT PRECONDITIONS)
@@ -25,11 +27,6 @@ endif()
 # enable mock functions with link option -ld
 if(UNIT_TESTING_MOCKS)
   add_compile_definitions(_az_MOCK_ENABLED)
-endif()
-
-# make libcurl option enabled to be visible to code
-if(TRANSPORT_CURL)
-  add_compile_definitions(TRANSPORT_CURL)
 endif()
 
 if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
@@ -65,22 +62,46 @@ add_subdirectory(sdk/iot/hub)
 add_subdirectory(sdk/iot/provisioning)
 
 #PAL
-if(AZ_PLATFORM_IMPL STREQUAL "POSIX")
-  add_subdirectory(sdk/platform/posix)
-  set(PAL az_posix)
-elseif(AZ_PLATFORM_IMPL STREQUAL "WIN32")
-  add_subdirectory(sdk/platform/win32)
-  set(PAL az_win32)
-else()
-  add_subdirectory(sdk/platform/noplatform)
-  set(PAL az_noplatform)
+if(PLATFORM STREQUAL "AUTO")
+  if (WIN32)
+    set(PLATFORM "WIN32")
+  elseif(UNIX)
+    set(PLATFORM "POSIX")
+  else()
+    set(PLATFORM "NONE")
+  endif()
 endif()
 
-add_subdirectory(sdk/platform/http_client/nohttp)
-# Adding transport implementation for curl
-# Users can still build Core and SDK client without depending on an HTTP transport implementation
-if(TRANSPORT_CURL)
+if(PLATFORM STREQUAL "WIN32")
+  add_subdirectory(sdk/platform/win32)
+  set(PLATFORM_LIB az_win32)
+elseif(PLATFORM STREQUAL "POSIX")
+  add_subdirectory(sdk/platform/posix)
+  set(PLATFORM_LIB az_posix)
+elseif(PLATFORM STREQUAL "NONE")
+  add_subdirectory(sdk/platform/noplatform)
+  set(PLATFORM_LIB az_noplatform)
+else()
+  set(PLATFORM_LIB ${PLATFORM})
+endif()
+
+#HTTP Transport
+if(HTTP_TRANSPORT STREQUAL "AUTO")
+  if (WIN32 OR UNIX)
+    set(HTTP_TRANSPORT "CURL")
+  else()
+    set(HTTP_TRANSPORT "NONE")
+  endif()
+endif()
+
+if(HTTP_TRANSPORT STREQUAL "CURL")
   add_subdirectory(sdk/platform/http_client/curl)
+  set(HTTP_TRANSPORT_LIB az_curl)
+elseif(HTTP_TRANSPORT STREQUAL "NONE")
+  add_subdirectory(sdk/platform/http_client/nohttp)
+  set(HTTP_TRANSPORT_LIB az_nohttp)
+else()
+  set(HTTP_TRANSPORT_LIB ${HTTP_TRANSPORT})
 endif()
 
 # User can disable samples generation by setting env variable AZ_SDK_C_NO_SAMPLES

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ The following compiler options are available for adding/removing project feature
 <td>ON</td>
 </tr>
 <tr>
-<td>TRANSPORT_CURL</td>
-<td>This option requires Libcurl dependency to be available. It generates an HTTP stack with libcurl for az_http to be able to send requests thru the wire. This library would replace the no_http.</td>
-<td>OFF</td>
+<td>HTTP_TRANSPORT</td>
+<td>This option generates a HTTP stack for az_http to be able to send requests thru the wire. Possible values:<br>- No_value: "NONE"<br>-NONE: an empty HTTP stack implementation.<br>- CURL: Uses libcurl implementation. Requires Libcurl dependency to be available.<br>- custom_http_lib: Use a customer-provided implementation.</td>
+<td>NONE</td>
 </tr>
 <tr>
 <td>TRANSPORT_PAHO</td>
@@ -124,8 +124,8 @@ The following compiler options are available for adding/removing project feature
 <td>OFF</td>
 </tr>
 <tr>
-<td>AZ_PLATFORM_IMPL</td>
-<td>This option can be set to any of the next values:<br>- No_value: default value is used and no_platform library is used.<br>- "POSIX": Provides implementation for Linux and Mac systems.<br>- "WIN32": Provides platform implementation for Windows based system<br>- "USER": Tells cmake to use an specific implementation provided by user. When setting this option, user must provide an implementation library and set option `AZ_USER_PLATFORM_IMPL_NAME` with the name of the library (i.e. <code>-DAZ_PLATFORM_IMPL=USER -DAZ_USER_PLATFORM_IMPL_NAME=user_platform_lib</code>). cmake will look for this library to link az_core</td>
+<td>PLATFORM</td>
+<td>This option can be set to any of the next values:<br>- No_value: "AUTO". <br>- "AUTO": Use "WIN32" when the CMake target build platform supports Win32 API, "POSIX" if POSIX is supported, "NONE" if neither of the two. <br>- "NONE": default no_platform library is used.<br>- "POSIX": Provides implementation for Linux and Mac systems.<br>- "WIN32": Provides platform implementation for Windows based system<br>- custom_platform_lib: Tells cmake to use an specific implementation provided by user. When setting this option, user must provide an implementation library and set this with the name of the library (i.e. <code>-DPLATFORM=custom_platform_lib</code>). cmake will look for this library to link az_core</td>
 <td>No_value</td>
 </tr>
 </table>
@@ -136,7 +136,7 @@ The following compiler options are available for adding/removing project feature
       Running sample with no_op HTTP implementation.
       Recompile az_core with an HTTP client implementation like CURL to see sample sending network requests.
 
-      i.e. cmake -DTRANSPORT_CURL=ON ..
+      i.e. cmake -DHTTP_TRANSPORT=CURL ..
 
 ## Running Samples
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -9,18 +9,19 @@ jobs:
     matrix:
       # Build with no dependencies at all (No samples) - PRECONDITIONS ON
       # WARNINGS_AS_ERRORS          ON
-      # TRANSPORT_CURL              OFF
       # UNIT_TESTING                OFF
       # UNIT_TESTING_MOCKS          OFF
       # TRANSPORT_PAHO              OFF
       # PRECONDITIONS               ON
       # LOGGING                     ON
-      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
+      # PLATFORM                    NONE
+      # HTTP_TRANSPORT              NONE
       Linux_x64:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AZ_SDK_C_NO_SAMPLES: 'true'
+        build.args: ' -DPLATFORM=NONE -DHTTP_TRANSPORT=NONE'
       Win_x86:
         vm.image: 'windows-2019'
         vcpkg.deps: ''
@@ -28,6 +29,7 @@ jobs:
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
         AZ_SDK_C_NO_SAMPLES: 'true'
+        build.args: ' -DPLATFORM=NONE -DHTTP_TRANSPORT=NONE'
       Win_x64:
         vm.image: 'windows-2019'
         vcpkg.deps: ''
@@ -35,95 +37,97 @@ jobs:
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
         AZ_SDK_C_NO_SAMPLES: 'true'
+        build.args: ' -DPLATFORM=NONE -DHTTP_TRANSPORT=NONE'
       MacOS_x64:
        vm.image: 'macOS-10.15'
        vcpkg.deps: ''
        VCPKG_DEFAULT_TRIPLET: 'x64-osx'
        AZ_SDK_C_NO_SAMPLES: 'true'
+       build.args: ' -DPLATFORM=NONE -DHTTP_TRANSPORT=NONE'
 
       # Build with sample dependencies [curl for transport] - PRECONDITIONS ON
       # WARNINGS_AS_ERRORS          ON
-      # TRANSPORT_CURL              ON
       # UNIT_TESTING                OFF
       # UNIT_TESTING_MOCKS          OFF
       # TRANSPORT_PAHO              ON
       # PRECONDITIONS               ON
       # LOGGING                     ON
-      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
+      # PLATFORM                    POSIX / WIN32
+      # HTTP_TRANSPORT              CURL
       Linux_x64_with_samples:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: 'curl[ssl] paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX'
+        build.args: ' -DHTTP_TRANSPORT=CURL -DTRANSPORT_PAHO=ON -DPLATFORM=POSIX'
       Win_x86_with_samples:
         vm.image: 'windows-2019'
         vcpkg.deps: 'curl[winssl] paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32'
+        build.args: ' -DHTTP_TRANSPORT=CURL -DTRANSPORT_PAHO=ON -DPLATFORM=WIN32'
       Win_x64_with_samples:
         vm.image: 'windows-2019'
         vcpkg.deps: 'curl[winssl] paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32'
+        build.args: ' -DHTTP_TRANSPORT=CURL -DTRANSPORT_PAHO=ON -DPLATFORM=WIN32'
       MacOS_x64_with_samples:
         vm.image: 'macOS-10.15'
         vcpkg.deps: 'curl[ssl] paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX'
+        build.args: ' -DHTTP_TRANSPORT=CURL -DTRANSPORT_PAHO=ON -DPLATFORM=POSIX'
 
       # Build with sample dependencies and unit testing [curl for transport and cmocka]  - PRECONDITIONS ON
       # WARNINGS_AS_ERRORS          ON
-      # TRANSPORT_CURL              ON
       # UNIT_TESTING                ON
       # UNIT_TESTING_MOCKS          OFF
       # TRANSPORT_PAHO              ON
       # PRECONDITIONS               ON
       # LOGGING                     ON
-      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
+      # PLATFORM                    POSIX / WIN32
+      # HTTP_TRANSPORT              CURL
       Linux_x64_with_samples_and_unit_test:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
+        build.args: ' -DHTTP_TRANSPORT=CURL -DTRANSPORT_PAHO=ON -DPLATFORM=POSIX -DUNIT_TESTING=ON'
       Win_x86_with_samples_and_unit_test:
         vm.image: 'windows-2019'
         vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
+        build.args: ' -DHTTP_TRANSPORT=CURL -DTRANSPORT_PAHO=ON -DPLATFORM=WIN32 -DUNIT_TESTING=ON'
       Win_x64_with_samples_and_unit_test:
         vm.image: 'windows-2019'
         vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
+        build.args: ' -DHTTP_TRANSPORT=CURL -DTRANSPORT_PAHO=ON -DPLATFORM=WIN32 -DUNIT_TESTING=ON'
       MacOS_x64_with_samples_and_unit_test:
         vm.image: 'macOS-10.15'
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
+        build.args: ' -DHTTP_TRANSPORT=CURL -DTRANSPORT_PAHO=ON -DPLATFORM=POSIX -DUNIT_TESTING=ON'
 
       # Build with unit testing only. No samples [cmocka] - PRECONDITIONS ON
       # WARNINGS_AS_ERRORS          ON
-      # TRANSPORT_CURL              OFF
       # UNIT_TESTING                ON
       # UNIT_TESTING_MOCKS          ON
       # TRANSPORT_PAHO              OFF
       # PRECONDITIONS               ON
       # LOGGING                     ON
-      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
+      # PLATFORM                    NONE
+      # HTTP_TRANSPORT              NONE
       Linux_x64_with_unit_test:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         # This is the only platform where we run mocking functions and generate CodeCoverage
-        build.args: ' -DUNIT_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING_MOCKS=ON'
+        build.args: ' -DUNIT_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DPLATFORM=NONE -DHTTP_TRANSPORT=NONE -DUNIT_TESTING_MOCKS=ON'
         AZ_SDK_CODE_COV: 1
         AZ_SDK_C_NO_SAMPLES: 'true'
       Win_x86_with_unit_test:
@@ -132,7 +136,7 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DUNIT_TESTING=ON'
+        build.args: ' -DUNIT_TESTING=ON -DPLATFORM=NONE -DHTTP_TRANSPORT=NONE'
         AZ_SDK_C_NO_SAMPLES: 'true'
       Win_x64_with_unit_test:
         vm.image: 'windows-2019'
@@ -140,29 +144,29 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DUNIT_TESTING=ON'
+        build.args: ' -DUNIT_TESTING=ON -DPLATFORM=NONE -DHTTP_TRANSPORT=NONE'
         AZ_SDK_C_NO_SAMPLES: 'true'
       MacOS_x64_with_unit_test:
         vm.image: 'macOS-10.15'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        build.args: ' -DUNIT_TESTING=ON'
+        build.args: ' -DUNIT_TESTING=ON -DPLATFORM=NONE -DHTTP_TRANSPORT=NONE'
         AZ_SDK_C_NO_SAMPLES: 'true'
 
       # Build with unit testing only. No samples [cmocka] - PRECONDITIONS OFF
       # WARNINGS_AS_ERRORS          ON
-      # TRANSPORT_CURL              OFF
       # UNIT_TESTING                ON
       # UNIT_TESTING_MOCKS          OFF
       # TRANSPORT_PAHO              OFF
       # PRECONDITIONS               OFF
       # LOGGING                     ON
-      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
+      # PLATFORM                    NONE
+      # HTTP_TRANSPORT              NONE
       Linux_x64_with_unit_test_no_preconditions:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
+        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF -DPLATFORM=NONE -DHTTP_TRANSPORT=NONE'
         AZ_SDK_C_NO_SAMPLES: 'true'
       Win_x86_with_unit_test_no_preconditions:
         vm.image: 'windows-2019'
@@ -170,7 +174,7 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
+        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF -DPLATFORM=NONE -DHTTP_TRANSPORT=NONE'
         AZ_SDK_C_NO_SAMPLES: 'true'
       Win_x64_with_unit_test_no_preconditions:
         vm.image: 'windows-2019'
@@ -178,29 +182,29 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
+        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF -DPLATFORM=NONE -DHTTP_TRANSPORT=NONE'
         AZ_SDK_C_NO_SAMPLES: 'true'
       MacOS_x64_with_unit_test_no_preconditions:
         vm.image: 'macOS-10.15'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
+        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF -DPLATFORM=NONE -DHTTP_TRANSPORT=NONE'
         AZ_SDK_C_NO_SAMPLES: 'true'
 
       # Build with no logging - samples - libcurl - paho - NoPreconditions
       # WARNINGS_AS_ERRORS          ON
-      # TRANSPORT_CURL              ON
       # UNIT_TESTING                ON
       # UNIT_TESTING_MOCK_ENABLED   OFF
       # TRANSPORT_PAHO              ON
       # PRECONDITIONS               OFF
       # LOGGING                     OFF
-      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX
+      # PLATFORM                    POSIX
+      # HTTP_TRANSPORT              CURL
       Linux_x64_with_unit_tests_and_samples_no_logging_no_preconditions:
         vm.image: 'ubuntu-18.04'
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DPRECONDITIONS=OFF -DLOGGING=OFF'
+        build.args: ' -DHTTP_TRANSPORT=CURL -DTRANSPORT_PAHO=ON -DPLATFORM=POSIX -DUNIT_TESTING=ON -DPRECONDITIONS=OFF -DLOGGING=OFF'
   pool:
     vmImage: $(vm.image)
   variables:

--- a/sdk/iot/common/tests/CMakeLists.txt
+++ b/sdk/iot/common/tests/CMakeLists.txt
@@ -17,5 +17,5 @@ add_cmocka_test(${TARGET_NAME} SOURCES
                 LINK_TARGETS                        
                     az_iot_common
                     az_core
-                    ${PAL}                
+                    ${PLATFORM_LIB}                
                 )

--- a/sdk/iot/hub/samples/CMakeLists.txt
+++ b/sdk/iot/hub/samples/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(
 )
 
 # PAL
-target_link_libraries(paho_iot_hub_c2d_example PRIVATE ${PAL})
+target_link_libraries(paho_iot_hub_c2d_example PRIVATE ${PLATFORM_LIB})
 
 target_link_libraries(
   paho_iot_hub_c2d_example PRIVATE
@@ -54,7 +54,7 @@ target_link_libraries(
   )
 
 # PAL
-target_link_libraries(paho_iot_hub_methods_example PRIVATE ${PAL})
+target_link_libraries(paho_iot_hub_methods_example PRIVATE ${PLATFORM_LIB})
 
 target_link_libraries(
   paho_iot_hub_methods_example PRIVATE
@@ -77,7 +77,7 @@ target_link_libraries(
   )
 
 # PAL
-target_link_libraries(paho_iot_hub_telemetry_example PRIVATE ${PAL})
+target_link_libraries(paho_iot_hub_telemetry_example PRIVATE ${PLATFORM_LIB})
 
 target_link_libraries(
   paho_iot_hub_telemetry_example PRIVATE
@@ -100,7 +100,7 @@ target_link_libraries(
   )
 
 # PAL
-target_link_libraries(paho_iot_hub_twin_example PRIVATE ${PAL})
+target_link_libraries(paho_iot_hub_twin_example PRIVATE ${PLATFORM_LIB})
 
 target_link_libraries(
   paho_iot_hub_twin_example PRIVATE

--- a/sdk/iot/hub/tests/CMakeLists.txt
+++ b/sdk/iot/hub/tests/CMakeLists.txt
@@ -23,5 +23,5 @@ add_cmocka_test(${TARGET_NAME} SOURCES
                     az_iot_common
                     az_iot_hub
                     az_core
-                    ${PAL}
+                    ${PLATFORM_LIB}
                 )

--- a/sdk/iot/provisioning/samples/CMakeLists.txt
+++ b/sdk/iot/provisioning/samples/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(
   )
 
 # PAL
-target_link_libraries(paho_iot_provisioning_example PRIVATE ${PAL})
+target_link_libraries(paho_iot_provisioning_example PRIVATE ${PLATFORM_LIB})
 
 target_link_libraries(
   paho_iot_provisioning_example PRIVATE

--- a/sdk/iot/provisioning/tests/CMakeLists.txt
+++ b/sdk/iot/provisioning/tests/CMakeLists.txt
@@ -20,5 +20,5 @@ add_cmocka_test(${TARGET_NAME} SOURCES
                     az_iot_common
                     az_iot_provisioning
                     az_core
-                    ${PAL}
+                    ${PLATFORM_LIB}
                 )

--- a/sdk/platform/http_client/curl/CMakeLists.txt
+++ b/sdk/platform/http_client/curl/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-if (TRANSPORT_CURL)
-
 cmake_minimum_required (VERSION 3.10)
 
 project (az_curl LANGUAGES C)
@@ -26,5 +24,3 @@ add_library (az::curl ALIAS az_curl)
 
 
 target_link_libraries(az_curl PRIVATE CURL::libcurl)
-
-endif()

--- a/sdk/samples/keyvault/keyvault/samples/CMakeLists.txt
+++ b/sdk/samples/keyvault/keyvault/samples/CMakeLists.txt
@@ -8,7 +8,7 @@ project (az_keyvault_keys_samples LANGUAGES C)
 set(CMAKE_C_STANDARD 99)
 
 # make sure libcurl is available for sample if compile option for libcurl is on
-if(TRANSPORT_CURL)
+if(HTTP_TRANSPORT STREQUAL "CURL")
   find_package(CURL ${CURL_MIN_REQUIRED_VERSION} CONFIG) 
   if(NOT CURL_FOUND)
     find_package(CURL ${CURL_MIN_REQUIRED_VERSION} REQUIRED)
@@ -27,9 +27,7 @@ if(TRANSPORT_CURL)
 else()
   # linking default no http implementation to be able to compile and link sample.
   target_link_libraries(keys_client_example PRIVATE az_nohttp)
-  # push compiler symbol so we can find out in Code about no http
-  target_compile_definitions(keys_client_example PRIVATE AZ_NO_HTTP)
 endif()
 
 # PAL
-target_link_libraries(keys_client_example PRIVATE ${PAL})
+target_link_libraries(keys_client_example PRIVATE ${PLATFORM_LIB})

--- a/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
+++ b/sdk/samples/keyvault/keyvault/samples/src/keys_client_example.c
@@ -153,7 +153,7 @@ int main()
   {
     printf("Running sample with no_op HTTP implementation.\nRecompile az_core with an HTTP client "
            "implementation like CURL to see sample sending network requests.\n\n"
-           "i.e. cmake -DTRANSPORT_CURL=ON ..\n\n");
+           "i.e. cmake -DHTTP_TRANSPORT=CURL ..\n\n");
 
     return 1;
   }

--- a/sdk/samples/keyvault/keyvault/test/CMakeLists.txt
+++ b/sdk/samples/keyvault/keyvault/test/CMakeLists.txt
@@ -18,5 +18,5 @@ add_cmocka_test(${TARGET_NAME} SOURCES
                     az_keyvault
                     az_core
                     az_nohttp
-                    ${PAL}
+                    ${PLATFORM_LIB}
                 )

--- a/sdk/storage/blobs/samples/CMakeLists.txt
+++ b/sdk/storage/blobs/samples/CMakeLists.txt
@@ -27,9 +27,7 @@ if(TRANSPORT_CURL)
 else()
   # linking default no http implementation to be able to compile and link sample.
   target_link_libraries(blobs_client_example PRIVATE az_nohttp)
-  # push compiler symbol so we can find out in Code about no http
-  target_compile_definitions(blobs_client_example PRIVATE AZ_NO_HTTP)
 endif()
 
 # get the appropiate PAL lib to link
-target_link_libraries(blobs_client_example PRIVATE ${PAL})
+target_link_libraries(blobs_client_example PRIVATE ${PLATFORM_LIB})

--- a/sdk/storage/blobs/samples/src/blobs_client_example.c
+++ b/sdk/storage/blobs/samples/src/blobs_client_example.c
@@ -98,7 +98,7 @@ int main()
   {
     printf("Running sample with no_op HTTP implementation.\nRecompile az_core with an HTTP client "
            "implementation like CURL to see sample sending network requests.\n\n"
-           "i.e. cmake -DTRANSPORT_CURL=ON ..\n\n");
+           "i.e. cmake -DHTTP_TRANSPORT=CURL ..\n\n");
 
     return 1;
   }

--- a/sdk/storage/blobs/test/CMakeLists.txt
+++ b/sdk/storage/blobs/test/CMakeLists.txt
@@ -18,5 +18,5 @@ add_cmocka_test(${TARGET_NAME} SOURCES
                     az_storage_blobs
                     az_core
                     az_nohttp
-                    ${PAL}
+                    ${PLATFORM_LIB}
                 )


### PR DESCRIPTION
Proposal:
* `PLATFORM`=`AUTO` | `WIN32` | `POSIX` | `NONE` | `<custom_lib>`
* `HTTP_TRANSPORT` : `NONE` | `CURL` | `<custom_lib>`

User downloads our repo and builds for Windows, Mac, Linux or FreeBSD (we look at the CMake target platform).
simple command line `cmake . && make` builds SDK with the corresponding `az_win32` or `az_posix`.
It works with minimum knowledge and minimum surprises.
If platform can't be detected (IoT), the implementation that gets picked if you provide no options is  `az_noplatform` - just as it does today.
Also, in the recent related commit we broke the custom PAL implementation scenario. Now, user provide `-DPLATFORM=mylib`, and it also works (no need to provide `-DPLATFORM=USER, -DUSER_PLATFORM_NAME=mylib`).

The default HTTP_TRANSPORT impl is `az_nohttp`, just as today. User can set it to CURL (`-DHTTP_TRANSPORT=CURL`) and we'll build with az_curl, just as today (currently: with `-DTRANSPORT_CURL=ON`).
User can provide their own implementation, the same way as with PAL: `-DHTTP_TRANSPORT=az_beast`.
Users can explicitly provide `NONE`, which is also the default, and it means `az_nohttp`.
Users can provide `AUTO` and then if the target platform is WIN32 or UNIX, we use `az_curl`, and `az_nohttp` otherwise.
I considered making `HTTP_TRANSPORT=AUTO` the default option, but CURL is an external dependency, and making it to build may require additional steps from the customer, and I don't want the default CMake build without any options to ever fail or require additional steps.