### PR TITLE
Add caching for Vcpkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ files and start again.
 vcpkg is the easiest way to have dependencies installed. It downloads packages sources, headers and build libraries for whatever TRIPLET is set up (platform/arq).
 VCPKG maintains any installed package inside its own folder, allowing to have multiple vcpkg folder with different dependencies installed on each. This is also great because you don't have to install dependencies globally on your system.
 
-Follow next steps to install VCPKG and have it linked to cmake. The vcpkg repository is checked out at the ref in [vcpkg.yml](eng/pipelines/templates/steps/vcpkg.yml#L11). Code in this version is known to work at that vcpkg ref.
+Follow next steps to install VCPKG and have it linked to cmake. The vcpkg repository is checked out at the ref in [vcpkg.yml](eng/pipelines/templates/steps/vcpkg.yml#L11). Azure SDK code in this version is known to work at that vcpkg ref.
 
 ```bash
 # Clone vcpkg:
@@ -323,7 +323,7 @@ Right after opening project, Visual Studio will read cmake files and generate ca
 VCPKG can be used to download packages sources, headers and build libraries for whatever TRIPLET is set up (platform/architecture).
 VCPKG maintains any installed package inside its own folder, allowing to have multiple vcpkg folder with different dependencies installed on each. This is also great because you don't have to install dependencies globally on your system.
 
-Follow next steps to install VCPKG and have it linked to cmake.  The vcpkg repository is checked out at the ref in [vcpkg.yml](eng/pipelines/templates/steps/vcpkg.yml#L11). Code in this version is known to work at that vcpkg ref.
+Follow next steps to install VCPKG and have it linked to cmake.  The vcpkg repository is checked out at the ref in [vcpkg.yml](eng/pipelines/templates/steps/vcpkg.yml#L11). Azure SDK code in this version is known to work at that vcpkg ref.
 
 ```bash
 # Clone vcpkg:
@@ -379,7 +379,7 @@ brew install gcc
 brew cleanup
 ```
 
-Follow next steps to install VCPKG and have it linked to cmake. The vcpkg repository is checked out at the ref in [vcpkg.yml](eng/pipelines/templates/steps/vcpkg.yml#L11). Code in this version is known to work at that vcpkg ref.
+Follow next steps to install VCPKG and have it linked to cmake. The vcpkg repository is checked out at the ref in [vcpkg.yml](eng/pipelines/templates/steps/vcpkg.yml#L11). Azure SDK code in this version is known to work at that vcpkg ref.
 
 ```bash
 # Clone vcpkg:

--- a/README.md
+++ b/README.md
@@ -275,13 +275,16 @@ files and start again.
 vcpkg is the easiest way to have dependencies installed. It downloads packages sources, headers and build libraries for whatever TRIPLET is set up (platform/arq).
 VCPKG maintains any installed package inside its own folder, allowing to have multiple vcpkg folder with different dependencies installed on each. This is also great because you don't have to install dependencies globally on your system.
 
-Follow next steps to install VCPKG and have it linked to cmake
+Follow next steps to install VCPKG and have it linked to cmake. The vcpkg repository is checked out at the ref in [vcpkg.yml](eng/pipelines/templates/steps/vcpkg.yml#L11). Code in this version is known to work at that vcpkg ref.
 
 ```bash
 # Clone vcpkg:
 git clone https://github.com/Microsoft/vcpkg.git
 # (consider this path as PATH_TO_VCPKG)
 cd vcpkg
+# Checkout the vcpkg ref from the vcpkg.yml file (link above)
+# git checkout <vcpkg ref>
+
 # build vcpkg (remove .bat on Linux/Mac)
 .\bootstrap-vcpkg.bat
 # install dependencies (remove .exe in Linux/Mac) and update triplet

--- a/README.md
+++ b/README.md
@@ -323,13 +323,16 @@ Right after opening project, Visual Studio will read cmake files and generate ca
 VCPKG can be used to download packages sources, headers and build libraries for whatever TRIPLET is set up (platform/architecture).
 VCPKG maintains any installed package inside its own folder, allowing to have multiple vcpkg folder with different dependencies installed on each. This is also great because you don't have to install dependencies globally on your system.
 
-Follow next steps to install VCPKG and have it linked to cmake
+Follow next steps to install VCPKG and have it linked to cmake.  The vcpkg repository is checked out at the ref in [vcpkg.yml](eng/pipelines/templates/steps/vcpkg.yml#L11). Code in this version is known to work at that vcpkg ref.
 
 ```bash
 # Clone vcpkg:
 git clone https://github.com/Microsoft/vcpkg.git
 # (consider this path as PATH_TO_VCPKG)
 cd vcpkg
+# Checkout the vcpkg ref from the vcpkg.yml file (link above)
+# git checkout <vcpkg ref>
+
 # build vcpkg
 ./bootstrap-vcpkg.sh
 ./vcpkg install --triplet x64-linux curl cmocka paho-mqtt
@@ -376,13 +379,16 @@ brew install gcc
 brew cleanup
 ```
 
-Follow next steps to install VCPKG and have it linked to cmake
+Follow next steps to install VCPKG and have it linked to cmake. The vcpkg repository is checked out at the ref in [vcpkg.yml](eng/pipelines/templates/steps/vcpkg.yml#L11). Code in this version is known to work at that vcpkg ref.
 
 ```bash
 # Clone vcpkg:
 git clone https://github.com/Microsoft/vcpkg.git
 # (consider this path as PATH_TO_VCPKG)
 cd vcpkg
+# Checkout the vcpkg ref from the vcpkg.yml file (link above)
+# git checkout <vcpkg ref>
+
 # build vcpkg
 ./bootstrap-vcpkg.sh
 ./vcpkg install --triplet x64-osx curl cmocka paho-mqtt

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -74,132 +74,132 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
         build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX'
 
-      # Build with sample dependencies and unit testing [curl for transport and cmocka]  - PRECONDITIONS ON
-      # WARNINGS_AS_ERRORS          ON
-      # TRANSPORT_CURL              ON
-      # UNIT_TESTING                ON
-      # UNIT_TESTING_MOCKS          OFF
-      # TRANSPORT_PAHO              ON
-      # PRECONDITIONS               ON
-      # LOGGING                     ON
-      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
-      Linux_x64_with_samples_and_unit_test:
-        OSVmImage: 'ubuntu-18.04'
-        vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
-      Win_x86_with_samples_and_unit_test:
-        OSVmImage: 'windows-2019'
-        vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
-      Win_x64_with_samples_and_unit_test:
-        OSVmImage: 'windows-2019'
-        vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
-      MacOS_x64_with_samples_and_unit_test:
-        OSVmImage: 'macOS-10.15'
-        vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
+      # # Build with sample dependencies and unit testing [curl for transport and cmocka]  - PRECONDITIONS ON
+      # # WARNINGS_AS_ERRORS          ON
+      # # TRANSPORT_CURL              ON
+      # # UNIT_TESTING                ON
+      # # UNIT_TESTING_MOCKS          OFF
+      # # TRANSPORT_PAHO              ON
+      # # PRECONDITIONS               ON
+      # # LOGGING                     ON
+      # # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
+      # Linux_x64_with_samples_and_unit_test:
+      #   OSVmImage: 'ubuntu-18.04'
+      #   vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
+      # Win_x86_with_samples_and_unit_test:
+      #   OSVmImage: 'windows-2019'
+      #   vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: Win32
+      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
+      # Win_x64_with_samples_and_unit_test:
+      #   OSVmImage: 'windows-2019'
+      #   vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: x64
+      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
+      # MacOS_x64_with_samples_and_unit_test:
+      #   OSVmImage: 'macOS-10.15'
+      #   vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
 
-      # Build with unit testing only. No samples [cmocka] - PRECONDITIONS ON
-      # WARNINGS_AS_ERRORS          ON
-      # TRANSPORT_CURL              OFF
-      # UNIT_TESTING                ON
-      # UNIT_TESTING_MOCKS          ON
-      # TRANSPORT_PAHO              OFF
-      # PRECONDITIONS               ON
-      # LOGGING                     ON
-      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
-      Linux_x64_with_unit_test:
-        OSVmImage: 'ubuntu-18.04'
-        vcpkg.deps: 'cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        # This is the only platform where we run mocking functions and generate CodeCoverage
-        build.args: ' -DUNIT_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING_MOCKS=ON'
-        AZ_SDK_CODE_COV: 1
-        AZ_SDK_C_NO_SAMPLES: 'true'
-      Win_x86_with_unit_test:
-        OSVmImage: 'windows-2019'
-        vcpkg.deps: 'cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DUNIT_TESTING=ON'
-        AZ_SDK_C_NO_SAMPLES: 'true'
-      Win_x64_with_unit_test:
-        OSVmImage: 'windows-2019'
-        vcpkg.deps: 'cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DUNIT_TESTING=ON'
-        AZ_SDK_C_NO_SAMPLES: 'true'
-      MacOS_x64_with_unit_test:
-        OSVmImage: 'macOS-10.15'
-        vcpkg.deps: 'cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        build.args: ' -DUNIT_TESTING=ON'
-        AZ_SDK_C_NO_SAMPLES: 'true'
+      # # Build with unit testing only. No samples [cmocka] - PRECONDITIONS ON
+      # # WARNINGS_AS_ERRORS          ON
+      # # TRANSPORT_CURL              OFF
+      # # UNIT_TESTING                ON
+      # # UNIT_TESTING_MOCKS          ON
+      # # TRANSPORT_PAHO              OFF
+      # # PRECONDITIONS               ON
+      # # LOGGING                     ON
+      # # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
+      # Linux_x64_with_unit_test:
+      #   OSVmImage: 'ubuntu-18.04'
+      #   vcpkg.deps: 'cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      #   # This is the only platform where we run mocking functions and generate CodeCoverage
+      #   build.args: ' -DUNIT_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING_MOCKS=ON'
+      #   AZ_SDK_CODE_COV: 1
+      #   AZ_SDK_C_NO_SAMPLES: 'true'
+      # Win_x86_with_unit_test:
+      #   OSVmImage: 'windows-2019'
+      #   vcpkg.deps: 'cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: Win32
+      #   build.args: ' -DUNIT_TESTING=ON'
+      #   AZ_SDK_C_NO_SAMPLES: 'true'
+      # Win_x64_with_unit_test:
+      #   OSVmImage: 'windows-2019'
+      #   vcpkg.deps: 'cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: x64
+      #   build.args: ' -DUNIT_TESTING=ON'
+      #   AZ_SDK_C_NO_SAMPLES: 'true'
+      # MacOS_x64_with_unit_test:
+      #   OSVmImage: 'macOS-10.15'
+      #   vcpkg.deps: 'cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+      #   build.args: ' -DUNIT_TESTING=ON'
+      #   AZ_SDK_C_NO_SAMPLES: 'true'
 
-      # Build with unit testing only. No samples [cmocka] - PRECONDITIONS OFF
-      # WARNINGS_AS_ERRORS          ON
-      # TRANSPORT_CURL              OFF
-      # UNIT_TESTING                ON
-      # UNIT_TESTING_MOCKS          OFF
-      # TRANSPORT_PAHO              OFF
-      # PRECONDITIONS               OFF
-      # LOGGING                     ON
-      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
-      Linux_x64_with_unit_test_no_preconditions:
-        OSVmImage: 'ubuntu-18.04'
-        vcpkg.deps: 'cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
-        AZ_SDK_C_NO_SAMPLES: 'true'
-      Win_x86_with_unit_test_no_preconditions:
-        OSVmImage: 'windows-2019'
-        vcpkg.deps: 'cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
-        AZ_SDK_C_NO_SAMPLES: 'true'
-      Win_x64_with_unit_test_no_preconditions:
-        OSVmImage: 'windows-2019'
-        vcpkg.deps: 'cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
-        AZ_SDK_C_NO_SAMPLES: 'true'
-      MacOS_x64_with_unit_test_no_preconditions:
-        OSVmImage: 'macOS-10.15'
-        vcpkg.deps: 'cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
-        AZ_SDK_C_NO_SAMPLES: 'true'
+      # # Build with unit testing only. No samples [cmocka] - PRECONDITIONS OFF
+      # # WARNINGS_AS_ERRORS          ON
+      # # TRANSPORT_CURL              OFF
+      # # UNIT_TESTING                ON
+      # # UNIT_TESTING_MOCKS          OFF
+      # # TRANSPORT_PAHO              OFF
+      # # PRECONDITIONS               OFF
+      # # LOGGING                     ON
+      # # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
+      # Linux_x64_with_unit_test_no_preconditions:
+      #   OSVmImage: 'ubuntu-18.04'
+      #   vcpkg.deps: 'cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      #   build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
+      #   AZ_SDK_C_NO_SAMPLES: 'true'
+      # Win_x86_with_unit_test_no_preconditions:
+      #   OSVmImage: 'windows-2019'
+      #   vcpkg.deps: 'cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: Win32
+      #   build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
+      #   AZ_SDK_C_NO_SAMPLES: 'true'
+      # Win_x64_with_unit_test_no_preconditions:
+      #   OSVmImage: 'windows-2019'
+      #   vcpkg.deps: 'cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: x64
+      #   build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
+      #   AZ_SDK_C_NO_SAMPLES: 'true'
+      # MacOS_x64_with_unit_test_no_preconditions:
+      #   OSVmImage: 'macOS-10.15'
+      #   vcpkg.deps: 'cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+      #   build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
+      #   AZ_SDK_C_NO_SAMPLES: 'true'
 
-      # Build with no logging - samples - libcurl - paho - NoPreconditions
-      # WARNINGS_AS_ERRORS          ON
-      # TRANSPORT_CURL              ON
-      # UNIT_TESTING                ON
-      # UNIT_TESTING_MOCK_ENABLED   OFF
-      # TRANSPORT_PAHO              ON
-      # PRECONDITIONS               OFF
-      # LOGGING                     OFF
-      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX
-      Linux_x64_with_unit_tests_and_samples_no_logging_no_preconditions:
-        OSVmImage: 'ubuntu-18.04'
-        vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DPRECONDITIONS=OFF -DLOGGING=OFF'
+      # # Build with no logging - samples - libcurl - paho - NoPreconditions
+      # # WARNINGS_AS_ERRORS          ON
+      # # TRANSPORT_CURL              ON
+      # # UNIT_TESTING                ON
+      # # UNIT_TESTING_MOCK_ENABLED   OFF
+      # # TRANSPORT_PAHO              ON
+      # # PRECONDITIONS               OFF
+      # # LOGGING                     OFF
+      # # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX
+      # Linux_x64_with_unit_tests_and_samples_no_logging_no_preconditions:
+      #   OSVmImage: 'ubuntu-18.04'
+      #   vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DPRECONDITIONS=OFF -DLOGGING=OFF'
   pool:
     vmImage: $(OSVmImage)
   variables:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -49,25 +49,25 @@ jobs:
       # PRECONDITIONS               ON
       # LOGGING                     ON
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
-      Linux_x64_with_samples:
-        OSVmImage: 'ubuntu-18.04'
-        vcpkg.deps: 'curl[ssl] paho-mqtt'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX'
-      Win_x86_with_samples:
-        OSVmImage: 'windows-2019'
-        vcpkg.deps: 'curl[winssl] paho-mqtt'
-        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: Win32
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32'
-      Win_x64_with_samples:
-        OSVmImage: 'windows-2019'
-        vcpkg.deps: 'curl[winssl] paho-mqtt'
-        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-        CMAKE_GENERATOR: 'Visual Studio 16 2019'
-        CMAKE_GENERATOR_PLATFORM: x64
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32'
+      # Linux_x64_with_samples:
+      #   OSVmImage: 'ubuntu-18.04'
+      #   vcpkg.deps: 'curl[ssl] paho-mqtt'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX'
+      # Win_x86_with_samples:
+      #   OSVmImage: 'windows-2019'
+      #   vcpkg.deps: 'curl[winssl] paho-mqtt'
+      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: Win32
+      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32'
+      # Win_x64_with_samples:
+      #   OSVmImage: 'windows-2019'
+      #   vcpkg.deps: 'curl[winssl] paho-mqtt'
+      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
+      #   CMAKE_GENERATOR_PLATFORM: x64
+      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32'
       MacOS_x64_with_samples:
         OSVmImage: 'macOS-10.15'
         vcpkg.deps: 'curl[ssl] paho-mqtt'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -74,132 +74,132 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
         build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX'
 
-      # # Build with sample dependencies and unit testing [curl for transport and cmocka]  - PRECONDITIONS ON
-      # # WARNINGS_AS_ERRORS          ON
-      # # TRANSPORT_CURL              ON
-      # # UNIT_TESTING                ON
-      # # UNIT_TESTING_MOCKS          OFF
-      # # TRANSPORT_PAHO              ON
-      # # PRECONDITIONS               ON
-      # # LOGGING                     ON
-      # # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
-      # Linux_x64_with_samples_and_unit_test:
-      #   OSVmImage: 'ubuntu-18.04'
-      #   vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
-      # Win_x86_with_samples_and_unit_test:
-      #   OSVmImage: 'windows-2019'
-      #   vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: Win32
-      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
-      # Win_x64_with_samples_and_unit_test:
-      #   OSVmImage: 'windows-2019'
-      #   vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: x64
-      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
-      # MacOS_x64_with_samples_and_unit_test:
-      #   OSVmImage: 'macOS-10.15'
-      #   vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
+      # Build with sample dependencies and unit testing [curl for transport and cmocka]  - PRECONDITIONS ON
+      # WARNINGS_AS_ERRORS          ON
+      # TRANSPORT_CURL              ON
+      # UNIT_TESTING                ON
+      # UNIT_TESTING_MOCKS          OFF
+      # TRANSPORT_PAHO              ON
+      # PRECONDITIONS               ON
+      # LOGGING                     ON
+      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
+      Linux_x64_with_samples_and_unit_test:
+        OSVmImage: 'ubuntu-18.04'
+        vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
+      Win_x86_with_samples_and_unit_test:
+        OSVmImage: 'windows-2019'
+        vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: Win32
+        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
+      Win_x64_with_samples_and_unit_test:
+        OSVmImage: 'windows-2019'
+        vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: x64
+        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON'
+      MacOS_x64_with_samples_and_unit_test:
+        OSVmImage: 'macOS-10.15'
+        vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON'
 
-      # # Build with unit testing only. No samples [cmocka] - PRECONDITIONS ON
-      # # WARNINGS_AS_ERRORS          ON
-      # # TRANSPORT_CURL              OFF
-      # # UNIT_TESTING                ON
-      # # UNIT_TESTING_MOCKS          ON
-      # # TRANSPORT_PAHO              OFF
-      # # PRECONDITIONS               ON
-      # # LOGGING                     ON
-      # # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
-      # Linux_x64_with_unit_test:
-      #   OSVmImage: 'ubuntu-18.04'
-      #   vcpkg.deps: 'cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      #   # This is the only platform where we run mocking functions and generate CodeCoverage
-      #   build.args: ' -DUNIT_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING_MOCKS=ON'
-      #   AZ_SDK_CODE_COV: 1
-      #   AZ_SDK_C_NO_SAMPLES: 'true'
-      # Win_x86_with_unit_test:
-      #   OSVmImage: 'windows-2019'
-      #   vcpkg.deps: 'cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: Win32
-      #   build.args: ' -DUNIT_TESTING=ON'
-      #   AZ_SDK_C_NO_SAMPLES: 'true'
-      # Win_x64_with_unit_test:
-      #   OSVmImage: 'windows-2019'
-      #   vcpkg.deps: 'cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: x64
-      #   build.args: ' -DUNIT_TESTING=ON'
-      #   AZ_SDK_C_NO_SAMPLES: 'true'
-      # MacOS_x64_with_unit_test:
-      #   OSVmImage: 'macOS-10.15'
-      #   vcpkg.deps: 'cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-      #   build.args: ' -DUNIT_TESTING=ON'
-      #   AZ_SDK_C_NO_SAMPLES: 'true'
+      # Build with unit testing only. No samples [cmocka] - PRECONDITIONS ON
+      # WARNINGS_AS_ERRORS          ON
+      # TRANSPORT_CURL              OFF
+      # UNIT_TESTING                ON
+      # UNIT_TESTING_MOCKS          ON
+      # TRANSPORT_PAHO              OFF
+      # PRECONDITIONS               ON
+      # LOGGING                     ON
+      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
+      Linux_x64_with_unit_test:
+        OSVmImage: 'ubuntu-18.04'
+        vcpkg.deps: 'cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        # This is the only platform where we run mocking functions and generate CodeCoverage
+        build.args: ' -DUNIT_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DUNIT_TESTING_MOCKS=ON'
+        AZ_SDK_CODE_COV: 1
+        AZ_SDK_C_NO_SAMPLES: 'true'
+      Win_x86_with_unit_test:
+        OSVmImage: 'windows-2019'
+        vcpkg.deps: 'cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: Win32
+        build.args: ' -DUNIT_TESTING=ON'
+        AZ_SDK_C_NO_SAMPLES: 'true'
+      Win_x64_with_unit_test:
+        OSVmImage: 'windows-2019'
+        vcpkg.deps: 'cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: x64
+        build.args: ' -DUNIT_TESTING=ON'
+        AZ_SDK_C_NO_SAMPLES: 'true'
+      MacOS_x64_with_unit_test:
+        OSVmImage: 'macOS-10.15'
+        vcpkg.deps: 'cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+        build.args: ' -DUNIT_TESTING=ON'
+        AZ_SDK_C_NO_SAMPLES: 'true'
 
-      # # Build with unit testing only. No samples [cmocka] - PRECONDITIONS OFF
-      # # WARNINGS_AS_ERRORS          ON
-      # # TRANSPORT_CURL              OFF
-      # # UNIT_TESTING                ON
-      # # UNIT_TESTING_MOCKS          OFF
-      # # TRANSPORT_PAHO              OFF
-      # # PRECONDITIONS               OFF
-      # # LOGGING                     ON
-      # # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
-      # Linux_x64_with_unit_test_no_preconditions:
-      #   OSVmImage: 'ubuntu-18.04'
-      #   vcpkg.deps: 'cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      #   build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
-      #   AZ_SDK_C_NO_SAMPLES: 'true'
-      # Win_x86_with_unit_test_no_preconditions:
-      #   OSVmImage: 'windows-2019'
-      #   vcpkg.deps: 'cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: Win32
-      #   build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
-      #   AZ_SDK_C_NO_SAMPLES: 'true'
-      # Win_x64_with_unit_test_no_preconditions:
-      #   OSVmImage: 'windows-2019'
-      #   vcpkg.deps: 'cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: x64
-      #   build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
-      #   AZ_SDK_C_NO_SAMPLES: 'true'
-      # MacOS_x64_with_unit_test_no_preconditions:
-      #   OSVmImage: 'macOS-10.15'
-      #   vcpkg.deps: 'cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-osx'
-      #   build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
-      #   AZ_SDK_C_NO_SAMPLES: 'true'
+      # Build with unit testing only. No samples [cmocka] - PRECONDITIONS OFF
+      # WARNINGS_AS_ERRORS          ON
+      # TRANSPORT_CURL              OFF
+      # UNIT_TESTING                ON
+      # UNIT_TESTING_MOCKS          OFF
+      # TRANSPORT_PAHO              OFF
+      # PRECONDITIONS               OFF
+      # LOGGING                     ON
+      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
+      Linux_x64_with_unit_test_no_preconditions:
+        OSVmImage: 'ubuntu-18.04'
+        vcpkg.deps: 'cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
+        AZ_SDK_C_NO_SAMPLES: 'true'
+      Win_x86_with_unit_test_no_preconditions:
+        OSVmImage: 'windows-2019'
+        vcpkg.deps: 'cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: Win32
+        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
+        AZ_SDK_C_NO_SAMPLES: 'true'
+      Win_x64_with_unit_test_no_preconditions:
+        OSVmImage: 'windows-2019'
+        vcpkg.deps: 'cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: x64
+        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
+        AZ_SDK_C_NO_SAMPLES: 'true'
+      MacOS_x64_with_unit_test_no_preconditions:
+        OSVmImage: 'macOS-10.15'
+        vcpkg.deps: 'cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x64-osx'
+        build.args: ' -DUNIT_TESTING=ON -DPRECONDITIONS=OFF'
+        AZ_SDK_C_NO_SAMPLES: 'true'
 
-      # # Build with no logging - samples - libcurl - paho - NoPreconditions
-      # # WARNINGS_AS_ERRORS          ON
-      # # TRANSPORT_CURL              ON
-      # # UNIT_TESTING                ON
-      # # UNIT_TESTING_MOCK_ENABLED   OFF
-      # # TRANSPORT_PAHO              ON
-      # # PRECONDITIONS               OFF
-      # # LOGGING                     OFF
-      # # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX
-      # Linux_x64_with_unit_tests_and_samples_no_logging_no_preconditions:
-      #   OSVmImage: 'ubuntu-18.04'
-      #   vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DPRECONDITIONS=OFF -DLOGGING=OFF'
+      # Build with no logging - samples - libcurl - paho - NoPreconditions
+      # WARNINGS_AS_ERRORS          ON
+      # TRANSPORT_CURL              ON
+      # UNIT_TESTING                ON
+      # UNIT_TESTING_MOCK_ENABLED   OFF
+      # TRANSPORT_PAHO              ON
+      # PRECONDITIONS               OFF
+      # LOGGING                     OFF
+      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX
+      Linux_x64_with_unit_tests_and_samples_no_logging_no_preconditions:
+        OSVmImage: 'ubuntu-18.04'
+        vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DPRECONDITIONS=OFF -DLOGGING=OFF'
   pool:
     vmImage: $(OSVmImage)
   variables:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -49,25 +49,25 @@ jobs:
       # PRECONDITIONS               ON
       # LOGGING                     ON
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
-      # Linux_x64_with_samples:
-      #   OSVmImage: 'ubuntu-18.04'
-      #   vcpkg.deps: 'curl[ssl] paho-mqtt'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX'
-      # Win_x86_with_samples:
-      #   OSVmImage: 'windows-2019'
-      #   vcpkg.deps: 'curl[winssl] paho-mqtt'
-      #   VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: Win32
-      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32'
-      # Win_x64_with_samples:
-      #   OSVmImage: 'windows-2019'
-      #   vcpkg.deps: 'curl[winssl] paho-mqtt'
-      #   VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
-      #   CMAKE_GENERATOR: 'Visual Studio 16 2019'
-      #   CMAKE_GENERATOR_PLATFORM: x64
-      #   build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32'
+      Linux_x64_with_samples:
+        OSVmImage: 'ubuntu-18.04'
+        vcpkg.deps: 'curl[ssl] paho-mqtt'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX'
+      Win_x86_with_samples:
+        OSVmImage: 'windows-2019'
+        vcpkg.deps: 'curl[winssl] paho-mqtt'
+        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: Win32
+        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32'
+      Win_x64_with_samples:
+        OSVmImage: 'windows-2019'
+        vcpkg.deps: 'curl[winssl] paho-mqtt'
+        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+        CMAKE_GENERATOR: 'Visual Studio 16 2019'
+        CMAKE_GENERATOR_PLATFORM: x64
+        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32'
       MacOS_x64_with_samples:
         OSVmImage: 'macOS-10.15'
         vcpkg.deps: 'curl[ssl] paho-mqtt'

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -135,7 +135,7 @@ steps:
         not(contains(variables['OSVmImage'], 'macOS')),
         not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''))
       )
