### PR TITLE
Remove support for non-finite double values while parsing/formatting and update tests.

### DIFF
--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -138,7 +138,8 @@ AZ_NODISCARD az_result az_json_token_get_int32(az_json_token const* json_token, 
  * @param json_token A pointer to an #az_json_token instance.
  * @param out_value A pointer to a variable to receive the value.
  * @return AZ_OK if the number is returned.<br>
- * AZ_ERROR_JSON_INVALID_STATE if the kind != AZ_JSON_TOKEN_NUMBER.
+ * AZ_ERROR_JSON_INVALID_STATE if the kind != AZ_JSON_TOKEN_NUMBER.<br>
+ * AZ_ERROR_UNEXPECTED_CHAR if the resulting \p out_value wouldn't be a finite double number
  */
 AZ_NODISCARD az_result az_json_token_get_double(az_json_token const* json_token, double* out_value);
 

--- a/sdk/inc/azure/core/az_span.h
+++ b/sdk/inc/azure/core/az_span.h
@@ -350,7 +350,7 @@ AZ_NODISCARD az_result az_span_atoi32(az_span source, int32_t* out_number);
  * @return An #az_result value indicating the result of the operation:
  *         - #AZ_OK if successful
  *         - #AZ_ERROR_UNEXPECTED_CHAR if a non-ASCII digit or an invalid character is found
- * within the span, or if the resulting \p out_number wouldn't be a finite number
+ * within the span, or if the resulting \p out_number wouldn't be a finite double number
  *
  * @remark The #az_span being parsed must contain a number that is finite. Values such as NAN,
  * INFINITY, and those that would overflow a double to +/-inf are not allowed.

--- a/sdk/inc/azure/core/az_span.h
+++ b/sdk/inc/azure/core/az_span.h
@@ -350,7 +350,10 @@ AZ_NODISCARD az_result az_span_atoi32(az_span source, int32_t* out_number);
  * @return An #az_result value indicating the result of the operation:
  *         - #AZ_OK if successful
  *         - #AZ_ERROR_UNEXPECTED_CHAR if a non-ASCII digit or an invalid character is found
- * within the span
+ * within the span, or if the resulting \p out_number wouldn't be a finite number
+ *
+ * @remark The #az_span being parsed must contain a number that is finite. Values such as NAN,
+ * INFINITY, and those that would overflow a double to +/-inf are not allowed.
  */
 AZ_NODISCARD az_result az_span_atod(az_span source, double* out_number);
 
@@ -433,8 +436,10 @@ AZ_NODISCARD az_result az_span_u64toa(az_span destination, uint64_t source, az_s
  *         - #AZ_OK if successful
  *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p destination is not big enough to contain the
  * copied bytes
- *         - #AZ_ERROR_NOT_SUPPORTED if the \p source contains an integer component that is too
- * large and would overflow beyond 2^53 - 1.
+ *         - #AZ_ERROR_NOT_SUPPORTED if the \p source is not a finite decimal number or contains an
+ * integer component that is too large and would overflow beyond 2^53 - 1.
+ *
+ * @remark Only finite double values are supported. Values such as NAN and INFINITY are not allowed.
  *
  * @remark Non-significant trailing zeros (after the decimal point) are not written, even if \p
  * fractional_digits is large enough to allow the zero padding.

--- a/sdk/tests/core/test_az_span.c
+++ b/sdk/tests/core/test_az_span.c
@@ -403,27 +403,6 @@ static void az_span_atod_test(void** state)
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("123.456e+78"), &value), AZ_OK);
   assert_true(value == 123.456e+78);
 
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("nan"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-nan"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("+nan"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  // assert_true(isnan(value));
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("inf"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("+inf"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  // assert_true(value == INFINITY);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-inf"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  // assert_true(value == -INFINITY);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("NAN"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  // assert_true(isnan(value));
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("INF"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("+INF"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  // assert_true(value == INFINITY);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-INF"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  // assert_true(value == -INFINITY);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("INFINITY"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("+INFINITY"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  // assert_true(value == INFINITY);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-INFINITY"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  // assert_true(value == -INFINITY);
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("0"), &value), AZ_OK);
   assert_true(value == 0);
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-0"), &value), AZ_OK);
@@ -606,10 +585,6 @@ static void az_span_atod_test(void** state)
   assert_true(value == 0);
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-1e-400"), &value), AZ_OK);
   assert_true(value == 0);
-
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1.8e308"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-1.8e308"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1.8e309"), &value), AZ_ERROR_UNEXPECTED_CHAR);
 }
 
 #ifdef __GNUC__
@@ -619,6 +594,29 @@ static void az_span_atod_test(void** state)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif // __clang__
+
+static void az_span_atod_non_finite_not_allowed(void** state)
+{
+  (void)state;
+  double value = 0;
+
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("nan"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-nan"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("+nan"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("inf"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("+inf"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-inf"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("NAN"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("INF"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("+INF"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-INF"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("INFINITY"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("+INFINITY"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-INFINITY"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1.8e308"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-1.8e308"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1.8e309"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+}
 
 static void az_span_ato_number_whitespace_or_invalid_not_allowed(void** state)
 {
@@ -1399,9 +1397,6 @@ static void az_span_dtoa_succeeds(void** state)
   // [-][0-9]{16}.[0-9]{15}, i.e. 1+16+1+15
   uint8_t raw_buffer[33] = { 0 };
 
-  /*az_span_dtoa_succeeds_helper(NAN, 15, AZ_SPAN_FROM_STR("nan"));
-  az_span_dtoa_succeeds_helper(INFINITY, 15, AZ_SPAN_FROM_STR("inf"));
-  az_span_dtoa_succeeds_helper(-INFINITY, 15, AZ_SPAN_FROM_STR("-inf"));*/
   az_span_dtoa_succeeds_helper(0, 15, AZ_SPAN_FROM_STR("0"));
   az_span_dtoa_succeeds_helper(1., 15, AZ_SPAN_FROM_STR("1"));
   az_span_dtoa_succeeds_helper(1.e3, 15, AZ_SPAN_FROM_STR("1000"));
@@ -1469,9 +1464,6 @@ static void az_span_dtoa_succeeds(void** state)
       12345.12300000010e5, 15, AZ_SPAN_FROM_STR("1234512300.000010013580322"));
   az_span_dtoa_succeeds_helper(1e-300, 15, AZ_SPAN_FROM_STR("0"));
 
-  /* az_span_dtoa_succeeds_helper(NAN, 2, AZ_SPAN_FROM_STR("nan"));
-   az_span_dtoa_succeeds_helper(INFINITY, 2, AZ_SPAN_FROM_STR("inf"));
-   az_span_dtoa_succeeds_helper(-INFINITY, 2, AZ_SPAN_FROM_STR("-inf"));*/
   az_span_dtoa_succeeds_helper(0, 2, AZ_SPAN_FROM_STR("0"));
   az_span_dtoa_succeeds_helper(1., 2, AZ_SPAN_FROM_STR("1"));
   az_span_dtoa_succeeds_helper(1.e3, 2, AZ_SPAN_FROM_STR("1000"));
@@ -1548,13 +1540,6 @@ static void az_span_dtoa_overflow_fails(void** state)
   az_span buff = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span o;
 
-  /*assert_int_equal(
-      az_span_dtoa(az_span_slice(buff, 0, 2), NAN, 15, &o), AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-  assert_int_equal(
-      az_span_dtoa(az_span_slice(buff, 0, 2), INFINITY, 15, &o), AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
-  assert_int_equal(
-      az_span_dtoa(az_span_slice(buff, 0, 3), -INFINITY, 15, &o),
-  AZ_ERROR_INSUFFICIENT_SPAN_SIZE);*/
   assert_int_equal(
       az_span_dtoa(az_span_slice(buff, 0, 0), 0, 15, &o), AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
   assert_int_equal(
@@ -1991,6 +1976,7 @@ int test_az_span()
     cmocka_unit_test(az_span_atou64_test),
     cmocka_unit_test(az_span_atoi64_test),
     cmocka_unit_test(az_span_atod_test),
+    cmocka_unit_test(az_span_atod_non_finite_not_allowed),
     cmocka_unit_test(az_span_ato_number_whitespace_or_invalid_not_allowed),
     cmocka_unit_test(az_span_ato_number_no_out_of_bounds_reads),
     cmocka_unit_test(az_span_i64toa_negative_number_test),

--- a/sdk/tests/core/test_az_span.c
+++ b/sdk/tests/core/test_az_span.c
@@ -403,22 +403,27 @@ static void az_span_atod_test(void** state)
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("123.456e+78"), &value), AZ_OK);
   assert_true(value == 123.456e+78);
 
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("nan"), &value), AZ_OK);
-  assert_true(isnan(value));
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("inf"), &value), AZ_OK);
-  assert_true(value == INFINITY);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-inf"), &value), AZ_OK);
-  assert_true(value == -INFINITY);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("NAN"), &value), AZ_OK);
-  assert_true(isnan(value));
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("INF"), &value), AZ_OK);
-  assert_true(value == INFINITY);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-INF"), &value), AZ_OK);
-  assert_true(value == -INFINITY);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("INFINITY"), &value), AZ_OK);
-  assert_true(value == INFINITY);
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-INFINITY"), &value), AZ_OK);
-  assert_true(value == -INFINITY);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("nan"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-nan"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("+nan"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  // assert_true(isnan(value));
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("inf"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("+inf"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  // assert_true(value == INFINITY);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-inf"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  // assert_true(value == -INFINITY);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("NAN"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  // assert_true(isnan(value));
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("INF"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("+INF"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  // assert_true(value == INFINITY);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-INF"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  // assert_true(value == -INFINITY);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("INFINITY"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("+INFINITY"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  // assert_true(value == INFINITY);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-INFINITY"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  // assert_true(value == -INFINITY);
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("0"), &value), AZ_OK);
   assert_true(value == 0);
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-0"), &value), AZ_OK);
@@ -589,15 +594,22 @@ static void az_span_atod_test(void** state)
   assert_true(value == -1e300);
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1.7e308"), &value), AZ_OK);
   assert_true(value == 1.7e308);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-1.7e308"), &value), AZ_OK);
+  assert_true(value == -1.7e308);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("2.22507e-308"), &value), AZ_OK);
+  assert_true(value == 2.22507e-308);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-2.22507e-308"), &value), AZ_OK);
+  assert_true(value == -2.22507e-308);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("4.94e-325"), &value), AZ_OK);
+  assert_true(value == 0);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1e-400"), &value), AZ_OK);
+  assert_true(value == 0);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-1e-400"), &value), AZ_OK);
+  assert_true(value == 0);
 
