### PR TITLE
make all links in readme's to other readme's relative

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 Many people all over the world have helped make this project better.  You'll want to check out:
 
 * [What are some good first issues for new contributors to the repo?](https://github.com/azure/azure-sdk-for-c/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs)
-* [How to build and test your change](https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md#developer-guide)
-* [How you can make a change happen!](https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md#pull-requests)
+* [How to build and test your change](#developer-guide)
+* [How you can make a change happen!](#pull-requests)
 * Conceptual Topics in the detailed [Azure SDK for Embedded C docs](https://azure.github.io/azure-sdk-for-c).
 
 ### Community

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ With this in mind, there are many tenets or principles that we follow in order t
   - [Table of Contents](#table-of-contents)
   - [Documentation](#documentation)
   - [The GitHub Repository](#the-github-repository)
-    - [Services](#service)
+    - [Services](#services)
     - [Structure](#structure)
     - [Master Branch](#master-branch)
     - [Release Branches and Release Tagging](#release-branches-and-release-tagging)
@@ -462,8 +462,8 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 Many people all over the world have helped make this project better.  You'll want to check out:
 
 * [What are some good first issues for new contributors to the repo?](https://github.com/azure/azure-sdk-for-c/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)
-* [How to build and test your change](https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md#developer-guide)
-* [How you can make a change happen!](https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md#pull-requests)
+* [How to build and test your change](./CONTRIBUTING.md#developer-guide)
+* [How you can make a change happen!](./CONTRIBUTING.md#pull-requests)
 
 ### Community
 

--- a/sdk/docs/core/README.md
+++ b/sdk/docs/core/README.md
@@ -162,10 +162,10 @@ If you'd like to contribute to this library, please read the [contributing guide
 Azure SDK for Embedded C is licensed under the [MIT][azure_sdk_for_c_license] license.
 
 <!-- LINKS -->
-[azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md
+[azure_sdk_for_c_contributing]: ../../../CONTRIBUTING.md
 [azure_sdk_for_c_license]: https://github.com/Azure/azure-sdk-for-c/blob/master/LICENSE
-[azure_sdk_for_c_contributing_developer_guide]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md#developer-guide
-[azure_sdk_for_c_contributing_pull_requests]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md#pull-requests
+[azure_sdk_for_c_contributing_developer_guide]: ../../../CONTRIBUTING.md#developer-guide
+[azure_sdk_for_c_contributing_pull_requests]: ../../../CONTRIBUTING.md#pull-requests
 [azure_cli]: https://docs.microsoft.com/cli/azure
 [azure_pattern_circuit_breaker]: https://docs.microsoft.com/azure/architecture/patterns/circuit-breaker
 [azure_pattern_retry]: https://docs.microsoft.com/azure/architecture/patterns/retry

--- a/sdk/docs/iot/README.md
+++ b/sdk/docs/iot/README.md
@@ -21,21 +21,21 @@ A full list of features can be found in the doxygen docs listed below in [Docs](
 For API documentation, please see the doxygen generated docs [here][azure_sdk_for_c_doxygen_docs]. You can find the IoT specific docs by navigating to the **Files -> File List** section near the top and choosing any of the header files prefixed with `az_iot_`.
 
 ### Build
-The Azure IoT library is compiled following the same steps listed on the root [README](https://github.com/Azure/azure-sdk-for-c/blob/master/README.md) documentation, under ["Getting Started Using the SDK"](https://github.com/Azure/azure-sdk-for-c/blob/master/README.md#getting-started-using-the-sdk).
+The Azure IoT library is compiled following the same steps listed on the root [README](../../../README.md) documentation, under ["Getting Started Using the SDK"](../../../README.md#getting-started-using-the-sdk).
 
 The library targets made available via CMake are the following:
 - `az::iot::hub`: For Azure IoT Hub features ([API documentation here][azure_sdk_for_c_doxygen_hub_docs])
 - `az::iot::provisioning`: For Azure IoT Provisioning features ([API documentation here][azure_sdk_for_c_doxygen_provisioning_docs])
 
 ### Samples
-[This page](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/samples/iot/readme.md) explains samples for the Azure Embedded C SDK IoT Hub Client and the Provisioning Clients and how to use them.
+[This page](../../../sdk/samples/iot/readme.md) explains samples for the Azure Embedded C SDK IoT Hub Client and the Provisioning Clients and how to use them.
 
  For step-by-step guides starting from scratch, you may refer to these documents:
-  - Linux: [How to Setup and Run Azure SDK for Embedded C IoT Hub Samples on Linux](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/samples/iot/hub/linux/how_to_iot_hub_samples_linux.md)
+  - Linux: [How to Setup and Run Azure SDK for Embedded C IoT Hub Samples on Linux](../../../sdk/samples/iot/hub/linux/how_to_iot_hub_samples_linux.md)
 
-  - Windows: [How to Setup and Run Azure SDK for Embedded C IoT Hub Samples on Microsoft Windows](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/samples/iot/hub/windows/how_to_iot_hub_samples_windows.md).
+  - Windows: [How to Setup and Run Azure SDK for Embedded C IoT Hub Samples on Microsoft Windows](../../../sdk/samples/iot/hub/windows/how_to_iot_hub_samples_windows.md).
 
-  - ESP8266: [How to Setup and Run Azure SDK for Embedded C IoT Hub Client on Esp8266 NodeMCU](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/samples/iot/hub/esp8266nodemcu/how_to_esp8266_nodemcu.md)
+  - ESP8266: [How to Setup and Run Azure SDK for Embedded C IoT Hub Client on Esp8266 NodeMCU](../../../sdk/samples/iot/hub/esp8266nodemcu/how_to_esp8266_nodemcu.md)
 
   **Note**: While Windows and Linux devices are not likely to be considered as contrained ones, these samples were created to make it simpler to test the Azure SDK for Embedded C libraries, even without a real device. 
 
@@ -185,7 +185,7 @@ If you'd like to contribute to this library, please read the [contributing guide
 Azure SDK for Embedded C is licensed under the [MIT][azure_sdk_for_c_license] license.
 
 <!-- LINKS -->
-[azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md
+[azure_sdk_for_c_contributing]: ../../../CONTRIBUTING.md
 [azure_sdk_for_c_doxygen_docs]: https://azure.github.io/azure-sdk-for-c
 [azure_sdk_for_c_doxygen_hub_docs]: https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.2/az__iot__hub__client_8h.html
 [azure_sdk_for_c_doxygen_provisioning_docs]: https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.2/az__iot__provisioning__client_8h.html

--- a/sdk/docs/iot/hub.md
+++ b/sdk/docs/iot/hub.md
@@ -4,7 +4,7 @@ Official Embedded C client for Azure IoT Hub.
 
 ## Getting Started
 
-- **Docs**: If you're new to the Azure SDK for Embedded C take a look at the [State Machine diagram](./mqtt_state_machine.md#device-provisioning-service) that explains the high-level architecture, SDK components, and a clear view of SDK x Application responsibilities. 
+- **Docs**: If you're new to the Azure SDK for Embedded C take a look at the [State Machine diagram](./mqtt_state_machine.md#iot-hub) that explains the high-level architecture, SDK components, and a clear view of SDK x Application responsibilities. 
 - **Samples**: [This page](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/samples/iot/hub/) explains samples for the Azure SDK for Embedded C and how to use them.
 
 ## Need Help?

--- a/sdk/docs/iot/hub.md
+++ b/sdk/docs/iot/hub.md
@@ -4,7 +4,7 @@ Official Embedded C client for Azure IoT Hub.
 
 ## Getting Started
 
-- **Docs**: If you're new to the Azure SDK for Embedded C take a look at the [State Machine diagram](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/docs/iot/mqtt_state_machine.md#device-provisioning-service) that explains the high-level architecture, SDK components, and a clear view of SDK x Application responsibilities. 
+- **Docs**: If you're new to the Azure SDK for Embedded C take a look at the [State Machine diagram](./mqtt_state_machine.md#device-provisioning-service) that explains the high-level architecture, SDK components, and a clear view of SDK x Application responsibilities. 
 - **Samples**: [This page](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/samples/iot/hub/) explains samples for the Azure SDK for Embedded C and how to use them.
 
 ## Need Help?
@@ -22,5 +22,5 @@ If you'd like to contribute to this library, please read the [contributing guide
 Azure SDK for Embedded C is licensed under the [MIT][azure_sdk_for_c_license] license.
 
 <!-- LINKS -->
-[azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md
+[azure_sdk_for_c_contributing]: ../../../CONTRIBUTING.md
 [azure_sdk_for_c_license]: https://github.com/Azure/azure-sdk-for-c/blob/master/LICENSE

--- a/sdk/docs/iot/provisioning.md
+++ b/sdk/docs/iot/provisioning.md
@@ -6,7 +6,7 @@ For more details about Provisioning Service check [Azure documentation](https://
 
 ## Getting Started
 
-- Please refer to the state machine diagram which describes the Azure SDK for Embedded C flow for Provisioning Service [here](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/docs/iot/mqtt_state_machine.md#device-provisioning-service). 
+- Please refer to the state machine diagram which describes the Azure SDK for Embedded C flow for Provisioning Service [here](./mqtt_state_machine.md#device-provisioning-service). 
 
 - **Samples**: [This page](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/samples/iot/provisioning/) explains samples for the Azure SDK for Embedded C IoT Provisioning Client and how to use them.
 
@@ -25,5 +25,5 @@ If you'd like to contribute to this library, please read the [contributing guide
 Azure SDK for Embedded C is licensed under the [MIT][azure_sdk_for_c_license] license.
 
 <!-- LINKS -->
-[azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md
+[azure_sdk_for_c_contributing]: ../../../CONTRIBUTING.md
 [azure_sdk_for_c_license]: https://github.com/Azure/azure-sdk-for-c/blob/master/LICENSE

--- a/sdk/docs/platform/README.md
+++ b/sdk/docs/platform/README.md
@@ -35,5 +35,5 @@ If you'd like to contribute to this library, please read the [contributing guide
 Azure SDK for Embedded C is licensed under the [MIT][azure_sdk_for_c_license] license.
 
 <!-- LINKS -->
-[azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md
+[azure_sdk_for_c_contributing]: ../../../CONTRIBUTING.md
 [azure_sdk_for_c_license]: https://github.com/Azure/azure-sdk-for-c/blob/master/LICENSE

--- a/sdk/docs/storage/README.md
+++ b/sdk/docs/storage/README.md
@@ -62,10 +62,10 @@ If you'd like to contribute to this library, please read the [contributing guide
 Azure SDK for Embedded C is licensed under the [MIT][azure_sdk_for_c_license] license.
 
 <!-- LINKS -->
-[azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md
+[azure_sdk_for_c_contributing]: ../../../CONTRIBUTING.md
 [azure_sdk_for_c_license]: https://github.com/Azure/azure-sdk-for-c/blob/master/LICENSE
-[azure_sdk_for_c_contributing_developer_guide]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md#developer-guide
-[azure_sdk_for_c_contributing_pull_requests]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md#pull-requests
+[azure_sdk_for_c_contributing_developer_guide]: ../../../CONTRIBUTING.md#developer-guide
+[azure_sdk_for_c_contributing_pull_requests]: ../../../CONTRIBUTING.md#pull-requests
 [azure_cli]: https://docs.microsoft.com/cli/azure
 [azure_pattern_circuit_breaker]: https://docs.microsoft.com/azure/architecture/patterns/circuit-breaker
 [azure_pattern_retry]: https://docs.microsoft.com/azure/architecture/patterns/retry

--- a/sdk/samples/core/README.md
+++ b/sdk/samples/core/README.md
@@ -35,6 +35,6 @@ This document explains samples and how to use them.
 This project welcomes contributions and suggestions. Find [more contributing][SDK_README_CONTRIBUTING] details here.
 
 <!-- LINKS -->
-[SDK_README_CONTRIBUTING]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md
+[SDK_README_CONTRIBUTING]: ../../../CONTRIBUTING.md
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-c%2Fsdk%2Fcore%2Fcore%2Fsamples%2FREADME.png)

--- a/sdk/samples/iot/hub/README.md
+++ b/sdk/samples/iot/hub/README.md
@@ -14,9 +14,9 @@ urlFragment: iot-hub-samples
 This document explains samples for the Azure SDK for Embedded C IoT Hub Client and how to use them. 
 
 For step-by-step guides starting from scratch, you may refer to these documents:
-  - Linux: [How to setup and run Azure SDK for Embedded C IoT Hub Samples on Linux](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/samples/iot/hub/linux/how_to_iot_hub_samples_linux.md)
-  - Windows: [How to setup and run Azure SDK for Embedded C IoT Hub Samples on Microsoft Windows](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/samples/iot/hub/windows/how_to_iot_hub_samples_windows.md).
-  - ESP8266: [How to Setup and Run Azure SDK for Embedded C IoT Hub Client on Esp8266 NodeMCU](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/samples/iot/hub/esp8266nodemcu/how_to_esp8266_nodemcu.md)
+  - Linux: [How to setup and run Azure SDK for Embedded C IoT Hub Samples on Linux](./linux/how_to_iot_hub_samples_linux.md)
+  - Windows: [How to setup and run Azure SDK for Embedded C IoT Hub Samples on Microsoft Windows](./windows/how_to_iot_hub_samples_windows.md).
+  - ESP8266: [How to Setup and Run Azure SDK for Embedded C IoT Hub Client on Esp8266 NodeMCU](./esp8266nodemcu/how_to_esp8266_nodemcu.md)
 
   **Note**: While Windows and Linux devices are not likely to be considered as contrained ones, these samples were created to make it simpler to test the Azure SDK for Embedded C libraries, even without a real device. 
 
@@ -152,5 +152,5 @@ For extensive documentation on Azure IoT Hub, see the [API reference documentati
 [telemetry_sample_cert]: src/paho_iot_hub_telemetry_example.c
 [twin_sample]: src/paho_iot_hub_twin_example.c
 [iot_hub_mqtt]: https://docs.microsoft.com/en-us/azure/iot-dps/iot-dps-mqtt-support
-[error_codes]: https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/docs/iot/mqtt_state_machine.md#iot-service-errors
+[error_codes]: ../../../../sdk/docs/iot/mqtt_state_machine.md#iot-service-errors
 [Eclipse_Paho]: https://www.eclipse.org/paho/clients/c/

--- a/sdk/samples/iot/hub/README.md
+++ b/sdk/samples/iot/hub/README.md
@@ -104,17 +104,13 @@ This sample uses a property named `device_count`, which records the number of ti
 
 * To initiate a reported property message from the device, you will use the command `r`.
 
-* To send a device twin desired property message from the service to the device, open the device twin document in your Azure IoT Hub.  Add the property `device_count` along with a corresponding value to the `desired` section of the JSON.
-
-  ```json
-  "properties": {
-      "desired": {
-        "device_count": 42,
-  ```
-
-  Select Save to send the message. The device will store the value locally and report the updated property to the service.
-
-
+* To send a device twin desired property message from the service to the device, open the device twin document in your Azure IoT Hub.  Add the property `device_count` along with a corresponding value to the `desired` section of the JSON.  
+```json
+"properties": {
+    "desired": {
+      "device_count": 42,
+```
+* Select Save to send the message. The device will store the value locally and report the updated property to the service.
 
 ### [IoT Hub Methods (Certificates)][methods_sample]
 Invoke methods from the cloud. The sample supports a method named "ping"

--- a/sdk/samples/iot/hub/esp8266nodemcu/how_to_esp8266_nodemcu.md
+++ b/sdk/samples/iot/hub/esp8266nodemcu/how_to_esp8266_nodemcu.md
@@ -253,5 +253,5 @@ If you'd like to contribute to this library, please read the [contributing guide
 Azure SDK for Embedded C is licensed under the [MIT][azure_sdk_for_c_license] license.
 
 <!-- LINKS -->
-[azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md
+[azure_sdk_for_c_contributing]: ../../../../../CONTRIBUTING.md
 [azure_sdk_for_c_license]: https://github.com/Azure/azure-sdk-for-c/blob/master/LICENSE

--- a/sdk/samples/iot/hub/linux/how_to_iot_hub_samples_linux.md
+++ b/sdk/samples/iot/hub/linux/how_to_iot_hub_samples_linux.md
@@ -410,10 +410,10 @@ If you'd like to contribute to this library, please read the [contributing guide
 Azure SDK for Embedded C is licensed under the [MIT][azure_sdk_for_c_license] license.
 
 <!-- LINKS -->
-[azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md
+[azure_sdk_for_c_contributing]: ../../../../../CONTRIBUTING.md
 [azure_sdk_for_c_license]: https://github.com/Azure/azure-sdk-for-c/blob/master/LICENSE
-[azure_sdk_for_c_contributing_developer_guide]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md#developer-guide
-[azure_sdk_for_c_contributing_pull_requests]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md#pull-requests
+[azure_sdk_for_c_contributing_developer_guide]: ../../../../../CONTRIBUTING.md#developer-guide
+[azure_sdk_for_c_contributing_pull_requests]: ../../../../../CONTRIBUTING.md#pull-requests
 [azure_cli]: https://docs.microsoft.com/cli/azure
 [azure_pattern_circuit_breaker]: https://docs.microsoft.com/azure/architecture/patterns/circuit-breaker
 [azure_pattern_retry]: https://docs.microsoft.com/azure/architecture/patterns/retry

--- a/sdk/samples/iot/hub/windows/how_to_iot_hub_samples_windows.md
+++ b/sdk/samples/iot/hub/windows/how_to_iot_hub_samples_windows.md
@@ -391,10 +391,10 @@ If you'd like to contribute to this library, please read the [contributing guide
 Azure SDK for Embedded C is licensed under the [MIT][azure_sdk_for_c_license] license.
 
 <!-- LINKS -->
-[azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md
-[azure_sdk_for_c_license]: https://github.com/Azure/azure-sdk-for-c/blob/master/LICENSEcense.
-[azure_sdk_for_c_contributing_developer_guide]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md#developer-guide
-[azure_sdk_for_c_contributing_pull_requests]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md#pull-requests
+[azure_sdk_for_c_contributing]: ../../../../../CONTRIBUTING.md
+[azure_sdk_for_c_license]: https://github.com/Azure/azure-sdk-for-c/blob/master/LICENSE
+[azure_sdk_for_c_contributing_developer_guide]: ../../../../../CONTRIBUTING.md#developer-guide
+[azure_sdk_for_c_contributing_pull_requests]: ../../../../../CONTRIBUTING.md#pull-requests
 [azure_cli]: https://docs.microsoft.com/cli/azure
 [azure_pattern_circuit_breaker]: https://docs.microsoft.com/azure/architecture/patterns/circuit-breaker
 [azure_pattern_retry]: https://docs.microsoft.com/azure/architecture/patterns/retry

--- a/sdk/samples/iot/provisioning/README.md
+++ b/sdk/samples/iot/provisioning/README.md
@@ -54,7 +54,7 @@ This project welcomes contributions and suggestions. Find [more contributing][SD
 [SDK_README_KEY_CONCEPTS]: https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot#azure-iot-clients
 [samples_paho]: src/paho_iot_provisioning_example.c
 [iot_provisioning_mqtt]: https://docs.microsoft.com/en-us/azure/iot-dps/iot-dps-mqtt-support
-[error_codes]: https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/docs/iot/mqtt_state_machine.md#iot-service-errors
+[error_codes]: ../../../../sdk/docs/iot/mqtt_state_machine.md#iot-service-errors
 [Eclipse_Paho]: https://www.eclipse.org/paho/clients/c/
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-c%2Fsdk%2Fiot%2Fprovisioning%2Fsamples%2FREADME.png)

--- a/sdk/samples/iot/readme.md
+++ b/sdk/samples/iot/readme.md
@@ -7,7 +7,7 @@ Samples for the Embedded C client for Azure IoT are divided into:
 
 ## Getting Started
 
-- **Docs**: If you're new to the Azure SDK for Embedded C take a look at the [State Machine diagram](../../../sdk/docs/iot/mqtt_state_machine.md#device-provisioning-service) that explains the high-level architecture, SDK components, and a clear view of SDK x Application responsibilities. 
+- **Docs**: If you're new to the Azure SDK for Embedded C take a look at the [State Machine diagram](../../../sdk/docs/iot/mqtt_state_machine.md) that explains the high-level architecture, SDK components, and a clear view of SDK x Application responsibilities. 
 - **Samples**: [This page](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/samples/iot/hub/) explains samples for the Azure SDK for Embedded C and how to use them.
 
 ## Need Help?

--- a/sdk/samples/iot/readme.md
+++ b/sdk/samples/iot/readme.md
@@ -2,12 +2,12 @@
 
 Samples for the Embedded C client for Azure IoT are divided into:
 
-- [IoT Hub Samples](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/samples/iot/hub/readme.md): Device samples for the common IoT Hub operations like D2C, C2D, Direct Methods, and Device Twin.
-- [Provisioning Samples](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/samples/iot/hub/provisioning/readme.md): Device samples for the Device Provisioning service. 
+- [IoT Hub Samples](./hub/README.md): Device samples for the common IoT Hub operations like D2C, C2D, Direct Methods, and Device Twin.
+- [Provisioning Samples](./provisioning/README.md): Device samples for the Device Provisioning service. 
 
 ## Getting Started
 
-- **Docs**: If you're new to the Azure SDK for Embedded C take a look at the [State Machine diagram](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/docs/iot/mqtt_state_machine.md#device-provisioning-service) that explains the high-level architecture, SDK components, and a clear view of SDK x Application responsibilities. 
+- **Docs**: If you're new to the Azure SDK for Embedded C take a look at the [State Machine diagram](../../../sdk/docs/iot/mqtt_state_machine.md#device-provisioning-service) that explains the high-level architecture, SDK components, and a clear view of SDK x Application responsibilities. 
 - **Samples**: [This page](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/samples/iot/hub/) explains samples for the Azure SDK for Embedded C and how to use them.
 
 ## Need Help?
@@ -25,5 +25,5 @@ If you'd like to contribute to this library, please read the [contributing guide
 Azure SDK for Embedded C is licensed under the [MIT][azure_sdk_for_c_license] license.
 
 <!-- LINKS -->
-[azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md
+[azure_sdk_for_c_contributing]: ../../../CONTRIBUTING.md
 [azure_sdk_for_c_license]: https://github.com/Azure/azure-sdk-for-c/blob/master/LICENSE

--- a/sdk/samples/keyvault/keyvault/README.md
+++ b/sdk/samples/keyvault/keyvault/README.md
@@ -96,9 +96,9 @@ Security issues and bugs should be reported privately, via email, to the Microso
 Azure SDK for Embedded C is licensed under the [MIT](LICENSE) license.
 
 <!-- LINKS -->
-[azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md
-[azure_sdk_for_c_contributing_developer_guide]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md#developer-guide
-[azure_sdk_for_c_contributing_pull_requests]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md#pull-requests
+[azure_sdk_for_c_contributing]: ../../../../CONTRIBUTING.md
+[azure_sdk_for_c_contributing_developer_guide]: ../../../../CONTRIBUTING.md#developer-guide
+[azure_sdk_for_c_contributing_pull_requests]: ../../../../CONTRIBUTING.md#pull-requests
 [azure_cli]: https://docs.microsoft.com/cli/azure
 [azure_pattern_circuit_breaker]: https://docs.microsoft.com/azure/architecture/patterns/circuit-breaker
 [azure_pattern_retry]: https://docs.microsoft.com/azure/architecture/patterns/retry

--- a/sdk/samples/storage/blobs/README.md
+++ b/sdk/samples/storage/blobs/README.md
@@ -46,7 +46,7 @@ If you'd like to contribute to this library, please read the [contributing guide
 Azure SDK for Embedded C is licensed under the [MIT][azure_sdk_for_c_license] license.
 
 <!-- LINKS -->
-[azure_sdk_for_c_contributing]: https://github.com/Azure/azure-sdk-for-c/blob/master/CONTRIBUTING.md
+[azure_sdk_for_c_contributing]: ../../../../CONTRIBUTING.md
 [azure_sdk_for_c_license]: https://github.com/Azure/azure-sdk-for-c/blob/master/LICENSE
 [BLOB_SDK_README]: https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/storage
 [SDK_README_CONTRIBUTING]:https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/storage#contributing


### PR DESCRIPTION
Good suggestion from @CIPop 
All links to README's should be relative so that if you are working on a branch they resolve to your branch's version.