### PR TITLE
Add to top level IoT readme

### DIFF
--- a/sdk/docs/iot/README.md
+++ b/sdk/docs/iot/README.md
@@ -1,10 +1,10 @@
 # Azure IoT Clients
 
-Azure SDK for Embedded C official IoT client library.
+Azure SDK for Embedded C official IoT client libraries.
 
 ## Getting Started
 
-The IoT Client library is created to facilitate connectivity to the Azure IoT Hub and Azure IoT Provisioning Service alongside an MQTT and TLS stack of the user's choice. This means that this SDK is **NOT** a platform but instead is a true library.
+The IoT Client library is created to facilitate connectivity to Azure IoT services alongside an MQTT and TLS stack of the user's choice. This means that this SDK is **NOT** a platform but instead is a true library.
 
 From a functional perspective, this means that the user's application code (not the SDK) calls directly to the MQTT stack of their choice. The SDK provides utilities (in the form of functions, default values, etc) which help make the connection and feature set easier. Some examples of those utilities include:
 - Publish topics to which messages can be sent and subscription topics to which users can subscribe for incoming messages.

--- a/sdk/docs/iot/README.md
+++ b/sdk/docs/iot/README.md
@@ -4,7 +4,7 @@ Azure SDK for Embedded C official IoT client libraries.
 
 ## Getting Started
 
-The IoT Client library is created to facilitate connectivity to Azure IoT services alongside an MQTT and TLS stack of the user's choice. This means that this SDK is **NOT** a platform but instead is a true library.
+The Azure IoT Client library is created to facilitate connectivity to Azure IoT services alongside an MQTT and TLS stack of the user's choice. This means that this SDK is **NOT** a platform but instead is a true SDK library.
 
 From a functional perspective, this means that the user's application code (not the SDK) calls directly to the MQTT stack of their choice. The SDK provides utilities (in the form of functions, default values, etc) which help make the connection and feature set easier. Some examples of those utilities include:
 - Publish topics to which messages can be sent and subscription topics to which users can subscribe for incoming messages.

--- a/sdk/docs/iot/README.md
+++ b/sdk/docs/iot/README.md
@@ -1,14 +1,32 @@
 # Azure IoT Clients
 
-Azure SDK for Embedded C official IoT Hub client library.
+Azure SDK for Embedded C official IoT client library.
 
 ## Getting Started
 
-- **Docs**: If you're new to the Azure SDK for Embedded C take a look at the [State Machine diagram](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/iot/doc/mqtt_state_machine.md) that explains the high-level architecture, SDK components, and a clear view of SDK x Application responsibilities. 
+The IoT Client library is created to facilitate connectivity to the Azure IoT Hub and Azure IoT Provisioning Service alongside an MQTT and TLS stack of the user's choice. This means that this SDK is **NOT** a platform but instead is a true library.
 
-- **Build**: The Azure IoT library is compiled following the same steps listed on the root [README](https://github.com/Azure/azure-sdk-for-c/blob/master/README.md) documentation, under ["Getting Started Using the SDK"](https://github.com/Azure/azure-sdk-for-c/blob/master/README.md#getting-started-using-the-sdk). 
+From a functional perspective, this means that the user's application code (not the SDK) calls directly to the MQTT stack of their choice. The SDK provides utilities (in the form of functions, default values, etc) which help make the connection and feature set easier. Some examples of those utilities include:
+- Publish topics to which messages can be sent and subscription topics to which users can subscribe for incoming messages.
+- Functions to parse incoming message topics which populate structs with crucial message information.
+- Default values for MQTT connect keep alive and connection port.
 
-- **Samples**: [This page](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/iot/hub/samples) explains samples for the Azure Embedded C SDK IoT Hub Client and [this page](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/iot/provisioning/samples) shows the Provisioning Clients and how to use them.
+A full list of features can be found in the doxygen docs listed below in [Docs](#docs).
+
+**Note**: this therefore requires a different programming model as compared to the earlier version of the SDK ([found here](https://github.com/Azure/azure-iot-sdk-c)). To better understand the responsibilities of the user application code and the SDK, please take a look at the [State Machine diagram](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/iot/doc/mqtt_state_machine.md) that explains the high-level architecture, SDK components, and a clear view of SDK x Application responsibilities.
+
+### Docs
+For API documentation, please see the doxygen generated docs [here][azure_sdk_for_c_doxygen_docs]. You can find the IoT specific docs by navigating to the **Files -> File List** section near the top and choosing any of the header files prefixed with `az_iot_`.
+
+### Build
+The Azure IoT library is compiled following the same steps listed on the root [README](https://github.com/Azure/azure-sdk-for-c/blob/master/README.md) documentation, under ["Getting Started Using the SDK"](https://github.com/Azure/azure-sdk-for-c/blob/master/README.md#getting-started-using-the-sdk).
+
+The library targets made available via CMake are the following:
+- `az::iot::hub`: For Azure IoT Hub features ([API documentation here][azure_sdk_for_c_doxygen_hub_docs])
+- `az::iot::provisioning`: For Azure IoT Provisioning features ([API documentation here][azure_sdk_for_c_doxygen_provisioning_docs])
+
+### Samples
+[This page](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/iot/hub/samples) explains samples for the Azure Embedded C SDK IoT Hub Client and [this page](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/iot/provisioning/samples) shows the Provisioning Clients and how to use them.
 
   For step-by-step guides starting from scratch, you may refer to these documents:
   - [How to setup and run Azure SDK for Embedded C IoT Hub Samples on Linux](how_to_iot_hub_samples_linux.md)
@@ -35,9 +53,6 @@ Feature | Azure SDK for Embedded C | Description
  Protocol | MQTT | The Azure SDK for Embedded C supports only MQTT.  
  Retry Policies | :heavy_check_mark:* | The Azure SDK for Embedded C provides guidelines for retries, but actual retries should be handled by the application.
  [Plug and Play](https://docs.microsoft.com/en-us/azure/iot-pnp/overview-iot-plug-and-play) | :heavy_multiplication_x: | IoT Plug and Play Preview enables solution developers to integrate devices with their solutions without writing any embedded code. 
-
-
-
 
 ## Examples
 
@@ -165,5 +180,8 @@ Azure SDK for Embedded C is licensed under the [MIT][azure_sdk_for_c_license] li
 
 <!-- LINKS -->
 [azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md
+[azure_sdk_for_c_doxygen_docs]: https://azure.github.io/azure-sdk-for-c
+[azure_sdk_for_c_doxygen_hub_docs]: https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.2/az__iot__hub__client_8h.html
+[azure_sdk_for_c_doxygen_provisioning_docs]: https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.2/az__iot__provisioning__client_8h.html
 [azure_sdk_for_c_license]: https://github.com/Azure/azure-sdk-for-c/blob/master/LICENSE
 


### PR DESCRIPTION
- Added more wording to set user expectations on how to use the SDK
- Linked to the generated doxygen docs.
- Specified which CMake lib targets are generated for users to link to.