### PR TITLE
Specify openssl command line for samples

### DIFF
--- a/sdk/iot/hub/samples/README.md
+++ b/sdk/iot/hub/samples/README.md
@@ -19,7 +19,7 @@ Key concepts are explained in detail [here][SDK_README_KEY_CONCEPTS].
 
 ## Prerequisites
 
-- To generate the device certificate, the provided script uses [OpenSSL 1.1.1 LTS](https://www.openssl.org/). Please
+- To generate the device certificate, the provided script uses [OpenSSL 1.1.1 LTS](https://www.openssl.org/source/). Please
 install the OpenSSL command line utility prior to using the script.
 - To use the samples, we use [Eclipse Paho MQTT C client][Eclipse_Paho]. You can use the directions
 [here][VCPKG_DIRECTIONS] to set up VCPKG to download and manage linking the dependency.

--- a/sdk/iot/hub/samples/README.md
+++ b/sdk/iot/hub/samples/README.md
@@ -19,7 +19,7 @@ Key concepts are explained in detail [here][SDK_README_KEY_CONCEPTS].
 
 ## Prerequisites
 
-- To generate the device certificate, the provided script uses [OpenSSL](https://www.openssl.org/). Please
+- To generate the device certificate, the provided script uses [OpenSSL 1.1.1 LTS](https://www.openssl.org/). Please
 install the OpenSSL command line utility prior to using the script.
 - To use the samples, we use [Eclipse Paho MQTT C client][Eclipse_Paho]. You can use the directions
 [here][VCPKG_DIRECTIONS] to set up VCPKG to download and manage linking the dependency.

--- a/sdk/iot/hub/samples/README.md
+++ b/sdk/iot/hub/samples/README.md
@@ -23,7 +23,7 @@ Key concepts are explained in detail [here][SDK_README_KEY_CONCEPTS].
 install the OpenSSL command line utility prior to using the script.
 - To use the samples, we use [Eclipse Paho MQTT C client][Eclipse_Paho]. You can use the directions
 [here][VCPKG_DIRECTIONS] to set up VCPKG to download and manage linking the dependency.
-- If you are having trouble with any of the prerequisites, please see our `how_to_iot_hub_sample_<platform>.md` documents [here](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/iot/doc) for more help.
+- If you are having trouble with any of the prerequisites, please see our `how_to_iot_hub_samples_<platform>.md` documents [here](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/iot/doc) for more help.
 
 ## Getting Started
 

--- a/sdk/iot/hub/samples/README.md
+++ b/sdk/iot/hub/samples/README.md
@@ -20,7 +20,7 @@ Key concepts are explained in detail [here][SDK_README_KEY_CONCEPTS].
 ## Prerequisites
 
 - To generate the device certificate, the provided script uses [OpenSSL](https://www.openssl.org/). Please
-install OpenSSL prior to using the script.
+install the OpenSSL command line utility prior to using the script.
 - To use the samples, we use [Eclipse Paho MQTT C client][Eclipse_Paho]. You can use the directions
 [here][VCPKG_DIRECTIONS] to set up VCPKG to download and manage linking the dependency.
 

--- a/sdk/iot/hub/samples/README.md
+++ b/sdk/iot/hub/samples/README.md
@@ -23,6 +23,7 @@ Key concepts are explained in detail [here][SDK_README_KEY_CONCEPTS].
 install the OpenSSL command line utility prior to using the script.
 - To use the samples, we use [Eclipse Paho MQTT C client][Eclipse_Paho]. You can use the directions
 [here][VCPKG_DIRECTIONS] to set up VCPKG to download and manage linking the dependency.
+- If you are having trouble with any of the prerequisites, please see our `how_to_iot_hub_sample_<platform>.md` documents [here](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/iot/doc) for more help.
 
 ## Getting Started
 


### PR DESCRIPTION
Specify that the user needs the command line version of OpenSSL to run the script.