### PR TITLE
Rename _az_is_finite to _az_isfinite to match STL and update call sites.

### DIFF
--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -808,7 +808,7 @@ az_json_writer_append_double(az_json_writer* json_writer, double value, int32_t 
   _az_PRECONDITION(_az_is_appending_value_valid(json_writer));
   // Non-finite numbers are not supported because they lead to invalid JSON.
   // Unquoted strings such as nan and -inf are invalid as JSON numbers.
-  _az_PRECONDITION(_az_is_finite(value));
+  _az_PRECONDITION(_az_isfinite(value));
   _az_PRECONDITION_RANGE(0, fractional_digits, _az_MAX_SUPPORTED_FRACTIONAL_DIGITS);
 
   int32_t required_size = _az_MAX_SIZE_FOR_DOUBLE; // Need enough space to write any double number.

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -389,7 +389,7 @@ AZ_NODISCARD az_result az_span_atod(az_span source, double* out_number)
   int32_t n = sscanf((char*)source_ptr, format, out_number, &chars_consumed);
 
   // Success if the entire source was consumed by sscanf and it set the out_number argument.
-  return (size == chars_consumed && n == 1 && _az_is_finite(*out_number))
+  return (size == chars_consumed && n == 1 && _az_isfinite(*out_number))
       ? AZ_OK
       : AZ_ERROR_UNEXPECTED_CHAR;
 }
@@ -747,14 +747,14 @@ az_span_dtoa(az_span destination, double source, int32_t fractional_digits, az_s
 {
   _az_PRECONDITION_VALID_SPAN(destination, 0, false);
   // Inputs that are either positive or negative infinity, or not a number, are not supported.
-  _az_PRECONDITION(_az_is_finite(source));
+  _az_PRECONDITION(_az_isfinite(source));
   _az_PRECONDITION_RANGE(0, fractional_digits, _az_MAX_SUPPORTED_FRACTIONAL_DIGITS);
   _az_PRECONDITION_NOT_NULL(out_span);
 
   *out_span = destination;
 
   // The input is either positive or negative infinity, or not a number.
-  if (!_az_is_finite(source))
+  if (!_az_isfinite(source))
   {
     return AZ_ERROR_NOT_SUPPORTED;
   }

--- a/sdk/src/azure/core/az_span_private.h
+++ b/sdk/src/azure/core/az_span_private.h
@@ -32,7 +32,7 @@ enum
  * @return `true` if the \p value is finite (that is, it is not infinite or not a number), otherwise
  * return `false`.
  */
-AZ_NODISCARD AZ_INLINE bool _az_is_finite(double value)
+AZ_NODISCARD AZ_INLINE bool _az_isfinite(double value)
 {
   uint64_t binary_value = *(uint64_t*)&value;
 

--- a/sdk/tests/core/test_az_span.c
+++ b/sdk/tests/core/test_az_span.c
@@ -352,54 +352,54 @@ static void az_span_atoi64_test(void** state)
       az_span_atoi64(AZ_SPAN_FROM_STR("-9223372036854775809"), &value), AZ_ERROR_UNEXPECTED_CHAR);
 }
 
-#define test_az_is_finite_helper(source, expected) \
+#define test_az_isfinite_helper(source, expected) \
   do \
   { \
     double decimal = *(double*)&source; \
-    assert_int_equal(_az_is_finite(decimal), expected); \
+    assert_int_equal(_az_isfinite(decimal), expected); \
   } while (0)
 
-static void test_az_is_finite(void** state)
+static void test_az_isfinite(void** state)
 {
   (void)state;
 
   uint64_t source = 0;
 
-  test_az_is_finite_helper(source, true);
+  test_az_isfinite_helper(source, true);
   source = 1;
-  test_az_is_finite_helper(source, true);
+  test_az_isfinite_helper(source, true);
   source = 0x6FFFFFFFFFFFFFFF;
-  test_az_is_finite_helper(source, true);
+  test_az_isfinite_helper(source, true);
   source = 0x7FEFFFFFFFFFFFFF;
-  test_az_is_finite_helper(source, true);
+  test_az_isfinite_helper(source, true);
 
   source = 0x7FF0000000000000; // +inf
-  test_az_is_finite_helper(source, false);
+  test_az_isfinite_helper(source, false);
   source = 0x7FF0000000000001; // nan
-  test_az_is_finite_helper(source, false);
+  test_az_isfinite_helper(source, false);
   source = 0x7FF7FFFFFFFFFFFF; // nan
-  test_az_is_finite_helper(source, false);
+  test_az_isfinite_helper(source, false);
   source = 0x7FF8000000000000; // nan
-  test_az_is_finite_helper(source, false);
+  test_az_isfinite_helper(source, false);
   source = 0x7FFFFFFFFFFFFFFF; // nan
-  test_az_is_finite_helper(source, false);
+  test_az_isfinite_helper(source, false);
 
   source = 0x8000000000000000;
-  test_az_is_finite_helper(source, true);
+  test_az_isfinite_helper(source, true);
   source = 0xFFEFFFFFFFFFFFFF;
-  test_az_is_finite_helper(source, true);
+  test_az_isfinite_helper(source, true);
 
   source = 0xFFF0000000000000; // -inf
-  test_az_is_finite_helper(source, false);
+  test_az_isfinite_helper(source, false);
   source = 0xFFF7FFFFFFFFFFFF; // nan
-  test_az_is_finite_helper(source, false);
+  test_az_isfinite_helper(source, false);
   source = 0xFFF8000000000000; // nan
-  test_az_is_finite_helper(source, false);
+  test_az_isfinite_helper(source, false);
   source = 0xFFFFFFFFFFFFFFFF; // nan
-  test_az_is_finite_helper(source, false);
+  test_az_isfinite_helper(source, false);
 
   source = 0xFFFFFFFFFFFFFFFF + 1;
-  test_az_is_finite_helper(source, true);
+  test_az_isfinite_helper(source, true);
 }
 
 // Disable warning for float comparisons, for this particular test
@@ -2026,7 +2026,7 @@ int test_az_span()
     cmocka_unit_test(az_span_atoi32_test),
     cmocka_unit_test(az_span_atou64_test),
     cmocka_unit_test(az_span_atoi64_test),
-    cmocka_unit_test(test_az_is_finite),
+    cmocka_unit_test(test_az_isfinite),
     cmocka_unit_test(az_span_atod_test),
     cmocka_unit_test(az_span_atod_non_finite_not_allowed),
     cmocka_unit_test(az_span_ato_number_whitespace_or_invalid_not_allowed),


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/983