-    displayName: Non-Mac - Set vcpkg version and bootstrap
+    displayName: Non-MacOS - vcpkg bootstrap
 
   - script: vcpkg version
     displayName: vcpkg version

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -47,7 +47,7 @@ steps:
 
   # Clear the vcpkg folder so the cache can successfully deploy to that location
   - bash: |
-      rm -rf $(VCPKG_INSTALLATION_ROOT)
+      sudo rm -rf $(VCPKG_INSTALLATION_ROOT)
       mkdir -p $(VCPKG_INSTALLATION_ROOT)
     displayName: Linux - Clear vcpkg folder
     condition: >-

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -66,7 +66,7 @@ steps:
     inputs:
       key: >-
         $(Agent.JobName)
-        | ${{ parameters.VcpkgVersion }}
+        | "${{ parameters.VcpkgVersion }}"
         | $(Agent.Os)
         | $(${{ parameters.DependenciesVariableName }})
       path: $(VCPKG_INSTALLATION_ROOT)

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -6,7 +6,8 @@ parameters:
   # invocations
   DependenciesVariableName: vcpkg.deps
 
-  # Ref at which to check out (can be commit SHA or tag in the form of `tags/<tag>`)
+  # Ref at which to check out (can be commit SHA or tag in the form of
+  # `tags/<tag>`)
   VcpkgVersion: c6d69984edceacbe880fad20ddc8305a7ec6fb8c
 
 steps:
