### PR TITLE
[iot] Fixes on SAS token generation

### DIFF
--- a/sdk/iot/common/inc/az_iot_common_internal.h
+++ b/sdk/iot/common/inc/az_iot_common_internal.h
@@ -32,6 +32,16 @@
  */
 AZ_NODISCARD int32_t _az_iot_u32toa_size(uint32_t number);
 
+/**
+ * @brief Copies the url-encoded content of `source` span into `destination`, returning the free remaining of `destination`.
+ *
+ * @param[in] destination The span where the `source` is url-encoded to.
+ * @param[in] source The span to url-encode and copy the content from.
+ * @param[out] out_remainder A slice of `destination` with the non-used buffer portion of `destination`.
+ * @return An `az_result` value.
+ */
+AZ_NODISCARD az_result _az_span_copy_url_encode(az_span destination, az_span source, az_span* out_remainder);
+
 #include <_az_cfg_suffix.h>
 
 #endif //!_az_IOT_CORE_INTERNAL_H

--- a/sdk/iot/common/src/az_iot_common.c
+++ b/sdk/iot/common/src/az_iot_common.c
@@ -8,6 +8,7 @@
 #include <az_precondition_internal.h>
 #include <az_result.h>
 #include <az_span.h>
+#include <az_span_internal.h>
 
 #include <az_log_internal.h>
 #include <az_retry_internal.h>
@@ -64,4 +65,12 @@ AZ_NODISCARD int32_t _az_iot_u32toa_size(uint32_t number)
 
     return digit_count;
   }
+}
+
+AZ_NODISCARD az_result _az_span_copy_url_encode(az_span destination, az_span source, az_span* out_remainder)
+{
+  int32_t length;
+  AZ_RETURN_IF_FAILED(_az_span_url_encode(destination, source, &length));
+  *out_remainder = az_span_slice(destination, length, az_span_size(destination));
+  return AZ_OK;
 }

--- a/sdk/iot/common/tests/test_az_iot_common.c
+++ b/sdk/iot/common/tests/test_az_iot_common.c
@@ -117,6 +117,34 @@ static void test_az_iot_provisioning_client_logging_succeed()
   az_log_set_classifications(NULL);
 }
 
+static void test_az_span_copy_url_encode_succeed()
+{
+  az_span url_decoded_span = AZ_SPAN_FROM_STR("abc/=%012");
+
+  uint8_t url_encoded[15];
+  az_span url_encoded_span = AZ_SPAN_FROM_BUFFER(url_encoded);
+
+  az_span remaining;
+
+  uint8_t expected_result[] = "abc%2F%3D%25012";
+
+  assert_int_equal(_az_span_copy_url_encode(url_encoded_span, url_decoded_span, &remaining), AZ_OK);
+  assert_int_equal(az_span_size(remaining), 0);
+  assert_int_equal(az_span_size(url_encoded_span) - az_span_size(remaining), _az_COUNTOF(expected_result) - 1);
+}
+
+static void test_az_span_copy_url_encode_insufficient_size_fail()
+{
+  az_span url_decoded_span = AZ_SPAN_FROM_STR("abc/=%012");
+
+  uint8_t url_encoded[14]; // Needs 15 bytes, this will cause a failure (as expected by this test).
+  az_span url_encoded_span = AZ_SPAN_FROM_BUFFER(url_encoded);
+
+  az_span remaining;
+
+  assert_int_equal(_az_span_copy_url_encode(url_encoded_span, url_decoded_span, &remaining), AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+}
+
 #ifdef _MSC_VER
 // warning C4113: 'void (__cdecl *)()' differs in parameter lists from 'CMUnitTestFunction'
 #pragma warning(disable : 4113)
@@ -131,6 +159,8 @@ int test_az_iot_common()
     cmocka_unit_test(test_az_iot_retry_calc_delay_common_timings_success),
     cmocka_unit_test(test_az_iot_retry_calc_delay_overflow_time_success),
     cmocka_unit_test(test_az_iot_provisioning_client_logging_succeed),
+    cmocka_unit_test(test_az_span_copy_url_encode_succeed),
+    cmocka_unit_test(test_az_span_copy_url_encode_insufficient_size_fail),
   };
   return cmocka_run_group_tests_name("az_iot_common", tests, NULL, NULL);
 }

