### PR TITLE
Http avoid query parameters to be duplicated

### DIFF
--- a/sdk/src/azure/core/az_http_request.c
+++ b/sdk/src/azure/core/az_http_request.c
@@ -204,7 +204,7 @@ az_http_request_set_query_parameter(_az_http_request* ref_request, az_span name,
         value_index,
         value_index + prexisting_query_parameter_value_size,
         value));
-    ref_request->_internal.url_length += required_length;
+    ref_request->_internal.url_length += difference;
     return AZ_OK;
   }
 

--- a/sdk/src/azure/core/az_http_request.c
+++ b/sdk/src/azure/core/az_http_request.c
@@ -180,7 +180,7 @@ az_http_request_set_query_parameter(_az_http_request* ref_request, az_span name,
   az_span url_remainder
       = az_span_slice_to_end(ref_request->_internal.url, ref_request->_internal.url_length);
 
-  if (az_span_ptr(pre_existing_query_parameter_value) != NULL)
+  if (pre_existing_query_parameter_start_index > 0)
   { // a negative difference means shifting left and no required length.
     // a positive difference means new value will require shifting right.
     int32_t pre_existing_query_parameter_value_size

--- a/sdk/src/azure/core/az_http_request.c
+++ b/sdk/src/azure/core/az_http_request.c
@@ -205,6 +205,17 @@ az_http_request_set_query_parameter(_az_http_request* ref_request, az_span name,
         pre_existing_query_parameter_start_index + pre_existing_query_parameter_value_size,
         value));
     ref_request->_internal.url_length += difference;
+    if (difference < 0)
+    {
+      // clear anything after a left shift
+      difference *= -1;
+      az_span_fill(
+          az_span_slice(
+              az_span_slice_to_end(ref_request->_internal.url, ref_request->_internal.url_length),
+              0,
+              difference),
+          0);
+    }
     return AZ_OK;
   }
 

--- a/sdk/src/azure/core/az_http_request.c
+++ b/sdk/src/azure/core/az_http_request.c
@@ -219,7 +219,8 @@ az_http_request_set_query_parameter(_az_http_request* ref_request, az_span name,
     return AZ_OK;
   }
 
-  // Adding new query parameter
+  // Adding new query parameter. Adding +2 to required length to include extra required symbols `=`
+  // and `?` or `&`.
   int32_t required_length = az_span_size(name) + az_span_size(value) + 2;
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(url_remainder, required_length);
 

--- a/sdk/tests/core/test_az_http.c
+++ b/sdk/tests/core/test_az_http.c
@@ -208,6 +208,14 @@ static void test_http_request(void** state)
             &request, AZ_SPAN_FROM_STR("q1"), AZ_SPAN_FROM_STR("v1")),
         AZ_OK);
 
