### PR TITLE
Remove PackageId from release tagging to follow new guidelines

### DIFF
--- a/eng/common/scripts/artifact-metadata-parsing.ps1
+++ b/eng/common/scripts/artifact-metadata-parsing.ps1
@@ -298,7 +298,7 @@ function ParseCArtifact($pkg, $workingDirectory) {
   }
 
   return New-Object PSObject -Property @{
-    PackageId      = 'azure-sdk-for-c'
+    PackageId      = ''
     PackageVersion = $pkgVersion
     # Artifact info is always considered deployable for C becasue it is not
     # deployed anywhere. Dealing with duplicate tags happens downstream in


### PR DESCRIPTION
Enacting propsed changes in https://github.com/Azure/azure-sdk/pull/1615... Tags will now use `<version>` instead of `<package-identifier>_<version>` 

Tag string is generated on https://github.com/Azure/azure-sdk-for-c/blob/faca36d1a015645a20b8bb5dd2421bdfbf10363e/eng/common/scripts/artifact-metadata-parsing.ps1#L447