### PR TITLE
fix red highlighting on GH PR's with JSON

### DIFF
--- a/sdk/samples/iot/hub/README.md
+++ b/sdk/samples/iot/hub/README.md
@@ -106,9 +106,13 @@ This sample uses a property named `device_count`, which records the number of ti
 
 * To send a device twin desired property message from the service to the device, open the device twin document in your Azure IoT Hub.  Add the property `device_count` along with a corresponding value to the `desired` section of the JSON.  
 ```json
-"properties": {
+{
+  "properties": {
     "desired": {
       "device_count": 42,
+    }
+  }
+}
 ```
 * Select Save to send the message. The device will store the value locally and report the updated property to the service.
 


### PR DESCRIPTION
GH PR's don't like that we have malformed JSON in our README. This should resolve this:

![image](https://user-images.githubusercontent.com/36710865/85908595-8623ee80-b7ca-11ea-898d-325cc351eee9.png)
