### PR TITLE
Fix DPS Sample documentation

### DIFF
--- a/sdk/samples/iot/provisioning/README.md
+++ b/sdk/samples/iot/provisioning/README.md
@@ -14,9 +14,9 @@ urlFragment: iot-provisioning-samples
 ## Introduction
 This document explains samples for the Azure Embedded C SDK IoT Device Provisioning Client and how to use them.
 
-Samples are designed to highlight the function calls required to connect with the Device Provisioning Service (DPS). These calls illustrate the happy path of the [mqtt state machine](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/docs/iot/mqtt_state_machine.md). As a result,  **these samples are NOT designed to be used as production-level code**. Production code needs to incorporate other elements, such as connection retries and more extensive error-handling, which these samples do not include.  These samples also utilizes OpenSSL, which is **NOT recommended to use in production code on Windows or macOS**.
+Samples are designed to highlight the function calls required to connect with the Device Provisioning Service (DPS). These calls illustrate the happy path of the [mqtt state machine](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/docs/iot/mqtt_state_machine.md). As a result, **these samples are NOT designed to be used as production-level code**. Production code needs to incorporate other elements, such as connection retries and more extensive error-handling, which these samples do not include. These samples also utilizes OpenSSL, which is **NOT recommended to use in production code on Windows or macOS**.
 
-The samples' instructions include specifics for both Windows and Linux based systems.  For Windows, the command line examples are based on the Command Prompt and not PowerShell.  The Linux examples are tailored to Debian/Ubuntu environments.  Samples are also designed to work on macOS systems, but the instructions do not yet include specific command line examples for this environment.
+The samples' instructions include specifics for both Windows and Linux based systems. For Windows, the command line examples are based on the Command Prompt and not PowerShell. The Linux examples are tailored to Debian/Ubuntu environments. Samples are also designed to work on macOS systems, but the instructions do not yet include specific command line examples for this environment.
 
 ## Key Concepts
 
@@ -41,11 +41,11 @@ Further background on the Azure IoT Client library and key concepts are explaine
 	  ```
 	 * For Windows systems, have [Microsoft Visual Studio](https://visualstudio.microsoft.com/downloads/) installed.
 	 * For all systems, have the latest version of [CMake](https://cmake.org/download) installed.
-* Have Microsoft [VCPKG](https://github.com/microsoft/vcpkg) package manager and [Eclipse Paho MQTT C client](https://www.eclipse.org/paho/) installed.  Use the directions [here](https://github.com/Azure/azure-sdk-for-c#development-environment) to download VCPKG and install Paho MQTT.
+* Have Microsoft [VCPKG](https://github.com/microsoft/vcpkg) package manager and [Eclipse Paho MQTT C client](https://www.eclipse.org/paho/) installed. Use the directions [here](https://github.com/Azure/azure-sdk-for-c#development-environment) to download VCPKG and install Paho MQTT.
 
 ## Getting Started
 ### Environment Variables
-Samples use environment variables for a variety of purposes, including filepaths and connection parameters. Please keep in mind, every time a new terminal is opened, the environment variables will have to be reset.  Setting a variable will take the following form:
+Samples use environment variables for a variety of purposes, including filepaths and connection parameters. Please keep in mind, every time a new terminal is opened, the environment variables will have to be reset. Setting a variable will take the following form:
 
 Linux:
 ```bash
@@ -54,18 +54,18 @@ export ENV_VARIABLE_NAME=VALUE
 
 Windows:
 ```cmd
-set "ENV_VARIABLE_NAME=VALUE"
+set ENV_VARIABLE_NAME=VALUE
 ```
 
