### PR TITLE
Update CMake targets to link to deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,15 +55,6 @@ include(eng/cmake/global_compile_options.txt)
 # At the end of cmake generate, this file will list the targets for code cov
 file(WRITE ${CMAKE_BINARY_DIR}/coverage_targets.txt "")
 
-
-add_subdirectory(sdk/core/az_core)
-
-# SDK Clients and tests
-add_subdirectory(sdk/storage/blobs)
-add_subdirectory(sdk/iot/common)
-add_subdirectory(sdk/iot/hub)
-add_subdirectory(sdk/iot/provisioning)
-
 #PAL
 if(AZ_PLATFORM_IMPL STREQUAL "POSIX")
   add_subdirectory(sdk/platform/posix)
@@ -75,6 +66,14 @@ else()
   add_subdirectory(sdk/platform/noplatform)
   set(PAL az_noplatform)
 endif()
+
+add_subdirectory(sdk/core/az_core)
+
+# SDK Clients and tests
+add_subdirectory(sdk/storage/blobs)
+add_subdirectory(sdk/iot/common)
+add_subdirectory(sdk/iot/hub)
+add_subdirectory(sdk/iot/provisioning)
 
 add_subdirectory(sdk/platform/http_client/nohttp)
 # Adding transport implementation for curl

--- a/sdk/core/az_core/CMakeLists.txt
+++ b/sdk/core/az_core/CMakeLists.txt
@@ -65,12 +65,28 @@ add_library (
   src/az_span.c
   src/az_spinlock.c)
 