@@ -45,7 +46,7 @@ steps:
   # Attempt to restore vcpkg from the cache
   - task: Cache@2
     inputs:
-      key: $(Agent.JobName) | ${{ parameters.VcpkgVersion }} | $(Agent.Os) | $(${{ parameters.DependenciesVariableName }}) | 1.0.0-beta.1
+      key: $(Agent.JobName) | ${{ parameters.VcpkgVersion }} | $(Agent.Os) | $(${{ parameters.DependenciesVariableName }}) | engsys-0001
       path: $(VCPKG_INSTALLATION_ROOT)
       cacheHitVar: VcpkgRestoredFromCache
     condition: >-

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -50,7 +50,7 @@ steps:
       id
       sudo rm -rf $(VCPKG_INSTALLATION_ROOT)
       sudo mkdir -p $(VCPKG_INSTALLATION_ROOT)
-      sudo chmod 777 $(VCPKG_INSTALLATION_ROOT)
+      sudo chown `id --name -u`.`id --name -g` $(VCPKG_INSTALLATION_ROOT)
     displayName: Linux - Clear vcpkg folder
     condition: >-
       and(

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -19,7 +19,7 @@ steps:
     condition: >-
       and(
         succeeded(),
-        not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''),
+        not(eq(variables['${{ parameters.DependenciesVariableName }}'], '')),
         contains(variables['OSVmImage'], 'macOS')
       )
 

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -49,6 +49,7 @@ steps:
 
   # Clear the vcpkg folder so the cache can successfully deploy to that location
   - bash: |
