### PR TITLE
Temporary measure for the header to point into token's memory

### DIFF
--- a/sdk/core/az_core/src/az_credential_client_secret.c
+++ b/sdk/core/az_core/src/az_credential_client_secret.c
@@ -67,8 +67,13 @@ static AZ_NODISCARD az_result _az_credential_client_secret_apply(
 
   int16_t const token_length = token._internal.token_length;
 
+  // Still bad in terms of cuncurrency, but at least the pointer is not pointing to an unknown memory.
+  // Temporary measure to improve https://github.com/Azure/azure-sdk-for-c/issues/799 a bit.
+  uint8_t* const token_buf_ptr
+      = (uint8_t*)credential->_internal.token_credential._internal.token._internal.token;
+
   AZ_RETURN_IF_FAILED(az_http_request_append_header(
-      ref_request, _az_auth_header_name, az_span_init(token._internal.token, token_length)));
+      ref_request, _az_auth_header_name, az_span_init(token_buf_ptr, token_length)));
 
   return AZ_OK;
 }

--- a/sdk/core/az_core/src/az_credential_client_secret.c
+++ b/sdk/core/az_core/src/az_credential_client_secret.c
@@ -67,7 +67,7 @@ static AZ_NODISCARD az_result _az_credential_client_secret_apply(
 
   int16_t const token_length = token._internal.token_length;
 
-  // Still bad in terms of cuncurrency, but at least the pointer is not pointing to an unknown
+  // Still bad in terms of concurrency, but at least the pointer is not pointing to an unknown
   // memory. Temporary measure to improve https://github.com/Azure/azure-sdk-for-c/issues/799 a bit.
   uint8_t* const token_buf_ptr
       = (uint8_t*)(uintptr_t)credential->_internal.token_credential._internal.token._internal.token;

--- a/sdk/core/az_core/src/az_credential_client_secret.c
+++ b/sdk/core/az_core/src/az_credential_client_secret.c
@@ -67,10 +67,10 @@ static AZ_NODISCARD az_result _az_credential_client_secret_apply(
 
   int16_t const token_length = token._internal.token_length;
 
-  // Still bad in terms of cuncurrency, but at least the pointer is not pointing to an unknown memory.
-  // Temporary measure to improve https://github.com/Azure/azure-sdk-for-c/issues/799 a bit.
+  // Still bad in terms of cuncurrency, but at least the pointer is not pointing to an unknown
+  // memory. Temporary measure to improve https://github.com/Azure/azure-sdk-for-c/issues/799 a bit.
   uint8_t* const token_buf_ptr
-      = (uint8_t*)credential->_internal.token_credential._internal.token._internal.token;
+      = (uint8_t*)(uintptr_t)credential->_internal.token_credential._internal.token._internal.token;
 
   AZ_RETURN_IF_FAILED(az_http_request_append_header(
       ref_request, _az_auth_header_name, az_span_init(token_buf_ptr, token_length)));


### PR DESCRIPTION
Pointing to a volatile memory is a bit better category of a bug, than pointing to a random location.
#799
Not a fix, but an improvement.

THese are exactly the same changes as https://github.com/Azure/azure-sdk-for-c/pull/800, but this one comes from a correct branch from my fork, and I pulled the most recent changes from our repo's master.