-  // https://github.com/Azure/azure-sdk-for-c/issues/893
-  // The result of this depends on the compiler.
-#ifdef _MSC_VER
-  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1.8e309"), &value), AZ_OK);
-  assert_true(value == INFINITY);
-#else
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1.8e308"), &value), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("-1.8e308"), &value), AZ_ERROR_UNEXPECTED_CHAR);
   assert_int_equal(az_span_atod(AZ_SPAN_FROM_STR("1.8e309"), &value), AZ_ERROR_UNEXPECTED_CHAR);
-#endif // _MSC_VER
 }
 
 #ifdef __GNUC__
@@ -1387,9 +1399,9 @@ static void az_span_dtoa_succeeds(void** state)
   // [-][0-9]{16}.[0-9]{15}, i.e. 1+16+1+15
   uint8_t raw_buffer[33] = { 0 };
 
-  az_span_dtoa_succeeds_helper(NAN, 15, AZ_SPAN_FROM_STR("nan"));
+  /*az_span_dtoa_succeeds_helper(NAN, 15, AZ_SPAN_FROM_STR("nan"));
   az_span_dtoa_succeeds_helper(INFINITY, 15, AZ_SPAN_FROM_STR("inf"));
-  az_span_dtoa_succeeds_helper(-INFINITY, 15, AZ_SPAN_FROM_STR("-inf"));
+  az_span_dtoa_succeeds_helper(-INFINITY, 15, AZ_SPAN_FROM_STR("-inf"));*/
   az_span_dtoa_succeeds_helper(0, 15, AZ_SPAN_FROM_STR("0"));
   az_span_dtoa_succeeds_helper(1., 15, AZ_SPAN_FROM_STR("1"));
   az_span_dtoa_succeeds_helper(1.e3, 15, AZ_SPAN_FROM_STR("1000"));