-Set the following environment  variables:
-  * `VCPKG_DEFAULT_TRIPLET` and `VCPKG_ROOT`: Refer to  these [directions](https://github.com/Azure/azure-sdk-for-c#development-environment).
+Set the following environment variables:
+  * `VCPKG_DEFAULT_TRIPLET` and `VCPKG_ROOT`: Refer to these [directions](https://github.com/Azure/azure-sdk-for-c#development-environment).
   * `AZ_IOT_DEVICE_X509_TRUST_PEM_FILE`: **Only for Windows or if required by OS.** Download [BaltimoreCyberTrustRoot.crt.pem](https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem) to `/azure-sdk-for-c/sdk/samples/iot/`. Copy the entire filepath to this downloaded .pem file, e.g. `C:/azure-sdk-for-c/sdk/samples/iot/BaltimoreCyberTrustRoot.crt.pem`.
 
 
 ### Paho IoT Provisioning (Certificates)
 **Executable:** paho_iot_provisioning_example
 
-This [sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/provisioning/src/paho_iot_provisioning_example.c) uses x509 authentication to connect to Azure IoT Hub Device Provisioning Service (DPS).  To easily run this sample, we have provided a script to generate a self-signed device certification used for device authentication.    **This script is intended for sample use only and not to be used in production code**.
+This [sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/provisioning/src/paho_iot_provisioning_example.c) uses x509 authentication to connect to Azure IoT Hub Device Provisioning Service (DPS). To easily run this sample, we have provided a script to generate a self-signed device certification used for device authentication. **This script is intended for sample use only and not to be used in production code**.
 1. Enter the directory `/azure-sdk-for-c/sdk/samples/iot/provisioning/src/` and run the script using the following form:
 
     Linux:

--- a/sdk/samples/iot/provisioning/README.md
+++ b/sdk/samples/iot/provisioning/README.md
@@ -59,7 +59,7 @@ set ENV_VARIABLE_NAME=VALUE
 
 Set the following environment variables:
   * `VCPKG_DEFAULT_TRIPLET` and `VCPKG_ROOT`: Refer to these [directions](https://github.com/Azure/azure-sdk-for-c#development-environment).
-  * `AZ_IOT_DEVICE_X509_TRUST_PEM_FILE`: **Only for Windows or if required by OS.** Download [BaltimoreCyberTrustRoot.crt.pem](https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem) to `/azure-sdk-for-c/sdk/samples/iot/`. Copy the entire filepath to this downloaded .pem file, e.g. `C:/azure-sdk-for-c/sdk/samples/iot/BaltimoreCyberTrustRoot.crt.pem`.
+  * `AZ_IOT_DEVICE_X509_TRUST_PEM_FILE`: **Only for Windows or if required by OS.** Download [BaltimoreCyberTrustRoot.crt.pem](https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem) to `/azure-sdk-for-c/sdk/samples/iot/`. Copy the full filepath to this downloaded .pem file, e.g. `C:/azure-sdk-for-c/sdk/samples/iot/BaltimoreCyberTrustRoot.crt.pem`.
 
 
 ### Paho IoT Provisioning (Certificates)

--- a/sdk/samples/iot/provisioning/README.md
+++ b/sdk/samples/iot/provisioning/README.md
@@ -76,7 +76,7 @@ This [sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/i
     ```cmd
     generate_certificate.cmd
     ```
-2. In your Azure DPS, add a new individual device enrollment using the recently generated `device_ec_cert.pem` file.  See [here](https://docs.microsoft.com/en-us/azure/iot-dps/quick-create-simulated-device-x509#create-a-device-enrollment-entry-in-the-portal) for further instruction.  After creation, the Registration ID of your device should appear as `paho-sample-device1` in the Individual Enrollments tab.
+2. In your Azure DPS, add a new individual device enrollment using the recently generated `device_ec_cert.pem` file. See [here](https://docs.microsoft.com/en-us/azure/iot-dps/quick-create-simulated-device-x509#create-a-device-enrollment-entry-in-the-portal) for further instruction. After creation, the Registration ID of your device should appear as `paho-sample-device1` in the Individual Enrollments tab.
 3. Set the following environment variables:
 *  `AZ_IOT_DEVICE_X509_CERT_PEM_FILE`: Copy the path of the generated .pem file noted at the bottom of the generate_certificate output.
 *  `AZ_IOT_REGISTRATION_ID`: This should be `paho-sample-device1`.
@@ -97,7 +97,7 @@ This [sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/i
 ## Build and Run the Sample
 
 1. Compile the code:
-  * Enter the directory `/azure-sdk-for-c/cmake`.  If it does not exist, please create it.
+  * Enter the directory `/azure-sdk-for-c/cmake`. If it does not exist, please create it.
   * Build the directory structure and the samples:
 
     ```bash

--- a/sdk/samples/iot/provisioning/README.md
+++ b/sdk/samples/iot/provisioning/README.md
@@ -44,8 +44,28 @@ Further background on the Azure IoT Client library and key concepts are explaine
 * Have Microsoft [VCPKG](https://github.com/microsoft/vcpkg) package manager and [Eclipse Paho MQTT C client](https://www.eclipse.org/paho/) installed.  Use the directions [here](https://github.com/Azure/azure-sdk-for-c#development-environment) to download VCPKG and install Paho MQTT.
 
 ## Getting Started
+### Environment Variables
+Samples use environment variables for a variety of purposes, including filepaths and connection parameters. Please keep in mind, every time a new terminal is opened, the environment variables will have to be reset.  Setting a variable will take the following form:
 
-All samples require either x509 certification or SAS symmetric key authentication to connect to Azure IoT Hub Device Provisioning Service (DPS).  To easily run this sample, we have provided a script to generate a self-signed device certification used for device authentication.  Three different `.pem` files will be produced.  **This script is intended for sample use only and not to be used in production code**.
+Linux:
+```bash
+export ENV_VARIABLE_NAME=VALUE
+```
+
+Windows:
+```cmd
+set "ENV_VARIABLE_NAME=VALUE"
+```
+
+Set the following environment  variables:
+  * `VCPKG_DEFAULT_TRIPLET` and `VCPKG_ROOT`: Refer to  these [directions](https://github.com/Azure/azure-sdk-for-c#development-environment).
+  * `AZ_IOT_DEVICE_X509_TRUST_PEM_FILE`: **Only for Windows or if required by OS.** Download [BaltimoreCyberTrustRoot.crt.pem](https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem) to `/azure-sdk-for-c/sdk/samples/iot/`. Copy the entire filepath to this downloaded .pem file, e.g. `C:/azure-sdk-for-c/sdk/samples/iot/BaltimoreCyberTrustRoot.crt.pem`.
+
+
+### Paho IoT Provisioning (Certificates)
+**Executable:** paho_iot_provisioning_example
+
+This [sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/provisioning/src/paho_iot_provisioning_example.c) uses x509 authentication to connect to Azure IoT Hub Device Provisioning Service (DPS).  To easily run this sample, we have provided a script to generate a self-signed device certification used for device authentication.    **This script is intended for sample use only and not to be used in production code**.
 1. Enter the directory `/azure-sdk-for-c/sdk/samples/iot/provisioning/src/` and run the script using the following form:
 
     Linux:
@@ -56,49 +76,27 @@ All samples require either x509 certification or SAS symmetric key authenticatio
     ```cmd
     generate_certificate.cmd
     ```
-
-2. For Windows (or if required on your OS), set the environment variable `AZ_IOT_DEVICE_X509_TRUST_PEM_FILE` to the path of the BaltimoreCyberTrustRoot.crt.pem file noted near the bottom of the output. You must [download this pem file](https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem) and store it in the location specified by that filepath.
-
-3. The remaining output will be used in the next steps.
-### #Paho IoT Provisioning (Certificates)
-**Executable:** paho_iot_provisioning_sample
-
-This [sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/provisioning/src/paho_iot_provisioning_example.c) uses x509 authentication to connect to Azure IoT Hub Device Provisioning Service (DPS).
-1. Set the environment variable `AZ_IOT_DEVICE_X509_CERT_PEM_FILE` to the path of the generated .pem file noted at the bottom of the output.
-
 2. In your Azure DPS, add a new individual device enrollment using the recently generated `device_ec_cert.pem` file.  See [here](https://docs.microsoft.com/en-us/azure/iot-dps/quick-create-simulated-device-x509#create-a-device-enrollment-entry-in-the-portal) for further instruction.  After creation, the Registration ID of your device should appear as `paho-sample-device1` in the Individual Enrollments tab.
+3. Set the following environment variables:
+*  `AZ_IOT_DEVICE_X509_CERT_PEM_FILE`: Copy the path of the generated .pem file noted at the bottom of the generate_certificate output.
+*  `AZ_IOT_REGISTRATION_ID`: This should be `paho-sample-device1`.
+*  `AZ_IOT_ID_SCOPE`: Copy this value from the Overview tab in your Azure DPS.
 
 ### Paho IoT Provisioning (SAS)
-**Executable:** paho_iot_provisioning_sas_sample
+**Executable:** paho_iot_provisioning_sas_example
 
 This [sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/provisioning/src/paho_iot_provisioning_sas_example.c) uses SAS symmetric key authentication to connect to Azure IoT Hub Device Provisioning Service (DPS).
 
-* In your Azure DPS, add a new individual device enrollment using SAS. See [here](https://docs.microsoft.com/en-us/azure/iot-dps/quick-create-simulated-device-symm-key#create-a-device-enrollment-entry-in-the-portal) for further instruction, with one exception--for the Primary Key, **you must use** the fingerprint noted in the output.  **Do NOT use** the *Auto-generate keys* option. After creation, the Registration ID of your device will appear in the Individual Enrollments tab.
+1. In your Azure DPS, add a new individual device enrollment using SAS. See [here](https://docs.microsoft.com/en-us/azure/iot-dps/quick-create-simulated-device-symm-key#create-a-device-enrollment-entry-in-the-portal) for further instruction. After creation, the Registration ID of your device will appear in the Individual Enrollments tab.
+
+2. Set the following environment variables:
+  * `AZ_IOT_PROVISIONING_SAS_KEY`: Select your enrolled device from the Individual Enrollments tab and copy its Primary Key.
+  * `AZ_IOT_REGISTRATION_ID_SAS`: Copy the Registration Id of your SAS device from the Individual Enrollments tab.
+  * `AZ_IOT_ID_SCOPE`: Copy this value from the Overview tab in your Azure DPS.
 
 ## Build and Run the Sample
 
-1. Set the remaining environment variables.  Setting a variable will take the following form:
-
-	  Linux:
-	  ```bash
-	  export ENV_VARIABLE_NAME=VALUE
-	  ```
-	  Windows:
-	  ```cmd
-	  set "ENV_VARIABLE_NAME=VALUE"
-	  ```
-	#### Paho IoT Provisioning (Certificates)
-  * `VCPKG_DEFAULT_TRIPLET` and `VCPKG_ROOT`: These should already be set per these [directions](https://github.com/Azure/azure-sdk-for-c#development-environment).
-  * `AZ_IOT_DEVICE_X509_CERT_PEM_FILE`: This should already be set per directions above.
-  * `AZ_IOT_ID_SCOPE`: Copy this value from the Overview tab in your Azure DPS.
-  * `AZ_IOT_REGISTRATION_ID`: This should be `paho-sample-device1`.
-	#### Paho IoT Provisioning (SAS)
-  * `VCPKG_DEFAULT_TRIPLET` and `VCPKG_ROOT`: These should already be set per these [directions](https://github.com/Azure/azure-sdk-for-c#development-environment).
-  * `AZ_IOT_PROVISIONING_SAS_KEY`: Select your enrolled device from the Individual Enrollments tab and copy its Primary Key.
-  * `AZ_IOT_ID_SCOPE`: Copy this value from the Overview tab in your Azure DPS.
-  * `AZ_IOT_REGISTRATION_ID_SAS`: Copy the Registration Id of your SAS device from the Individual Enrollments tab.
-
-2. Compile the code:
+1. Compile the code:
   * Enter the directory `/azure-sdk-for-c/cmake`.  If it does not exist, please create it.
   * Build the directory structure and the samples:
 
@@ -106,7 +104,7 @@ This [sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/i
     cmake -DTRANSPORT_PAHO=ON ..
     cmake --build .
     ```
-3. From within the cmake directory, run the sample:
+2. From within the cmake directory, run the sample:
 
     Linux:
     ```bash

--- a/sdk/samples/iot/provisioning/src/generate_certificate.cmd
+++ b/sdk/samples/iot/provisioning/src/generate_certificate.cmd
@@ -4,13 +4,13 @@
 @echo off
 
 openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
-IF %ERRORLEVEL% NEQ 0 ( 
+IF %ERRORLEVEL% NEQ 0 (
 echo "Failed generating certificate key"
 exit /b 1
 )
 
 openssl req -new -days 365 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -config x509_config.cfg -subj "/CN=paho-sample-device1"
-IF %ERRORLEVEL% NEQ 0 ( 
+IF %ERRORLEVEL% NEQ 0 (
 echo "Failed generating certificate"
 exit /b 1
 )
@@ -20,10 +20,6 @@ openssl x509 -noout -text -in device_ec_cert.pem
 type device_ec_cert.pem > device_cert_store.pem
 type device_ec_key.pem >> device_cert_store.pem
 
-FOR /F "tokens=*" %%a in ('openssl x509 -noout -fingerprint -in device_ec_cert.pem') do SET output=%%a
-set fingerprint=%output::=%
-echo %fingerprint% > fingerprint.txt
-
 echo.
 echo IMPORTANT:
 echo It is NOT recommended to use OpenSSL on Windows or OSX. Recommended TLS stacks are:
@@ -32,22 +28,8 @@ echo OR
 echo Apple Secure Transport : https://developer.apple.com/documentation/security/secure_transport
 echo If using OpenSSL, it is recommended to use the OpenSSL Trusted CA store configured on your system.
 echo.
-echo.
-echo SAS SAMPLES:
-echo Use the following fingerprint when enrolling your device in Device Provisioning Service.
-echo The fingerprint has also been placed in fingerprint.txt for future reference.
-echo.
-echo %fingerprint%
-echo.
-echo.
-echo CERTIFICATE SAMPLES:
-echo If required (for example on Windows), download the Baltimore PEM CA from https://www.digicert.com/digicert-root-certificates.htm to the current folder.
-echo Once it is downloaded, run the following command to set the environment variable for the samples:
-echo.
-echo        set "AZ_IOT_DEVICE_X509_TRUST_PEM_FILE=%CD%\BaltimoreCyberTrustRoot.crt.pem"
-echo.
-echo Sample certificate generated:
-echo Upload device_ec_cert.pem to Device Provisioning Service.
-echo Use the following command to set the environment variable for the samples:
+echo SAMPLE CERTIFICATE GENERATED:
+echo Upload device_ec_cert.pem when enrolling your device with the Device Provisioning Service.
+echo Use the following command to set the environment variable for the sample:
 echo.
 echo        set "AZ_IOT_DEVICE_X509_CERT_PEM_FILE=%CD%\device_cert_store.pem"

--- a/sdk/samples/iot/provisioning/src/generate_certificate.cmd
+++ b/sdk/samples/iot/provisioning/src/generate_certificate.cmd
@@ -32,4 +32,4 @@ echo SAMPLE CERTIFICATE GENERATED:
 echo Upload device_ec_cert.pem when enrolling your device with the Device Provisioning Service.
 echo Use the following command to set the environment variable for the sample:
 echo.
-echo        set "AZ_IOT_DEVICE_X509_CERT_PEM_FILE=%CD%\device_cert_store.pem"
+echo        set AZ_IOT_DEVICE_X509_CERT_PEM_FILE=%CD%\device_cert_store.pem

--- a/sdk/samples/iot/provisioning/src/generate_certificate.sh
+++ b/sdk/samples/iot/provisioning/src/generate_certificate.sh
@@ -20,19 +20,7 @@ echo "OR"
 echo "Apple Secure Transport : https://developer.apple.com/documentation/security/secure_transport"
 echo "If using OpenSSL, it is recommended to use the OpenSSL Trusted CA store configured on your system."
 
-echo -e "\n\nSAS SAMPLES:"
-
-echo "Use the following fingerprint when enrolling your device in Device Provisioning Service."
-echo -e "The fingerprint has also been placed in fingerprint.txt for future reference.\n"
-openssl x509 -noout -fingerprint -in device_ec_cert.pem | sed 's/://g'| tee fingerprint.txt
-
-echo -e "\n\nCERTIFICATE SAMPLES:"
-
-echo "If required (for example on Windows), download the Baltimore PEM CA from https://www.digicert.com/digicert-root-certificates.htm to the current folder."
-echo "Once it is downloaded, use the following command to set the environment variable for the samples:"
-echo -e "\n\texport AZ_IOT_DEVICE_X509_TRUST_PEM_FILE=$(pwd)/BaltimoreCyberTrustRoot.crt.pem"
-
-echo -e "\nSample certificate generated:"
-echo "Upload device_ec_cert.pem to Device Provisioning Service."
-echo "Use the following command to set the environment variable for the samples:"
+echo -e "\nSAMPLE CERTIFICATE GENERATED:"
+echo "Upload device_ec_cert.pem when enrolling your device with the Device Provisioning Service."
+echo "Use the following command to set the environment variable for the sample:"
 echo -e "\n\texport AZ_IOT_DEVICE_X509_CERT_PEM_FILE=$(pwd)/device_cert_store.pem"


### PR DESCRIPTION
* SAS auto generate primary key  -- will be logging a bug that auto generate key is not currently working within sample.
* TRUST Pem for SAS and Cert for Windows
* Remove TRUST Pem info from cert generate scrips since also required for SAS