### PR TITLE
Limit use of sscanf only to double parsing, using a custom implementation for {u}int{32|64} parsing.

### DIFF
--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -231,7 +231,7 @@ AZ_NODISCARD az_result az_span_atoi64(az_span source, int64_t* out_number)
   // else, (-1 * sign + 1) / 2 = 0
   // This is necessary to correctly account for the fact that the absolute value of INT64_MIN is 1
   // more than than the absolute value of INT64_MAX.
-  uint64_t sign_factor = (-1 * sign + 1) / 2;
+  uint64_t sign_factor = (uint64_t)(-1 * sign + 1) / 2;
 
   // Using unsigned int while parsing to account for potential overflow.
   uint64_t value = 0;
@@ -243,9 +243,9 @@ AZ_NODISCARD az_result az_span_atoi64(az_span source, int64_t* out_number)
     {
       return AZ_ERROR_UNEXPECTED_CHAR;
     }
-    int64_t const d = (int64_t)next_byte - '0';
+    uint64_t const d = (uint64_t)next_byte - '0';
 
-    if ((INT64_MAX - d + sign_factor) / 10 < value)
+    if ((uint64_t)(INT64_MAX - d + sign_factor) / 10 < value)
     {
       return AZ_ERROR_UNEXPECTED_CHAR;
     }
@@ -292,7 +292,7 @@ AZ_NODISCARD az_result az_span_atoi32(az_span source, int32_t* out_number)
   // else, (-1 * sign + 1) / 2 = 0
   // This is necessary to correctly account for the fact that the absolute value of INT32_MIN is 1
   // more than than the absolute value of INT32_MAX.
-  uint32_t sign_factor = (-1 * sign + 1) / 2;
+  uint32_t sign_factor = (uint32_t)(-1 * sign + 1) / 2;
 
   // Using unsigned int while parsing to account for potential overflow.
   uint32_t value = 0;
@@ -304,9 +304,9 @@ AZ_NODISCARD az_result az_span_atoi32(az_span source, int32_t* out_number)
     {
       return AZ_ERROR_UNEXPECTED_CHAR;
     }
-    int32_t const d = (int32_t)next_byte - '0';
+    uint32_t const d = (uint32_t)next_byte - '0';
 
-    if ((INT32_MAX - d + sign_factor) / 10 < value)
+    if ((uint32_t)(INT32_MAX - d + sign_factor) / 10 < value)
     {
       return AZ_ERROR_UNEXPECTED_CHAR;
     }

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -138,6 +138,9 @@ AZ_NODISCARD az_result az_span_atou64(az_span source, uint64_t* out_number)
       return AZ_ERROR_UNEXPECTED_CHAR;
     }
     uint64_t const d = (uint64_t)next_byte - '0';