@@ -1457,9 +1469,9 @@ static void az_span_dtoa_succeeds(void** state)
       12345.12300000010e5, 15, AZ_SPAN_FROM_STR("1234512300.000010013580322"));
   az_span_dtoa_succeeds_helper(1e-300, 15, AZ_SPAN_FROM_STR("0"));
 
-  az_span_dtoa_succeeds_helper(NAN, 2, AZ_SPAN_FROM_STR("nan"));
-  az_span_dtoa_succeeds_helper(INFINITY, 2, AZ_SPAN_FROM_STR("inf"));
-  az_span_dtoa_succeeds_helper(-INFINITY, 2, AZ_SPAN_FROM_STR("-inf"));
+  /* az_span_dtoa_succeeds_helper(NAN, 2, AZ_SPAN_FROM_STR("nan"));
+   az_span_dtoa_succeeds_helper(INFINITY, 2, AZ_SPAN_FROM_STR("inf"));
+   az_span_dtoa_succeeds_helper(-INFINITY, 2, AZ_SPAN_FROM_STR("-inf"));*/
   az_span_dtoa_succeeds_helper(0, 2, AZ_SPAN_FROM_STR("0"));
   az_span_dtoa_succeeds_helper(1., 2, AZ_SPAN_FROM_STR("1"));
   az_span_dtoa_succeeds_helper(1.e3, 2, AZ_SPAN_FROM_STR("1000"));
@@ -1536,12 +1548,13 @@ static void az_span_dtoa_overflow_fails(void** state)
   az_span buff = AZ_SPAN_FROM_BUFFER(raw_buffer);
   az_span o;
 
-  assert_int_equal(
+  /*assert_int_equal(
       az_span_dtoa(az_span_slice(buff, 0, 2), NAN, 15, &o), AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
   assert_int_equal(
       az_span_dtoa(az_span_slice(buff, 0, 2), INFINITY, 15, &o), AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
   assert_int_equal(
-      az_span_dtoa(az_span_slice(buff, 0, 3), -INFINITY, 15, &o), AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
+      az_span_dtoa(az_span_slice(buff, 0, 3), -INFINITY, 15, &o),
+  AZ_ERROR_INSUFFICIENT_SPAN_SIZE);*/
   assert_int_equal(
       az_span_dtoa(az_span_slice(buff, 0, 0), 0, 15, &o), AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
   assert_int_equal(


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/893