+      id
       sudo rm -rf $(VCPKG_INSTALLATION_ROOT)
       sudo mkdir -p $(VCPKG_INSTALLATION_ROOT)
       sudo chown `id --name -u`.`id --name -g` $(VCPKG_INSTALLATION_ROOT)
@@ -68,7 +69,7 @@ steps:
         | ${{ parameters.VcpkgVersion }}
         | $(Agent.Os)
         | $(${{ parameters.DependenciesVariableName }})
-        | engsys-0002
+        | engsys-0001
       path: $(VCPKG_INSTALLATION_ROOT)
       cacheHitVar: VcpkgRestoredFromCache
     displayName: Vcpkg Cache

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -49,6 +49,7 @@ steps:
   - bash: |
       sudo rm -rf $(VCPKG_INSTALLATION_ROOT)
       sudo mkdir -p $(VCPKG_INSTALLATION_ROOT)
+      sudo chmod 777 $(VCPKG_INSTALLATION_ROOT)
     displayName: Linux - Clear vcpkg folder
     condition: >-
       and(

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -47,7 +47,6 @@ steps:
 
   # Clear the vcpkg folder so the cache can successfully deploy to that location
   - bash: |
-      id
       sudo rm -rf $(VCPKG_INSTALLATION_ROOT)
       sudo mkdir -p $(VCPKG_INSTALLATION_ROOT)
       sudo chown `id --name -u`.`id --name -g` $(VCPKG_INSTALLATION_ROOT)
@@ -67,7 +66,7 @@ steps:
         | ${{ parameters.VcpkgVersion }}
         | $(Agent.Os)
         | $(${{ parameters.DependenciesVariableName }})
-        | engsys-0001
+        | engsys-0002
       path: $(VCPKG_INSTALLATION_ROOT)
       cacheHitVar: VcpkgRestoredFromCache
     displayName: Vcpkg Cache

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -38,7 +38,7 @@ steps:
     condition: >-
       and(
         succeeded(),
-        not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''),
+        not(eq(variables['${{ parameters.DependenciesVariableName }}'], '')),
         contains(variables['OSVmImage'], 'macOS')
       )
 

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -69,7 +69,6 @@ steps:
         | ${{ parameters.VcpkgVersion }}
         | $(Agent.Os)
         | $(${{ parameters.DependenciesVariableName }})
