### PR TITLE
show VCPKG version in CI

### DIFF
--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -41,6 +41,11 @@ steps:
     condition: and(succeeded(), contains(variables['OSVmImage'], 'macOS'), not(eq(variables['${{ parameters.DependenciesVariableName }}'], '')))
     displayName: vcpkg bootstrap
 
+  #Show vcpkg version
+  - script: |
+      vcpkg version
+    displayName: vcpkg version
+
   - script: |
       vcpkg install $(${{ parameters.DependenciesVariableName }})
     displayName: vcpkg install dependencies


### PR DESCRIPTION
There is a different version of VCPKG used on CI for the pipelines that bootstrap it after clonning it than the ones with it already installed (Windows)

We should always use the same version