-target_include_directories (${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc> $<INSTALL_INTERFACE:include/${TARGET_NAME}>)
+target_include_directories (${TARGET_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+    $<INSTALL_INTERFACE:include/${TARGET_NAME}>
+)
 # include internal headers
-target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/internal> $<INSTALL_INTERFACE:include/az_core_internal>)
+target_include_directories(${TARGET_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/internal>
+    $<INSTALL_INTERFACE:include/az_core_internal>
+)
 
 # include test internal headers
-target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test/inc>)
+target_include_directories(${TARGET_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test/inc>
+)
+
+target_link_libraries(${TARGET_NAME}
+  PUBLIC
+    ${PAL}
+)
 
 # make sure that users can consume the project as a library.
 add_library (az::core ALIAS ${TARGET_NAME})

--- a/sdk/iot/common/CMakeLists.txt
+++ b/sdk/iot/common/CMakeLists.txt
@@ -11,20 +11,22 @@ set(CMAKE_C_STANDARD 99)
 
 include(CheckAndIncludeCodeCov)
 
-add_library (
-    ${TARGET_NAME}
-    src/az_iot_common.c
+add_library (${TARGET_NAME}
+  src/az_iot_common.c
 )
 
 target_include_directories (${TARGET_NAME} PUBLIC inc)
 target_include_directories (${TARGET_NAME} PRIVATE src)
 
-target_link_libraries(${TARGET_NAME} PRIVATE az_core)
+target_link_libraries(${TARGET_NAME}
+  PUBLIC
+    az::core
+)
 
 add_library (az::iot::common ALIAS ${TARGET_NAME})
 
 # set coverage excluding for az_core. Don't show coverage outside iot
 set(COV_EXCLUDE
-    ${az_SOURCE_DIR}/sdk/core/az_core/inc/*
-    ${az_SOURCE_DIR}/sdk/core/az_core/internal/*)
+  ${az_SOURCE_DIR}/sdk/core/az_core/inc/*
+  ${az_SOURCE_DIR}/sdk/core/az_core/internal/*)
 include(CreateCodeCoverageTargets)

--- a/sdk/iot/hub/CMakeLists.txt
+++ b/sdk/iot/hub/CMakeLists.txt
@@ -11,26 +11,28 @@ set(CMAKE_C_STANDARD 99)
 
 include(CheckAndIncludeCodeCov)
 
-add_library (
-    ${TARGET_NAME}
-    src/az_iot_hub_client.c
-    src/az_iot_hub_client_sas.c
-    src/az_iot_hub_client_telemetry.c
-    src/az_iot_hub_client_c2d.c
-    src/az_iot_hub_client_twin.c
-    src/az_iot_hub_client_methods.c
+add_library (${TARGET_NAME}
+  src/az_iot_hub_client.c
+  src/az_iot_hub_client_sas.c
+  src/az_iot_hub_client_telemetry.c
+  src/az_iot_hub_client_c2d.c
+  src/az_iot_hub_client_twin.c
+  src/az_iot_hub_client_methods.c
 )
 
 target_include_directories (${TARGET_NAME} PUBLIC inc)
 target_include_directories (${TARGET_NAME} PRIVATE src)
 
-target_link_libraries(${TARGET_NAME} PRIVATE az_core)
-target_link_libraries(${TARGET_NAME} PRIVATE az_iot_common)
+target_link_libraries(${TARGET_NAME}
+  PUBLIC
+    az::core
+    az::iot::common
+)
 
 add_library (az::iot::hub ALIAS ${TARGET_NAME})
 
 # set coverage excluding for az_core. Don't show coverage outside iot
 set(COV_EXCLUDE
-    ${az_SOURCE_DIR}/sdk/core/az_core/inc/*
-    ${az_SOURCE_DIR}/sdk/core/az_core/internal/*)
+  ${az_SOURCE_DIR}/sdk/core/az_core/inc/*
+  ${az_SOURCE_DIR}/sdk/core/az_core/internal/*)
 include(CreateCodeCoverageTargets)

--- a/sdk/iot/hub/samples/CMakeLists.txt
+++ b/sdk/iot/hub/samples/CMakeLists.txt
@@ -17,78 +17,95 @@ if(NOT OpenSSL_FOUND)
   find_package(OpenSSL REQUIRED)
 endif()
 
-set (sample_link_libraries 
-  az_iot_hub
-  az_iot_common
-  az_core
-  ${PAL}
-  eclipse-paho-mqtt-c::paho-mqtt3cs-static
-  OpenSSL::SSL
-  OpenSSL::Crypto
+# C2D Sample
+add_executable (paho_iot_hub_c2d_example
+  ${CMAKE_CURRENT_LIST_DIR}/src/paho_iot_hub_c2d_example.c
 )
 
-# C2D Sample
-add_executable (
-  paho_iot_hub_c2d_example 
-  ${CMAKE_CURRENT_LIST_DIR}/src/paho_iot_hub_c2d_example.c
-  )
+target_link_libraries(paho_iot_hub_c2d_example
+  PRIVATE
+    az::core
+    az::iot::hub
+)
+
 
 target_link_libraries(
   paho_iot_hub_c2d_example PRIVATE
-  ${sample_link_libraries}
-)
-
-# Methods Sample
-add_executable (
-  paho_iot_hub_methods_example 
-  ${CMAKE_CURRENT_LIST_DIR}/src/paho_iot_hub_methods_example.c
-  )
-
-target_link_libraries(
-  paho_iot_hub_methods_example PRIVATE
-  ${sample_link_libraries}
-)
-
-# Telemetry Sample
-add_executable (
-  paho_iot_hub_telemetry_example
-  ${CMAKE_CURRENT_LIST_DIR}/src/paho_iot_hub_telemetry_example.c
-  )
-
-target_link_libraries(
-  paho_iot_hub_telemetry_example PRIVATE
-  ${sample_link_libraries}
-)
-
-# Telemetry Sample
-add_executable (
-  paho_iot_hub_sas_telemetry_example
-  ${CMAKE_CURRENT_LIST_DIR}/src/paho_iot_hub_sas_telemetry_example.c
-  ${CMAKE_CURRENT_LIST_DIR}/src/sample_sas_utility.c
-  )
-
-target_link_libraries(
-  paho_iot_hub_sas_telemetry_example PRIVATE
-  ${sample_link_libraries}
-  )
-
-# PAL
-target_link_libraries(paho_iot_hub_sas_telemetry_example PRIVATE ${PAL})
-
-target_link_libraries(
-  paho_iot_hub_sas_telemetry_example PRIVATE
   eclipse-paho-mqtt-c::paho-mqtt3cs-static
   OpenSSL::SSL
   OpenSSL::Crypto
   )
 
-# Twin Sample
-add_executable (
-  paho_iot_hub_twin_example 
-  ${CMAKE_CURRENT_LIST_DIR}/src/paho_iot_hub_twin_example.c
-  )
+# Methods Sample
+add_executable (paho_iot_hub_methods_example
+  ${CMAKE_CURRENT_LIST_DIR}/src/paho_iot_hub_methods_example.c
+)
 
-target_link_libraries(
-  paho_iot_hub_twin_example PRIVATE
-  ${sample_link_libraries}
+target_link_libraries(paho_iot_hub_methods_example
+  PRIVATE
+    az::core
+    az::iot::hub
+)
+
+target_link_libraries(paho_iot_hub_methods_example
+  PRIVATE
+    eclipse-paho-mqtt-c::paho-mqtt3cs-static
+    OpenSSL::SSL
+    OpenSSL::Crypto
+)
+
+# Telemetry Sample
+add_executable (paho_iot_hub_telemetry_example
+  ${CMAKE_CURRENT_LIST_DIR}/src/paho_iot_hub_telemetry_example.c
+)
+
+target_link_libraries(paho_iot_hub_telemetry_example
+  PRIVATE
+    az::core
+    az::iot::hub
+)
+
+target_link_libraries(paho_iot_hub_telemetry_example
+  PRIVATE
+    eclipse-paho-mqtt-c::paho-mqtt3cs-static
+    OpenSSL::SSL
+    OpenSSL::Crypto
+)
+
+# Telemetry Sample
+add_executable (paho_iot_hub_sas_telemetry_example
+  ${CMAKE_CURRENT_LIST_DIR}/src/paho_iot_hub_sas_telemetry_example.c
+  ${CMAKE_CURRENT_LIST_DIR}/src/sample_sas_utility.c
+)
+
+target_link_libraries(paho_iot_hub_sas_telemetry_example
+  PRIVATE
+    az::core
+    az::iot::hub
+)
+
+target_link_libraries(paho_iot_hub_sas_telemetry_example
+  PRIVATE
+    eclipse-paho-mqtt-c::paho-mqtt3cs-static
+    OpenSSL::SSL
+    OpenSSL::Crypto
+)
+
+# Twin Sample
+add_executable (paho_iot_hub_twin_example
+  ${CMAKE_CURRENT_LIST_DIR}/src/paho_iot_hub_twin_example.c
+)
+
+target_link_libraries(paho_iot_hub_twin_example
+  PRIVATE
+    az::core
+    az::iot::hub
+)
+
+
+target_link_libraries(paho_iot_hub_twin_example
+  PRIVATE
+    eclipse-paho-mqtt-c::paho-mqtt3cs-static
+    OpenSSL::SSL
+    OpenSSL::Crypto
 )

--- a/sdk/iot/hub/samples/CMakeLists.txt
+++ b/sdk/iot/hub/samples/CMakeLists.txt
@@ -22,31 +22,32 @@ add_executable (paho_iot_hub_c2d_example
   ${CMAKE_CURRENT_LIST_DIR}/src/paho_iot_hub_c2d_example.c
 )
 
+# SDK deps
 target_link_libraries(paho_iot_hub_c2d_example
   PRIVATE
-    az::core
     az::iot::hub
 )
 
-
-target_link_libraries(
-  paho_iot_hub_c2d_example PRIVATE
-  eclipse-paho-mqtt-c::paho-mqtt3cs-static
-  OpenSSL::SSL
-  OpenSSL::Crypto
-  )
+# External deps
+target_link_libraries(paho_iot_hub_c2d_example
+  PRIVATE
+    eclipse-paho-mqtt-c::paho-mqtt3cs-static
+    OpenSSL::SSL
+    OpenSSL::Crypto
+)
 
 # Methods Sample
 add_executable (paho_iot_hub_methods_example
   ${CMAKE_CURRENT_LIST_DIR}/src/paho_iot_hub_methods_example.c
 )
 
+# SDK deps
 target_link_libraries(paho_iot_hub_methods_example
   PRIVATE
-    az::core
     az::iot::hub
 )
 
+# External deps
 target_link_libraries(paho_iot_hub_methods_example
   PRIVATE
     eclipse-paho-mqtt-c::paho-mqtt3cs-static
@@ -59,12 +60,13 @@ add_executable (paho_iot_hub_telemetry_example
   ${CMAKE_CURRENT_LIST_DIR}/src/paho_iot_hub_telemetry_example.c
 )
 
+# SDK deps
 target_link_libraries(paho_iot_hub_telemetry_example
   PRIVATE
-    az::core
     az::iot::hub
 )
 
+# External deps
 target_link_libraries(paho_iot_hub_telemetry_example
   PRIVATE
     eclipse-paho-mqtt-c::paho-mqtt3cs-static
@@ -78,12 +80,13 @@ add_executable (paho_iot_hub_sas_telemetry_example
   ${CMAKE_CURRENT_LIST_DIR}/src/sample_sas_utility.c
 )
 
+# SDK deps
 target_link_libraries(paho_iot_hub_sas_telemetry_example
   PRIVATE
-    az::core
     az::iot::hub
 )
 
+# External deps
 target_link_libraries(paho_iot_hub_sas_telemetry_example
   PRIVATE
     eclipse-paho-mqtt-c::paho-mqtt3cs-static
@@ -96,13 +99,13 @@ add_executable (paho_iot_hub_twin_example
   ${CMAKE_CURRENT_LIST_DIR}/src/paho_iot_hub_twin_example.c
 )
 
+# SDK deps
 target_link_libraries(paho_iot_hub_twin_example
   PRIVATE
-    az::core
     az::iot::hub
 )
 
-
+# External deps
 target_link_libraries(paho_iot_hub_twin_example
   PRIVATE
     eclipse-paho-mqtt-c::paho-mqtt3cs-static

--- a/sdk/iot/provisioning/CMakeLists.txt
+++ b/sdk/iot/provisioning/CMakeLists.txt
@@ -11,22 +11,24 @@ set(CMAKE_C_STANDARD 99)
 
 include(CheckAndIncludeCodeCov)
 
-add_library (
-    ${TARGET_NAME}
-    src/az_iot_provisioning_client.c
-    src/az_iot_provisioning_client_sas.c
+add_library (${TARGET_NAME}
+  src/az_iot_provisioning_client.c
+  src/az_iot_provisioning_client_sas.c
 )
 
 target_include_directories (${TARGET_NAME} PUBLIC inc)
 target_include_directories (${TARGET_NAME} PRIVATE src)
 
-target_link_libraries(${TARGET_NAME} PRIVATE az_core)
-target_link_libraries(${TARGET_NAME} PRIVATE az_iot_common)
+target_link_libraries(${TARGET_NAME}
+  PUBLIC
+    az::core
+    az::iot::common
+)
 
 add_library (az::iot::provisioning ALIAS ${TARGET_NAME})
 
 # set coverage excluding for az_core. Don't show coverage outside iot
 set(COV_EXCLUDE
-    ${az_SOURCE_DIR}/sdk/core/az_core/inc/*
-    ${az_SOURCE_DIR}/sdk/core/az_core/internal/*)
+  ${az_SOURCE_DIR}/sdk/core/az_core/inc/*
+  ${az_SOURCE_DIR}/sdk/core/az_core/internal/*)
 include(CreateCodeCoverageTargets)

--- a/sdk/iot/provisioning/samples/CMakeLists.txt
+++ b/sdk/iot/provisioning/samples/CMakeLists.txt
@@ -19,24 +19,22 @@ if(NOT OpenSSL_FOUND)
   find_package(OpenSSL REQUIRED)
 endif()
 
-set (sample_link_libraries 
-  az_iot_provisioning
-  az_iot_common
-  az_core
-  ${PAL}
-  eclipse-paho-mqtt-c::paho-mqtt3cs-static
-  OpenSSL::SSL
-  OpenSSL::Crypto
+add_executable (paho_iot_provisioning_example 
+  src/paho_iot_provisioning_example.c
 )
 
-add_executable (
-  paho_iot_provisioning_example 
-  src/paho_iot_provisioning_example.c
-  )
+target_link_libraries(paho_iot_provisioning_example
+    PRIVATE
+      az::core
+      az::iot::provisioning
+)
 
-target_link_libraries(
-  paho_iot_provisioning_example PRIVATE
-  ${sample_link_libraries}
-  )
+
+target_link_libraries(paho_iot_provisioning_example
+  PRIVATE
+    eclipse-paho-mqtt-c::paho-mqtt3cs-static
+    OpenSSL::SSL
+    OpenSSL::Crypto
+)
 
 endif()

--- a/sdk/iot/provisioning/samples/CMakeLists.txt
+++ b/sdk/iot/provisioning/samples/CMakeLists.txt
@@ -23,13 +23,13 @@ add_executable (paho_iot_provisioning_example
   src/paho_iot_provisioning_example.c
 )
 
+# SDK deps
 target_link_libraries(paho_iot_provisioning_example
     PRIVATE
-      az::core
       az::iot::provisioning
 )
 
-
+# External deps
 target_link_libraries(paho_iot_provisioning_example
   PRIVATE
     eclipse-paho-mqtt-c::paho-mqtt3cs-static

--- a/sdk/platform/posix/CMakeLists.txt
+++ b/sdk/platform/posix/CMakeLists.txt
@@ -11,4 +11,3 @@ add_library(az_posix STATIC)
 target_link_libraries(az_posix PRIVATE az_core)
 
 target_sources(az_posix PRIVATE src/az_posix.c)
-

--- a/sdk/platform/win32/CMakeLists.txt
+++ b/sdk/platform/win32/CMakeLists.txt
@@ -11,4 +11,3 @@ add_library(az_win32 STATIC)
 target_link_libraries(az_win32 PRIVATE az_core)
 
 target_sources(az_win32 PRIVATE src/az_win32.c)
-

--- a/sdk/samples/keyvault/keyvault/CMakeLists.txt
+++ b/sdk/samples/keyvault/keyvault/CMakeLists.txt
@@ -19,14 +19,9 @@ add_library (
 target_include_directories (${TARGET_NAME} PUBLIC inc)
 target_include_directories (${TARGET_NAME} PRIVATE src)
 
-target_include_directories (${TARGET_NAME} PUBLIC 
-  $<BUILD_INTERFACE:${az_SOURCE_DIR}/sdk/core/az_core/inc>
-  $<INSTALL_INTERFACE:include/az_core>
-)
-# include internal headers
-target_include_directories(${TARGET_NAME} PUBLIC
-  $<BUILD_INTERFACE:${az_SOURCE_DIR}/sdk/core/az_core/internal>
-  $<INSTALL_INTERFACE:include/az_core_internal>
+target_link_libraries(${TARGET_NAME}
+  PRIVATE
+    az::core
 )
 
 # make sure that users can consume the project as a library.

--- a/sdk/storage/blobs/CMakeLists.txt
+++ b/sdk/storage/blobs/CMakeLists.txt
@@ -17,15 +17,11 @@ add_library (
 
 target_include_directories (${TARGET_NAME} PUBLIC inc)
 
-target_include_directories (${TARGET_NAME} PUBLIC
-  $<BUILD_INTERFACE:${az_SOURCE_DIR}/sdk/core/az_core/inc>
-  $<INSTALL_INTERFACE:include/az_core>
+target_link_libraries(${TARGET_NAME}
+  PUBLIC
+    az::core
 )
-# include internal headers
-target_include_directories(${TARGET_NAME} PUBLIC
-  $<BUILD_INTERFACE:${az_SOURCE_DIR}/sdk/core/az_core/internal>
-  $<INSTALL_INTERFACE:include/az_core_internal>
-)
+
 # make sure that users can consume the project as a library.
 add_library (az::storage::blobs ALIAS ${TARGET_NAME})
 


### PR DESCRIPTION
Confirmed to fix #824.

We talked previously about doing away with the idea of the user needing to explicitly link to all the dependencies they might need for versioning reasons. This breaks the current integration with linking as described in the GH issue. This would fix that integration and also remove the burden of the developer needing to know the whole dependency tree of a library.