--- a/sdk/iot/hub/src/az_iot_hub_client_sas.c
+++ b/sdk/iot/hub/src/az_iot_hub_client_sas.c
@@ -18,8 +18,8 @@
 #define AMPERSAND '&'
 #define EQUAL_SIGN '='
 #define STRING_NULL_TERMINATOR '\0'
-#define SCOPE_DEVICES_STRING "/devices/"
-#define SCOPE_MODULES_STRING "/modules/"
+#define SCOPE_DEVICES_STRING "%2Fdevices%2F"
+#define SCOPE_MODULES_STRING "%2Fmodules%2F"
 #define SAS_TOKEN_SR "SharedAccessSignature sr"
 #define SAS_TOKEN_SE "se"
 #define SAS_TOKEN_SIG "sig"
@@ -32,6 +32,7 @@ static const az_span sr_string = AZ_SPAN_LITERAL_FROM_STR(SAS_TOKEN_SR);
 static const az_span sig_string = AZ_SPAN_LITERAL_FROM_STR(SAS_TOKEN_SIG);
 static const az_span se_string = AZ_SPAN_LITERAL_FROM_STR(SAS_TOKEN_SE);
 
+
 AZ_NODISCARD az_result az_iot_hub_client_sas_get_signature(
     az_iot_hub_client const* client,
     uint32_t token_expiration_epoch_time,
@@ -43,38 +44,33 @@ AZ_NODISCARD az_result az_iot_hub_client_sas_get_signature(
   _az_PRECONDITION_VALID_SPAN(signature, 1, false);
   _az_PRECONDITION_NOT_NULL(out_signature);
 
-  int32_t required_size = az_span_size(client->_internal.iot_hub_hostname)
-      + az_span_size(devices_string)
-      + az_span_size(client->_internal.device_id)
-      + 1 // LF
-      + _az_iot_u32toa_size(token_expiration_epoch_time);
-
-  if (az_span_size(client->_internal.options.module_id) > 0)
-  {
-    required_size += 
-        az_span_size(modules_string) 
-        + az_span_size(client->_internal.options.module_id);
-  }
-
-  AZ_RETURN_IF_NOT_ENOUGH_SIZE(signature, required_size);
-
   az_span remainder = signature;
+  int32_t signature_size = az_span_size(signature);
 
-  remainder = az_span_copy(remainder, client->_internal.iot_hub_hostname);
+  AZ_RETURN_IF_FAILED(_az_span_copy_url_encode(remainder, client->_internal.iot_hub_hostname, &remainder));
+
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(devices_string));
   remainder = az_span_copy(remainder, devices_string);
-  remainder = az_span_copy(remainder, client->_internal.device_id);
+  
+  AZ_RETURN_IF_FAILED(_az_span_copy_url_encode(remainder, client->_internal.device_id, &remainder));
 
   if (az_span_size(client->_internal.options.module_id) > 0)
   {
+    AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(modules_string));
     remainder = az_span_copy(remainder, modules_string);
-    remainder = az_span_copy(remainder, client->_internal.options.module_id);
+
+    AZ_RETURN_IF_FAILED(_az_span_copy_url_encode(remainder, client->_internal.options.module_id, &remainder));
   }
+
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, 
+    1 + // LF
+    _az_iot_u32toa_size(token_expiration_epoch_time));
 
   remainder = az_span_copy_u8(remainder, LF);
 
   AZ_RETURN_IF_FAILED(az_span_u32toa(remainder, token_expiration_epoch_time, &remainder));
 
