### PR TITLE
Bump test metric thresholds to 90 and 65 from 85 and 60 (for line and branch coverage respectively).

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -273,8 +273,8 @@ jobs:
       checkCoverage: true
       coverageFailOption: fixed
       coverageType: branch
-      # 70% minimum branch coverage
-      coverageThreshold: 70
+      # 65% minimum branch coverage
+      coverageThreshold: 65
     condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
 - job: GenerateReleaseArtifacts

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -273,8 +273,8 @@ jobs:
       checkCoverage: true
       coverageFailOption: fixed
       coverageType: branch
-      # 65% minimum branch coverage
-      coverageThreshold: 65
+      # 70% minimum branch coverage
+      coverageThreshold: 70
     condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
 - job: GenerateReleaseArtifacts

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -263,8 +263,8 @@ jobs:
       checkCoverage: true
       coverageFailOption: fixed
       coverageType: line
-      # 85% minimum line coverage
-      coverageThreshold: 85
+      # 90% minimum line coverage
+      coverageThreshold: 90
     condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
   - task: mspremier.BuildQualityChecks.QualityChecks-task.BuildQualityChecks@6
@@ -273,8 +273,8 @@ jobs:
       checkCoverage: true
       coverageFailOption: fixed
       coverageType: branch
-      # 60% minimum branch coverage
-      coverageThreshold: 60
+      # 65% minimum branch coverage
+      coverageThreshold: 65
     condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
 - job: GenerateReleaseArtifacts


### PR DESCRIPTION
Even though we are above 90% line coverage already, I think either 90% (or maybe 95%) is a good line coverage bar to settle on. Anything higher as a CI blocking bar has diminishing returns.

Bumping branch coverage to 65%, and we should keep incrementing that one, to reach a goal of at least 80% (ideally that should settle around 85-90% as well).

Current snapshot:
![image](https://user-images.githubusercontent.com/6527137/88443759-6fbf8180-cdce-11ea-89b0-2fdff3b53ebb.png)