-        | engsys-0001
       path: $(VCPKG_INSTALLATION_ROOT)
       cacheHitVar: VcpkgRestoredFromCache
     displayName: Vcpkg Cache

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -107,6 +107,7 @@ steps:
     condition: >-
       and(
         succeeded(),
+        ne(variables['VcpkgRestoredFromCache'], 'true'),
         not(contains(variables['OSVmImage'], 'macOS')),
         not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''))
       )

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -114,6 +114,11 @@ steps:
 
   - script: vcpkg version
     displayName: vcpkg version
+    condition: >-
+      and(
+        succeeded(),
+        not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''))
+      )
 
   - script: |
       vcpkg install $(${{ parameters.DependenciesVariableName }})

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -6,8 +6,24 @@ parameters:
   # invocations
   DependenciesVariableName: vcpkg.deps
 
+  # Ref at which to check out (can be commit SHA or tag in the form of `tags/<tag>`)
+  VcpkgVersion: c6d69984edceacbe880fad20ddc8305a7ec6fb8c
+
 steps:
-  # Mac OS specific requirements
+  # Set VCPKG_INSTALLATION_ROOT location for cache on Mac OS hosts
+  - task: Bash@3
+    inputs:
+      targetType: inline
+      workingDirectory: $(Agent.TempDirectory)
+      script: echo "##vso[task.setvariable variable=VCPKG_INSTALLATION_ROOT;]$(Agent.TempDirectory)/vcpkg"
+    condition: >-
+      and(
+        succeeded(),
+        not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''),
+        contains(variables['OSVmImage'], 'macOS')
+      )
+
+  # Set MacOS specific build environment features for vcpkg
   - task: Bash@3
     inputs:
       targetType: inline
