### PR TITLE
Remove AZ_ERROR_MUTEX as it is no longer needed anymore.

### DIFF
--- a/sdk/inc/azure/core/az_result.h
+++ b/sdk/inc/azure/core/az_result.h
@@ -100,8 +100,6 @@ typedef enum
   AZ_ERROR_NOT_SUPPORTED = _az_RESULT_MAKE_ERROR(_az_FACILITY_CORE, 7),
 
   // Platform
-  AZ_ERROR_MUTEX = _az_RESULT_MAKE_ERROR(_az_FACILITY_PLATFORM, 1), ///< Mutex operation error.
-
   AZ_ERROR_OUT_OF_MEMORY = _az_RESULT_MAKE_ERROR(
       _az_FACILITY_PLATFORM,
       2), ///< Dynamic memory allocation request was not successful.


### PR DESCRIPTION
Instead of mutex, we now have atomic compare exchange (see https://github.com/Azure/azure-sdk-for-c/pull/771 by @antkmsft)
The usage of this `az_result` was removed by @vhvb1989 in https://github.com/Azure/azure-sdk-for-c/pull/763

Therefore, we no longer need it.

Addressing feedback from @JeffreyRichter - https://github.com/Azure/azure-sdk-for-c/pull/885#discussion_r449659092