### PR TITLE
remove url encoding from url request

### DIFF
--- a/sdk/inc/azure/core/internal/az_span_internal.h
+++ b/sdk/inc/azure/core/internal/az_span_internal.h
@@ -49,9 +49,7 @@ _az_span_url_encode(az_span destination, az_span source, int32_t* out_length);
  * @brief Calculates what would it be the length of \p source #az_span after url-encoding it.
  *
  * @param[in] source The #az_span containing the non-URL-encoded bytes.
- * @param[out] out_length A pointer to an int32_t that is going to be assigned the length
- * of URL-encoding the \p source.
- * @return the length of source if it would be url-encoded.
+ * @return The length of source if it would be url-encoded.
  *
  */
 AZ_NODISCARD int32_t _az_span_url_encode_calc_length(az_span source);

--- a/sdk/inc/azure/core/internal/az_span_internal.h
+++ b/sdk/inc/azure/core/internal/az_span_internal.h
@@ -4,9 +4,9 @@
 #ifndef _az_SPAN_INTERNAL_H
 #define _az_SPAN_INTERNAL_H
 
-#include <azure/core/internal/az_precondition_internal.h>
 #include <azure/core/az_result.h>
 #include <azure/core/az_span.h>
+#include <azure/core/internal/az_precondition_internal.h>
 
 #include <stdint.h>
 
