### PR TITLE
remove platform from span

### DIFF
--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -3,7 +3,6 @@
 
 #include "az_hex_private.h"
 #include "az_span_private.h"
-#include <azure/core/az_platform.h>
 #include <azure/core/az_precondition.h>
 #include <azure/core/az_span.h>
 #include <azure/core/internal/az_precondition_internal.h>


### PR DESCRIPTION
`az_span` is taking a dependency on `az_platform.h` which I don't believe it needs