### PR TITLE
MSVC: /W4 instead of /Wall

### DIFF
--- a/eng/cmake/global_compile_options.txt
+++ b/eng/cmake/global_compile_options.txt
@@ -3,7 +3,7 @@ if(MSVC)
     set(WARNINGS_AS_ERRORS_FLAG "/WX")
   endif()
 
-  add_compile_options(/Wall ${WARNINGS_AS_ERRORS_FLAG} /wd5031 /wd4668 /wd4820 /wd4255 /wd4710 /analyze)
+  add_compile_options(/W4 ${WARNINGS_AS_ERRORS_FLAG} /wd5031 /wd4668 /wd4820 /wd4255 /wd4710 /analyze)
 elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
   if(WARNINGS_AS_ERRORS)
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")


### PR DESCRIPTION
I confirmed with Bliiy, we should rather be using /W4 instead of /Wall for MSVC.
https://github.com/Azure/azure-sdk-for-c/issues/813