+    {
+      az_span expected_url = AZ_SPAN_FROM_STR("http://example.com?q1=v1");
+      uint8_t result[100];
+      az_span url_result = AZ_SPAN_FROM_BUFFER(result);
+      assert_return_code(az_http_request_get_url(&request, &url_result), AZ_OK);
+      assert_true(az_span_is_content_equal(url_result, expected_url));
+    }
+
     // set same qp new value
     assert_return_code(
         az_http_request_set_query_parameter(

--- a/sdk/tests/core/test_az_http.c
+++ b/sdk/tests/core/test_az_http.c
@@ -3,12 +3,12 @@
 
 #include "az_http_header_validation_private.h"
 #include "az_test_definitions.h"
-#include <azure/core/az_http.h>
-#include <azure/core/internal/az_http_internal.h>
 #include <az_http_private.h>
+#include <azure/core/az_http.h>
 #include <azure/core/az_http_transport.h>
 #include <azure/core/az_json.h>
 #include <azure/core/az_span.h>
+#include <azure/core/internal/az_http_internal.h>
 
 #include <azure/core/az_precondition.h>
 #include <azure/core/internal/az_precondition_internal.h>
@@ -179,6 +179,148 @@ static void test_http_request(void** state)
     // Empty header
     assert_return_code(
         az_http_request_append_header(&request, AZ_SPAN_FROM_STR("header"), AZ_SPAN_NULL), AZ_OK);
+  }
+  { // Test adding duplicated query parameters
+    uint8_t buf[100];
+    uint8_t header_buf[(2 * sizeof(az_pair))];
+    memset(buf, 0, sizeof(buf));
+    memset(header_buf, 0, sizeof(header_buf));
+
+    az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
+    az_span initial_url = AZ_SPAN_FROM_STR("http://example.com");
+    az_span remainder = az_span_copy(url_span, initial_url);
+    assert_int_equal(az_span_size(remainder), 100 - az_span_size(initial_url));
+    az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
+    _az_http_request request;
+
+    TEST_EXPECT_SUCCESS(az_http_request_init(
+        &request,
+        &az_context_app,
+        az_http_method_get(),
+        url_span,
+        az_span_size(initial_url),
+        header_span,
+        AZ_SPAN_FROM_STR("body")));
+
+    // set qp
+    assert_return_code(
+        az_http_request_set_query_parameter(
+            &request, AZ_SPAN_FROM_STR("q1"), AZ_SPAN_FROM_STR("v1")),
+        AZ_OK);
+
+    // set same qp new value
+    assert_return_code(
+        az_http_request_set_query_parameter(
+            &request, AZ_SPAN_FROM_STR("q1"), AZ_SPAN_FROM_STR("value1")),
+        AZ_OK);
+
+    az_span expected_url = AZ_SPAN_FROM_STR("http://example.com?q1=value1");
+    uint8_t result[100];
+    az_span url_result = AZ_SPAN_FROM_BUFFER(result);
+    assert_return_code(az_http_request_get_url(&request, &url_result), AZ_OK);
+    assert_true(az_span_is_content_equal(url_result, expected_url));
+  }
+  { // Test adding duplicated query parameters
+    uint8_t buf[100];
+    uint8_t header_buf[(2 * sizeof(az_pair))];
+    memset(buf, 0, sizeof(buf));
+    memset(header_buf, 0, sizeof(header_buf));
+
+    az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
+    az_span initial_url = AZ_SPAN_FROM_STR("http://example.com?q1=");
+    az_span remainder = az_span_copy(url_span, initial_url);
+    assert_int_equal(az_span_size(remainder), 100 - az_span_size(initial_url));
+    az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
+    _az_http_request request;
+
+    TEST_EXPECT_SUCCESS(az_http_request_init(
+        &request,
+        &az_context_app,
+        az_http_method_get(),
+        url_span,
+        az_span_size(initial_url),
+        header_span,
+        AZ_SPAN_FROM_STR("body")));
+
+    // set same qp new value
+    assert_return_code(
+        az_http_request_set_query_parameter(
+            &request, AZ_SPAN_FROM_STR("q1"), AZ_SPAN_FROM_STR("value1")),
+        AZ_OK);
+
+    az_span expected_url = AZ_SPAN_FROM_STR("http://example.com?q1=value1");
+    uint8_t result[100];
+    az_span url_result = AZ_SPAN_FROM_BUFFER(result);
+    assert_return_code(az_http_request_get_url(&request, &url_result), AZ_OK);
+    assert_true(az_span_is_content_equal(url_result, expected_url));
+  }
+  { // Test adding duplicated query parameters same value
+    uint8_t buf[100];
+    uint8_t header_buf[(2 * sizeof(az_pair))];
+    memset(buf, 0, sizeof(buf));
+    memset(header_buf, 0, sizeof(header_buf));
+
+    az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
+    az_span initial_url = AZ_SPAN_FROM_STR("http://example.com?q1=123");
+    az_span remainder = az_span_copy(url_span, initial_url);
+    assert_int_equal(az_span_size(remainder), 100 - az_span_size(initial_url));
+    az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
+    _az_http_request request;
+
+    TEST_EXPECT_SUCCESS(az_http_request_init(
+        &request,
+        &az_context_app,
+        az_http_method_get(),
+        url_span,
+        az_span_size(initial_url),
+        header_span,
+        AZ_SPAN_FROM_STR("body")));
+
+    // set same qp new value
+    assert_return_code(
+        az_http_request_set_query_parameter(
+            &request, AZ_SPAN_FROM_STR("q1"), AZ_SPAN_FROM_STR("123")),
+        AZ_OK);
+
+    az_span expected_url = AZ_SPAN_FROM_STR("http://example.com?q1=123");
+    uint8_t result[100];
+    az_span url_result = AZ_SPAN_FROM_BUFFER(result);
+    assert_return_code(az_http_request_get_url(&request, &url_result), AZ_OK);
+    assert_true(az_span_is_content_equal(url_result, expected_url));
+  }
+  { // Test adding duplicated query parameter multiple qp
+    uint8_t buf[100];
+    uint8_t header_buf[(2 * sizeof(az_pair))];
+    memset(buf, 0, sizeof(buf));
+    memset(header_buf, 0, sizeof(header_buf));
+
+    az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
+    az_span initial_url = AZ_SPAN_FROM_STR("http://example.com?q1=123&q2=456");
+    az_span remainder = az_span_copy(url_span, initial_url);
+    assert_int_equal(az_span_size(remainder), 100 - az_span_size(initial_url));
+    az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
+    _az_http_request request;
+
+    TEST_EXPECT_SUCCESS(az_http_request_init(
+        &request,
+        &az_context_app,
+        az_http_method_get(),
+        url_span,
+        az_span_size(initial_url),
+        header_span,
+        AZ_SPAN_FROM_STR("body")));
+
+    // set same qp new value
+    assert_return_code(
+        az_http_request_set_query_parameter(
+            &request, AZ_SPAN_FROM_STR("q1"), AZ_SPAN_FROM_STR("value1")),
+        AZ_OK);
+
+    az_span expected_url = AZ_SPAN_FROM_STR("http://example.com?q1=value1&q2=456");
+    uint8_t result[100];
+    az_span url_result = AZ_SPAN_FROM_BUFFER(result);
+    assert_return_code(az_http_request_get_url(&request, &url_result), AZ_OK);
+    assert_true(az_span_is_content_equal(url_result, expected_url));
   }
   {
     uint8_t buf[100];


### PR DESCRIPTION
Adding code to validate if a query parameter was previously added.
If yes, only the actual value is updated instead of inserting a new query parameter.

There is a little performance impact while adding a query parameter because I am doing a lineal search every time to check if the parameter is already there, and also when the value is updated to a different size than previous because it requires a memory shifting right or left on the url.
This is because we don't have something like a SET for the query parameters. We just use a pre-allocated buffer.

Also. The case of someone adding an initial URL with duplicated query parameters like `http://url.com?p1=1&p1=2` is not covered.

fixes: https://github.com/Azure/azure-sdk-for-c/issues/517