-  *out_signature = az_span_slice(signature, 0, required_size);
+  *out_signature = az_span_slice(signature, 0, signature_size - az_span_size(remainder));
   _az_LOG_WRITE(AZ_LOG_IOT_SAS_TOKEN, *out_signature);
 
   return AZ_OK;
@@ -98,87 +94,66 @@ AZ_NODISCARD az_result az_iot_hub_client_sas_get_password(
   // Concatenates: "SharedAccessSignature sr=" scope "&sig=" sig  "&se=" expiration_time_secs
   //               plus, if key_name size > 0, "&skn=" key_name
 
-  // This does not account for the size of `token_expiration_epoch_time`, which will be handled by az_span_u32toa.
-  int32_t required_size = 
-      az_span_size(sr_string) 
-      + 1 // EQUAL_SIGN
-      + az_span_size(client->_internal.iot_hub_hostname)
-      + az_span_size(devices_string)
-      + az_span_size(client->_internal.device_id)
-      + 1 // AMPERSAND
-      + az_span_size(sig_string) 
-      + 1 // EQUAL_SIGN
-      + az_span_size(base64_hmac_sha256_signature)
-      + 1 // AMPERSAND
-      + az_span_size(se_string) 
-      + 1 // EQUAL_SIGN
-      + _az_iot_u32toa_size(token_expiration_epoch_time)
-      + 1; // STRING_NULL_TERMINATOR
-
-  if (az_span_size(client->_internal.options.module_id) > 0)
-  {
-    required_size +=
-        az_span_size(modules_string) 
-        + az_span_size(client->_internal.options.module_id);
-  }
-
-  if (az_span_size(key_name) > 0)
-  {
-    required_size += 
-        1 // AMPERSAND
-        + az_span_size(skn_string) 
-        + 1 // EQUAL_SIGN
-        + az_span_size(key_name);
-  }
-
   az_span mqtt_password_span = az_span_init((uint8_t*)mqtt_password, (int32_t)mqtt_password_size);
 
-  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_password_span, required_size);
 
   // SharedAccessSignature
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_password_span, az_span_size(sr_string) + 1 /* EQUAL_SIGN */);
   mqtt_password_span = az_span_copy(mqtt_password_span, sr_string);
   mqtt_password_span = az_span_copy_u8(mqtt_password_span, EQUAL_SIGN);
-  mqtt_password_span = az_span_copy(mqtt_password_span, client->_internal.iot_hub_hostname);
+
+  AZ_RETURN_IF_FAILED(_az_span_copy_url_encode(mqtt_password_span, client->_internal.iot_hub_hostname, &mqtt_password_span));
 
   // Device ID
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_password_span, az_span_size(devices_string));
   mqtt_password_span = az_span_copy(mqtt_password_span, devices_string);
-  mqtt_password_span = az_span_copy(mqtt_password_span, client->_internal.device_id);
+
+  AZ_RETURN_IF_FAILED(_az_span_copy_url_encode(mqtt_password_span, client->_internal.device_id, &mqtt_password_span));
 
   // Module ID
   if (az_span_size(client->_internal.options.module_id) > 0)
   {
+    AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_password_span, az_span_size(modules_string));
     mqtt_password_span = az_span_copy(mqtt_password_span, modules_string);
-    mqtt_password_span = az_span_copy(mqtt_password_span, client->_internal.options.module_id);
+
+    AZ_RETURN_IF_FAILED(_az_span_copy_url_encode(mqtt_password_span, client->_internal.options.module_id, &mqtt_password_span));
   }
 
   // Signature
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_password_span, 1 /* AMPERSAND */ + az_span_size(sig_string) + 1 /* EQUAL_SIGN */);
+
   mqtt_password_span = az_span_copy_u8(mqtt_password_span, AMPERSAND);
   mqtt_password_span = az_span_copy(mqtt_password_span, sig_string);
   mqtt_password_span = az_span_copy_u8(mqtt_password_span, EQUAL_SIGN);
