### PR TITLE
Update azure_iot_hub_telemetry.ino

### DIFF
--- a/sdk/samples/iot/hub/esp8266nodemcu/azure_iot_hub_telemetry.ino
+++ b/sdk/samples/iot/hub/esp8266nodemcu/azure_iot_hub_telemetry.ino
@@ -92,7 +92,7 @@ void receivedCallback(char* topic, byte* payload, unsigned int length)
   Serial.print("Received [");
   Serial.print(topic);
   Serial.print("]: ");
-  for (int i = 0; i < length; i++)
+  for (int i = 0; i <= length; i++)
   {
     Serial.print((char)payload[i]);
   }
@@ -281,4 +281,6 @@ void loop()
 
     next_telemetry_send_time_ms = millis() + TELEMETRY_FREQUENCY_MILLISECS;
   }
+  
+  mqtt_client.loop();
 }


### PR DESCRIPTION
receiveCallback was losing the last character.

without 'mqtt_client.loop();', C2D were not being processed