@@ -19,10 +35,35 @@ steps:
         # Install gcc 9
         brew install gcc@9
         gcc --version
+    condition: >-
+      and(
+        succeeded(),
+        not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''),
+        contains(variables['OSVmImage'], 'macOS')
+      )
 
+  # Attempt to restore vcpkg from the cache
+  - task: Cache@2
+    inputs:
+      key: $(Agent.JobName) | ${{ parameters.VcpkgVersion }} | $(Agent.Os) | $(${{ parameters.DependenciesVariableName }})
+      path: $(VCPKG_INSTALLATION_ROOT)
+      cacheHitVar: VcpkgRestoredFromCache
+    condition: >-
+      and(
+        succeeded(),
+        not(eq(variables['${{ parameters.DependenciesVariableName }}'], '')
+      )
+
+  # Install vcpkg on MacOS
+  - task: Bash@3
+    inputs:
+      targetType: inline
+      workingDirectory: $(Agent.TempDirectory)
+      script: |
         git clone https://github.com/Microsoft/vcpkg.git
         cd vcpkg
         git rev-parse --verify HEAD
+        git checkout ${{ parameters.VcpkgVersion }}
         git status
 
         ./bootstrap-vcpkg.sh
@@ -38,8 +79,14 @@ steps:
         echo "##vso[task.prependpath]$(pwd)"
         echo "##vso[task.setvariable variable=VCPKG_INSTALLATION_ROOT;]$(pwd)"
     # Execute only for Mac and if there is at least one dependency to be installed
-    condition: and(succeeded(), contains(variables['OSVmImage'], 'macOS'), not(eq(variables['${{ parameters.DependenciesVariableName }}'], '')))
-    displayName: vcpkg bootstrap (Mac)
+    condition: >-
+      and(
+        succeeded(),
+        ne(variables['VcpkgRestoredFromCache'], 'true'),
+        contains(variables['OSVmImage'], 'macOS'),
+        not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''))
+      )
+    displayName: vcpkg bootstrap (MacOS)
 
   # Update vcpkg and re-bootstrap on non-Mac OS'. Vcpkg is installed on the
   # image at a given time stamp and not moved forward until some update