-  mqtt_password_span = az_span_copy(mqtt_password_span, base64_hmac_sha256_signature);
+
+  AZ_RETURN_IF_FAILED(_az_span_copy_url_encode(mqtt_password_span, base64_hmac_sha256_signature, &mqtt_password_span));
 
   // Expiration
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_password_span, 1 /* AMPERSAND */ + az_span_size(se_string) + 1 /* EQUAL_SIGN */);
   mqtt_password_span = az_span_copy_u8(mqtt_password_span, AMPERSAND);
   mqtt_password_span = az_span_copy(mqtt_password_span, se_string);
   mqtt_password_span = az_span_copy_u8(mqtt_password_span, EQUAL_SIGN);
+
   AZ_RETURN_IF_FAILED(az_span_u32toa(mqtt_password_span, token_expiration_epoch_time, &mqtt_password_span));
 
   if (az_span_size(key_name) > 0)
   {
     // Key Name
+    AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_password_span, 1 /* AMPERSAND */ + az_span_size(skn_string) + 1 /* EQUAL_SIGN */ + az_span_size(key_name));
     mqtt_password_span = az_span_copy_u8(mqtt_password_span, AMPERSAND);
     mqtt_password_span = az_span_copy(mqtt_password_span, skn_string);
     mqtt_password_span = az_span_copy_u8(mqtt_password_span, EQUAL_SIGN);
     mqtt_password_span = az_span_copy(mqtt_password_span, key_name);
   }
 
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_password_span, 1 /* NULL TERMINATOR */);
+
   mqtt_password_span = az_span_copy_u8(mqtt_password_span, STRING_NULL_TERMINATOR);
 
   if (out_mqtt_password_length != NULL)
   {
-    *out_mqtt_password_length = ((size_t)required_size - 1);
+    *out_mqtt_password_length = mqtt_password_size - (size_t)az_span_size(mqtt_password_span) - 1 /* NULL TERMINATOR */;
   }
-
 
   return AZ_OK;
 }

--- a/sdk/iot/hub/tests/test_az_iot_hub_client_sas.c
+++ b/sdk/iot/hub/tests/test_az_iot_hub_client_sas.c
@@ -23,7 +23,8 @@
 #define TEST_DEVICE_ID_STR "my_device"
 #define TEST_MODULE_ID_STR "my_module"
 #define TEST_DEVICE_HOSTNAME_STR "myiothub.azure-devices.net"
-#define TEST_SIG "cS1eHM%2FlDjsRsrZV9508wOFrgmZk4g8FNg8NwHVSiSQ"
+#define TEST_SIG "cS1eHM/lDjsRsrZV9508wOFrgmZk4g8FNg8NwHVSiSQ"
+#define TEST_URL_ENC_SIG "cS1eHM%2FlDjsRsrZV9508wOFrgmZk4g8FNg8NwHVSiSQ"
 #define TEST_EXPIRATION_STR "1578941692"
 #define TEST_KEY_NAME "iothubowner"
 
@@ -128,7 +129,7 @@ static void az_iot_hub_client_sas_get_signature_device_succeeds()
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
   const char expected_signature[]
-      = TEST_DEVICE_HOSTNAME_STR "/devices/" TEST_DEVICE_ID_STR "\n" TEST_EXPIRATION_STR;
+      = TEST_DEVICE_HOSTNAME_STR "%2Fdevices%2F" TEST_DEVICE_ID_STR "\n" TEST_EXPIRATION_STR;
 
   uint8_t signature_buffer[TEST_SPAN_BUFFER_SIZE];
   az_span signature = az_span_for_test_init(signature_buffer, _az_COUNTOF(signature_buffer));
