### PR TITLE
Update provisioning client parser to retain original logic for partial JSON

### DIFF
--- a/sdk/samples/iot/hub/src/paho_iot_hub_twin_example.c
+++ b/sdk/samples/iot/hub/src/paho_iot_hub_twin_example.c
@@ -555,6 +555,9 @@ static az_result update_property(az_span desired_payload)
     }
     else if (az_json_token_is_text_equal(&json_parser.token, reported_property_name))
     {
+      // Move to the value token
+      AZ_RETURN_IF_FAILED(az_json_parser_next_token(&json_parser));
+
       // TODO: Change back to int32_t once that is supported.
       uint32_t temp_property_value = 0;
       AZ_RETURN_IF_FAILED(az_json_token_get_uint32(&json_parser.token, &temp_property_value));

--- a/sdk/src/azure/iot/az_iot_provisioning_client.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client.c
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/iot/az_iot_provisioning_client.h>
-#include <azure/iot/az_iot_common.h>
 #include <azure/core/az_json.h>
 #include <azure/core/az_result.h>
 #include <azure/core/az_span.h>
 #include <azure/core/internal/az_span_internal.h>
+#include <azure/iot/az_iot_common.h>
+#include <azure/iot/az_iot_provisioning_client.h>
 
 #include <azure/core/internal/az_log_internal.h>
 #include <azure/core/internal/az_precondition_internal.h>
@@ -278,9 +278,8 @@ AZ_INLINE az_result _az_iot_provisioning_client_payload_registration_result_pars
   bool found_assigned_hub = false;
   bool found_device_id = false;
 
-  AZ_RETURN_IF_FAILED(az_json_parser_next_token(jp));
-
-  while (jp->token.kind != AZ_JSON_TOKEN_END_OBJECT)
+  while ((!(found_device_id && found_assigned_hub)) && az_succeeded(az_json_parser_next_token(jp))
+         && jp->token.kind != AZ_JSON_TOKEN_END_OBJECT)
   {
     if (az_json_token_is_text_equal(&jp->token, AZ_SPAN_FROM_STR("assignedHub")))
     {
@@ -329,8 +328,6 @@ AZ_INLINE az_result _az_iot_provisioning_client_payload_registration_result_pars
       // ignore other tokens
       AZ_RETURN_IF_FAILED(az_json_parser_skip_children(jp));
     }
-
-    AZ_RETURN_IF_FAILED(az_json_parser_next_token(jp));
   }
 
   if (found_assigned_hub != found_device_id)
@@ -361,9 +358,7 @@ AZ_INLINE az_result az_iot_provisioning_client_parse_payload(
   bool found_operation_status = false;
   bool found_error = false;
 
-  AZ_RETURN_IF_FAILED(az_json_parser_next_token(&jp));
-
-  while (jp.token.kind != AZ_JSON_TOKEN_END_OBJECT)
+  while (az_succeeded(az_json_parser_next_token(&jp)) && jp.token.kind != AZ_JSON_TOKEN_END_OBJECT)
   {
     if (az_json_token_is_text_equal(&jp.token, AZ_SPAN_FROM_STR("operationId")))
     {
@@ -428,8 +423,6 @@ AZ_INLINE az_result az_iot_provisioning_client_parse_payload(
       // ignore other tokens
       AZ_RETURN_IF_FAILED(az_json_parser_skip_children(&jp));
     }
-
-    AZ_RETURN_IF_FAILED(az_json_parser_next_token(&jp));
   }
 
   if (!(found_operation_status && found_operation_id))

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
@@ -369,7 +369,7 @@ test_az_iot_provisioning_client_received_topic_and_payload_parse_invalid_result_
   az_iot_provisioning_client_register_response response;
   az_result ret = az_iot_provisioning_client_parse_received_topic_and_payload(
       &client, received_topic, received_payload, &response);
-  assert_int_equal(AZ_ERROR_EOF, ret);
+  assert_int_equal(AZ_ERROR_ITEM_NOT_FOUND, ret);
 }
 
 static void test_az_iot_provisioning_client_received_topic_and_payload_parse_hub_not_found_fails()


### PR DESCRIPTION
Addressing leftover feedback from https://github.com/Azure/azure-sdk-for-c/pull/871#pullrequestreview-443507443 to retain the original logic where we don't parse through the entire JSON payload, nor validate/require that it was complete.

Also revert back the single unit test change.