@@ -54,10 +101,16 @@ steps:
         # then pull
         git reset --hard HEAD
         git pull origin master
+        git checkout ${{ parameters.VcpkgVersion }}
 
         ./bootstrap-vcpkg.sh
-    condition: and(succeeded(), not(contains(variables['OSVmImage'], 'macOS')), not(eq(variables['${{ parameters.DependenciesVariableName }}'], '')))
-    displayName: Upgrade vcpkg
+    condition: >-
+      and(
+        succeeded(),
+        not(contains(variables['OSVmImage'], 'macOS')),
+        not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''))
+      )
+    displayName: Set vcpkg version
 
   - script: vcpkg version
     displayName: vcpkg version
@@ -66,4 +119,8 @@ steps:
       vcpkg install $(${{ parameters.DependenciesVariableName }})
     displayName: vcpkg install dependencies
     # Execute only if there is at least one dependency to be installed
-    condition: and(succeeded(), not(eq(variables['${{ parameters.DependenciesVariableName }}'], '')))
+    condition: >-
+      and(
+        succeeded(),
+        not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''))
+      )

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -104,7 +104,7 @@ steps:
       and(
         succeeded(),
         ne(variables['VcpkgRestoredFromCache'], 'true'),
-        not(contains(variables['OSVmImage'], 'windows'))
+        not(contains(variables['OSVmImage'], 'windows')),
         not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''))
       )
     displayName: MacOS & Linux - vcpkg bootstrap

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -45,7 +45,7 @@ steps:
   # Attempt to restore vcpkg from the cache
   - task: Cache@2
     inputs:
-      key: $(Agent.JobName) | ${{ parameters.VcpkgVersion }} | $(Agent.Os) | $(${{ parameters.DependenciesVariableName }})
+      key: $(Agent.JobName) | ${{ parameters.VcpkgVersion }} | $(Agent.Os) | $(${{ parameters.DependenciesVariableName }}) | 1.0.0-beta.1
       path: $(VCPKG_INSTALLATION_ROOT)
       cacheHitVar: VcpkgRestoredFromCache
     condition: >-

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -46,7 +46,12 @@ steps:
   # Attempt to restore vcpkg from the cache
   - task: Cache@2
     inputs:
-      key: $(Agent.JobName) | ${{ parameters.VcpkgVersion }} | $(Agent.Os) | $(${{ parameters.DependenciesVariableName }}) | engsys-0001
+      key: >-
+        $(Agent.JobName)
+        | ${{ parameters.VcpkgVersion }}
+        | $(Agent.Os)
+        | $(${{ parameters.DependenciesVariableName }})
+        | engsys-0001
       path: $(VCPKG_INSTALLATION_ROOT)
       cacheHitVar: VcpkgRestoredFromCache
     condition: >-

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -47,7 +47,7 @@ steps:
 
   # Clear the vcpkg folder so the cache can successfully deploy to that location
   - bash: |
-      whoami
+      id
       sudo rm -rf $(VCPKG_INSTALLATION_ROOT)
       sudo mkdir -p $(VCPKG_INSTALLATION_ROOT)
       sudo chmod 777 $(VCPKG_INSTALLATION_ROOT)

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -48,7 +48,7 @@ steps:
   # Clear the vcpkg folder so the cache can successfully deploy to that location
   - bash: |
       sudo rm -rf $(VCPKG_INSTALLATION_ROOT)
