### PR TITLE
Turn off clobbered warning for longjmp for UT'S

### DIFF
--- a/cmake-modules/AddTestCMocka.cmake
+++ b/cmake-modules/AddTestCMocka.cmake
@@ -65,6 +65,11 @@ function(ADD_CMOCKA_TEST _TARGET_NAME)
 
     add_executable(${_TARGET_NAME} ${_add_cmocka_test_SOURCES})
 
+    # Suppress clobber warning for longjmp
+    if(CMAKE_C_COMPILER_ID MATHES "GNU")
+      target_compile_options(${_TARGET_NAME} -Wno-clobbered)
+    endif()
+
     if (DEFINED _add_cmocka_test_COMPILE_OPTIONS)
         target_compile_options(${_TARGET_NAME}
             PRIVATE ${_add_cmocka_test_COMPILE_OPTIONS}

--- a/cmake-modules/AddTestCMocka.cmake
+++ b/cmake-modules/AddTestCMocka.cmake
@@ -66,8 +66,8 @@ function(ADD_CMOCKA_TEST _TARGET_NAME)
     add_executable(${_TARGET_NAME} ${_add_cmocka_test_SOURCES})
 
     # Suppress clobber warning for longjmp
-    if(CMAKE_C_COMPILER_ID MATHES "GNU")
-      target_compile_options(${_TARGET_NAME} -Wno-clobbered)
+    if(CMAKE_C_COMPILER_ID MATCHES "GNU")
+      target_compile_options(${_TARGET_NAME} PRIVATE -Wno-clobbered)
     endif()
 
     if (DEFINED _add_cmocka_test_COMPILE_OPTIONS)

--- a/eng/cmake/global_compile_options.txt
+++ b/eng/cmake/global_compile_options.txt
@@ -15,5 +15,5 @@ else()
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")
   endif()
 
-  add_compile_options(-Wall -Wextra -pedantic  ${WARNINGS_AS_ERRORS_FLAG} -Wcast-qual -Wunused -Wuninitialized -Wmissing-declarations -Wconversion -Wpointer-arith -Wshadow -Wlogical-op -Wfloat-equal)
+  add_compile_options(-Wall -Wextra -pedantic  ${WARNINGS_AS_ERRORS_FLAG} -Wcast-qual -Wunused -Wuninitialized -Wmissing-declarations -Wconversion -Wpointer-arith -Wshadow -Wlogical-op -Wfloat-equal -Wno-clobbered)
 endif()

--- a/eng/cmake/global_compile_options.txt
+++ b/eng/cmake/global_compile_options.txt
@@ -15,5 +15,5 @@ else()
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")
   endif()
 
-  add_compile_options(-Wall -Wextra -pedantic  ${WARNINGS_AS_ERRORS_FLAG} -Wcast-qual -Wunused -Wuninitialized -Wmissing-declarations -Wconversion -Wpointer-arith -Wshadow -Wlogical-op -Wfloat-equal -Wno-clobbered)
+  add_compile_options(-Wall -Wextra -pedantic  ${WARNINGS_AS_ERRORS_FLAG} -Wcast-qual -Wunused -Wuninitialized -Wmissing-declarations -Wconversion -Wpointer-arith -Wshadow -Wlogical-op -Wfloat-equal)
 endif()


### PR DESCRIPTION
Fixes #801 

From GCC docs
> Warn for variables that might be changed by longjmp or vfork. This warning is also enabled by -Wextra.

Full disclosure. There is another way to fix this that is more involved that doesn't suppress the warning. All function calls which have parameters with `AZ_SPAN_` literals as parameters would have to change to have local spans set to those values which are then passed on to the function. 

So this :arrow_down: 
```c
  ASSERT_PRECONDITION_CHECKED(
      az_http_request_append_header(&hrb, AZ_SPAN_FROM_STR(" \t\r"), AZ_SPAN_NULL));
```
becomes :arrow_down: 

```c
  az_span precondition_span = AZ_SPAN_FROM_STR(" \t\r");
  az_span precondition_null_span = AZ_SPAN_NULL;
  ASSERT_PRECONDITION_CHECKED(
      az_http_request_append_header(&hrb, precondition_span, precondition_null_span));
```
However, I think suppressing the warning also works since even if those variables get changed, it doesn't matter since they were valid values at the time that the precondition was evaluated. 

If others don't think that is correct thinking please let me know and I can update all the calls to `_PRECONDITION_CHECKED`.