@@ -44,6 +44,17 @@ AZ_INLINE AZ_NODISCARD int32_t _az_span_diff(az_span sliced_span, az_span origin
  */
 AZ_NODISCARD az_result
 _az_span_url_encode(az_span destination, az_span source, int32_t* out_length);
+
+/**
+ * @brief Calculates what would it be the length of \p source #az_span after url-encoding it.
+ *
+ * @param[in] source The #az_span containing the non-URL-encoded bytes.
+ * @param[out] out_length A pointer to an int32_t that is going to be assigned the length
+ * of URL-encoding the \p source.
+ * @return the length of source if it would be url-encoded.
+ *
+ */
+AZ_NODISCARD int32_t _az_span_url_encode_calc_length(az_span source);
 
 /**
  * @brief String tokenizer for #az_span.

--- a/sdk/inc/azure/core/internal/az_span_internal.h
+++ b/sdk/inc/azure/core/internal/az_span_internal.h
@@ -46,7 +46,7 @@ AZ_NODISCARD az_result
 _az_span_url_encode(az_span destination, az_span source, int32_t* out_length);
 
 /**
- * @brief Calculates what would it be the length of \p source #az_span after url-encoding it.
+ * @brief Calculates what would be the length of \p source #az_span after url-encoding it.
  *
  * @param[in] source The #az_span containing the non-URL-encoded bytes.
  * @return The length of source if it would be url-encoded.

--- a/sdk/src/azure/core/az_aad.c
+++ b/sdk/src/azure/core/az_aad.c
@@ -21,11 +21,8 @@ _az_aad_build_url(az_span url, az_span authority, az_span tenant_id, az_span* ou
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(url, az_span_size(authority));
   az_span remainder = az_span_copy(url, authority);
 
-  {
-    int32_t url_length = 0;
-    AZ_RETURN_IF_FAILED(_az_span_url_encode(remainder, tenant_id, &url_length));
-    remainder = az_span_slice_to_end(remainder, url_length);
-  }
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(tenant_id));
+  remainder = az_span_copy(remainder, tenant_id);
 
   az_span const oath_token = AZ_SPAN_FROM_STR("/oauth2/v2.0/token");
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(oath_token));
@@ -49,18 +46,18 @@ AZ_NODISCARD az_result _az_aad_build_body(
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(body, az_span_size(grant_type_and_client_id_key));
 
   az_span remainder = az_span_copy(body, grant_type_and_client_id_key);
-  int32_t url_length = 0;
+  int32_t body_length = 0;
 
-  AZ_RETURN_IF_FAILED(_az_span_url_encode(remainder, client_id, &url_length));
-  remainder = az_span_slice_to_end(remainder, url_length);
+  AZ_RETURN_IF_FAILED(_az_span_url_encode(remainder, client_id, &body_length));
+  remainder = az_span_slice_to_end(remainder, body_length);
 
   az_span const scope_key = AZ_SPAN_FROM_STR("&scope=");
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(scope_key));
 
   remainder = az_span_copy(remainder, scope_key);
 
-  AZ_RETURN_IF_FAILED(_az_span_url_encode(remainder, scopes, &url_length));
-  remainder = az_span_slice_to_end(remainder, url_length);
+  AZ_RETURN_IF_FAILED(_az_span_url_encode(remainder, scopes, &body_length));
+  remainder = az_span_slice_to_end(remainder, body_length);
 
   if (az_span_size(client_secret) > 0)
   {
@@ -69,8 +66,8 @@ AZ_NODISCARD az_result _az_aad_build_body(
 
     remainder = az_span_copy(remainder, client_secret_key);
 
-    AZ_RETURN_IF_FAILED(_az_span_url_encode(remainder, client_secret, &url_length));
-    remainder = az_span_slice_to_end(remainder, url_length);
+    AZ_RETURN_IF_FAILED(_az_span_url_encode(remainder, client_secret, &body_length));
+    remainder = az_span_slice_to_end(remainder, body_length);
   }
 
   *out_body = az_span_slice(body, 0, _az_span_diff(remainder, body));

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -993,22 +993,21 @@ AZ_NODISCARD int32_t _az_span_url_encode_calc_length(az_span source)
     return 0;
   }
 
-  // We may or may not have enough space, given whether the input needs much encoding or not.
   uint8_t* const src_ptr = az_span_ptr(source);
-  int32_t extra_space_used = 0;
+  int32_t required_symbols_to_be_added = 0;
   int32_t src_idx = 0;
   do
   {
     uint8_t c = src_ptr[src_idx];
     if (_az_span_url_should_encode(c))
     {
-      extra_space_used
+      required_symbols_to_be_added
           += 2; // Adding '%' plus 2 digits (minus 1 as original symbol is counted as 1)
     }
     ++src_idx;
   } while (src_idx < source_size);
 
-  return source_size + extra_space_used;
+  return source_size + required_symbols_to_be_added;
 }
 
 AZ_NODISCARD az_result _az_span_url_encode(az_span destination, az_span source, int32_t* out_length)

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -1001,8 +1001,8 @@ AZ_NODISCARD int32_t _az_span_url_encode_calc_length(az_span source)
     uint8_t c = src_ptr[src_idx];
     if (_az_span_url_should_encode(c))
     {
-      required_symbols_to_be_added
-          += 2; // Adding '%' plus 2 digits (minus 1 as original symbol is counted as 1)
+      // Adding '%' plus 2 digits (minus 1 as original symbol is counted as 1)
+      required_symbols_to_be_added += 2; 
     }
     ++src_idx;
   } while (src_idx < source_size);

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -983,6 +983,34 @@ AZ_NODISCARD AZ_INLINE bool _az_span_url_should_encode(uint8_t c)
   }
 }
 
+AZ_NODISCARD int32_t _az_span_url_encode_calc_length(az_span source)
+{
+  _az_PRECONDITION_VALID_SPAN(source, 0, true);
+
+  int32_t const source_size = az_span_size(source);
+  if (source_size == 0)
+  {
+    return 0;
+  }
+
+  // We may or may not have enough space, given whether the input needs much encoding or not.
+  uint8_t* const src_ptr = az_span_ptr(source);
+  int32_t extra_space_used = 0;
+  int32_t src_idx = 0;
+  do
+  {
+    uint8_t c = src_ptr[src_idx];
+    if (_az_span_url_should_encode(c))
+    {
+      extra_space_used
+          += 2; // Adding '%' plus 2 digits (minus 1 as original symbol is counted as 1)
+    }
+    ++src_idx;
+  } while (src_idx < source_size);
+
+  return source_size + extra_space_used;
+}
+
 AZ_NODISCARD az_result _az_span_url_encode(az_span destination, az_span source, int32_t* out_length)
 {
   _az_PRECONDITION_NOT_NULL(out_length);

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -986,6 +986,9 @@ AZ_NODISCARD AZ_INLINE bool _az_span_url_should_encode(uint8_t c)
 AZ_NODISCARD int32_t _az_span_url_encode_calc_length(az_span source)
 {
   _az_PRECONDITION_VALID_SPAN(source, 0, true);
+  // trying to calculate the number of bytes to encode more than INT32_MAX / 3 might overflow an
+  // int32 and return an erroneous number back
+  _az_PRECONDITION_RANGE(0, az_span_size(source), INT32_MAX / 3);
 
   int32_t const source_size = az_span_size(source);
   if (source_size == 0)
@@ -1002,7 +1005,7 @@ AZ_NODISCARD int32_t _az_span_url_encode_calc_length(az_span source)
     if (_az_span_url_should_encode(c))
     {
       // Adding '%' plus 2 digits (minus 1 as original symbol is counted as 1)
-      required_symbols_to_be_added += 2; 
+      required_symbols_to_be_added += 2;
     }
     ++src_idx;
   } while (src_idx < source_size);

--- a/sdk/tests/core/test_az_url_encode.c
+++ b/sdk/tests/core/test_az_url_encode.c
@@ -86,42 +86,6 @@ static void test_url_encode_basic(void** state)
         AZ_SPAN_FROM_BUFFER(buf20), AZ_SPAN_FROM_STR("aBc%2Fg*************")));
   }
   {
-    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("aBc/g"));
-    assert_int_equal(url_length, sizeof("aBc%2Fg") - 1);
-  }
-  {
-    // Empty span
-    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_NULL);
-    assert_int_equal(url_length, 0);
-    url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR(""));
-    assert_int_equal(url_length, 0);
-  }
-  {
-    // Nothing gets encoded
-    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("123"));
-    assert_int_equal(url_length, 3);
-  }
-  {
-    // first last encoded
-    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR(" 123 "));
-    assert_int_equal(url_length, 9);
-  }
-  {
-    // every character is encoded
-    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("   "));
-    assert_int_equal(url_length, 9);
-  }
-  {
-    // % character, which in itself is encoded as %25
-    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("%"));
-    assert_int_equal(url_length, 3);
-  }
-  {
-    // a single length span with the \0 NULL character
-    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("\0"));
-    assert_int_equal(url_length, 3);
-  }
-  {
     // Could've been enough space to encode, but the character needs percent-encoding.
     uint8_t buf20[20] = {
       '*', '*', '*', '*', '*', '*', '*', '*', '*', '*',
@@ -240,6 +204,42 @@ static void test_url_encode_basic(void** state)
     assert_int_equal(url_length, sizeof("AbC%2F%2F%2F") - 1);
     assert_true(az_span_is_content_equal(
         AZ_SPAN_FROM_BUFFER(buf20), AZ_SPAN_FROM_STR("AbC%2F%2F%2F********")));
+  }
+  {
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("aBc/g"));
+    assert_int_equal(url_length, sizeof("aBc%2Fg") - 1);
+  }
+  {
+    // Empty span
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_NULL);
+    assert_int_equal(url_length, 0);
+    url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR(""));
+    assert_int_equal(url_length, 0);
+  }
+  {
+    // Nothing gets encoded
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("123"));
+    assert_int_equal(url_length, 3);
+  }
+  {
+    // first last encoded
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR(" 123 "));
+    assert_int_equal(url_length, 9);
+  }
+  {
+    // every character is encoded
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("   "));
+    assert_int_equal(url_length, 9);
+  }
+  {
+    // % character, which in itself is encoded as %25
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("%"));
+    assert_int_equal(url_length, 3);
+  }
+  {
+    // a single length span with the \0 NULL character
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("\0"));
+    assert_int_equal(url_length, 3);
   }
 }
 

--- a/sdk/tests/core/test_az_url_encode.c
+++ b/sdk/tests/core/test_az_url_encode.c
@@ -90,6 +90,38 @@ static void test_url_encode_basic(void** state)
     assert_int_equal(url_length, sizeof("aBc%2Fg") - 1);
   }
   {
+    // Empty span
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_NULL);
+    assert_int_equal(url_length, 0);
+    url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR(""));
+    assert_int_equal(url_length, 0);
+  }
+  {
+    // Nothing gets encoded
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("123"));
+    assert_int_equal(url_length, 3);
+  }
+  {
+    // first last encoded
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR(" 123 "));
+    assert_int_equal(url_length, 9);
+  }
+  {
+    // every character is encoded
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("   "));
+    assert_int_equal(url_length, 9);
+  }
+  {
+    // % character, which in itself is encoded as %25
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("%"));
+    assert_int_equal(url_length, 3);
+  }
+  {
+    // a single length span with the \0 NULL character
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("\0"));
+    assert_int_equal(url_length, 3);
+  }
+  {
     // Could've been enough space to encode, but the character needs percent-encoding.
     uint8_t buf20[20] = {
       '*', '*', '*', '*', '*', '*', '*', '*', '*', '*',

--- a/sdk/tests/core/test_az_url_encode.c
+++ b/sdk/tests/core/test_az_url_encode.c
@@ -374,6 +374,16 @@ static void test_url_encode_preconditions(void** state)
       ASSERT_PRECONDITION_CHECKED(_az_span_url_encode(buffer0, AZ_SPAN_NULL, NULL));
       assert_true(az_span_is_content_equal(AZ_SPAN_FROM_BUFFER(buf1), AZ_SPAN_FROM_STR("*")));
     }
+    {
+      // precondition -> bigger than INT32_MAX / 3
+      az_span simulate_span = { ._internal = { .ptr = NULL, .size = INT32_MAX / 3 + 1 } };
+      ASSERT_PRECONDITION_CHECKED(_az_span_url_encode_calc_length(simulate_span));
+    }
+    {
+      // precondition -> less than 0
+      az_span simulate_span = { ._internal = { .ptr = NULL, .size = -1 } };
+      ASSERT_PRECONDITION_CHECKED(_az_span_url_encode_calc_length(simulate_span));
+    }
   }
 #endif // AZ_NO_PRECONDITION_CHECKING
 }

--- a/sdk/tests/core/test_az_url_encode.c
+++ b/sdk/tests/core/test_az_url_encode.c
@@ -3,6 +3,7 @@
 
 #include "az_test_definitions.h"
 #include <azure/core/internal/az_span_internal.h>
+
 #include <az_test_precondition.h>
 
 #include <stdarg.h>
@@ -83,6 +84,10 @@ static void test_url_encode_basic(void** state)
     assert_int_equal(url_length, sizeof("aBc%2Fg") - 1);
     assert_true(az_span_is_content_equal(
         AZ_SPAN_FROM_BUFFER(buf20), AZ_SPAN_FROM_STR("aBc%2Fg*************")));
+  }
+  {
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR("aBc/g"));
+    assert_int_equal(url_length, sizeof("aBc%2Fg") - 1);
   }
   {
     // Could've been enough space to encode, but the character needs percent-encoding.


### PR DESCRIPTION
Adding a new internal API to calculate the size of one span after it gets url-encoded.   
This method is used by our curl transport adapter to know how many bytes to allocate for a url.

*Adding internal header into curl transport adapter to consume az_span_url_encode(...)..  
I think this is OK since we are the ones providing the transport adapter, so we can access internal stuff.

Some one else implementing a transport adapter would need to make sure to url-enconde the url from http request somehow. (or we could expose _az_span_url_enconde to public API in the future if we want/customer ask for it)

fixes: https://github.com/Azure/azure-sdk-for-c/issues/963