-      mkdir -p $(VCPKG_INSTALLATION_ROOT)
+      sudo mkdir -p $(VCPKG_INSTALLATION_ROOT)
     displayName: Linux - Clear vcpkg folder
     condition: >-
       and(

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -17,6 +17,7 @@ steps:
       targetType: inline
       workingDirectory: $(Agent.TempDirectory)
       script: echo "##vso[task.setvariable variable=VCPKG_INSTALLATION_ROOT;]$(Agent.TempDirectory)/vcpkg"
+    displayName: MacOS - Set VCPKG_INSTALLATION_ROOT
     condition: >-
       and(
         succeeded(),
@@ -36,11 +37,24 @@ steps:
         # Install gcc 9
         brew install gcc@9
         gcc --version
+    displayName: MacOS - Set tools versions
     condition: >-
       and(
         succeeded(),
         not(eq(variables['${{ parameters.DependenciesVariableName }}'], '')),
         contains(variables['OSVmImage'], 'macOS')
+      )
+
+  # Clear the vcpkg folder so the cache can successfully deploy to that location
+  - bash: |
+      rm -rf $(VCPKG_INSTALLATION_ROOT)
+      mkdir -p $(VCPKG_INSTALLATION_ROOT)
+    displayName: Linux - Clear vcpkg folder
+    condition: >-
+      and(
+        succeeded(),
+        not(eq(variables['${{ parameters.DependenciesVariableName }}'], '')),
+        contains(variables['OSVmImage'], 'ubuntu')
       )
 
   # Attempt to restore vcpkg from the cache
@@ -54,6 +68,7 @@ steps:
         | engsys-0001
       path: $(VCPKG_INSTALLATION_ROOT)
       cacheHitVar: VcpkgRestoredFromCache
+    displayName: Vcpkg Cache
     condition: >-
       and(
         succeeded(),
@@ -89,10 +104,10 @@ steps:
       and(
         succeeded(),
         ne(variables['VcpkgRestoredFromCache'], 'true'),
-        contains(variables['OSVmImage'], 'macOS'),
+        not(contains(variables['OSVmImage'], 'windows'))
         not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''))
       )
-    displayName: vcpkg bootstrap (MacOS)
+    displayName: MacOS & Linux - vcpkg bootstrap
 
   # Update vcpkg and re-bootstrap on non-Mac OS'. Vcpkg is installed on the
   # image at a given time stamp and not moved forward until some update
@@ -117,7 +132,7 @@ steps:
         not(contains(variables['OSVmImage'], 'macOS')),
         not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''))
       )
-    displayName: Set vcpkg version
+    displayName: Non-Mac - Set vcpkg version and bootstrap
 
   - script: vcpkg version
     displayName: vcpkg version
@@ -129,7 +144,7 @@ steps:
 
   - script: |
       vcpkg install $(${{ parameters.DependenciesVariableName }})
-    displayName: vcpkg install dependencies
+    displayName: Install Dependencies (vcpkg)
     # Execute only if there is at least one dependency to be installed
     condition: >-
       and(

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -76,7 +76,8 @@ steps:
     condition: >-
       and(
         succeeded(),
-        not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''))
+        not(eq(variables['${{ parameters.DependenciesVariableName }}'], '')),
+        not(eq(variables['Skip.VcpkgCache'], 'true'))
       )
 
   # Install vcpkg on MacOS

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -47,6 +47,7 @@ steps:
 
   # Clear the vcpkg folder so the cache can successfully deploy to that location
   - bash: |
+      whoami
       sudo rm -rf $(VCPKG_INSTALLATION_ROOT)
       sudo mkdir -p $(VCPKG_INSTALLATION_ROOT)
       sudo chmod 777 $(VCPKG_INSTALLATION_ROOT)

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -16,7 +16,9 @@ steps:
     inputs:
       targetType: inline
       workingDirectory: $(Agent.TempDirectory)
-      script: echo "##vso[task.setvariable variable=VCPKG_INSTALLATION_ROOT;]$(Agent.TempDirectory)/vcpkg"
+      script: |
+        echo "##vso[task.prependpath]$(Agent.TempDirectory)/vcpkg"
+        echo "##vso[task.setvariable variable=VCPKG_INSTALLATION_ROOT;]$(Agent.TempDirectory)/vcpkg"
     displayName: MacOS - Set VCPKG_INSTALLATION_ROOT
     condition: >-
       and(

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -51,7 +51,7 @@ steps:
     condition: >-
       and(
         succeeded(),
-        not(eq(variables['${{ parameters.DependenciesVariableName }}'], '')
+        not(eq(variables['${{ parameters.DependenciesVariableName }}'], ''))
       )
 
   # Install vcpkg on MacOS

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -8,7 +8,7 @@ parameters:
 
   # Ref at which to check out (can be commit SHA or tag in the form of
   # `tags/<tag>`)
-  VcpkgVersion: c6d69984edceacbe880fad20ddc8305a7ec6fb8c
+  VcpkgVersion: tags/2020.06
 
 steps:
   # Set VCPKG_INSTALLATION_ROOT location for cache on Mac OS hosts
@@ -103,7 +103,6 @@ steps:
 
         echo "##vso[task.prependpath]$(pwd)"
         echo "##vso[task.setvariable variable=VCPKG_INSTALLATION_ROOT;]$(pwd)"
-    # Execute only for Mac and if there is at least one dependency to be installed
     condition: >-
       and(
         succeeded(),


### PR DESCRIPTION
**NB: This adds a `VcpkgVersion` to our vcpkg process that pins vcpkg to a given version. This makes our builds more repeatable but we'll have to move this value up periodically to get the latest version of vcpkg.**

This caches the `vcpkg` folder with a cache key that's made up of the Job name, vcpkg version, agent OS, dependencies. This means that for any given matrix entry you'll only need to run the `vcpkg` steps once and any subsequent runs of `vcpkg` will be cached. You won't have to bootstrap vcpkg or wait for the install process. 

Props to Tara for showing how to do caching in vcpkg: https://devblogs.microsoft.com/cppblog/vcpkg-2019-07-update/ 

Build times are down considerably: 
![image](https://user-images.githubusercontent.com/2158838/87327734-4dce2100-c4e9-11ea-8e52-6d8ef234fb18.png)
