### PR TITLE
Update console output values for sample environment vars

### DIFF
--- a/sdk/iot/hub/samples/src/paho_iot_hub_c2d_example.c
+++ b/sdk/iot/hub/samples/src/paho_iot_hub_c2d_example.c
@@ -116,19 +116,19 @@ static az_result read_configuration_and_init_client()
 {
   az_span cert = AZ_SPAN_FROM_BUFFER(x509_cert_pem_file);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "X509 Certificate PEM Store File", ENV_DEVICE_X509_CERT_PEM_FILE, NULL, false, cert, &cert));
+      ENV_DEVICE_X509_CERT_PEM_FILE, ENV_DEVICE_X509_CERT_PEM_FILE, NULL, false, cert, &cert));
 
   az_span trusted = AZ_SPAN_FROM_BUFFER(x509_trust_pem_file);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "X509 Trusted PEM Store File", ENV_DEVICE_X509_TRUST_PEM_FILE, "", false, trusted, &trusted));
+      ENV_DEVICE_X509_TRUST_PEM_FILE, ENV_DEVICE_X509_TRUST_PEM_FILE, "", false, trusted, &trusted));
 
   az_span device_id_span = AZ_SPAN_FROM_BUFFER(device_id);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "Device ID", ENV_DEVICE_ID, "", false, device_id_span, &device_id_span));
+      ENV_DEVICE_ID, ENV_DEVICE_ID, "", false, device_id_span, &device_id_span));
 
   az_span iot_hub_hostname_span = AZ_SPAN_FROM_BUFFER(iot_hub_hostname);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "IoT Hub Hostname",
+      ENV_IOT_HUB_HOSTNAME,
       ENV_IOT_HUB_HOSTNAME,
       "",
       false,

--- a/sdk/iot/hub/samples/src/paho_iot_hub_methods_example.c
+++ b/sdk/iot/hub/samples/src/paho_iot_hub_methods_example.c
@@ -124,19 +124,19 @@ static az_result read_configuration_and_init_client()
 {
   az_span cert = AZ_SPAN_FROM_BUFFER(x509_cert_pem_file);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "X509 Certificate PEM Store File", ENV_DEVICE_X509_CERT_PEM_FILE, NULL, false, cert, &cert));
+      ENV_DEVICE_X509_CERT_PEM_FILE, ENV_DEVICE_X509_CERT_PEM_FILE, NULL, false, cert, &cert));
 
   az_span trusted = AZ_SPAN_FROM_BUFFER(x509_trust_pem_file);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "X509 Trusted PEM Store File", ENV_DEVICE_X509_TRUST_PEM_FILE, "", false, trusted, &trusted));
+      ENV_DEVICE_X509_TRUST_PEM_FILE, ENV_DEVICE_X509_TRUST_PEM_FILE, "", false, trusted, &trusted));
 
   az_span device_id_span = AZ_SPAN_FROM_BUFFER(device_id);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "Device ID", ENV_DEVICE_ID, "", false, device_id_span, &device_id_span));
+      ENV_DEVICE_ID, ENV_DEVICE_ID, "", false, device_id_span, &device_id_span));
 
   az_span iot_hub_hostname_span = AZ_SPAN_FROM_BUFFER(iot_hub_hostname);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "IoT Hub Hostname",
+      ENV_IOT_HUB_HOSTNAME,
       ENV_IOT_HUB_HOSTNAME,
       "",
       false,

--- a/sdk/iot/hub/samples/src/paho_iot_hub_sas_telemetry_example.c
+++ b/sdk/iot/hub/samples/src/paho_iot_hub_sas_telemetry_example.c
@@ -159,7 +159,7 @@ static az_result read_configuration_and_init_client()
 {
   az_span trusted = AZ_SPAN_FROM_BUFFER(x509_trust_pem_file);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "X509 Trusted PEM Store File", ENV_DEVICE_X509_TRUST_PEM_FILE, "", false, trusted, &trusted));
+      ENV_DEVICE_X509_TRUST_PEM_FILE, ENV_DEVICE_X509_TRUST_PEM_FILE, "", false, trusted, &trusted));
 
   char iot_hub_sas_key_expiration_char[SAS_TOKEN_EXPIRATION_TIME_DIGITS];
   az_span iot_hub_sas_expiration_span = AZ_SPAN_FROM_BUFFER(iot_hub_sas_key_expiration_char);
@@ -184,11 +184,11 @@ static az_result read_configuration_and_init_client()
 
   az_span device_id_span = AZ_SPAN_FROM_BUFFER(device_id);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "Device ID", ENV_DEVICE_ID, "", false, device_id_span, &device_id_span));
+      ENV_DEVICE_ID, ENV_DEVICE_ID, "", false, device_id_span, &device_id_span));
 
   az_span iot_hub_hostname_span = AZ_SPAN_FROM_BUFFER(iot_hub_hostname);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "IoT Hub Hostname",
+      ENV_IOT_HUB_HOSTNAME,
       ENV_IOT_HUB_HOSTNAME,
       "",
       false,

--- a/sdk/iot/hub/samples/src/paho_iot_hub_telemetry_example.c
+++ b/sdk/iot/hub/samples/src/paho_iot_hub_telemetry_example.c
@@ -141,19 +141,19 @@ static az_result read_configuration_and_init_client()
 {
   az_span cert = AZ_SPAN_FROM_BUFFER(x509_cert_pem_file);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "X509 Certificate PEM Store File", ENV_DEVICE_X509_CERT_PEM_FILE, NULL, false, cert, &cert));
