### PR TITLE
Fix IAR warnings for enums

### DIFF
--- a/sdk/core/az_core/internal/az_http_internal.h
+++ b/sdk/core/az_core/internal/az_http_internal.h
@@ -109,7 +109,11 @@ AZ_NODISCARD AZ_INLINE _az_http_policy_telemetry_options _az_http_policy_telemet
 AZ_NODISCARD AZ_INLINE _az_http_policy_apiversion_options
 _az_http_policy_apiversion_options_default()
 {
-  return (_az_http_policy_apiversion_options){ 0 };
+  return (_az_http_policy_apiversion_options){
+    ._internal = { .option_location = _az_http_policy_apiversion_option_location_header,
+                   .name = AZ_SPAN_NULL,
+                   .version = AZ_SPAN_NULL }
+  };
 }
 
 /**

--- a/sdk/core/az_core/src/az_json_parser.c
+++ b/sdk/core/az_core/src/az_json_parser.c
@@ -39,7 +39,7 @@ AZ_NODISCARD AZ_INLINE bool az_json_parser_stack_is_empty(az_json_parser const* 
 AZ_NODISCARD AZ_INLINE _az_json_stack_item
 az_json_parser_stack_last(az_json_parser const* json_parser)
 {
-  return json_parser->_internal.stack & 1;
+  return json_parser->_internal.stack & 1 ? _az_JSON_STACK_OBJECT : _az_JSON_STACK_ARRAY;
 }
 
 AZ_NODISCARD AZ_INLINE az_result
@@ -538,7 +538,7 @@ az_json_parser_skip_children(az_json_parser* json_parser, az_json_token token)
       }
       default:
       {
-        az_json_token element = { 0 };
+        az_json_token element = _az_JSON_TOKEN_DEFAULT;
         az_result result = az_json_parser_parse_array_item(json_parser, &element);
         if (result != AZ_ERROR_ITEM_NOT_FOUND)
         {

--- a/sdk/core/az_core/src/az_json_private.h
+++ b/sdk/core/az_core/src/az_json_private.h
@@ -9,6 +9,11 @@
 
 #include <_az_cfg_prefix.h>
 
+#define _az_JSON_TOKEN_DEFAULT (az_json_token){ \
+  .kind = AZ_JSON_TOKEN_NONE, \
+  ._internal = { 0 } \
+}
+
 enum
 {
   // We are using a uint64_t to represent our nested state, so we can only go 64 levels deep.
@@ -40,7 +45,7 @@ AZ_INLINE _az_json_stack_item _az_json_stack_pop(_az_json_bit_stack* json_stack)
   }
 
   // true (i.e. 1) means _az_JSON_STACK_OBJECT, while false (i.e. 0) means _az_JSON_STACK_ARRAY
-  return (json_stack->_internal.az_json_stack & 1) != 0;
+  return (json_stack->_internal.az_json_stack & 1) != 0 ? _az_JSON_STACK_OBJECT : _az_JSON_STACK_ARRAY;
 }
 
 AZ_INLINE void _az_json_stack_push(_az_json_bit_stack* json_stack, _az_json_stack_item item)
@@ -61,7 +66,7 @@ AZ_NODISCARD AZ_INLINE _az_json_stack_item _az_json_stack_peek(_az_json_bit_stac
       && json_stack->_internal.current_depth <= _az_MAX_JSON_STACK_SIZE);
 
   // true (i.e. 1) means _az_JSON_STACK_OBJECT, while false (i.e. 0) means _az_JSON_STACK_ARRAY
-  return (json_stack->_internal.az_json_stack & 1) != 0;
+  return (json_stack->_internal.az_json_stack & 1) != 0 ? _az_JSON_STACK_OBJECT : _az_JSON_STACK_ARRAY;
 }
 
 #include <_az_cfg_suffix.h>

--- a/sdk/iot/common/inc/az_iot_common.h
+++ b/sdk/iot/common/inc/az_iot_common.h
@@ -35,6 +35,9 @@ enum
  */
 typedef enum
 {
+  // Default, unset value
+  AZ_IOT_STATUS_UNSET = 0,
+
   // Service success codes
   AZ_IOT_STATUS_OK = 200,
   AZ_IOT_STATUS_ACCEPTED = 202,

--- a/sdk/iot/common/inc/az_iot_common.h
+++ b/sdk/iot/common/inc/az_iot_common.h
@@ -36,7 +36,7 @@ enum
 typedef enum
 {
   // Default, unset value
-  AZ_IOT_STATUS_UNSET = 0,
+  AZ_IOT_STATUS_UNKNOWN = 0,
 
   // Service success codes
   AZ_IOT_STATUS_OK = 200,

--- a/sdk/iot/provisioning/src/az_iot_provisioning_client.c
+++ b/sdk/iot/provisioning/src/az_iot_provisioning_client.c
@@ -224,7 +224,7 @@ _az_iot_provisioning_registration_result_default()
 {
   return (az_iot_provisioning_client_registration_result){ .assigned_hub_hostname = AZ_SPAN_NULL,
                                                            .device_id = AZ_SPAN_NULL,
-                                                           .error_code = AZ_IOT_STATUS_UNSET,
+                                                           .error_code = AZ_IOT_STATUS_UNKNOWN,
                                                            .extended_error_code = 0,
                                                            .error_message = AZ_SPAN_NULL,
                                                            .error_tracking_id = AZ_SPAN_NULL,

--- a/sdk/iot/provisioning/src/az_iot_provisioning_client.c
+++ b/sdk/iot/provisioning/src/az_iot_provisioning_client.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "az_iot_provisioning_client.h"
+#include <az_iot_common.h>
 #include <az_json.h>
 #include <az_result.h>
 #include <az_span.h>
@@ -223,7 +224,7 @@ _az_iot_provisioning_registration_result_default()
 {
   return (az_iot_provisioning_client_registration_result){ .assigned_hub_hostname = AZ_SPAN_NULL,
                                                            .device_id = AZ_SPAN_NULL,
-                                                           .error_code = 0,
+                                                           .error_code = AZ_IOT_STATUS_UNSET,
                                                            .extended_error_code = 0,
                                                            .error_message = AZ_SPAN_NULL,
                                                            .error_tracking_id = AZ_SPAN_NULL,


### PR DESCRIPTION
IAR gives warnings for ->

> Warning[Pe188]: enumerated type mixed with another type

So `0` initialized structs trigger the warnings. This explicitly sets the enums to default values.