### PR TITLE
[iot] Fix ESP8266 sample after directory restructuring

### DIFF
--- a/sdk/samples/iot/hub/esp8266nodemcu/azure_iot_hub_telemetry.ino
+++ b/sdk/samples/iot/hub/esp8266nodemcu/azure_iot_hub_telemetry.ino
@@ -12,9 +12,9 @@
 #include <bearssl/bearssl_hmac.h>
 #include <libb64/cdecode.h>
 
-#include <azure/core/az_result.h>
-#include <azure/core/az_span.h>
-#include <azure/iot/az_iot_hub_client.h>
+#include <az_result.h>
+#include <az_span.h>
+#include <az_iot_hub_client.h>
 
 #include "iot_configs.h"
 

--- a/sdk/samples/iot/hub/esp8266nodemcu/generate_arduino_zip_library.sh
+++ b/sdk/samples/iot/hub/esp8266nodemcu/generate_arduino_zip_library.sh
@@ -3,14 +3,16 @@ command -v zip >/dev/null 2>&1 || { echo >&2 "Please install zip."; exit 1; }
 git clone https://github.com/Azure/azure-sdk-for-c sdkrepo
 mkdir azure-sdk-for-c
 
-mkdir -p azure-sdk-for-c/azure/core
-cp -r sdkrepo/sdk/inc/azure/core/* azure-sdk-for-c/azure/core
-mkdir -p azure-sdk-for-c/azure/iot/
-cp -r sdkrepo/sdk/inc/azure/iot/* azure-sdk-for-c/azure/iot
+cp sdkrepo/sdk/inc/azure/core/* azure-sdk-for-c
+cp sdkrepo/sdk/inc/azure/core/internal/* azure-sdk-for-c
+cp sdkrepo/sdk/inc/azure/iot/* azure-sdk-for-c
+cp sdkrepo/sdk/inc/azure/iot/internal/* azure-sdk-for-c
 
 cp -r sdkrepo/sdk/src/azure/core/* azure-sdk-for-c/
 cp -r sdkrepo/sdk/src/azure/iot/* azure-sdk-for-c/
 cp sdkrepo/sdk/src/azure/platform/az_noplatform.c azure-sdk-for-c/
+
+sed -i -e 's/<azure\/core\/internal\//</g' -e 's/<azure\/core\//</g' -e 's/<azure\/iot\/internal\//</g' -e 's/<azure\/iot\//</g' ./azure-sdk-for-c/*
 
 zip -r9 azure-sdk-for-c azure-sdk-for-c/
 

--- a/sdk/samples/iot/hub/esp8266nodemcu/how_to_esp8266_nodemcu.md
+++ b/sdk/samples/iot/hub/esp8266nodemcu/how_to_esp8266_nodemcu.md
@@ -25,7 +25,7 @@ _The following was run on an Ubuntu Desktop 18.04 environment, with Arduino IDE 
 01. Create an Arduino library for Azure Embedded SDK for C 
 
     ```
-    $ wget https://raw.githubusercontent.com/azure/azure-sdk-for-c/master/sdk/iot/hub/samples/esp8266nodemcu/generate_arduino_zip_library.sh
+    $ wget https://raw.githubusercontent.com/Azure/azure-sdk-for-c/master/sdk/samples/iot/hub/esp8266nodemcu/generate_arduino_zip_library.sh
     $ chmod 777 generate_arduino_zip_library.sh
     $ ./generate_arduino_zip_library.sh
     ```
@@ -87,7 +87,7 @@ _The following was run on an Ubuntu Desktop 18.04 environment, with Arduino IDE 
 
 06. Create a sketch on Arduino IDE for the IoT Hub client telemetry sample
 
-    Copy the code from [here](https://github.com/azure/azure-sdk-for-c/blob/master/sdk/iot/hub/samples/esp8266nodemcu) into your sketch.
+    Copy the code from the [ESP8266 Node MCU sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/hub/esp8266nodemcu) into your sketch.
     
     Edit the following parameters in `iot_configs.h`, filling in your own information:
 


### PR DESCRIPTION
- Changed script to flatten the file structure of the azure-sdk-for-c library for Arduino (the IDE cannot include headers in subdirectories);
- Updated guide to reflect updated paths;
- Updated sample to use headers in flat structure.