@@ -154,7 +155,7 @@ static void az_iot_hub_client_sas_get_signature_module_succeeds()
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   const char* expected_signature = TEST_DEVICE_HOSTNAME_STR
-      "/devices/" TEST_DEVICE_ID_STR "/modules/" TEST_MODULE_ID_STR "\n" TEST_EXPIRATION_STR;
+      "%2Fdevices%2F" TEST_DEVICE_ID_STR "%2Fmodules%2F" TEST_MODULE_ID_STR "\n" TEST_EXPIRATION_STR;
 
   uint8_t signature_buffer[TEST_SPAN_BUFFER_SIZE];
   az_span signature = az_span_for_test_init(signature_buffer, _az_COUNTOF(signature_buffer));
@@ -177,8 +178,8 @@ static void az_iot_hub_client_sas_get_password_device_succeeds()
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
   const char expected_password[]
-      = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "/devices/" TEST_DEVICE_ID_STR
-        "&sig=" TEST_SIG "&se=" TEST_EXPIRATION_STR;
+      = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "%2Fdevices%2F" TEST_DEVICE_ID_STR
+        "&sig=" TEST_URL_ENC_SIG "&se=" TEST_EXPIRATION_STR;
 
   az_span key_name = AZ_SPAN_NULL;
 
@@ -204,8 +205,8 @@ static void az_iot_hub_client_sas_get_password_device_no_out_length_succeeds()
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
   const char expected_password[]
-      = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "/devices/" TEST_DEVICE_ID_STR
-        "&sig=" TEST_SIG "&se=" TEST_EXPIRATION_STR;
+      = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "%2Fdevices%2F" TEST_DEVICE_ID_STR
+        "&sig=" TEST_URL_ENC_SIG "&se=" TEST_EXPIRATION_STR;
 
   az_span key_name = AZ_SPAN_NULL;
 
@@ -233,8 +234,8 @@ static void az_iot_hub_client_sas_get_password_module_succeeds()
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   const char expected_password[]
-      = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "/devices/" TEST_DEVICE_ID_STR
-        "/modules/" TEST_MODULE_ID_STR "&sig=" TEST_SIG "&se=" TEST_EXPIRATION_STR;
+      = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "%2Fdevices%2F" TEST_DEVICE_ID_STR
+        "%2Fmodules%2F" TEST_MODULE_ID_STR "&sig=" TEST_URL_ENC_SIG "&se=" TEST_EXPIRATION_STR;
 
   az_span key_name = AZ_SPAN_NULL;
 
@@ -263,8 +264,8 @@ static void az_iot_hub_client_sas_get_password_module_no_length_succeeds()
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   const char expected_password[]
-      = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "/devices/" TEST_DEVICE_ID_STR
-        "/modules/" TEST_MODULE_ID_STR "&sig=" TEST_SIG "&se=" TEST_EXPIRATION_STR;
+      = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "%2Fdevices%2F" TEST_DEVICE_ID_STR
+        "%2Fmodules%2F" TEST_MODULE_ID_STR "&sig=" TEST_URL_ENC_SIG "&se=" TEST_EXPIRATION_STR;
 
   az_span key_name = AZ_SPAN_NULL;
 
@@ -289,8 +290,8 @@ static void az_iot_hub_client_sas_get_password_device_with_keyname_succeeds()
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
   const char expected_password[]
-      = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "/devices/" TEST_DEVICE_ID_STR
-        "&sig=" TEST_SIG "&se=" TEST_EXPIRATION_STR "&skn=" TEST_KEY_NAME;
+      = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "%2Fdevices%2F" TEST_DEVICE_ID_STR
+        "&sig=" TEST_URL_ENC_SIG "&se=" TEST_EXPIRATION_STR "&skn=" TEST_KEY_NAME;
 
   az_span key_name = AZ_SPAN_FROM_STR(TEST_KEY_NAME);
 
@@ -319,8 +320,8 @@ static void az_iot_hub_client_sas_get_password_module_with_keyname_succeeds()
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
   const char expected_password[]
