### PR TITLE
add cfg to provisioning test

### DIFF
--- a/sdk/iot/hub/tests/test_az_iot_hub_client_c2d.c
+++ b/sdk/iot/hub/tests/test_az_iot_hub_client_c2d.c
@@ -18,6 +18,8 @@
 
 #include <cmocka.h>
 
+#include <_az_cfg.h>
+
 #define TEST_SPAN_BUFFER_SIZE 128
 
 #define TEST_DEVICE_ID_STR "my_device"

--- a/sdk/iot/hub/tests/test_az_iot_hub_client_methods.c
+++ b/sdk/iot/hub/tests/test_az_iot_hub_client_methods.c
@@ -19,6 +19,8 @@
 
 #include <cmocka.h>
 
+#include <_az_cfg.h>
+
 #define TEST_SPAN_BUFFER_SIZE 128
 
 #define TEST_DEVICE_ID_STR "my_device"

--- a/sdk/iot/hub/tests/test_az_iot_hub_client_sas.c
+++ b/sdk/iot/hub/tests/test_az_iot_hub_client_sas.c
@@ -18,6 +18,8 @@
 
 #include <cmocka.h>
 
+#include <_az_cfg.h>
+
 #define TEST_SPAN_BUFFER_SIZE 256
 
 #define TEST_DEVICE_ID_STR "my_device"

--- a/sdk/iot/hub/tests/test_az_iot_hub_client_twin.c
+++ b/sdk/iot/hub/tests/test_az_iot_hub_client_twin.c
@@ -18,6 +18,8 @@
 
 #include <cmocka.h>
 
+#include <_az_cfg.h>
+
 #define TEST_SPAN_BUFFER_SIZE 128
 
 static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR("my_device");

--- a/sdk/iot/provisioning/tests/test_az_iot_provisioning_client_sas.c
+++ b/sdk/iot/provisioning/tests/test_az_iot_provisioning_client_sas.c
@@ -18,6 +18,8 @@
 
 #include <cmocka.h>
 
+#include <_az_cfg.h>
+
 #define TEST_SPAN_BUFFER_SIZE 256
 
 #define TEST_REGISTRATION_ID_STR "myRegistrationId"


### PR DESCRIPTION
Warnings were getting triggered which other tests have disabled by `_az_cfg.h`