### PR TITLE
remove TARGET_NAME usage from CMakeList files

### DIFF
--- a/sdk/samples/iot/CMakeLists.txt
+++ b/sdk/samples/iot/CMakeLists.txt
@@ -5,8 +5,6 @@ if (TRANSPORT_PAHO)
 
 cmake_minimum_required (VERSION 3.10)
 
-set(TARGET_NAME "az_iot_samples_common")
-
 project (az_iot_samples LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
@@ -22,34 +20,34 @@ if(NOT OpenSSL_FOUND)
 endif()
 
 # Azure IoT Samples Library
-add_library (${TARGET_NAME}
+add_library (az_iot_samples_common
   ${CMAKE_CURRENT_LIST_DIR}/sample_sas_utility.c
 )
 
 # Workaround for linker warning LNK4098: defaultlib 'LIBCMTD' conflicts with use of other libs
 if (MSVC)
-    set_target_properties(${TARGET_NAME}
+    set_target_properties(az_iot_samples_common
         PROPERTIES LINK_FLAGS
         "/NODEFAULTLIB:libcmtd.lib"
     )
 endif()
 
 # Internal deps
-target_link_libraries(${TARGET_NAME}
+target_link_libraries(az_iot_samples_common
   PUBLIC
     az::iot::hub
     az::iot::provisioning
 )
 
 # External deps
-target_link_libraries(${TARGET_NAME}
+target_link_libraries(az_iot_samples_common
   PUBLIC
     eclipse-paho-mqtt-c::paho-mqtt3cs-static
     OpenSSL::SSL
     OpenSSL::Crypto
 )
 
-add_library (az::iot::samples::common ALIAS ${TARGET_NAME})
+add_library (az::iot::samples::common ALIAS az_iot_samples_common)
 
 # Azure IoT Samples Executables
 

--- a/sdk/samples/storage/blobs/CMakeLists.txt
+++ b/sdk/samples/storage/blobs/CMakeLists.txt
@@ -3,9 +3,7 @@
 
 cmake_minimum_required (VERSION 3.10)
 
-set(TARGET_NAME "blobs_client_example")
-
-project (${TARGET_NAME} LANGUAGES C)
+project (blobs_client_example LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 
@@ -18,13 +16,13 @@ if(TRANSPORT_CURL)
 endif()
 
 # make keys client example
-add_executable (${TARGET_NAME} src/blobs_client_example.c)
+add_executable (blobs_client_example src/blobs_client_example.c)
 
-target_link_libraries(${TARGET_NAME} PRIVATE az_storage_blobs az_core)
+target_link_libraries(blobs_client_example PRIVATE az_storage_blobs az_core)
 
 # Workaround for linker warning LNK4098: defaultlib 'LIBCMTD' conflicts with use of other libs
 if (MSVC)
-    set_target_properties(${TARGET_NAME}
+    set_target_properties(blobs_client_example
         PROPERTIES LINK_FLAGS
         "/NODEFAULTLIB:libcmtd.lib"
     )
@@ -33,13 +31,13 @@ endif()
 # link libcurl impl when option is on
 # When using a different HTTP transport adapter implementation, link it here instead of az_curl and libcurl
 if(TRANSPORT_CURL)
-  target_link_libraries(${TARGET_NAME} PRIVATE az_curl CURL::libcurl)
+  target_link_libraries(blobs_client_example PRIVATE az_curl CURL::libcurl)
 else()
   # linking default no http implementation to be able to compile and link sample.
-  target_link_libraries(${TARGET_NAME} PRIVATE az_nohttp)
+  target_link_libraries(blobs_client_example PRIVATE az_nohttp)
   # push compiler symbol so we can find out in Code about no http
-  target_compile_definitions(${TARGET_NAME} PRIVATE AZ_NO_HTTP)
+  target_compile_definitions(blobs_client_example PRIVATE AZ_NO_HTTP)
 endif()
 
 # get the appropriate PAL lib to link
-target_link_libraries(${TARGET_NAME} PRIVATE ${PAL})
+target_link_libraries(blobs_client_example PRIVATE ${PAL})

--- a/sdk/src/azure/core/CMakeLists.txt
+++ b/sdk/src/azure/core/CMakeLists.txt
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 cmake_minimum_required (VERSION 3.10)
-set(TARGET_NAME "az_core")
 
 # Read in az_version.h
 #   The build will fail with an error if the file is not found or improperly formatted
@@ -38,13 +37,13 @@ else()
   message(FATAL_ERROR "Missing Version file ${AZ_SDK_VERSION_H_FILE}")
 endif()
 
-project (${TARGET_NAME} LANGUAGES C VERSION ${AZ_SDK_VERSION_MAJOR}.${AZ_SDK_VERSION_MINOR}.${AZ_SDK_VERSION_PATCH})
+project (az_core LANGUAGES C VERSION ${AZ_SDK_VERSION_MAJOR}.${AZ_SDK_VERSION_MINOR}.${AZ_SDK_VERSION_PATCH})
 set(CMAKE_C_STANDARD 99)
 
 include(CheckAndIncludeCodeCov)
 
 add_library (
-  ${TARGET_NAME}
+  az_core
   ${CMAKE_CURRENT_LIST_DIR}/az_aad.c
   ${CMAKE_CURRENT_LIST_DIR}/az_credential_client_secret.c
   ${CMAKE_CURRENT_LIST_DIR}/az_credential_token.c
@@ -63,24 +62,24 @@ add_library (
   ${CMAKE_CURRENT_LIST_DIR}/az_span.c
   ${CMAKE_CURRENT_LIST_DIR}/az_spinlock.c)
 
-target_include_directories (${TARGET_NAME}
+target_include_directories (az_core
   PUBLIC
   $<BUILD_INTERFACE:${az_SOURCE_DIR}/sdk/inc>
-  $<INSTALL_INTERFACE:include/${TARGET_NAME}>
+  $<INSTALL_INTERFACE:include/az_core>
 )
 
 # include test internal headers
-target_include_directories(${TARGET_NAME}
+target_include_directories(az_core
   PUBLIC
     $<BUILD_INTERFACE:${az_SOURCE_DIR}/sdk/tests/core/inc>
 )
 
-target_link_libraries(${TARGET_NAME}
+target_link_libraries(az_core
   PUBLIC
     ${PAL}
 )
 
 # make sure that users can consume the project as a library.
-add_library (az::core ALIAS ${TARGET_NAME})
+add_library (az::core ALIAS az_core)
 
-create_code_coverage_targets(${TARGET_NAME})
+create_code_coverage_targets(az_core)

--- a/sdk/src/azure/storage/CMakeLists.txt
+++ b/sdk/src/azure/storage/CMakeLists.txt
@@ -3,31 +3,30 @@
 
 cmake_minimum_required (VERSION 3.10)
 
-set(TARGET_NAME "az_storage_blobs")
-project (${TARGET_NAME} LANGUAGES C)
+project (az_storage_blobs LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 
 include(CheckAndIncludeCodeCov)
 
 add_library (
-  ${TARGET_NAME}
+  az_storage_blobs
   ${CMAKE_CURRENT_LIST_DIR}/az_storage_blobs_blob_client.c
   )
 
-target_include_directories (${TARGET_NAME} PUBLIC inc)
+target_include_directories (az_storage_blobs PUBLIC inc)
 
-target_link_libraries(${TARGET_NAME}
+target_link_libraries(az_storage_blobs
   PUBLIC
     az::core
 )
 
 # make sure that users can consume the project as a library.
-add_library (az::storage::blobs ALIAS ${TARGET_NAME})
+add_library (az::storage::blobs ALIAS az_storage_blobs)
 
 # set coverage excluding for az_core. Don't show coverage outside storage blobs
 set(COV_EXCLUDE
     ${az_SOURCE_DIR}/sdk/inc/azure/core/*
     ${az_SOURCE_DIR}/sdk/inc/azure/core/internal/*)
 
-create_code_coverage_targets(${TARGET_NAME})
+create_code_coverage_targets(az_storage_blobs)

--- a/sdk/tests/core/CMakeLists.txt
+++ b/sdk/tests/core/CMakeLists.txt
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 cmake_minimum_required (VERSION 3.10)
-set(TARGET_NAME "az_core_test")
 
-project (${TARGET_NAME} LANGUAGES C)
+project (az_core_test LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 
@@ -17,7 +16,7 @@ else()
     set(WRAP_FUNCTIONS "")
 endif()
 
-add_cmocka_test(${TARGET_NAME} SOURCES
+add_cmocka_test(az_core_test SOURCES
                 main.c
                 test_az_context.c
                 test_az_credential_client_secret.c

--- a/sdk/tests/iot/common/CMakeLists.txt
+++ b/sdk/tests/iot/common/CMakeLists.txt
@@ -2,15 +2,14 @@
 # SPDX-License-Identifier: MIT
 
 cmake_minimum_required (VERSION 3.10)
-set(TARGET_NAME "az_iot_common_test")
 
-project (${TARGET_NAME} LANGUAGES C)
+project (az_iot_common_test LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 
 include(AddTestCMocka)
 
-add_cmocka_test(${TARGET_NAME} SOURCES
+add_cmocka_test(az_iot_common_test SOURCES
                 main.c
                 test_az_iot_common.c
                 COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS}

--- a/sdk/tests/iot/hub/CMakeLists.txt
+++ b/sdk/tests/iot/hub/CMakeLists.txt
@@ -2,15 +2,14 @@
 # SPDX-License-Identifier: MIT
 
 cmake_minimum_required (VERSION 3.10)
-set(TARGET_NAME "az_iot_hub_test")
 
-project (${TARGET_NAME} LANGUAGES C)
+project (az_iot_hub_test LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 
 include(AddTestCMocka)
 
-add_cmocka_test(${TARGET_NAME} SOURCES
+add_cmocka_test(az_iot_hub_test SOURCES
                 main.c
                 test_az_iot_hub_client_sas.c
                 test_az_iot_hub_client_telemetry.c

--- a/sdk/tests/iot/provisioning/CMakeLists.txt
+++ b/sdk/tests/iot/provisioning/CMakeLists.txt
@@ -2,15 +2,14 @@
 # SPDX-License-Identifier: MIT
 
 cmake_minimum_required (VERSION 3.10)
-set(TARGET_NAME "az_iot_provisioning_test")
 
-project (${TARGET_NAME} LANGUAGES C)
+project (az_iot_provisioning_test LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 
 include(AddTestCMocka)
 
-add_cmocka_test(${TARGET_NAME} SOURCES
+add_cmocka_test(az_iot_provisioning_test SOURCES
                 main.c
                 test_az_iot_provisioning_client.c
                 test_az_iot_provisioning_client_sas.c

--- a/sdk/tests/storage/blobs/CMakeLists.txt
+++ b/sdk/tests/storage/blobs/CMakeLists.txt
@@ -2,15 +2,14 @@
 # SPDX-License-Identifier: MIT
 
 cmake_minimum_required (VERSION 3.10)
-set(TARGET_NAME "az_storage_blobs_test")
 
-project (${TARGET_NAME} LANGUAGES C)
+project (az_storage_blobs_test LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 
 include(AddTestCMocka)
 
-add_cmocka_test(${TARGET_NAME} SOURCES
+add_cmocka_test(az_storage_blobs_test SOURCES
                 main.c
                 az_storage_blobs_unit_tests.c
                 COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS}


### PR DESCRIPTION
For reasons listed here:
https://github.com/Azure/azure-sdk-for-c/pull/991#discussion_r466017835
we should avoid using the `TARGET_NAME` usage from our CMakeList files.