### PR TITLE
update project name on iot CMake

### DIFF
--- a/sdk/samples/iot/CMakeLists.txt
+++ b/sdk/samples/iot/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required (VERSION 3.10)
 
 set(TARGET_NAME "az_iot_samples_common")
 
-project (${TARGET_NAME} LANGUAGES C)
+project (az_iot_samples LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 


### PR DESCRIPTION
Anything in a CMake project gets grouped in IDE integrations. Currently it looks like this in VSCode:
![Screenshot 2020-08-05 174051](https://user-images.githubusercontent.com/36710865/89477786-fbc49800-d742-11ea-8c9a-7423980fbc21.png)

The title `az_iot_samples_common` isn't exactly right so updated the name to better reflect the grouping.