+      ENV_DEVICE_X509_CERT_PEM_FILE, ENV_DEVICE_X509_CERT_PEM_FILE, NULL, false, cert, &cert));
 
   az_span trusted = AZ_SPAN_FROM_BUFFER(x509_trust_pem_file);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "X509 Trusted PEM Store File", ENV_DEVICE_X509_TRUST_PEM_FILE, "", false, trusted, &trusted));
+      ENV_DEVICE_X509_TRUST_PEM_FILE, ENV_DEVICE_X509_TRUST_PEM_FILE, "", false, trusted, &trusted));
 
   az_span device_id_span = AZ_SPAN_FROM_BUFFER(device_id);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "Device ID", ENV_DEVICE_ID, "", false, device_id_span, &device_id_span));
+      ENV_DEVICE_ID, ENV_DEVICE_ID, "", false, device_id_span, &device_id_span));
 
   az_span iot_hub_hostname_span = AZ_SPAN_FROM_BUFFER(iot_hub_hostname);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "IoT Hub Hostname",
+      ENV_IOT_HUB_HOSTNAME,
       ENV_IOT_HUB_HOSTNAME,
       "",
       false,

--- a/sdk/iot/hub/samples/src/paho_iot_hub_twin_example.c
+++ b/sdk/iot/hub/samples/src/paho_iot_hub_twin_example.c
@@ -127,19 +127,19 @@ static az_result read_configuration_and_init_client()
 {
   az_span cert = AZ_SPAN_FROM_BUFFER(x509_cert_pem_file);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "X509 Certificate PEM Store File", ENV_DEVICE_X509_CERT_PEM_FILE, NULL, false, cert, &cert));
+      ENV_DEVICE_X509_CERT_PEM_FILE, ENV_DEVICE_X509_CERT_PEM_FILE, NULL, false, cert, &cert));
 
   az_span trusted = AZ_SPAN_FROM_BUFFER(x509_trust_pem_file);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "X509 Trusted PEM Store File", ENV_DEVICE_X509_TRUST_PEM_FILE, "", false, trusted, &trusted));
+      ENV_DEVICE_X509_TRUST_PEM_FILE, ENV_DEVICE_X509_TRUST_PEM_FILE, "", false, trusted, &trusted));
 
   az_span device_id_span = AZ_SPAN_FROM_BUFFER(device_id);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "Device ID", ENV_DEVICE_ID, "", false, device_id_span, &device_id_span));
+      ENV_DEVICE_ID, ENV_DEVICE_ID, "", false, device_id_span, &device_id_span));
 
   az_span iot_hub_hostname_span = AZ_SPAN_FROM_BUFFER(iot_hub_hostname);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "IoT Hub Hostname",
+      ENV_IOT_HUB_HOSTNAME,
       ENV_IOT_HUB_HOSTNAME,
       "",
       false,

--- a/sdk/iot/provisioning/samples/src/paho_iot_provisioning_example.c
+++ b/sdk/iot/provisioning/samples/src/paho_iot_provisioning_example.c
@@ -114,7 +114,7 @@ static az_result read_configuration_and_init_client()
 {
   az_span endpoint_span = AZ_SPAN_FROM_BUFFER(global_provisioning_endpoint);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "Global Device Endpoint",
+      ENV_GLOBAL_PROVISIONING_ENDPOINT,
       ENV_GLOBAL_PROVISIONING_ENDPOINT,
       ENV_GLOBAL_PROVISIONING_ENDPOINT_DEFAULT,
       false,
@@ -123,11 +123,11 @@ static az_result read_configuration_and_init_client()
 
   az_span id_scope_span = AZ_SPAN_FROM_BUFFER(id_scope);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "ID_Scope", ENV_ID_SCOPE_ENV, NULL, false, id_scope_span, &id_scope_span));
+      ENV_ID_SCOPE_ENV, ENV_ID_SCOPE_ENV, NULL, false, id_scope_span, &id_scope_span));
 
   az_span registration_id_span = AZ_SPAN_FROM_BUFFER(registration_id);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "Registration ID",
+      ENV_REGISTRATION_ID_ENV,
       ENV_REGISTRATION_ID_ENV,
       NULL,
       false,

--- a/sdk/iot/provisioning/samples/src/paho_iot_provisioning_example.c
+++ b/sdk/iot/provisioning/samples/src/paho_iot_provisioning_example.c
@@ -136,11 +136,11 @@ static az_result read_configuration_and_init_client()
 
   az_span cert = AZ_SPAN_FROM_BUFFER(x509_cert_pem_file);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "X509 Certificate PEM Store File", ENV_DEVICE_X509_CERT_PEM_FILE, NULL, false, cert, &cert));
+      ENV_DEVICE_X509_CERT_PEM_FILE, ENV_DEVICE_X509_CERT_PEM_FILE, NULL, false, cert, &cert));
 
   az_span trusted = AZ_SPAN_FROM_BUFFER(x509_trust_pem_file);
   AZ_RETURN_IF_FAILED(read_configuration_entry(
-      "X509 Trusted PEM Store File", ENV_DEVICE_X509_TRUST_PEM_FILE, "", false, trusted, &trusted));
+      ENV_DEVICE_X509_TRUST_PEM_FILE, ENV_DEVICE_X509_TRUST_PEM_FILE, "", false, trusted, &trusted));
 
   // Initialize the provisioning client with the provisioning endpoint and the default connection
   // options


### PR DESCRIPTION
It does little from a debugging perspective to have the strings which are output from the samples mismatch the environment vars which they represent. Updating to have the output to console match the env var names.