-      = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "/devices/" TEST_DEVICE_ID_STR
-        "/modules/" TEST_MODULE_ID_STR "&sig=" TEST_SIG "&se=" TEST_EXPIRATION_STR
+      = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "%2Fdevices%2F" TEST_DEVICE_ID_STR
+        "%2Fmodules%2F" TEST_MODULE_ID_STR "&sig=" TEST_URL_ENC_SIG "&se=" TEST_EXPIRATION_STR
         "&skn=" TEST_KEY_NAME;
 
   az_span key_name = AZ_SPAN_FROM_STR(TEST_KEY_NAME);
@@ -423,7 +424,7 @@ static int _log_invoked_sas = 0;
 static void _log_listener(az_log_classification classification, az_span message)
 {
   const char expected[]
-      = TEST_DEVICE_HOSTNAME_STR "/devices/" TEST_DEVICE_ID_STR "\n" TEST_EXPIRATION_STR;
+      = TEST_DEVICE_HOSTNAME_STR "%2Fdevices%2F" TEST_DEVICE_ID_STR "\n" TEST_EXPIRATION_STR;
 
   switch (classification)
   {

--- a/sdk/iot/provisioning/tests/test_az_iot_provisioning_client_sas.c
+++ b/sdk/iot/provisioning/tests/test_az_iot_provisioning_client_sas.c
@@ -24,7 +24,8 @@
 #define TEST_ID_SCOPE "0neFEEDC0DE"
 #define TEST_URL_ENCODED_RESOURCE_URI "0neFEEDC0DE%2fregistrations%2fmyRegistrationId"
 
-#define TEST_SIG "cS1eHM%2FlDjsRsrZV9508wOFrgmZk4g8FNg8NwHVSiSQ"
+#define TEST_SIG "cS1eHM/lDjsRsrZV9508wOFrgmZk4g8FNg8NwHVSiSQ"
+#define TEST_URL_ENC_SIG "cS1eHM%2FlDjsRsrZV9508wOFrgmZk4g8FNg8NwHVSiSQ"
 #define TEST_EXPIRATION_STR "1578941692"
 #define TEST_KEY_NAME "iothubowner"
 
@@ -174,8 +175,8 @@ static void az_iot_provisioning_client_sas_get_password_device_succeeds()
       AZ_OK);
 
   const char expected_password[]
-      = "SharedAccessSignature sr=" TEST_ID_SCOPE "%2fregistrations%2f" TEST_REGISTRATION_ID_STR
-        "&sig=" TEST_SIG "&se=" TEST_EXPIRATION_STR;
+      = "SharedAccessSignature sr=" TEST_URL_ENCODED_RESOURCE_URI
+        "&sig=" TEST_URL_ENC_SIG "&se=" TEST_EXPIRATION_STR;
 
   az_span key_name = AZ_SPAN_NULL;
 
@@ -204,8 +205,8 @@ static void az_iot_provisioning_client_sas_get_password_device_with_keyname_succ
       AZ_OK);
 
   const char expected_password[]
-      = "SharedAccessSignature sr=" TEST_ID_SCOPE "%2fregistrations%2f" TEST_REGISTRATION_ID_STR
-        "&sig=" TEST_SIG "&se=" TEST_EXPIRATION_STR "&skn=" TEST_KEY_NAME;
+      = "SharedAccessSignature sr=" TEST_URL_ENCODED_RESOURCE_URI
+        "&sig=" TEST_URL_ENC_SIG "&se=" TEST_EXPIRATION_STR "&skn=" TEST_KEY_NAME;
 
   az_span key_name = AZ_SPAN_FROM_STR(TEST_KEY_NAME);
 


### PR DESCRIPTION
Implemented URL-encoding of components of SAS tokens according to Azure IoT documentation:

For IoT Hub:
https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#security-token-structure

For Device Provisioning:
https://docs.microsoft.com/en-us/azure/iot-dps/concepts-symmetric-key-attestation#detailed-attestation-process