+
+    // Check whether the next digit will cause an integer overflow.
+    // Before actually doing the math below, this is checking whether value * 10 + d > UINT64_MAX.
     if ((UINT64_MAX - d) / 10 < value)
     {
       return AZ_ERROR_UNEXPECTED_CHAR;
@@ -169,6 +172,8 @@ AZ_NODISCARD az_result az_span_atou32(az_span source, uint32_t* out_number)
 
   if (!isdigit(next_byte))
   {
+    // There must be another byte after a sign.
+    // The loop below checks that it must be a digit.
     if (next_byte != '+' || span_size < 2)
     {
       return AZ_ERROR_UNEXPECTED_CHAR;
@@ -186,6 +191,9 @@ AZ_NODISCARD az_result az_span_atou32(az_span source, uint32_t* out_number)
       return AZ_ERROR_UNEXPECTED_CHAR;
     }
     uint32_t const d = (uint32_t)next_byte - '0';
+
+    // Check whether the next digit will cause an integer overflow.
+    // Before actually doing the math below, this is checking whether value * 10 + d > UINT32_MAX.
     if ((UINT32_MAX - d) / 10 < value)
     {
       return AZ_ERROR_UNEXPECTED_CHAR;
@@ -253,6 +261,9 @@ AZ_NODISCARD az_result az_span_atoi64(az_span source, int64_t* out_number)
     }
     uint64_t const d = (uint64_t)next_byte - '0';
 
+    // Check whether the next digit will cause an integer overflow.
+    // Before actually doing the math below, this is checking whether value * 10 + d > INT64_MAX, or
+    // in the case of negative numbers, checking whether value * 10 + d > INT64_MAX + 1.
     if ((uint64_t)(INT64_MAX - d + sign_factor) / 10 < value)
     {
       return AZ_ERROR_UNEXPECTED_CHAR;
@@ -320,6 +331,9 @@ AZ_NODISCARD az_result az_span_atoi32(az_span source, int32_t* out_number)
     }
     uint32_t const d = (uint32_t)next_byte - '0';
 
+    // Check whether the next digit will cause an integer overflow.
+    // Before actually doing the math below, this is checking whether value * 10 + d > INT32_MAX, or
+    // in the case of negative numbers, checking whether value * 10 + d > INT32_MAX + 1.
     if ((uint32_t)(INT32_MAX - d + sign_factor) / 10 < value)
     {
       return AZ_ERROR_UNEXPECTED_CHAR;
@@ -366,7 +380,8 @@ AZ_NODISCARD az_result az_span_atod(az_span source, double* out_number)
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
 
-  // Stack based string to allow thread-safe mutation by _az_span_ato_number_helper
+  // Stack based string to allow thread-safe mutation.
+  // The length is 8 to allow space for the null-terminating character.
   char format[8] = "%00lf%n";
 
   // Starting at 1 to skip the '%' character

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -119,7 +119,9 @@ AZ_NODISCARD az_result az_span_atou64(az_span source, uint64_t* out_number)
 
   if (!isdigit(next_byte))
   {
-    if (next_byte != '+')
+    // There must be another byte after a sign.
+    // The loop below checks that it must be a digit.
+    if (next_byte != '+' || span_size < 2)
     {
       return AZ_ERROR_UNEXPECTED_CHAR;
     }
@@ -167,7 +169,7 @@ AZ_NODISCARD az_result az_span_atou32(az_span source, uint32_t* out_number)
 
   if (!isdigit(next_byte))
   {
-    if (next_byte != '+')
+    if (next_byte != '+' || span_size < 2)
     {
       return AZ_ERROR_UNEXPECTED_CHAR;
     }
@@ -212,10 +214,12 @@ AZ_NODISCARD az_result az_span_atoi64(az_span source, int64_t* out_number)
   int32_t starting_index = 0;
   uint8_t* source_ptr = az_span_ptr(source);
   uint8_t next_byte = source_ptr[0];
-  int32_t sign = 1;
+  int64_t sign = 1;
 
   if (!isdigit(next_byte))
   {
+    // There must be another byte after a sign.
+    // The loop below checks that it must be a digit.
     if (next_byte != '+')
     {
       if (next_byte != '-')
@@ -223,6 +227,10 @@ AZ_NODISCARD az_result az_span_atoi64(az_span source, int64_t* out_number)
         return AZ_ERROR_UNEXPECTED_CHAR;
       }
       sign = -1;
+    }
+    if (span_size < 2)
+    {
+      return AZ_ERROR_UNEXPECTED_CHAR;
     }
     starting_index++;
   }
@@ -277,6 +285,8 @@ AZ_NODISCARD az_result az_span_atoi32(az_span source, int32_t* out_number)
 
   if (!isdigit(next_byte))
   {
+    // There must be another byte after a sign.
+    // The loop below checks that it must be a digit.
     if (next_byte != '+')
     {
       if (next_byte != '-')
@@ -284,6 +294,10 @@ AZ_NODISCARD az_result az_span_atoi32(az_span source, int32_t* out_number)
         return AZ_ERROR_UNEXPECTED_CHAR;
       }
       sign = -1;
+    }
+    if (span_size < 2)
+    {
+      return AZ_ERROR_UNEXPECTED_CHAR;
     }
     starting_index++;
   }

--- a/sdk/tests/core/test_az_span.c
+++ b/sdk/tests/core/test_az_span.c
@@ -164,12 +164,23 @@ static void az_span_atox_return_errors(void** state)
 
   az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("test"));
   az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR(" "));
+  az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR(" 1"));
+  az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("-"));
+  az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("+"));
+  az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("--1"));
+  az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("++1"));
+  az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("-+"));
+  az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("+-"));
+  az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("-0+"));
+  az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("0-"));
+  az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("+0-"));
   az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("1-"));
   az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("123a"));
   az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("123,"));
   az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("123 "));
   az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("--123"));
   az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("-+123"));
