### PR TITLE
Fix IoT samples link in readme

### DIFF
--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -92,9 +92,9 @@ This section provides an overview of the different samples available to run and 
 
 ### IoT Hub Plug and Play Multiple Component
 
-- *Executable:* `paho_iot_hub_pnp_component_sample`
+- *Executable:* `paho_iot_hub_pnp_component_example`
 
-This [sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c) connects an IoT Plug and Play enabled device with the Digital Twin Model ID (DTMI) detailed [here](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json). X509 self-certification is used.
+This [sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/paho_iot_hub_pnp_component_example.c) connects an IoT Plug and Play enabled device with the Digital Twin Model ID (DTMI) detailed [here](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json). X509 self-certification is used.
 
 This temperature controller is made up of the following sub-components
 


### PR DESCRIPTION
In order to merge this gate we need to correct broken links and broken links keep making their way into the docs. https://github.com/Azure/azure-sdk-for-c/pull/1000

This corrects the last failure to unblock the merge: https://dev.azure.com/azure-sdk/public/_build/results?buildId=486239&view=logs&j=95bd4e70-cc59-559e-27a0-8a7162764761&t=e775084c-82cf-5cac-bab9-bdca870ea01f&l=33