### PR TITLE
Use custom, portable implementation of IEEE 754 compliant isfinite since some embedded platforms don't have it.

### DIFF
--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -806,7 +806,7 @@ az_json_writer_append_double(az_json_writer* json_writer, double value, int32_t 
   _az_PRECONDITION(_az_is_appending_value_valid(json_writer));
   // Non-finite numbers are not supported because they lead to invalid JSON.
   // Unquoted strings such as nan and -inf are invalid as JSON numbers.
-  _az_PRECONDITION(isfinite(value));
+  _az_PRECONDITION(_az_is_finite(value));
   _az_PRECONDITION_RANGE(0, fractional_digits, _az_MAX_SUPPORTED_FRACTIONAL_DIGITS);
 
   int32_t required_size = _az_MAX_SIZE_FOR_DOUBLE; // Need enough space to write any double number.

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -553,22 +553,6 @@ void az_span_to_str(char* destination, int32_t destination_max_size, az_span sou
   destination[size_to_write] = 0;
 }
 
-AZ_NODISCARD bool _az_is_finite(double value)
-{
-  uint64_t binary_value = *(uint64_t*)&value;
-
-  // These are the binary representations of the various non-finite value ranges,
-  // according to the IEEE 754 standard:
-  // +inf - 0x7FF0000000000000
-  // -inf - 0xFFF0000000000000 Anything in the following
-  // nan - 0x7FF0000000000001 to 0x7FFFFFFFFFFFFFFF and 0xFFF0000000000001 to 0xFFFFFFFFFFFFFFFF
-
-  // This is equivalent to checking the following ranges, condensed into a single check:
-  // (binary_value < 0x7FF0000000000000 ||
-  //   (binary_value > 0x7FFFFFFFFFFFFFFF && binary_value < 0xFFF0000000000000))
-  return ((binary_value & 0x7FF0000000000000) != 0x7FF0000000000000);
-}
-
 /**
  * @brief Replace all contents from a starting position to an end position with the content of a
  * provided span

--- a/sdk/src/azure/core/az_span_private.h
+++ b/sdk/src/azure/core/az_span_private.h
@@ -25,10 +25,10 @@ enum
 };
 
 /**
- * @brief A portable implementation of the standard isfinite implementation, which may not be
- * available on certain embedded systems that use older compilers.
+ * @brief A portable implementation of the standard isfinite method, which may not be available on
+ * certain embedded systems that use older compilers.
  *
- * @param value The floating point value to test.
+ * @param value The 64-bit floating point value to test.
  * @return `true` if the \p value is finite (that is, it is not infinite or not a number), otherwise
  * return `false`.
  */

--- a/sdk/src/azure/core/az_span_private.h
+++ b/sdk/src/azure/core/az_span_private.h
@@ -32,7 +32,21 @@ enum
  * @return `true` if the \p value is finite (that is, it is not infinite or not a number), otherwise
  * return `false`.
  */
-AZ_NODISCARD bool _az_is_finite(double value);
+AZ_NODISCARD AZ_INLINE bool _az_is_finite(double value)
+{
+  uint64_t binary_value = *(uint64_t*)&value;
+
+  // These are the binary representations of the various non-finite value ranges,
+  // according to the IEEE 754 standard:
+  // +inf - 0x7FF0000000000000
+  // -inf - 0xFFF0000000000000 Anything in the following
+  // nan - 0x7FF0000000000001 to 0x7FFFFFFFFFFFFFFF and 0xFFF0000000000001 to 0xFFFFFFFFFFFFFFFF
+
+  // This is equivalent to checking the following ranges, condensed into a single check:
+  // (binary_value < 0x7FF0000000000000 ||
+  //   (binary_value > 0x7FFFFFFFFFFFFFFF && binary_value < 0xFFF0000000000000))
+  return ((binary_value & 0x7FF0000000000000) != 0x7FF0000000000000);
+}
 
 /**
  * @brief Replace all contents from a starting position to an end position with the content of a

--- a/sdk/src/azure/core/az_span_private.h
+++ b/sdk/src/azure/core/az_span_private.h
@@ -25,6 +25,16 @@ enum
 };
 
 /**
+ * @brief A portable implementation of the standard isfinite implementation, which may not be
+ * available on certain embedded systems that use older compilers.
+ *
+ * @param value The floating point value to test.
+ * @return `true` if the \p value is finite (that is, it is not infinite or not a number), otherwise
+ * return `false`.
+ */
+AZ_NODISCARD bool _az_is_finite(double value);
+
+/**
  * @brief Replace all contents from a starting position to an end position with the content of a
  * provided span
  *

--- a/sdk/tests/core/test_az_span.c
+++ b/sdk/tests/core/test_az_span.c
@@ -373,15 +373,15 @@ static void test_az_is_finite(void** state)
   source = 0x7FEFFFFFFFFFFFFF;
   test_az_is_finite_helper(source, true);
 
-  source = 0x7FF0000000000000;
+  source = 0x7FF0000000000000; // +inf
   test_az_is_finite_helper(source, false);
-  source = 0x7FF0000000000001;
+  source = 0x7FF0000000000001; // nan
   test_az_is_finite_helper(source, false);
-  source = 0x7FF7FFFFFFFFFFFF;
+  source = 0x7FF7FFFFFFFFFFFF; // nan
   test_az_is_finite_helper(source, false);
-  source = 0x7FF8000000000000;
+  source = 0x7FF8000000000000; // nan
   test_az_is_finite_helper(source, false);
-  source = 0x7FFFFFFFFFFFFFFF;
+  source = 0x7FFFFFFFFFFFFFFF; // nan
   test_az_is_finite_helper(source, false);
 
   source = 0x8000000000000000;
@@ -389,13 +389,13 @@ static void test_az_is_finite(void** state)
   source = 0xFFEFFFFFFFFFFFFF;
   test_az_is_finite_helper(source, true);
 
-  source = 0xFFF0000000000000;
+  source = 0xFFF0000000000000; // -inf
   test_az_is_finite_helper(source, false);
-  source = 0xFFF7FFFFFFFFFFFF;
+  source = 0xFFF7FFFFFFFFFFFF; // nan
   test_az_is_finite_helper(source, false);
-  source = 0xFFF8000000000000;
+  source = 0xFFF8000000000000; // nan
   test_az_is_finite_helper(source, false);
-  source = 0xFFFFFFFFFFFFFFFF;
+  source = 0xFFFFFFFFFFFFFFFF; // nan
   test_az_is_finite_helper(source, false);
 
   source = 0xFFFFFFFFFFFFFFFF + 1;


### PR DESCRIPTION
Fixes issue where certain embedded compilers used by some micro-controllers don't implement or support standard library methods like `isfinite`, `isnan`, etc., by providing our own portable implementation of it.

For example: https://ww1.microchip.com/downloads/en/DeviceDoc/Readme_XC16_150.html, which targets GCC 4.5.1.

![image](https://user-images.githubusercontent.com/6527137/89239742-eae31d80-d5ae-11ea-84c7-dade5a65c8e4.png)

`isfinite` needs GCC 4.6.4+, which is below the supported version currently listed in the guidelines:
https://azure.github.io/azure-sdk/clang_implementation.html#supported-platforms

See https://www.doc.ic.ac.uk/~eedwards/compsys/float/nan.html for more info about the implementation details.
> ... NaNs are represented by the largest biased exponent allowed by the format (single- or double-precision) and a mantissa that is non-zero.

For additional context, here's a thread specifically about the XC16 compiler and its lack of support for float NaN and Infinity: https://www.microchip.com/forums/m1018477.aspx

cc @danewalton 