+  az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("+-123"));
   az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("  -1-"));
   az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("- INFINITY"));
   az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("- 0"));
@@ -177,6 +188,9 @@ static void az_span_atox_return_errors(void** state)
   az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("1.-e3"));
   az_span_atox_return_errors_helper(AZ_SPAN_FROM_STR("1.-e/3"));
   az_span_atox_return_errors_helper_exclude_double(AZ_SPAN_FROM_STR("1.23"));
+  az_span_atox_return_errors_helper_exclude_double(AZ_SPAN_FROM_STR("-1.23"));
+  az_span_atox_return_errors_helper_exclude_double(AZ_SPAN_FROM_STR("11e2"));
+  az_span_atox_return_errors_helper_exclude_double(AZ_SPAN_FROM_STR("-1.1e+2"));
   az_span_atox_return_errors_helper_exclude_double(AZ_SPAN_FROM_STR("1.23e3"));
   az_span_atox_return_errors_helper_exclude_double(AZ_SPAN_FROM_STR("99999999999999999999"));
   az_span_atox_return_errors_helper_exclude_double(AZ_SPAN_FROM_STR("999999999999999999999"));
@@ -223,11 +237,6 @@ static void az_span_atou32_test(void** state)
       az_span_atou32(AZ_SPAN_FROM_STR("9223372036854775808"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
       az_span_atou32(AZ_SPAN_FROM_STR("18446744073709551615"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("-42"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("-1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("11e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("1.1e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
 }
 
 static void az_span_atoi32_test(void** state)
@@ -264,10 +273,6 @@ static void az_span_atoi32_test(void** state)
       az_span_atoi32(AZ_SPAN_FROM_STR("-4294967296"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
       az_span_atoi32(AZ_SPAN_FROM_STR("9223372036854775807"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("-1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("11e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("1.1e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
 }
 
 static void az_span_atou64_test(void** state)
@@ -294,17 +299,13 @@ static void az_span_atou64_test(void** state)
   assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("000018446744073709551615"), &value), AZ_OK);
   assert_int_equal(value, 18446744073709551615UL);
 
+  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("-123"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
       az_span_atou64(AZ_SPAN_FROM_STR("184467440737095516150"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
       az_span_atou64(AZ_SPAN_FROM_STR("18446744073709551616"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
       az_span_atou64(AZ_SPAN_FROM_STR("-9223372036854775809"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("-42"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("-1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("11e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("1.1e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
 }
 
 static void az_span_atoi64_test(void** state)
@@ -349,10 +350,6 @@ static void az_span_atoi64_test(void** state)
       az_span_atoi64(AZ_SPAN_FROM_STR("18446744073709551616"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
       az_span_atoi64(AZ_SPAN_FROM_STR("-9223372036854775809"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("-1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("11e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("1.1e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
 }
 
 // Disable warning for float comparisons, for this particular test

--- a/sdk/tests/core/test_az_span.c
+++ b/sdk/tests/core/test_az_span.c
@@ -193,13 +193,20 @@ static void az_span_atou32_test(void** state)
   assert_int_equal(value, 0);
   assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("1024"), &value), AZ_OK);
   assert_int_equal(value, 1024);
+  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("+1024"), &value), AZ_OK);
+  assert_int_equal(value, 1024);
+  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("001024"), &value), AZ_OK);
+  assert_int_equal(value, 1024);
   assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("2147483647"), &value), AZ_OK);
   assert_int_equal(value, 2147483647);
   assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("4294967295"), &value), AZ_OK);
   assert_int_equal(value, 4294967295);
+  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("00004294967295"), &value), AZ_OK);
+  assert_int_equal(value, 4294967295);
 
+  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("-123"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
-      az_span_atou32(AZ_SPAN_FROM_STR("-123"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+      az_span_atou32(AZ_SPAN_FROM_STR("42949672950"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
       az_span_atou32(AZ_SPAN_FROM_STR("-2147483648"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
@@ -211,14 +218,16 @@ static void az_span_atou32_test(void** state)
   assert_int_equal(
       az_span_atou32(AZ_SPAN_FROM_STR("42949672950"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
-      az_span_atou32(AZ_SPAN_FROM_STR("9223372036854775807"), &value),
-      AZ_ERROR_UNEXPECTED_CHAR);
+      az_span_atou32(AZ_SPAN_FROM_STR("9223372036854775807"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
-      az_span_atou32(AZ_SPAN_FROM_STR("9223372036854775808"), &value),
-      AZ_ERROR_UNEXPECTED_CHAR);
+      az_span_atou32(AZ_SPAN_FROM_STR("9223372036854775808"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
-      az_span_atou32(AZ_SPAN_FROM_STR("18446744073709551615"), &value),
-      AZ_ERROR_UNEXPECTED_CHAR);
+      az_span_atou32(AZ_SPAN_FROM_STR("18446744073709551615"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("-42"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("-1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("11e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("1.1e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
 }
 
 static void az_span_atoi32_test(void** state)
@@ -230,13 +239,21 @@ static void az_span_atoi32_test(void** state)
   assert_int_equal(value, 0);
   assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("1024"), &value), AZ_OK);
   assert_int_equal(value, 1024);
+  assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("+1024"), &value), AZ_OK);
+  assert_int_equal(value, 1024);
   assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("-1024"), &value), AZ_OK);
   assert_int_equal(value, -1024);
+  assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("001024"), &value), AZ_OK);
+  assert_int_equal(value, 1024);
   assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("2147483647"), &value), AZ_OK);
   assert_int_equal(value, 2147483647);
   assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("-2147483648"), &value), AZ_OK);
   assert_int_equal(value, -2147483647 - 1);
+  assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("-00002147483648"), &value), AZ_OK);
+  assert_int_equal(value, -2147483647 - 1);
 
+  assert_int_equal(
+      az_span_atoi32(AZ_SPAN_FROM_STR("21474836470"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
       az_span_atoi32(AZ_SPAN_FROM_STR("2147483648"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
@@ -246,8 +263,11 @@ static void az_span_atoi32_test(void** state)
   assert_int_equal(
       az_span_atoi32(AZ_SPAN_FROM_STR("-4294967296"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
-      az_span_atoi32(AZ_SPAN_FROM_STR("9223372036854775807"), &value),
-      AZ_ERROR_UNEXPECTED_CHAR);
+      az_span_atoi32(AZ_SPAN_FROM_STR("9223372036854775807"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("-1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("11e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("1.1e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
 }
 
 static void az_span_atou64_test(void** state)
@@ -259,6 +279,10 @@ static void az_span_atou64_test(void** state)
   assert_int_equal(value, 0);
   assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("1024"), &value), AZ_OK);
   assert_int_equal(value, 1024);
+  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("+1024"), &value), AZ_OK);
+  assert_int_equal(value, 1024);
+  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("001024"), &value), AZ_OK);
+  assert_int_equal(value, 1024);
   assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("2147483647"), &value), AZ_OK);
   assert_int_equal(value, 2147483647);
   assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("4294967295"), &value), AZ_OK);
@@ -267,19 +291,20 @@ static void az_span_atou64_test(void** state)
   assert_int_equal(value, 9223372036854775807UL);
   assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("18446744073709551615"), &value), AZ_OK);
   assert_int_equal(value, 18446744073709551615UL);
+  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("000018446744073709551615"), &value), AZ_OK);
+  assert_int_equal(value, 18446744073709551615UL);
 
   assert_int_equal(
-      az_span_atou64(AZ_SPAN_FROM_STR("18446744073709551616"), &value),
-      AZ_ERROR_UNEXPECTED_CHAR);
+      az_span_atou64(AZ_SPAN_FROM_STR("184467440737095516150"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
-      az_span_atou64(AZ_SPAN_FROM_STR("-9223372036854775809"), &value),
-      AZ_ERROR_UNEXPECTED_CHAR);
+      az_span_atou64(AZ_SPAN_FROM_STR("18446744073709551616"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
-      az_span_atou64(AZ_SPAN_FROM_STR("-42"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atou64(AZ_SPAN_FROM_STR("1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atou64(AZ_SPAN_FROM_STR("-1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+      az_span_atou64(AZ_SPAN_FROM_STR("-9223372036854775809"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("-42"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("-1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("11e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("1.1e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
 }
 
 static void az_span_atoi64_test(void** state)
@@ -291,8 +316,12 @@ static void az_span_atoi64_test(void** state)
   assert_int_equal(value, 0);
   assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("1024"), &value), AZ_OK);
   assert_int_equal(value, 1024);
+  assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("+1024"), &value), AZ_OK);
+  assert_int_equal(value, 1024);
   assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("-1024"), &value), AZ_OK);
   assert_int_equal(value, -1024);
+  assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("001024"), &value), AZ_OK);
+  assert_int_equal(value, 1024);
   assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("2147483647"), &value), AZ_OK);
   assert_int_equal(value, 2147483647);
   assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("-2147483648"), &value), AZ_OK);
@@ -305,23 +334,25 @@ static void az_span_atoi64_test(void** state)
   assert_int_equal(value, 9223372036854775807L);
   assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("-9223372036854775808"), &value), AZ_OK);
   assert_int_equal(value, -9223372036854775807L - 1);
+  assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("-00009223372036854775808"), &value), AZ_OK);
+  assert_int_equal(value, -9223372036854775807L - 1);
 
   assert_int_equal(
-      az_span_atoi64(AZ_SPAN_FROM_STR("9223372036854775808"), &value),
-      AZ_ERROR_UNEXPECTED_CHAR);
+      az_span_atoi64(AZ_SPAN_FROM_STR("92233720368547758070"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
-      az_span_atoi64(AZ_SPAN_FROM_STR("18446744073709551615"), &value),
-      AZ_ERROR_UNEXPECTED_CHAR);
+      az_span_atoi64(AZ_SPAN_FROM_STR("12233720368547758070"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
-      az_span_atoi64(AZ_SPAN_FROM_STR("18446744073709551616"), &value),
-      AZ_ERROR_UNEXPECTED_CHAR);
+      az_span_atoi64(AZ_SPAN_FROM_STR("9223372036854775808"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
-      az_span_atoi64(AZ_SPAN_FROM_STR("-9223372036854775809"), &value),
-      AZ_ERROR_UNEXPECTED_CHAR);
+      az_span_atoi64(AZ_SPAN_FROM_STR("18446744073709551615"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
-      az_span_atoi64(AZ_SPAN_FROM_STR("1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+      az_span_atoi64(AZ_SPAN_FROM_STR("18446744073709551616"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
-      az_span_atoi64(AZ_SPAN_FROM_STR("-1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+      az_span_atoi64(AZ_SPAN_FROM_STR("-9223372036854775809"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("-1.2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("11e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("1.1e2"), &value), AZ_ERROR_UNEXPECTED_CHAR);
 }
 
 // Disable warning for float comparisons, for this particular test
@@ -554,8 +585,7 @@ static void az_span_atod_test(void** state)
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1.8e309"), &value), AZ_OK);
   assert_true(value == INFINITY);
 #else
-  assert_int_equal(
-      az_span_atod(AZ_SPAN_FROM_STR("1.8e309"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1.8e309"), &value), AZ_ERROR_UNEXPECTED_CHAR);
 #endif // _MSC_VER
 }
 
@@ -584,41 +614,25 @@ static void az_span_ato_number_whitespace_or_invalid_not_allowed(void** state)
       az_span_atoi64(AZ_SPAN_FROM_STR("   123"), &value_i64), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
       az_span_atou64(AZ_SPAN_FROM_STR("   123"), &value_u64), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atod(AZ_SPAN_FROM_STR("   123"), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("   123"), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
 
-  assert_int_equal(
-      az_span_atoi32(AZ_SPAN_FROM_STR("\n123"), &value_i32), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atou32(AZ_SPAN_FROM_STR("\n123"), &value_u32), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atoi64(AZ_SPAN_FROM_STR("\n123"), &value_i64), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atou64(AZ_SPAN_FROM_STR("\n123"), &value_u64), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atod(AZ_SPAN_FROM_STR("\n123"), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("\n123"), &value_i32), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("\n123"), &value_u32), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("\n123"), &value_i64), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("\n123"), &value_u64), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("\n123"), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
 
-  assert_int_equal(
-      az_span_atoi32(AZ_SPAN_FROM_STR("a123"), &value_i32), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atou32(AZ_SPAN_FROM_STR("a123"), &value_u32), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atoi64(AZ_SPAN_FROM_STR("a123"), &value_i64), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atou64(AZ_SPAN_FROM_STR("a123"), &value_u64), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atod(AZ_SPAN_FROM_STR("a123"), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("a123"), &value_i32), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("a123"), &value_u32), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("a123"), &value_i64), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("a123"), &value_u64), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("a123"), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
 
-  assert_int_equal(
-      az_span_atoi32(AZ_SPAN_FROM_STR("- 123"), &value_i32), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atou32(AZ_SPAN_FROM_STR("- 123"), &value_u32), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atoi64(AZ_SPAN_FROM_STR("- 123"), &value_i64), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atou64(AZ_SPAN_FROM_STR("- 123"), &value_u64), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atod(AZ_SPAN_FROM_STR("- 123"), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atoi32(AZ_SPAN_FROM_STR("- 123"), &value_i32), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou32(AZ_SPAN_FROM_STR("- 123"), &value_u32), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atoi64(AZ_SPAN_FROM_STR("- 123"), &value_i64), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atou64(AZ_SPAN_FROM_STR("- 123"), &value_u64), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("- 123"), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
 
   assert_int_equal(
       az_span_atoi32(AZ_SPAN_FROM_STR("-\n123"), &value_i32), AZ_ERROR_UNEXPECTED_CHAR);
@@ -628,8 +642,7 @@ static void az_span_ato_number_whitespace_or_invalid_not_allowed(void** state)
       az_span_atoi64(AZ_SPAN_FROM_STR("-\n123"), &value_i64), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(
       az_span_atou64(AZ_SPAN_FROM_STR("-\n123"), &value_u64), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atod(AZ_SPAN_FROM_STR("-\n123"), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-\n123"), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
 }
 
 static void az_span_ato_number_no_out_of_bounds_reads(void** state)
@@ -643,8 +656,7 @@ static void az_span_ato_number_no_out_of_bounds_reads(void** state)
   // within the span slice
   assert_int_equal(
       az_span_atoi32(az_span_slice(source, 0, 6), &value_i32), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atod(az_span_slice(source, 0, 6), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(az_span_slice(source, 0, 6), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
 
   assert_int_equal(az_span_atoi32(az_span_slice(source, 3, 6), &value_i32), AZ_OK);
   assert_int_equal(value_i32, 123);
@@ -656,8 +668,7 @@ static void az_span_ato_number_no_out_of_bounds_reads(void** state)
   // within the span slice
   assert_int_equal(
       az_span_atoi32(az_span_slice(source, 0, 6), &value_i32), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atod(az_span_slice(source, 0, 6), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(az_span_slice(source, 0, 6), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
 
   assert_int_equal(az_span_atoi32(az_span_slice(source, 3, 6), &value_i32), AZ_OK);
   assert_int_equal(value_i32, 123);
@@ -669,8 +680,7 @@ static void az_span_ato_number_no_out_of_bounds_reads(void** state)
   // within the span slice
   assert_int_equal(
       az_span_atoi32(az_span_slice(source, 0, 6), &value_i32), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atod(az_span_slice(source, 0, 6), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(az_span_slice(source, 0, 6), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
 
   assert_int_equal(az_span_atoi32(az_span_slice(source, 3, 6), &value_i32), AZ_OK);
   assert_int_equal(value_i32, 123);
@@ -680,8 +690,7 @@ static void az_span_ato_number_no_out_of_bounds_reads(void** state)
   source = AZ_SPAN_FROM_STR("   123-");
   assert_int_equal(
       az_span_atoi32(az_span_slice(source, 0, 6), &value_i32), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atod(az_span_slice(source, 0, 6), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(az_span_slice(source, 0, 6), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
 
   assert_int_equal(az_span_atoi32(az_span_slice(source, 3, 6), &value_i32), AZ_OK);
   assert_int_equal(value_i32, 123);
@@ -691,13 +700,11 @@ static void az_span_ato_number_no_out_of_bounds_reads(void** state)
   source = AZ_SPAN_FROM_STR("   12-4");
   assert_int_equal(
       az_span_atoi32(az_span_slice(source, 0, 6), &value_i32), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atod(az_span_slice(source, 0, 6), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(az_span_slice(source, 0, 6), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
 
   assert_int_equal(
       az_span_atoi32(az_span_slice(source, 3, 6), &value_i32), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(
-      az_span_atod(az_span_slice(source, 3, 6), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(az_span_slice(source, 3, 6), &value_d), AZ_ERROR_UNEXPECTED_CHAR);
 
   source = AZ_SPAN_FROM_STR("n1");
   assert_int_equal(az_span_atoi32(source, &value_i32), AZ_ERROR_UNEXPECTED_CHAR);

--- a/sdk/tests/core/test_az_span.c
+++ b/sdk/tests/core/test_az_span.c
@@ -376,6 +376,10 @@ static void az_span_atod_test(void** state)
   assert_true(value == 0);
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1024"), &value), AZ_OK);
   assert_true(value == 1024);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("+1024"), &value), AZ_OK);
+  assert_true(value == 1024);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("001024"), &value), AZ_OK);
+  assert_true(value == 1024);
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-1024"), &value), AZ_OK);
   assert_true(value == -1024);
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("2147483647"), &value), AZ_OK);
@@ -392,6 +396,8 @@ static void az_span_atod_test(void** state)
   assert_true(value == -2147483647 * (double)4294967298);
 
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1.23e3"), &value), AZ_OK);
+  assert_true(value == 1.23e3);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("+001.23e3"), &value), AZ_OK);
   assert_true(value == 1.23e3);
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1.23"), &value), AZ_OK);
   assert_true(value == 1.23);
@@ -566,6 +572,14 @@ static void az_span_atod_test(void** state)
   assert_int_equal(
       az_span_atod(AZ_SPAN_FROM_STR("18446744073709551615.18446744073709551615"), &value), AZ_OK);
   assert_true(value == 18446744073709551615.18446744073709551615);
+  assert_int_equal(
+      az_span_atod(AZ_SPAN_FROM_STR("+000018446744073709551615.18446744073709551615"), &value),
+      AZ_OK);
+  assert_true(value == 18446744073709551615.18446744073709551615);
+  assert_int_equal(
+      az_span_atod(AZ_SPAN_FROM_STR("-000018446744073709551615.18446744073709551615"), &value),
+      AZ_OK);
+  assert_true(value == -18446744073709551615.18446744073709551615);
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1e16"), &value), AZ_OK);
   assert_true(value == 1e16);
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("12345.123e15"), &value), AZ_OK);


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/962

- Leading zeroes are allowed and ignored, just like `sscanf`.
- Leading optional `+` sign is allowed and ignored, just like `sscanf`.
- Integers in scientific notation using `e` are not allowed, just like `sscanf` (for example `1.1e1` or `11e1`).
- Avoid using `int64_t` or `uint64_t` in the implementation of `int32_t` and `uint32_t` parsing. Is this necessary? We can avoid some duplication (and possibly reduce code size) if we don't have this requirement.
- This PR does not change `double` parsing, leaving the implementation as is (aside from some code refactoring since the common helper `_az_span_ato_number_helper` isn't needed anymore).

cc @bo-ms, @hihigupt, @yuxin-azrtos