### PR TITLE
Add support for reading JSON in non-contiguous buffers

### DIFF
--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -60,36 +60,53 @@ typedef struct
 /**
  * @brief Represents a JSON token. The kind field indicates the type of the JSON token and the slice
  * represents the portion of the JSON payload that points to the token value.
+ *
+ * @remarks An instance of #az_json_token must not outlive the lifetime of the #az_json_reader it
+ * came from.
  */
-// Token cannot outlive the lifetime of the reader.
-// The reader cannot outlive the lifetime of the JSON payload (spans).
 typedef struct
 {
-  az_json_token_kind kind;
-
-  // AZ_SPAN_NULL if the token straddles, call copy_into_span if you want in contiguous
-  az_span slice;
-  // int32_t token_size;
+  az_json_token_kind kind; ///< This read-only field gives access to the type of the token returned
+                           ///< by the #az_json_reader, and it shouldn't be modified by the caller.
+  az_span slice; ///< This read-only field gives access to the slice of the JSON text that
+                 ///< represents the token value, and it shouldn't be modified by the caller.
+                 ///< If the token straddles non-contiguous buffers, this is set to #AZ_SPAN_NULL.
+                 ///< The user can call #az_json_token_copy_into_span() to get the token value into
+                 ///< a contiguous buffer.
+                 ///< In the case of JSON strings, the slice does not include the surrounding
+                 ///< quotes.
+  int32_t size; ///< This read-only field gives access to the size of the JSON text slice that
+                ///< represents the token value, and it shouldn't be modified by the caller. This is
+                ///< useful of the token straddles non-contiguous buffers, to figure out what sized
+                ///< destination buffer to provide when calling #az_json_token_copy_into_span().
 
   struct
   {
     bool string_has_escaped_chars;
-
-    // az_span* pointer_to_first_buffer;
-    // az_span buffer_array[]; // Use AZ_SPAN_NULL as a terminator
-
-    // int32_t start_buffer_index;
-    // int32_t start_buffer_offset;
-    // int32_t end_buffer_index;
-    // int32_t end_buffer_offset;
-
+    az_span* pointer_to_first_buffer;
+    int32_t start_buffer_index;
+    int32_t start_buffer_offset;
+    int32_t end_buffer_index;
+    int32_t end_buffer_offset;
   } _internal;
 } az_json_token;
 
-// az_span az_json_token_get_span(az_json_token token);
-// az_span az_json_token_copy_into_span(az_json_token token, az_span destination_buffer);
-// az_result az_json_token_copy_into_span(az_json_token token, az_span destination_buffer, az_span*
-// out_slice);
+// TODO: Should the parameters be reversed?
+/**
+ * @brief Copies the content of the \p token #az_json_token to the \p destination #az_span.
+ *
+ * @param[in] json_token A pointer to an #az_json_token instance containing the JSON text to copy to
+ * the destination.
+ * @param[in] destination The #az_span whose bytes will be replaced by the JSON text from the \p
+ * token.
+ * @return An #az_span that is a slice of the \p destination #az_span (i.e. the remainder) after the
+ * token bytes have been copied.
+ *
+ * @remarks The method assumes that the \p destination has a large enough size to hold the contents
+ * of \p token.
+ * @remarks If \p token doesn't contain any text, this function will just return \p destination.
+ */
+az_span az_json_token_copy_into_span(az_json_token const* json_token, az_span destination);
 
 /**
  * @brief Returns the JSON token's boolean.
@@ -516,9 +533,9 @@ AZ_NODISCARD AZ_INLINE az_json_reader_options az_json_reader_options_default()
  */
 typedef struct
 {
-  az_json_token
-      token; ///< This read-only field gives access to the current token that the #az_json_reader
-             ///< has processed, and it shouldn't be modified by the caller.
+  az_json_token token; ///< This read-only field gives access to the current token that the
+                       ///< #az_json_reader has processed, and it shouldn't be modified by the
+                       ///< caller.
 
   struct
   {
@@ -548,6 +565,9 @@ typedef struct
  *         - #AZ_OK if the #az_json_reader is initialized successfully
  *
  * @remarks The provided json buffer must not be empty, as that is invalid JSON.
+ *
+ * @remarks An instance of #az_json_reader must not outlive the lifetime of the JSON payload within
+ * the \p json_buffer.
  */
 AZ_NODISCARD az_result az_json_reader_init(
     az_json_reader* json_reader,
@@ -558,7 +578,7 @@ AZ_NODISCARD az_result az_json_reader_init(
  * @brief Initializes an #az_json_reader to read the JSON payload contained within the provided
  * set of discontiguous buffers.
  *
- * @param[out] az_json_reader A pointer to an #az_json_reader instance to initialize.
+ * @param[out] json_reader A pointer to an #az_json_reader instance to initialize.
  * @param[in] json_buffers An array of non-contiguous byte buffers, as spans, containing the JSON
  * text to read.
  * @param[in] number_of_buffers The number of buffer segments provided, i.e. the length of the \p
@@ -573,6 +593,9 @@ AZ_NODISCARD az_result az_json_reader_init(
  * @remarks The provided array of json buffers must not be empty, as that is invalid JSON, and
  * therefore \p number_of_buffers must also be greater than 0. The array must also not contain any
  * empty span segments.
+ *
+ * @remarks An instance of #az_json_reader must not outlive the lifetime of the JSON payload within
+ * the \p json_buffers.
  */
 AZ_NODISCARD az_result az_json_reader_chunked_init(
     az_json_reader* json_reader,

--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -545,7 +545,7 @@ typedef struct
  * will use the default options (i.e. #az_json_reader_options_default()).
  *
  * @return An #az_result value indicating the result of the operation:
- *         - #AZ_OK if the az_json_reader is initialized successfully
+ *         - #AZ_OK if the #az_json_reader is initialized successfully
  *
  * @remarks The provided json buffer must not be empty, as that is invalid JSON.
  */
@@ -560,7 +560,7 @@ AZ_NODISCARD az_result az_json_reader_init(
  *
  * @param[out] az_json_reader A pointer to an #az_json_reader instance to initialize.
  * @param[in] json_buffers An array of non-contiguous byte buffers, as spans, containing the JSON
- * text to parse.
+ * text to read.
  * @param[in] number_of_buffers The number of buffer segments provided, i.e. the length of the \p
  * json_buffers array.
  * @param[in] options __[nullable]__ A reference to an #az_json_reader_options
@@ -568,14 +568,14 @@ AZ_NODISCARD az_result az_json_reader_init(
  * will use the default options (i.e. #az_json_reader_options_default()).
  *
  * @return An #az_result value indicating the result of the operation:
- *         - #AZ_OK if the az_json_parser is initialized successfully
+ *         - #AZ_OK if the #az_json_reader is initialized successfully
  *
  * @remarks The provided array of json buffers must not be empty, as that is invalid JSON, and
  * therefore \p number_of_buffers must also be greater than 0. The array must also not contain any
  * empty span segments.
  */
 AZ_NODISCARD az_result az_json_reader_chunked_init(
-    az_json_reader* json_parser,
+    az_json_reader* json_reader,
     az_span json_buffers[],
     int32_t number_of_buffers,
     az_json_reader_options const* options);

--- a/sdk/src/azure/core/az_json_reader.c
+++ b/sdk/src/azure/core/az_json_reader.c
@@ -7,7 +7,6 @@
 #include <azure/core/internal/az_span_internal.h>
 
 #include <ctype.h>
-#include <stdlib.h>
 
 #include <azure/core/_az_cfg.h>
 
@@ -24,8 +23,14 @@ AZ_NODISCARD az_result az_json_reader_init(
     .token = (az_json_token){
       .kind = AZ_JSON_TOKEN_NONE,
       .slice = AZ_SPAN_NULL,
+      .size = 0,
       ._internal = {
         .string_has_escaped_chars = false,
+        .pointer_to_first_buffer = &AZ_SPAN_NULL,
+        .start_buffer_index = 0,
+        .start_buffer_offset = 0,
+        .end_buffer_index = 0,
+        .end_buffer_offset = 0,
       },
     },
     ._internal = {
@@ -56,8 +61,14 @@ AZ_NODISCARD az_result az_json_reader_chunked_init(
     .token = (az_json_token){
       .kind = AZ_JSON_TOKEN_NONE,
       .slice = AZ_SPAN_NULL,
+      .size = 0,
       ._internal = {
         .string_has_escaped_chars = false,
+        .pointer_to_first_buffer = json_buffers,
+        .start_buffer_index = 0,
+        .start_buffer_offset = 0,
+        .end_buffer_index = 0,
+        .end_buffer_offset = 0,
       },
     },
     ._internal = {
@@ -92,6 +103,7 @@ static void _az_json_reader_update_state(
 {
   json_reader->token.kind = token_kind;
   json_reader->token.slice = token_slice;
+  json_reader->token.size = az_span_size(token_slice);
   json_reader->_internal.bytes_consumed += current_segment_consumed;
   json_reader->_internal.total_bytes_consumed += consumed;
 }

--- a/sdk/src/azure/core/az_json_reader.c
+++ b/sdk/src/azure/core/az_json_reader.c
@@ -11,6 +11,8 @@
 
 #include <azure/core/_az_cfg.h>
 
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
 AZ_NODISCARD az_result az_json_reader_init(
     az_json_reader* json_reader,
     az_span json_buffer,
@@ -666,7 +668,7 @@ AZ_NODISCARD static az_result _az_json_reader_process_literal(
   while (true)
   {
     int32_t token_size = az_span_size(token);
-    max_comparable_size = min(token_size, expected_literal_size - already_matched);
+    max_comparable_size = MIN(token_size, expected_literal_size - already_matched);
 
     token = az_span_slice(token, 0, max_comparable_size);
 

--- a/sdk/src/azure/core/az_json_reader.c
+++ b/sdk/src/azure/core/az_json_reader.c
@@ -710,7 +710,7 @@ AZ_NODISCARD static az_result _az_json_reader_process_literal(
 
     // Return if the subslice that can be compared contains a mismatch.
     if (!az_span_is_content_equal(
-            token, az_span_slice(literal, already_matched, max_comparable_size)))
+            token, az_span_slice(literal, already_matched, already_matched + max_comparable_size)))
     {
       return AZ_ERROR_UNEXPECTED_CHAR;
     }

--- a/sdk/src/azure/core/az_json_reader.c
+++ b/sdk/src/azure/core/az_json_reader.c
@@ -3,10 +3,11 @@
 
 #include "az_json_private.h"
 #include "az_span_private.h"
-
 #include <azure/core/az_precondition.h>
+#include <azure/core/internal/az_span_internal.h>
 
 #include <ctype.h>
+#include <stdlib.h>
 
 #include <azure/core/_az_cfg.h>
 
@@ -15,7 +16,6 @@ AZ_NODISCARD az_result az_json_reader_init(
     az_span json_buffer,
     az_json_reader_options const* options)
 {
-  _az_PRECONDITION_NOT_NULL(json_reader);
   _az_PRECONDITION(az_span_size(json_buffer) >= 1);
 
   *json_reader = (az_json_reader){
@@ -28,7 +28,43 @@ AZ_NODISCARD az_result az_json_reader_init(
     },
     ._internal = {
       .json_buffer = json_buffer,
+      .json_buffers = &AZ_SPAN_NULL,
+      .number_of_buffers = 1,
+      .buffer_index = 0,
       .bytes_consumed = 0,
+      .total_bytes_consumed = 0,
+      .is_complex_json = false,
+      .bit_stack = { 0 },
+      .options = options == NULL ? az_json_reader_options_default() : *options,
+    },
+  };
+  return AZ_OK;
+}
+
+AZ_NODISCARD az_result az_json_reader_chunked_init(
+    az_json_reader* json_reader,
+    az_span json_buffers[],
+    int32_t number_of_buffers,
+    az_json_reader_options const* options)
+{
+  _az_PRECONDITION(number_of_buffers >= 1);
+  _az_PRECONDITION(az_span_size(json_buffers[0]) >= 1);
+
+  *json_reader = (az_json_reader){
+    .token = (az_json_token){
+      .kind = AZ_JSON_TOKEN_NONE,
+      .slice = AZ_SPAN_NULL,
+      ._internal = {
+        .string_has_escaped_chars = false,
+      },
+    },
+    ._internal = {
+      .json_buffer = json_buffers[0],
+      .json_buffers = json_buffers,
+      .number_of_buffers = number_of_buffers,
+      .buffer_index = 0,
+      .bytes_consumed = 0,
+      .total_bytes_consumed = 0,
       .is_complex_json = false,
       .bit_stack = { 0 },
       .options = options == NULL ? az_json_reader_options_default() : *options,
@@ -49,20 +85,64 @@ static void _az_json_reader_update_state(
     az_json_reader* json_reader,
     az_json_token_kind token_kind,
     az_span token_slice,
+    int32_t current_segment_consumed,
     int32_t consumed)
 {
   json_reader->token.kind = token_kind;
   json_reader->token.slice = token_slice;
-  json_reader->_internal.bytes_consumed += consumed;
+  json_reader->_internal.bytes_consumed += current_segment_consumed;
+  json_reader->_internal.total_bytes_consumed += consumed;
+}
+
+AZ_NODISCARD static az_result _az_json_reader_get_next_buffer(
+    az_json_reader* json_reader,
+    az_span* remaining)
+{
+  json_reader->_internal.buffer_index++;
+
+  // If we only had one buffer, or we ran out of the set of discontiguous buffers, return error.
+  if (json_reader->_internal.buffer_index >= json_reader->_internal.number_of_buffers)
+  {
+    return AZ_ERROR_EOF;
+  }
+
+  json_reader->_internal.json_buffer
+      = json_reader->_internal.json_buffers[json_reader->_internal.buffer_index];
+  json_reader->_internal.bytes_consumed = 0;
+
+  az_span place_holder = _get_remaining_json(json_reader);
+
+  // Found an empty segment in the json_buffers array, which isn't allowed.
+  if (az_span_size(place_holder) < 1)
+  {
+    return AZ_ERROR_EOF;
+  }
+
+  *remaining = place_holder;
+  return AZ_OK;
 }
 
 AZ_NODISCARD static az_span _az_json_reader_skip_whitespace(az_json_reader* json_reader)
 {
+  az_span json = { 0 };
   az_span remaining = _get_remaining_json(json_reader);
-  az_span json = _az_span_trim_whitespace_from_start(remaining);
 
-  // Find out how many whitespace characters were trimmed.
-  json_reader->_internal.bytes_consumed += az_span_size(remaining) - az_span_size(json);
+  while (true)
+  {
+    json = _az_span_trim_whitespace_from_start(remaining);
+
+    // Find out how many whitespace characters were trimmed.
+    int32_t consumed = _az_span_diff(json, remaining);
+
+    json_reader->_internal.bytes_consumed += consumed;
+    json_reader->_internal.total_bytes_consumed += consumed;
+
+    if (az_span_size(json) >= 1
+        || az_failed(_az_json_reader_get_next_buffer(json_reader, &remaining)))
+    {
+      break;
+    }
+  }
 
   return json;
 }
@@ -82,7 +162,7 @@ AZ_NODISCARD static az_result _az_json_reader_process_container_end(
 
   az_span token = _get_remaining_json(json_reader);
   _az_json_stack_pop(&json_reader->_internal.bit_stack);
-  _az_json_reader_update_state(json_reader, token_kind, az_span_slice(token, 0, 1), 1);
+  _az_json_reader_update_state(json_reader, token_kind, az_span_slice(token, 0, 1), 1, 1);
   return AZ_OK;
 }
 
@@ -101,7 +181,7 @@ AZ_NODISCARD static az_result _az_json_reader_process_container_start(
   az_span token = _get_remaining_json(json_reader);
 
   _az_json_stack_push(&json_reader->_internal.bit_stack, container_kind);
-  _az_json_reader_update_state(json_reader, token_kind, az_span_slice(token, 0, 1), 1);
+  _az_json_reader_update_state(json_reader, token_kind, az_span_slice(token, 0, 1), 1, 1);
   return AZ_OK;
 }
 
@@ -123,31 +203,23 @@ AZ_NODISCARD static bool _az_is_valid_escaped_character(uint8_t byte)
   }
 }
 
-AZ_NODISCARD static bool _az_validate_hex_digits(uint8_t* token_ptr, int32_t index)
-{
-  // The caller already guaranteed that we have at least 4 bytes in the buffer.
-  for (int32_t i = 0; i < 4; i++)
-  {
-    uint8_t next_byte = token_ptr[index + i];
-
-    if (!isxdigit(next_byte))
-    {
-      return false;
-    }
-  }
-  return true;
-}
-
 AZ_NODISCARD static az_result _az_json_reader_process_string(az_json_reader* json_reader)
 {
   // Move past the first '"' character
   json_reader->_internal.bytes_consumed++;
 
   az_span token = _get_remaining_json(json_reader);
-  uint8_t* const token_ptr = az_span_ptr(token);
-  int32_t const remaining_size = az_span_size(token);
+  int32_t remaining_size = az_span_size(token);
 
+  if (remaining_size < 1)
+  {
+    AZ_RETURN_IF_FAILED(_az_json_reader_get_next_buffer(json_reader, &token));
+    remaining_size = az_span_size(token);
+  }
+
+  int32_t current_index = 0;
   int32_t string_length = 0;
+  uint8_t* token_ptr = az_span_ptr(token);
   uint8_t next_byte = token_ptr[0];
 
   // Clear the state of any previous string token.
@@ -162,29 +234,46 @@ AZ_NODISCARD static az_result _az_json_reader_process_string(az_json_reader* jso
     else if (next_byte == '\\')
     {
       json_reader->token._internal.string_has_escaped_chars = true;
+      current_index++;
       string_length++;
-      if (string_length >= remaining_size)
+      if (current_index >= remaining_size)
       {
-        return AZ_ERROR_EOF;
+        AZ_RETURN_IF_FAILED(_az_json_reader_get_next_buffer(json_reader, &token));
+        current_index = 0;
+        token_ptr = az_span_ptr(token);
+        remaining_size = az_span_size(token);
       }
-      next_byte = token_ptr[string_length];
+      next_byte = token_ptr[current_index];
 
       if (next_byte == 'u')
       {
+        current_index++;
         string_length++;
+
         // Expecting 4 hex digits to follow the escaped 'u'
-        if (string_length > remaining_size - 4)
+        for (int32_t i = 0; i < 4; i++)
         {
-          return AZ_ERROR_EOF;
+          if (current_index > remaining_size)
+          {
+            AZ_RETURN_IF_FAILED(_az_json_reader_get_next_buffer(json_reader, &token));
+            current_index = 0;
+            token_ptr = az_span_ptr(token);
+            remaining_size = az_span_size(token);
+          }
+
+          string_length++;
+          next_byte = token_ptr[current_index++];
+
+          if (!isxdigit(next_byte))
+          {
+            return AZ_ERROR_UNEXPECTED_CHAR;
+          }
         }
 
-        if (!_az_validate_hex_digits(token_ptr, string_length))
-        {
-          return AZ_ERROR_UNEXPECTED_CHAR;
-        }
-
-        // Skip past the 4 hex digits, the loop accounts for incrementing by 1 more.
-        string_length += 3;
+        // We have already skipped past the u and 4 hex digits. The loop accounts for incrementing
+        // by 1 more, so subtract one to account for that.
+        current_index--;
+        string_length--;
       }
       else
       {
@@ -203,17 +292,26 @@ AZ_NODISCARD static az_result _az_json_reader_process_string(az_json_reader* jso
       }
     }
 
+    current_index++;
     string_length++;
-    if (string_length >= remaining_size)
+
+    if (current_index >= remaining_size)
     {
-      return AZ_ERROR_EOF;
+      AZ_RETURN_IF_FAILED(_az_json_reader_get_next_buffer(json_reader, &token));
+      current_index = 0;
+      token_ptr = az_span_ptr(token);
+      remaining_size = az_span_size(token);
     }
-    next_byte = token_ptr[string_length];
+    next_byte = token_ptr[current_index];
   }
 
   // Add 1 to number of bytes consumed to account for the last '"' character.
   _az_json_reader_update_state(
-      json_reader, AZ_JSON_TOKEN_STRING, az_span_slice(token, 0, string_length), string_length + 1);
+      json_reader,
+      AZ_JSON_TOKEN_STRING,
+      az_span_slice(token, 0, current_index),
+      current_index + 1,
+      string_length + 1);
 
   return AZ_OK;
 }
@@ -240,6 +338,7 @@ AZ_NODISCARD static az_result _az_json_reader_process_property_name(az_json_read
   // Therefore, we don't call _az_json_reader_update_state here.
   json_reader->token.kind = AZ_JSON_TOKEN_PROPERTY_NAME;
   json_reader->_internal.bytes_consumed += 1; // For the name / value separator
+  json_reader->_internal.total_bytes_consumed += 1; // For the name / value separator
 
   return AZ_OK;
 }
@@ -278,51 +377,77 @@ AZ_NODISCARD static bool _az_finished_consuming_json_number(
   return false;
 }
 
-AZ_NODISCARD static int32_t _az_json_reader_consume_digits(az_span token)
+static void _az_json_reader_consume_digits(
+    az_json_reader* json_reader,
+    az_span* token,
+    int32_t* current_consumed,
+    int32_t* total_consumed)
 {
-  int32_t const token_size = az_span_size(token);
-  uint8_t* next_byte_ptr = az_span_ptr(token);
-
   int32_t counter = 0;
-  while (counter < token_size)
+  az_span current = az_span_slice_to_end(*token, *current_consumed);
+  while (true)
   {
-    if (isdigit(*next_byte_ptr))
+    int32_t const token_size = az_span_size(current);
+    uint8_t* next_byte_ptr = az_span_ptr(current);
+
+    while (counter < token_size)
     {
-      counter++;
-      next_byte_ptr++;
+      if (isdigit(*next_byte_ptr))
+      {
+        counter++;
+        next_byte_ptr++;
+      }
+      else
+      {
+        break;
+      }
     }
-    else
+    if (counter == token_size && az_succeeded(_az_json_reader_get_next_buffer(json_reader, token)))
     {
-      break;
+      *total_consumed += counter;
+      counter = 0;
+      *current_consumed = 0;
+      current = *token;
+      continue;
     }
+    break;
   }
 
-  return counter;
+  *total_consumed += counter;
+  *current_consumed += counter;
 }
 
 AZ_NODISCARD static az_result _az_json_reader_update_number_state_if_single_value(
     az_json_reader* json_reader,
     az_span token_slice,
-    int32_t consumed_count)
+    int32_t current_consumed,
+    int32_t total_consumed)
 {
   if (json_reader->_internal.is_complex_json)
   {
     return AZ_ERROR_EOF;
   }
 
-  _az_json_reader_update_state(json_reader, AZ_JSON_TOKEN_NUMBER, token_slice, consumed_count);
+  _az_json_reader_update_state(
+      json_reader, AZ_JSON_TOKEN_NUMBER, token_slice, current_consumed, total_consumed);
 
   return AZ_OK;
 }
 
-AZ_NODISCARD static az_result _az_validate_next_byte_is_digit(az_span remaining_number)
+AZ_NODISCARD static az_result _az_validate_next_byte_is_digit(
+    az_json_reader* json_reader,
+    az_span* remaining_number,
+    int32_t* current_consumed)
 {
-  if (az_span_size(remaining_number) < 1)
+  az_span current = az_span_slice_to_end(*remaining_number, *current_consumed);
+  if (az_span_size(current) < 1)
   {
-    return AZ_ERROR_EOF;
+    AZ_RETURN_IF_FAILED(_az_json_reader_get_next_buffer(json_reader, remaining_number));
+    current = *remaining_number;
+    *current_consumed = 0;
   }
 
-  if (!isdigit(az_span_ptr(remaining_number)[0]))
+  if (!isdigit(az_span_ptr(current)[0]))
   {
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
@@ -334,37 +459,43 @@ AZ_NODISCARD static az_result _az_json_reader_process_number(az_json_reader* jso
 {
   az_span token = _get_remaining_json(json_reader);
 
-  int32_t const token_size = az_span_size(token);
-  uint8_t* const next_byte_ptr = az_span_ptr(token);
+  int32_t total_consumed = 0;
+  int32_t current_consumed = 0;
 
-  int32_t consumed_count = 0;
-
-  uint8_t next_byte = next_byte_ptr[consumed_count];
+  uint8_t next_byte = az_span_ptr(token)[0];
   if (next_byte == '-')
   {
-    consumed_count++;
+    total_consumed++;
+    current_consumed++;
 
     // A negative sign must be followed by at least one digit.
-    AZ_RETURN_IF_FAILED(
-        _az_validate_next_byte_is_digit(az_span_slice_to_end(token, consumed_count)));
+    AZ_RETURN_IF_FAILED(_az_validate_next_byte_is_digit(json_reader, &token, &current_consumed));
 
-    next_byte = next_byte_ptr[consumed_count];
+    next_byte = az_span_ptr(token)[current_consumed];
   }
 
   if (next_byte == '0')
   {
-    consumed_count++;
+    total_consumed++;
+    current_consumed++;
 
-    if (consumed_count >= token_size)
+    if (current_consumed >= az_span_size(token))
     {
-      // If there is no more JSON, this is a valid end state only when the JSON payload contains a
-      // single value: "[-]0"
-      // Otherwise, the payload is incomplete and ending too early.
-      return _az_json_reader_update_number_state_if_single_value(
-          json_reader, az_span_slice(token, 0, consumed_count), consumed_count);
+      if (az_failed(_az_json_reader_get_next_buffer(json_reader, &token)))
+      {
+        // If there is no more JSON, this is a valid end state only when the JSON payload contains a
+        // single value: "[-]0"
+        // Otherwise, the payload is incomplete and ending too early.
+        return _az_json_reader_update_number_state_if_single_value(
+            json_reader,
+            az_span_slice(token, 0, current_consumed),
+            current_consumed,
+            total_consumed);
+      }
+      current_consumed = 0;
     }
 
-    next_byte = next_byte_ptr[consumed_count];
+    next_byte = az_span_ptr(token)[current_consumed];
     az_result result = AZ_OK;
     if (_az_finished_consuming_json_number(next_byte, AZ_SPAN_FROM_STR(".eE"), &result))
     {
@@ -373,8 +504,9 @@ AZ_NODISCARD static az_result _az_json_reader_process_number(az_json_reader* jso
         _az_json_reader_update_state(
             json_reader,
             AZ_JSON_TOKEN_NUMBER,
-            az_span_slice(token, 0, consumed_count),
-            consumed_count);
+            az_span_slice(token, 0, current_consumed),
+            current_consumed,
+            total_consumed);
       }
       return result;
     }
@@ -382,19 +514,27 @@ AZ_NODISCARD static az_result _az_json_reader_process_number(az_json_reader* jso
   else
   {
     _az_PRECONDITION(isdigit(next_byte));
-    // Integer part before decimal
-    consumed_count += _az_json_reader_consume_digits(az_span_slice_to_end(token, consumed_count));
 
-    if (consumed_count >= token_size)
+    // Integer part before decimal
+    _az_json_reader_consume_digits(json_reader, &token, &current_consumed, &total_consumed);
+
+    if (current_consumed >= az_span_size(token))
     {
-      // If there is no more JSON, this is a valid end state only when the JSON payload contains a
-      // single value: "[-][digits]"
-      // Otherwise, the payload is incomplete and ending too early.
-      return _az_json_reader_update_number_state_if_single_value(
-          json_reader, az_span_slice(token, 0, consumed_count), consumed_count);
+      if (az_failed(_az_json_reader_get_next_buffer(json_reader, &token)))
+      {
+        // If there is no more JSON, this is a valid end state only when the JSON payload contains a
+        // single value: "[-][digits]"
+        // Otherwise, the payload is incomplete and ending too early.
+        return _az_json_reader_update_number_state_if_single_value(
+            json_reader,
+            az_span_slice(token, 0, current_consumed),
+            current_consumed,
+            total_consumed);
+      }
+      current_consumed = 0;
     }
 
-    next_byte = next_byte_ptr[consumed_count];
+    next_byte = az_span_ptr(token)[current_consumed];
     az_result result = AZ_OK;
     if (_az_finished_consuming_json_number(next_byte, AZ_SPAN_FROM_STR(".eE"), &result))
     {
@@ -403,8 +543,9 @@ AZ_NODISCARD static az_result _az_json_reader_process_number(az_json_reader* jso
         _az_json_reader_update_state(
             json_reader,
             AZ_JSON_TOKEN_NUMBER,
-            az_span_slice(token, 0, consumed_count),
-            consumed_count);
+            az_span_slice(token, 0, current_consumed),
+            current_consumed,
+            total_consumed);
       }
       return result;
     }
@@ -412,25 +553,32 @@ AZ_NODISCARD static az_result _az_json_reader_process_number(az_json_reader* jso
 
   if (next_byte == '.')
   {
-    consumed_count++;
+    total_consumed++;
+    current_consumed++;
 
     // A decimal point must be followed by at least one digit.
-    AZ_RETURN_IF_FAILED(
-        _az_validate_next_byte_is_digit(az_span_slice_to_end(token, consumed_count)));
+    AZ_RETURN_IF_FAILED(_az_validate_next_byte_is_digit(json_reader, &token, &current_consumed));
 
     // Integer part after decimal
-    consumed_count += _az_json_reader_consume_digits(az_span_slice_to_end(token, consumed_count));
+    _az_json_reader_consume_digits(json_reader, &token, &current_consumed, &total_consumed);
 
-    if (consumed_count >= token_size)
+    if (current_consumed >= az_span_size(token))
     {
-      // If there is no more JSON, this is a valid end state only when the JSON payload contains a
-      // single value: "[-][digits].[digits]"
-      // Otherwise, the payload is incomplete and ending too early.
-      return _az_json_reader_update_number_state_if_single_value(
-          json_reader, az_span_slice(token, 0, consumed_count), consumed_count);
+      if (az_failed(_az_json_reader_get_next_buffer(json_reader, &token)))
+      {
+        // If there is no more JSON, this is a valid end state only when the JSON payload contains a
+        // single value: "[-][digits].[digits]"
+        // Otherwise, the payload is incomplete and ending too early.
+        return _az_json_reader_update_number_state_if_single_value(
+            json_reader,
+            az_span_slice(token, 0, current_consumed),
+            current_consumed,
+            total_consumed);
+      }
+      current_consumed = 0;
     }
 
-    next_byte = next_byte_ptr[consumed_count];
+    next_byte = az_span_ptr(token)[current_consumed];
     az_result result = AZ_OK;
     if (_az_finished_consuming_json_number(next_byte, AZ_SPAN_FROM_STR("eE"), &result))
     {
@@ -439,46 +587,54 @@ AZ_NODISCARD static az_result _az_json_reader_process_number(az_json_reader* jso
         _az_json_reader_update_state(
             json_reader,
             AZ_JSON_TOKEN_NUMBER,
-            az_span_slice(token, 0, consumed_count),
-            consumed_count);
+            az_span_slice(token, 0, current_consumed),
+            current_consumed,
+            total_consumed);
       }
       return result;
     }
   }
 
   // Move past 'e'/'E'
-  consumed_count++;
+  total_consumed++;
+  current_consumed++;
 
   // The 'e'/'E' character must be followed by a sign or at least one digit.
-  if (consumed_count >= token_size)
+  if (current_consumed >= az_span_size(token))
   {
-    return AZ_ERROR_EOF;
+    AZ_RETURN_IF_FAILED(_az_json_reader_get_next_buffer(json_reader, &token));
+    current_consumed = 0;
   }
 
-  next_byte = next_byte_ptr[consumed_count];
+  next_byte = az_span_ptr(token)[current_consumed];
   if (next_byte == '-' || next_byte == '+')
   {
-    consumed_count++;
+    total_consumed++;
+    current_consumed++;
 
     // A sign must be followed by at least one digit.
-    AZ_RETURN_IF_FAILED(
-        _az_validate_next_byte_is_digit(az_span_slice_to_end(token, consumed_count)));
+    AZ_RETURN_IF_FAILED(_az_validate_next_byte_is_digit(json_reader, &token, &current_consumed));
   }
 
   // Integer part after the 'e'/'E'
-  consumed_count += _az_json_reader_consume_digits(az_span_slice_to_end(token, consumed_count));
+  _az_json_reader_consume_digits(json_reader, &token, &current_consumed, &total_consumed);
 
-  if (consumed_count >= token_size)
+  if (current_consumed >= az_span_size(token))
   {
-    // If there is no more JSON, this is a valid end state only when the JSON payload contains a
-    // single value: "[-][digits].[digits]e[+|-][digits]"
-    // Otherwise, the payload is incomplete and ending too early.
-    return _az_json_reader_update_number_state_if_single_value(
-        json_reader, az_span_slice(token, 0, consumed_count), consumed_count);
+    if (az_failed(_az_json_reader_get_next_buffer(json_reader, &token)))
+    {
+
+      // If there is no more JSON, this is a valid end state only when the JSON payload contains a
+      // single value: "[-][digits].[digits]e[+|-][digits]"
+      // Otherwise, the payload is incomplete and ending too early.
+      return _az_json_reader_update_number_state_if_single_value(
+          json_reader, az_span_slice(token, 0, current_consumed), current_consumed, total_consumed);
+    }
+    current_consumed = 0;
   }
 
   // Checking if we are done processing a JSON number
-  next_byte = next_byte_ptr[consumed_count];
+  next_byte = az_span_ptr(token)[current_consumed];
   int32_t index = az_span_find(json_delimiters, az_span_create(&next_byte, 1));
   if (index == -1)
   {
@@ -486,7 +642,11 @@ AZ_NODISCARD static az_result _az_json_reader_process_number(az_json_reader* jso
   }
 
   _az_json_reader_update_state(
-      json_reader, AZ_JSON_TOKEN_NUMBER, az_span_slice(token, 0, consumed_count), consumed_count);
+      json_reader,
+      AZ_JSON_TOKEN_NUMBER,
+      az_span_slice(token, 0, current_consumed),
+      current_consumed,
+      total_consumed);
 
   return AZ_OK;
 }
@@ -498,22 +658,38 @@ AZ_NODISCARD static az_result _az_json_reader_process_literal(
 {
   az_span token = _get_remaining_json(json_reader);
 
-  int32_t const token_size = az_span_size(token);
   int32_t const expected_literal_size = az_span_size(literal);
 
-  // Return EOF because the token is smaller than the expected literal.
-  if (token_size < expected_literal_size)
+  int32_t already_matched = 0;
+
+  int32_t max_comparable_size = 0;
+  while (true)
   {
-    return AZ_ERROR_EOF;
+    int32_t token_size = az_span_size(token);
+    max_comparable_size = min(token_size, expected_literal_size - already_matched);
+
+    token = az_span_slice(token, 0, max_comparable_size);
+
+    // Return if the subslice that can be compared contains a mismatch.
+    if (!az_span_is_content_equal(
+            token, az_span_slice(literal, already_matched, max_comparable_size)))
+    {
+      return AZ_ERROR_UNEXPECTED_CHAR;
+    }
+    already_matched += max_comparable_size;
+
+    if (already_matched == expected_literal_size)
+    {
+      break;
+    }
+
+    // If there is no more data, return EOF because the token is smaller than the expected literal.
+    AZ_RETURN_IF_FAILED(_az_json_reader_get_next_buffer(json_reader, &token));
   }
 
-  token = az_span_slice(token, 0, expected_literal_size);
-  if (az_span_is_content_equal(token, literal))
-  {
-    _az_json_reader_update_state(json_reader, kind, token, expected_literal_size);
-    return AZ_OK;
-  }
-  return AZ_ERROR_UNEXPECTED_CHAR;
+  _az_json_reader_update_state(
+      json_reader, kind, token, max_comparable_size, expected_literal_size);
+  return AZ_OK;
 }
 
 AZ_NODISCARD static az_result _az_json_reader_process_value(
@@ -552,7 +728,7 @@ AZ_NODISCARD static az_result _az_json_reader_read_first_token(
   {
     _az_json_stack_push(&json_reader->_internal.bit_stack, _az_JSON_STACK_OBJECT);
     _az_json_reader_update_state(
-        json_reader, AZ_JSON_TOKEN_BEGIN_OBJECT, az_span_slice(json, 0, 1), 1);
+        json_reader, AZ_JSON_TOKEN_BEGIN_OBJECT, az_span_slice(json, 0, 1), 1, 1);
     json_reader->_internal.is_complex_json = true;
     return AZ_OK;
   }
@@ -560,7 +736,7 @@ AZ_NODISCARD static az_result _az_json_reader_read_first_token(
   {
     _az_json_stack_push(&json_reader->_internal.bit_stack, _az_JSON_STACK_ARRAY);
     _az_json_reader_update_state(
-        json_reader, AZ_JSON_TOKEN_BEGIN_ARRAY, az_span_slice(json, 0, 1), 1);
+        json_reader, AZ_JSON_TOKEN_BEGIN_ARRAY, az_span_slice(json, 0, 1), 1, 1);
     json_reader->_internal.is_complex_json = true;
     return AZ_OK;
   }
@@ -633,9 +809,18 @@ AZ_NODISCARD az_result az_json_reader_next_token(az_json_reader* json_reader)
 
   az_span json = _az_json_reader_skip_whitespace(json_reader);
 
-  if (az_span_size(json) < 1 && json_reader->token.kind != AZ_JSON_TOKEN_NONE)
+  if (az_span_size(json) < 1)
   {
-    return AZ_ERROR_JSON_READER_DONE;
+    if (json_reader->token.kind == AZ_JSON_TOKEN_NONE)
+    {
+      // An empty JSON payload is invalid.
+      return AZ_ERROR_EOF;
+    }
+    else
+    {
+      // No more JSON text left to process, we are done.
+      return AZ_ERROR_JSON_READER_DONE;
+    }
   }
 
   uint8_t const first_byte = az_span_ptr(json)[0];
@@ -644,11 +829,6 @@ AZ_NODISCARD az_result az_json_reader_next_token(az_json_reader* json_reader)
   {
     case AZ_JSON_TOKEN_NONE:
     {
-      // An empty JSON payload is invalid.
-      if (az_span_size(json) < 1)
-      {
-        return AZ_ERROR_EOF;
-      }
       return _az_json_reader_read_first_token(json_reader, json, first_byte);
     }
     case AZ_JSON_TOKEN_BEGIN_OBJECT:

--- a/sdk/src/azure/core/az_json_token.c
+++ b/sdk/src/azure/core/az_json_token.c
@@ -235,7 +235,20 @@ AZ_NODISCARD az_result az_json_token_get_boolean(az_json_token const* json_token
   // az_json_reader and that if json_token->kind == AZ_JSON_TOKEN_TRUE, then the slice contains the
   // characters "true", otherwise it contains "false". Therefore, there is no need to check the
   // contents again.
-  *out_value = json_token->size == _az_STRING_LITERAL_LEN("true");
+
+  az_span token_slice = json_token->slice;
+
+  // Contiguous token
+  if (az_span_ptr(token_slice) != NULL)
+  {
+    *out_value = az_span_size(token_slice) == _az_STRING_LITERAL_LEN("true");
+  }
+  else
+  {
+    // Token straddles more than one segment
+    *out_value = json_token->size == _az_STRING_LITERAL_LEN("true");
+  }
+
   return AZ_OK;
 }
 

--- a/sdk/src/azure/core/az_json_token.c
+++ b/sdk/src/azure/core/az_json_token.c
@@ -2,10 +2,51 @@
 // SPDX-License-Identifier: MIT
 
 #include <azure/core/internal/az_precondition_internal.h>
+#include <azure/core/internal/az_span_internal.h>
 
 #include "az_json_private.h"
 
 #include <azure/core/_az_cfg.h>
+
+// Used to copy discontiguous token values into a contiguous buffer, for number parsing.
+static uint8_t _az_scratch_buffer[64] = { 0 };
+
+az_span az_json_token_copy_into_span(az_json_token const* json_token, az_span destination)
+{
+  _az_PRECONDITION_VALID_SPAN(destination, json_token->size, false);
+
+  az_span token_slice = json_token->slice;
+
+  // Contiguous token
+  if (az_span_ptr(token_slice) != NULL)
+  {
+    return az_span_copy(destination, token_slice);
+  }
+
+  if (json_token->size == 0)
+  {
+    return destination;
+  }
+
+  // Token straddles more than one segment
+  for (int32_t i = json_token->_internal.start_buffer_index;
+       i <= json_token->_internal.end_buffer_index;
+       i++)
+  {
+    az_span source = json_token->_internal.pointer_to_first_buffer[i];
+    if (i == json_token->_internal.start_buffer_index)
+    {
+      source = az_span_slice_to_end(source, json_token->_internal.start_buffer_offset);
+    }
+    else if (i == json_token->_internal.end_buffer_index)
+    {
+      source = az_span_slice(source, 0, json_token->_internal.end_buffer_offset);
+    }
+    destination = az_span_copy(destination, source);
+  }
+
+  return destination;
+}
 
 AZ_NODISCARD static uint8_t _az_json_unescape_single_byte(uint8_t ch)
 {
@@ -34,6 +75,60 @@ AZ_NODISCARD static uint8_t _az_json_unescape_single_byte(uint8_t ch)
   }
 }
 
+AZ_NODISCARD bool _az_json_token_is_text_equal_helper(az_span token_slice, az_span* expected_text)
+{
+  int32_t token_size = az_span_size(token_slice);
+  uint8_t* token_ptr = az_span_ptr(token_slice);
+
+  int32_t expected_size = az_span_size(*expected_text);
+  uint8_t* expected_ptr = az_span_ptr(*expected_text);
+
+  int32_t token_idx = 0;
+  for (int32_t i = 0; i < expected_size; i++)
+  {
+    if (token_idx >= token_size)
+    {
+      *expected_text = az_span_slice_to_end(*expected_text, i);
+      return false;
+    }
+    uint8_t token_byte = token_ptr[token_idx];
+
+    if (token_byte == '\\')
+    {
+      token_idx++;
+      if (token_idx >= token_size)
+      {
+        *expected_text = az_span_slice_to_end(*expected_text, i);
+        return false;
+      }
+      token_byte = token_ptr[token_idx];
+      token_byte = _az_json_unescape_single_byte(token_byte);
+
+      // TODO: Characters escaped in the form of \uXXXX where XXXX is the UTF-16 code point, is
+      // not currently supported.
+      // To do this, we need to encode UTF-16 codepoints (including surrogate pairs) into UTF-8.
+      if (token_byte == 'u')
+      {
+        *expected_text = AZ_SPAN_NULL;
+        return false;
+      }
+    }
+
+    if (token_ptr[i] != expected_ptr[i])
+    {
+      *expected_text = AZ_SPAN_NULL;
+      return false;
+    }
+
+    token_idx++;
+  }
+
+  *expected_text = AZ_SPAN_NULL;
+
+  // Only return true if the size of the unescaped token matches the expected size exactly.
+  return token_idx == token_size;
+}
+
 AZ_NODISCARD bool az_json_token_is_text_equal(
     az_json_token const* json_token,
     az_span expected_text)
@@ -47,16 +142,44 @@ AZ_NODISCARD bool az_json_token_is_text_equal(
   }
 
   az_span token_slice = json_token->slice;
+
+  // There is nothing to unescape here, compare directly.
   if (!json_token->_internal.string_has_escaped_chars)
   {
-    return az_span_is_content_equal(token_slice, expected_text);
+    // Contiguous token
+    if (az_span_ptr(token_slice) != NULL)
+    {
+      return az_span_is_content_equal(token_slice, expected_text);
+    }
+
+    // Token straddles more than one segment
+    for (int32_t i = json_token->_internal.start_buffer_index;
+         i <= json_token->_internal.end_buffer_index;
+         i++)
+    {
+      az_span source = json_token->_internal.pointer_to_first_buffer[i];
+      if (i == json_token->_internal.start_buffer_index)
+      {
+        source = az_span_slice_to_end(source, json_token->_internal.start_buffer_offset);
+      }
+      else if (i == json_token->_internal.end_buffer_index)
+      {
+        source = az_span_slice(source, 0, json_token->_internal.end_buffer_offset);
+      }
+
+      int32_t source_size = az_span_size(source);
+      if (az_span_size(expected_text) < source_size
+          || !az_span_is_content_equal(source, az_span_slice(expected_text, 0, source_size)))
+      {
+        return false;
+      }
+      expected_text = az_span_slice_to_end(expected_text, source_size);
+    }
+    return true;
   }
 
   int32_t token_size = az_span_size(token_slice);
-  uint8_t* token_ptr = az_span_ptr(token_slice);
-
   int32_t expected_size = az_span_size(expected_text);
-  uint8_t* expected_ptr = az_span_ptr(expected_text);
 
   // No need to try to unescape the token slice, since the lengths won't match anyway.
   // Unescaping always shrinks the string, at most by a factor of 6.
@@ -66,44 +189,36 @@ AZ_NODISCARD bool az_json_token_is_text_equal(
     return false;
   }
 
-  int32_t token_idx = 0;
-  for (int32_t i = 0; i < expected_size; i++)
+  // Contiguous token
+  if (az_span_ptr(token_slice) != NULL)
   {
-    if (token_idx >= token_size)
-    {
-      return false;
-    }
-    uint8_t token_byte = token_ptr[token_idx];
-
-    if (token_byte == '\\')
-    {
-      token_idx++;
-      if (token_idx >= token_size)
-      {
-        return false;
-      }
-      token_byte = token_ptr[token_idx];
-      token_byte = _az_json_unescape_single_byte(token_byte);
-
-      // TODO: Characters escaped in the form of \uXXXX where XXXX is the UTF-16 code point, is
-      // not currently supported.
-      // To do this, we need to encode UTF-16 codepoints (including surrogate pairs) into UTF-8.
-      if (token_byte == 'u')
-      {
-        return false;
-      }
-    }
-
-    if (token_ptr[i] != expected_ptr[i])
-    {
-      return false;
-    }
-
-    token_idx++;
+    return _az_json_token_is_text_equal_helper(token_slice, &expected_text);
   }
 
-  // Only return true if the size of the unescaped token matches the expected size exactly.
-  return token_idx == token_size;
+  // Token straddles more than one segment
+  for (int32_t i = json_token->_internal.start_buffer_index;
+       i <= json_token->_internal.end_buffer_index;
+       i++)
+  {
+    az_span source = json_token->_internal.pointer_to_first_buffer[i];
+    if (i == json_token->_internal.start_buffer_index)
+    {
+      source = az_span_slice_to_end(source, json_token->_internal.start_buffer_offset);
+    }
+    else if (i == json_token->_internal.end_buffer_index)
+    {
+      source = az_span_slice(source, 0, json_token->_internal.end_buffer_offset);
+    }
+
+    if (!_az_json_token_is_text_equal_helper(source, &expected_text)
+        && az_span_ptr(expected_text) == NULL)
+    {
+      return false;
+    }
+  }
+
+  // Only return true if we have gone through and compared the entire expected_text.
+  return az_span_ptr(expected_text) == NULL;
 }
 
 AZ_NODISCARD az_result az_json_token_get_boolean(az_json_token const* json_token, bool* out_value)
@@ -116,7 +231,48 @@ AZ_NODISCARD az_result az_json_token_get_boolean(az_json_token const* json_token
     return AZ_ERROR_JSON_INVALID_STATE;
   }
 
-  *out_value = az_span_size(json_token->slice) == _az_STRING_LITERAL_LEN("true");
+  // We assume the az_json_token is well-formed and self-consistent when returned from the
+  // az_json_reader and that if json_token->kind == AZ_JSON_TOKEN_TRUE, then the slice contains the
+  // characters "true", otherwise it contains "false". Therefore, there is no need to check the
+  // contents again.
+  *out_value = json_token->size == _az_STRING_LITERAL_LEN("true");
+  return AZ_OK;
+}
+
+AZ_NODISCARD az_result _az_json_token_get_string_helper(
+    az_span source,
+    char* destination,
+    int32_t destination_max_size,
+    int32_t* dest_idx)
+{
+  int32_t source_size = az_span_size(source);
+  uint8_t* source_ptr = az_span_ptr(source);
+  for (int32_t i = 0; i < source_size; i++)
+  {
+    if (*dest_idx >= destination_max_size)
+    {
+      return AZ_ERROR_INSUFFICIENT_SPAN_SIZE;
+    }
+    uint8_t token_byte = source_ptr[i];
+
+    if (token_byte == '\\')
+    {
+      i++;
+      // For all valid JSON tokens, this is guaranteed to be within the bounds.
+      token_byte = _az_json_unescape_single_byte(source_ptr[i]);
+
+      // TODO: Characters escaped in the form of \uXXXX where XXXX is the UTF-16 code point, is
+      // not currently supported.
+      // To do this, we need to encode UTF-16 codepoints (including surrogate pairs) into UTF-8.
+      if (token_byte == 'u')
+      {
+        return AZ_ERROR_NOT_IMPLEMENTED;
+      }
+    }
+
+    destination[*dest_idx++] = (char)token_byte;
+  }
+
   return AZ_OK;
 }
 
@@ -136,7 +292,7 @@ AZ_NODISCARD az_result az_json_token_get_string(
   }
 
   az_span token_slice = json_token->slice;
-  int32_t token_size = az_span_size(token_slice);
+  int32_t token_size = json_token->size;
 
   // There is nothing to unescape here, copy directly.
   if (!json_token->_internal.string_has_escaped_chars)
@@ -147,8 +303,21 @@ AZ_NODISCARD az_result az_json_token_get_string(
       return AZ_ERROR_INSUFFICIENT_SPAN_SIZE;
     }
 
-    // This will add a null terminator.
-    az_span_to_str(destination, destination_max_size, token_slice);
+    // Contiguous token
+    if (az_span_ptr(token_slice) != NULL)
+    {
+      // This will add a null terminator.
+      az_span_to_str(destination, destination_max_size, token_slice);
+    }
+    else
+    {
+      // Token straddles more than one segment
+      az_span remainder = az_json_token_copy_into_span(
+          json_token, az_span_create((uint8_t*)destination, destination_max_size));
+
+      // Add a null terminator.
+      az_span_copy_u8(remainder, 0);
+    }
 
     if (out_string_length != NULL)
     {
@@ -165,34 +334,34 @@ AZ_NODISCARD az_result az_json_token_get_string(
     return AZ_ERROR_INSUFFICIENT_SPAN_SIZE;
   }
 
-  uint8_t* token_ptr = az_span_ptr(token_slice);
-
   int32_t dest_idx = 0;
-  for (int32_t i = 0; i < token_size; i++)
+
+  // Contiguous token
+  if (az_span_ptr(token_slice) != NULL)
   {
-    if (dest_idx >= destination_max_size)
+    AZ_RETURN_IF_FAILED(_az_json_token_get_string_helper(
+        token_slice, destination, destination_max_size, &dest_idx));
+  }
+  else
+  {
+    // Token straddles more than one segment
+    for (int32_t i = json_token->_internal.start_buffer_index;
+         i <= json_token->_internal.end_buffer_index;
+         i++)
     {
-      return AZ_ERROR_INSUFFICIENT_SPAN_SIZE;
-    }
-    uint8_t token_byte = token_ptr[i];
-
-    if (token_byte == '\\')
-    {
-      i++;
-      // For all valid JSON tokens, this is guaranteed to be within the bounds.
-      token_byte = _az_json_unescape_single_byte(token_ptr[i]);
-
-      // TODO: Characters escaped in the form of \uXXXX where XXXX is the UTF-16 code point, is
-      // not currently supported.
-      // To do this, we need to encode UTF-16 codepoints (including surrogate pairs) into UTF-8.
-      if (token_byte == 'u')
+      az_span source = json_token->_internal.pointer_to_first_buffer[i];
+      if (i == json_token->_internal.start_buffer_index)
       {
-        return AZ_ERROR_NOT_IMPLEMENTED;
+        source = az_span_slice_to_end(source, json_token->_internal.start_buffer_offset);
       }
-    }
+      else if (i == json_token->_internal.end_buffer_index)
+      {
+        source = az_span_slice(source, 0, json_token->_internal.end_buffer_offset);
+      }
 
-    destination[dest_idx] = (char)token_byte;
-    dest_idx++;
+      AZ_RETURN_IF_FAILED(
+          _az_json_token_get_string_helper(source, destination, destination_max_size, &dest_idx));
+    }
   }
 
   if (dest_idx >= destination_max_size)
@@ -220,7 +389,26 @@ az_json_token_get_uint64(az_json_token const* json_token, uint64_t* out_value)
     return AZ_ERROR_JSON_INVALID_STATE;
   }
 
-  return az_span_atou64(json_token->slice, out_value);
+  az_span token_slice = json_token->slice;
+
+  // Contiguous token
+  if (az_span_ptr(token_slice) != NULL)
+  {
+    return az_span_atou64(token_slice, out_value);
+  }
+
+  // Token straddles more than one segment
+  az_span scratch = AZ_SPAN_FROM_BUFFER(_az_scratch_buffer);
+
+  // Any number that won't fit in 64 bytes, will overflow.
+  if (az_span_size(scratch) < json_token->size)
+  {
+    return AZ_ERROR_UNEXPECTED_CHAR;
+  }
+
+  az_span remainder = az_json_token_copy_into_span(json_token, scratch);
+
+  return az_span_atou64(az_span_slice(scratch, 0, _az_span_diff(remainder, scratch)), out_value);
 }
 
 AZ_NODISCARD az_result
@@ -234,7 +422,26 @@ az_json_token_get_uint32(az_json_token const* json_token, uint32_t* out_value)
     return AZ_ERROR_JSON_INVALID_STATE;
   }
 
-  return az_span_atou32(json_token->slice, out_value);
+  az_span token_slice = json_token->slice;
+
+  // Contiguous token
+  if (az_span_ptr(token_slice) != NULL)
+  {
+    return az_span_atou32(token_slice, out_value);
+  }
+
+  // Token straddles more than one segment
+  az_span scratch = AZ_SPAN_FROM_BUFFER(_az_scratch_buffer);
+
+  // Any number that won't fit in 64 bytes, will overflow.
+  if (az_span_size(scratch) < json_token->size)
+  {
+    return AZ_ERROR_UNEXPECTED_CHAR;
+  }
+
+  az_span remainder = az_json_token_copy_into_span(json_token, scratch);
+
+  return az_span_atou32(az_span_slice(scratch, 0, _az_span_diff(remainder, scratch)), out_value);
 }
 
 AZ_NODISCARD az_result az_json_token_get_int64(az_json_token const* json_token, int64_t* out_value)
@@ -247,7 +454,26 @@ AZ_NODISCARD az_result az_json_token_get_int64(az_json_token const* json_token, 
     return AZ_ERROR_JSON_INVALID_STATE;
   }
 
-  return az_span_atoi64(json_token->slice, out_value);
+  az_span token_slice = json_token->slice;
+
+  // Contiguous token
+  if (az_span_ptr(token_slice) != NULL)
+  {
+    return az_span_atoi64(token_slice, out_value);
+  }
+
+  // Token straddles more than one segment
+  az_span scratch = AZ_SPAN_FROM_BUFFER(_az_scratch_buffer);
+
+  // Any number that won't fit in 64 bytes, will overflow.
+  if (az_span_size(scratch) < json_token->size)
+  {
+    return AZ_ERROR_UNEXPECTED_CHAR;
+  }
+
+  az_span remainder = az_json_token_copy_into_span(json_token, scratch);
+
+  return az_span_atoi64(az_span_slice(scratch, 0, _az_span_diff(remainder, scratch)), out_value);
 }
 
 AZ_NODISCARD az_result az_json_token_get_int32(az_json_token const* json_token, int32_t* out_value)
@@ -260,7 +486,26 @@ AZ_NODISCARD az_result az_json_token_get_int32(az_json_token const* json_token, 
     return AZ_ERROR_JSON_INVALID_STATE;
   }
 
-  return az_span_atoi32(json_token->slice, out_value);
+  az_span token_slice = json_token->slice;
+
+  // Contiguous token
+  if (az_span_ptr(token_slice) != NULL)
+  {
+    return az_span_atoi32(token_slice, out_value);
+  }
+
+  // Token straddles more than one segment
+  az_span scratch = AZ_SPAN_FROM_BUFFER(_az_scratch_buffer);
+
+  // Any number that won't fit in 64 bytes, will overflow.
+  if (az_span_size(scratch) < json_token->size)
+  {
+    return AZ_ERROR_UNEXPECTED_CHAR;
+  }
+
+  az_span remainder = az_json_token_copy_into_span(json_token, scratch);
+
+  return az_span_atoi32(az_span_slice(scratch, 0, _az_span_diff(remainder, scratch)), out_value);
 }
 
 AZ_NODISCARD az_result az_json_token_get_double(az_json_token const* json_token, double* out_value)
@@ -273,5 +518,24 @@ AZ_NODISCARD az_result az_json_token_get_double(az_json_token const* json_token,
     return AZ_ERROR_JSON_INVALID_STATE;
   }
 
-  return az_span_atod(json_token->slice, out_value);
+  az_span token_slice = json_token->slice;
+
+  // Contiguous token
+  if (az_span_ptr(token_slice) != NULL)
+  {
+    return az_span_atod(token_slice, out_value);
+  }
+
+  // Token straddles more than one segment
+  az_span scratch = AZ_SPAN_FROM_BUFFER(_az_scratch_buffer);
+
+  // Any number that won't fit in 64 bytes, will overflow.
+  if (az_span_size(scratch) < json_token->size)
+  {
+    return AZ_ERROR_UNEXPECTED_CHAR;
+  }
+
+  az_span remainder = az_json_token_copy_into_span(json_token, scratch);
+
+  return az_span_atod(az_span_slice(scratch, 0, _az_span_diff(remainder, scratch)), out_value);
 }

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -3,7 +3,7 @@
 
 #include "az_test_definitions.h"
 #include <azure/core/az_json.h>
-#include <azure/core/az_span.h>
+#include <azure/core/internal/az_span_internal.h>
 
 #include <math.h>
 #include <setjmp.h>
@@ -1553,9 +1553,16 @@ static void test_json_value(void** state)
   }
   // number from string
   {
-    uint64_t number_value = 1;
-    assert_true(
-        az_json_token_get_uint64(&json_string, &number_value) == AZ_ERROR_JSON_INVALID_STATE);
+    uint64_t number_u64 = 1;
+    assert_true(az_json_token_get_uint64(&json_string, &number_u64) == AZ_ERROR_JSON_INVALID_STATE);
+    int64_t number_i64 = 1;
+    assert_true(az_json_token_get_int64(&json_string, &number_i64) == AZ_ERROR_JSON_INVALID_STATE);
+    uint32_t number_u32 = 1;
+    assert_true(az_json_token_get_uint32(&json_string, &number_u32) == AZ_ERROR_JSON_INVALID_STATE);
+    int32_t number_i32 = 1;
+    assert_true(az_json_token_get_int32(&json_string, &number_i32) == AZ_ERROR_JSON_INVALID_STATE);
+    double number_d = 1;
+    assert_true(az_json_token_get_double(&json_string, &number_d) == AZ_ERROR_JSON_INVALID_STATE);
   }
   // az_json_token_is_text_equal
   {
@@ -1691,41 +1698,6 @@ static void test_az_json_token_get_string_and_text_equal(void** state)
   assert_int_equal(str_length, 20);
   assert_true(az_json_token_is_text_equal(&json_string, az_span_create_from_str(dest)));
   _az_json_token_is_text_equal_name_helper(json_string);
-
-  // TODO: Characters escaped in the form of \uXXXX where XXXX is the UTF-16 code point, is not
-  // currently supported.
-  /*json_string = (az_json_token){
-      .kind = AZ_JSON_TOKEN_STRING,
-      .slice = AZ_SPAN_FROM_STR("\\u0048\\u0065\\u006C\\u006C\\u006F"),
-      ._internal = {
-        .string_has_escaped_chars = true,
-      },
-    };
-  assert_int_equal(az_json_token_get_string(&json_string, dest, 128, &str_length), AZ_OK);
-  assert_true(az_json_token_is_text_equal(&json_string, az_span_create_from_str(dest)));
-  _az_json_token_is_text_equal_hello_helper(json_string);
-
-  json_string = (az_json_token){
-      .kind = AZ_JSON_TOKEN_STRING,
-      .slice = AZ_SPAN_FROM_STR("\\u0048ello"),
-      ._internal = {
-        .string_has_escaped_chars = true,
-      },
-    };
-  assert_int_equal(az_json_token_get_string(&json_string, dest, 128, &str_length), AZ_OK);
-  assert_true(az_json_token_is_text_equal(&json_string, az_span_create_from_str(dest)));
-  _az_json_token_is_text_equal_hello_helper(json_string);
-
-  json_string = (az_json_token){
-      .kind = AZ_JSON_TOKEN_STRING,
-      .slice = AZ_SPAN_FROM_STR("Hell\\u006F"),
-      ._internal = {
-        .string_has_escaped_chars = true,
-      },
-    };
-  assert_int_equal(az_json_token_get_string(&json_string, dest, 128, &str_length), AZ_OK);
-  assert_true(az_json_token_is_text_equal(&json_string, az_span_create_from_str(dest)));
-  _az_json_token_is_text_equal_hello_helper(json_string);*/
 }
 
 static void _az_split_buffers(az_span input, az_span* output)
@@ -1814,10 +1786,10 @@ static void test_az_json_token_get_string_and_text_equal_discontiguous(void** st
   assert_true(az_json_token_is_text_equal(&json_string, az_span_create_from_str(dest)));
   _az_json_token_is_text_equal_hello_helper(json_string);
 
-  az_span buffers12_one[12] = { 0 };
-  _az_split_buffers_single_byte(json, buffers12_one);
+  az_span buffers11_one[11] = { 0 };
+  _az_split_buffers_single_byte(json, buffers11_one);
 
-  TEST_EXPECT_SUCCESS(az_json_reader_chunked_init(&reader, buffers12_one, 12, NULL));
+  TEST_EXPECT_SUCCESS(az_json_reader_chunked_init(&reader, buffers11_one, 11, NULL));
   TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
   TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
 
@@ -1852,10 +1824,10 @@ static void test_az_json_token_get_string_and_text_equal_discontiguous(void** st
   assert_true(az_json_token_is_text_equal(&json_string, az_span_create_from_str(dest)));
   _az_json_token_is_text_equal_name_helper(json_string);
 
-  az_span buffers26_one[26] = { 0 };
-  _az_split_buffers_single_byte(json, buffers26_one);
+  az_span buffers25_one[25] = { 0 };
+  _az_split_buffers_single_byte(json, buffers25_one);
 
-  TEST_EXPECT_SUCCESS(az_json_reader_chunked_init(&reader, buffers26_one, 26, NULL));
+  TEST_EXPECT_SUCCESS(az_json_reader_chunked_init(&reader, buffers25_one, 25, NULL));
   TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
 
   json_string = reader.token;
@@ -1891,10 +1863,10 @@ static void test_az_json_token_get_string_and_text_equal_discontiguous(void** st
   assert_true(az_json_token_is_text_equal(&json_string, az_span_create_from_str(dest)));
   _az_json_token_is_text_equal_name_helper(json_string);
 
-  az_span buffers30_one[30] = { 0 };
-  _az_split_buffers_single_byte(json, buffers30_one);
+  az_span buffers29_one[29] = { 0 };
+  _az_split_buffers_single_byte(json, buffers29_one);
 
-  TEST_EXPECT_SUCCESS(az_json_reader_chunked_init(&reader, buffers30_one, 30, NULL));
+  TEST_EXPECT_SUCCESS(az_json_reader_chunked_init(&reader, buffers29_one, 29, NULL));
   TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
   TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
 
@@ -1904,6 +1876,598 @@ static void test_az_json_token_get_string_and_text_equal_discontiguous(void** st
   assert_int_equal(str_length, 20);
   assert_true(az_json_token_is_text_equal(&json_string, az_span_create_from_str(dest)));
   _az_json_token_is_text_equal_name_helper(json_string);
+}
+
+static az_span _az_buffers64_one[64] = { 0 };
+static uint8_t _az_buffer_for_complex_json[64] = { 0 };
+
+#define _az_json_reader_double_helper(json, expected) \
+  do \
+  { \
+\
+    TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, json, NULL)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+\
+    actual_d = 0; \
+    json_number = reader.token; \
+    assert_int_equal(json_number.size, az_span_size(json)); \
+    assert_int_equal(az_json_token_get_double(&json_number, &actual_d), AZ_OK); \
+    assert_true(_is_double_equal(actual_d, expected, 1e-2)); \
+\
+    az_span buffers_half[2] = { 0 }; \
+    _az_split_buffers(json, buffers_half); \
+\
+    TEST_EXPECT_SUCCESS(az_json_reader_chunked_init(&reader, buffers_half, 2, NULL)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+\
+    actual_d = 0; \
+    json_number = reader.token; \
+    assert_int_equal(json_number.size, az_span_size(json)); \
+    assert_int_equal(az_json_token_get_double(&json_number, &actual_d), AZ_OK); \
+    assert_true(_is_double_equal(actual_d, expected, 1e-2)); \
+\
+    _az_split_buffers_single_byte(json, _az_buffers64_one); \
+\
+    TEST_EXPECT_SUCCESS( \
+        az_json_reader_chunked_init(&reader, _az_buffers64_one, az_span_size(json), NULL)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+\
+    actual_d = 0; \
+    json_number = reader.token; \
+    assert_int_equal(json_number.size, az_span_size(json)); \
+    assert_int_equal(az_json_token_get_double(&json_number, &actual_d), AZ_OK); \
+    assert_true(_is_double_equal(actual_d, expected, 1e-2)); \
+\
+    json_nested_array = AZ_SPAN_FROM_BUFFER(_az_buffer_for_complex_json); \
+    remainder = az_span_copy(json_nested_array, AZ_SPAN_FROM_STR("[")); \
+    remainder = az_span_copy(remainder, json); \
+    remainder = az_span_copy_u8(remainder, ']'); \
+\
+    json_nested_array \
+        = az_span_slice(json_nested_array, 0, _az_span_diff(remainder, json_nested_array)); \
+\
+    TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, json_nested_array, NULL)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+\
+    actual_d = 0; \
+    json_number = reader.token; \
+    assert_int_equal(json_number.size, az_span_size(json)); \
+    assert_int_equal(az_json_token_get_double(&json_number, &actual_d), AZ_OK); \
+    assert_true(_is_double_equal(actual_d, expected, 1e-2)); \
+\
+    _az_split_buffers(json_nested_array, buffers_half); \
+\
+    TEST_EXPECT_SUCCESS(az_json_reader_chunked_init(&reader, buffers_half, 2, NULL)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+\
+    actual_d = 0; \
+    json_number = reader.token; \
+    assert_int_equal(json_number.size, az_span_size(json)); \
+    assert_int_equal(az_json_token_get_double(&json_number, &actual_d), AZ_OK); \
+    assert_true(_is_double_equal(actual_d, expected, 1e-2)); \
+\
+    _az_split_buffers_single_byte(json_nested_array, _az_buffers64_one); \
+\
+    TEST_EXPECT_SUCCESS(az_json_reader_chunked_init( \
+        &reader, _az_buffers64_one, az_span_size(json_nested_array), NULL)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+\
+    actual_d = 0; \
+    json_number = reader.token; \
+    assert_int_equal(json_number.size, az_span_size(json)); \
+    assert_int_equal(az_json_token_get_double(&json_number, &actual_d), AZ_OK); \
+    assert_true(_is_double_equal(actual_d, expected, 1e-2)); \
+\
+    json_object = AZ_SPAN_FROM_BUFFER(_az_buffer_for_complex_json); \
+    remainder = az_span_copy(json_object, AZ_SPAN_FROM_STR("{\"name\":")); \
+    remainder = az_span_copy(remainder, json); \
+    remainder = az_span_copy_u8(remainder, '}'); \
+\
+    json_object = az_span_slice(json_object, 0, _az_span_diff(remainder, json_object)); \
+\
+    TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, json_object, NULL)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+\
+    actual_d = 0; \
+    json_number = reader.token; \
+    assert_int_equal(json_number.size, az_span_size(json)); \
+    assert_int_equal(az_json_token_get_double(&json_number, &actual_d), AZ_OK); \
+    assert_true(_is_double_equal(actual_d, expected, 1e-2)); \
+\
+    _az_split_buffers(json_object, buffers_half); \
+\
+    TEST_EXPECT_SUCCESS(az_json_reader_chunked_init(&reader, buffers_half, 2, NULL)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+\
+    actual_d = 0; \
+    json_number = reader.token; \
+    assert_int_equal(json_number.size, az_span_size(json)); \
+    assert_int_equal(az_json_token_get_double(&json_number, &actual_d), AZ_OK); \
+    assert_true(_is_double_equal(actual_d, expected, 1e-2)); \
+\
+    _az_split_buffers_single_byte(json_object, _az_buffers64_one); \
+\
+    TEST_EXPECT_SUCCESS( \
+        az_json_reader_chunked_init(&reader, _az_buffers64_one, az_span_size(json_object), NULL)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+    TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader)); \
+\
+    actual_d = 0; \
+    json_number = reader.token; \
+    assert_int_equal(json_number.size, az_span_size(json)); \
+    assert_int_equal(az_json_token_get_double(&json_number, &actual_d), AZ_OK); \
+    assert_true(_is_double_equal(actual_d, expected, 1e-2)); \
+  } while (0)
+
+static void test_az_json_reader_double(void** state)
+{
+  (void)state;
+
+  az_json_reader reader = { 0 };
+  double actual_d = 0;
+  az_json_token json_number = reader.token;
+  az_span json_nested_array = { 0 };
+  az_span json_object = { 0 };
+  az_span remainder = { 0 };
+
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-0"), 0);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1024"), 1024);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1024"), -1024);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("2147483647"), 2147483647);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-2147483648"), -2147483647 - 1);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("4294967295"), 4294967295);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-4294967296"), -4294967296);
+  _az_json_reader_double_helper(
+      AZ_SPAN_FROM_STR("9223372036854775807"), (double)9223372036854775807);
+  _az_json_reader_double_helper(
+      AZ_SPAN_FROM_STR("-9223372036854775808"), -2147483647 * (double)4294967298);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.23e3"), 1.23e3);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.23"), 1.23);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-123.456e-78"), -123.456e-78);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("123.456e+78"), 123.456e+78);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0"), 0);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0e0"), 0);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0e-0"), 0);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0e+0"), 0);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0e-1"), 0);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0e+1"), 0);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1"), -1);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.0"), 1);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1.0"), -1);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("123.123"), 123.123);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("123.1230"), 123.1230);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("123.0100"), 123.0100);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("123.01"), 123.01);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("123.001"), 123.001);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.000000000000001"), 0.000000000000001);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.0000000001"), 1.0000000001);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1.0000000001"), -1.0000000001);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("100.001"), 100.001);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("100.00100"), 100.00100);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.001"), 0.001);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0012"), 0.0012);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.2e4"), 1.2e4);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.2e-4"), 1.2e-4);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.2e+4"), 1.2e+4);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1.2e4"), -1.2e4);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1.2e-4"), -1.2e-4);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0001"), 0.0001);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.00102"), 0.00102);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.34567"), .34567);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-0.34567"), -.34567);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("9876.54321"), 9876.54321);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-9876.54321"), -9876.54321);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("987654.321"), 987654.321);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-987654.321"), -987654.321);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("987654.0000321"), 987654.0000321);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("4503599627370496"), 4503599627370496);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("9007199254740991"), 9007199254740991);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("4503599627370496.2"), 4503599627370496.2);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e15"), 1e15);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1e15"), -1e15);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.8e10"), 1.8e10);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1.8e10"), -1.8e10);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e-15"), 1e-15);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e-10"), 1e-10);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e-5"), 1e-5);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.1234567890123456"), 0.1234567890123456);
+  _az_json_reader_double_helper(
+      AZ_SPAN_FROM_STR("123456789012345.123456789012340000"), 123456789012345.123456789012340000);
+  _az_json_reader_double_helper(
+      AZ_SPAN_FROM_STR("1000000000000.123456789012340000"), 1000000000000.123456789012340000);
+  _az_json_reader_double_helper(
+      AZ_SPAN_FROM_STR("123456789012345.1234567890123400001"), 123456789012345.1234567890123400001);
+  _az_json_reader_double_helper(
+      AZ_SPAN_FROM_STR("1000000000000.1234567890123400001"), 1000000000000.1234567890123400001);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("12345.123e-15"), 12345.123e-15);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("12345.12300000010e5"), 12345.12300000010e5);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e-300"), 1e-300);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("9007199254740992"), 9007199254740992);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("9007199254740993"), (double)9007199254740993);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("45035996273704961"), (double)45035996273704961);
+  _az_json_reader_double_helper(
+      AZ_SPAN_FROM_STR("9223372036854775806"), (double)9223372036854775806);
+  _az_json_reader_double_helper(
+      AZ_SPAN_FROM_STR("-9223372036854775806"), (double)-9223372036854775806);
+  _az_json_reader_double_helper(
+      AZ_SPAN_FROM_STR("1844674407370955100"), (double)1844674407370955100);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.844674407370955e+19"), 1.844674407370955e+19);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.8446744073709551e+19"), 1.8446744073709551e+19);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.8446744073709552e+19"), 1.8446744073709552e+19);
+  _az_json_reader_double_helper(
+      AZ_SPAN_FROM_STR("18446744073709551615"), (double)18446744073709551615UL);
+  _az_json_reader_double_helper(
+      AZ_SPAN_FROM_STR("18446744073709551615.18446744073709551615"),
+      18446744073709551615.18446744073709551615);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e16"), 1e16);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("12345.123e15"), 12345.123e15);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-12345.123e15"), -12345.123e15);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e300"), 1e300);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1e300"), -1e300);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.7e308"), 1.7e308);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1.7e308"), -1.7e308);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("2.22507e-308"), 2.22507e-308);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-2.22507e-308"), -2.22507e-308);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("4.94e-325"), 0);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e-400"), 0);
+  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1e-400"), 0);
+}
+
+static void test_az_json_token_number_too_large(void** state)
+{
+  (void)state;
+
+  az_json_reader reader = { 0 };
+  az_span json = AZ_SPAN_FROM_STR("9999999999999999999999999999999999999999999999999999999999999999"
+                                  "999999999999999999999999999999999999");
+  TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, json, NULL));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+
+  az_json_token json_number = reader.token;
+  assert_int_equal(json_number.size, az_span_size(json));
+
+  int32_t actual_i32 = 0;
+  assert_int_equal(az_json_token_get_int32(&json_number, &actual_i32), AZ_ERROR_UNEXPECTED_CHAR);
+
+  uint32_t actual_u32 = 0;
+  assert_int_equal(az_json_token_get_uint32(&json_number, &actual_u32), AZ_ERROR_UNEXPECTED_CHAR);
+
+  int64_t actual_i64 = 0;
+  assert_int_equal(az_json_token_get_int64(&json_number, &actual_i64), AZ_ERROR_UNEXPECTED_CHAR);
+
+  uint64_t actual_u64 = 0;
+  assert_int_equal(az_json_token_get_uint64(&json_number, &actual_u64), AZ_ERROR_UNEXPECTED_CHAR);
+
+  // double actual_d = 0;
+  // assert_int_equal(az_json_token_get_double(&json_number, &actual_d), AZ_ERROR_UNEXPECTED_CHAR);
+
+  az_span buffers_half[2] = { 0 };
+  _az_split_buffers(json, buffers_half);
+
+  TEST_EXPECT_SUCCESS(az_json_reader_chunked_init(&reader, buffers_half, 2, NULL));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+
+  json_number = reader.token;
+  assert_int_equal(json_number.size, az_span_size(json));
+
+  assert_int_equal(az_json_token_get_int32(&json_number, &actual_i32), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_json_token_get_uint32(&json_number, &actual_u32), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_json_token_get_int64(&json_number, &actual_i64), AZ_ERROR_UNEXPECTED_CHAR);
+  assert_int_equal(az_json_token_get_uint64(&json_number, &actual_u64), AZ_ERROR_UNEXPECTED_CHAR);
+  // assert_int_equal(az_json_token_get_double(&json_number, &actual_d), AZ_ERROR_UNEXPECTED_CHAR);
+}
+
+static void _az_json_token_literal_helper(az_span json, bool expected)
+{
+  az_json_reader reader = { 0 };
+  az_json_token json_literal = { 0 };
+  bool value = false;
+  az_span json_nested_array = { 0 };
+  az_span json_object = { 0 };
+  az_span remainder = { 0 };
+
+  TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, json, NULL));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+
+  json_literal = reader.token;
+  assert_int_equal(json_literal.size, az_span_size(json));
+
+  if (json_literal.kind != AZ_JSON_TOKEN_NULL)
+  {
+    value = false;
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_OK);
+    assert_true(value == expected);
+  }
+  else
+  {
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_ERROR_JSON_INVALID_STATE);
+  }
+
+  az_span buffers_half[2] = { 0 };
+  _az_split_buffers(json, buffers_half);
+
+  TEST_EXPECT_SUCCESS(az_json_reader_chunked_init(&reader, buffers_half, 2, NULL));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+
+  json_literal = reader.token;
+  assert_int_equal(json_literal.size, az_span_size(json));
+
+  if (json_literal.kind != AZ_JSON_TOKEN_NULL)
+  {
+    value = false;
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_OK);
+    assert_true(value == expected);
+  }
+  else
+  {
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_ERROR_JSON_INVALID_STATE);
+  }
+
+  _az_split_buffers_single_byte(json, _az_buffers64_one);
+
+  TEST_EXPECT_SUCCESS(
+      az_json_reader_chunked_init(&reader, _az_buffers64_one, az_span_size(json), NULL));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+
+  json_literal = reader.token;
+  assert_int_equal(json_literal.size, az_span_size(json));
+
+  if (json_literal.kind != AZ_JSON_TOKEN_NULL)
+  {
+    value = false;
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_OK);
+    assert_true(value == expected);
+  }
+  else
+  {
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_ERROR_JSON_INVALID_STATE);
+  }
+
+  json_nested_array = AZ_SPAN_FROM_BUFFER(_az_buffer_for_complex_json);
+  remainder = az_span_copy(json_nested_array, AZ_SPAN_FROM_STR("["));
+  remainder = az_span_copy(remainder, json);
+  remainder = az_span_copy_u8(remainder, ']');
+
+  json_nested_array
+      = az_span_slice(json_nested_array, 0, _az_span_diff(remainder, json_nested_array));
+
+  TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, json_nested_array, NULL));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+
+  json_literal = reader.token;
+  assert_int_equal(json_literal.size, az_span_size(json));
+
+  if (json_literal.kind != AZ_JSON_TOKEN_NULL)
+  {
+    value = false;
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_OK);
+    assert_true(value == expected);
+  }
+  else
+  {
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_ERROR_JSON_INVALID_STATE);
+  }
+
+  _az_split_buffers(json_nested_array, buffers_half);
+
+  TEST_EXPECT_SUCCESS(az_json_reader_chunked_init(&reader, buffers_half, 2, NULL));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+
+  json_literal = reader.token;
+  assert_int_equal(json_literal.size, az_span_size(json));
+
+  if (json_literal.kind != AZ_JSON_TOKEN_NULL)
+  {
+    value = false;
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_OK);
+    assert_true(value == expected);
+  }
+  else
+  {
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_ERROR_JSON_INVALID_STATE);
+  }
+
+  _az_split_buffers_single_byte(json_nested_array, _az_buffers64_one);
+
+  TEST_EXPECT_SUCCESS(az_json_reader_chunked_init(
+      &reader, _az_buffers64_one, az_span_size(json_nested_array), NULL));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+
+  json_literal = reader.token;
+  assert_int_equal(json_literal.size, az_span_size(json));
+
+  if (json_literal.kind != AZ_JSON_TOKEN_NULL)
+  {
+    value = false;
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_OK);
+    assert_true(value == expected);
+  }
+  else
+  {
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_ERROR_JSON_INVALID_STATE);
+  }
+
+  json_object = AZ_SPAN_FROM_BUFFER(_az_buffer_for_complex_json);
+  remainder = az_span_copy(json_object, AZ_SPAN_FROM_STR("{\"name\":"));
+  remainder = az_span_copy(remainder, json);
+  remainder = az_span_copy_u8(remainder, '}');
+
+  json_object = az_span_slice(json_object, 0, _az_span_diff(remainder, json_object));
+
+  TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, json_object, NULL));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+
+  json_literal = reader.token;
+  assert_int_equal(json_literal.size, az_span_size(json));
+
+  if (json_literal.kind != AZ_JSON_TOKEN_NULL)
+  {
+    value = false;
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_OK);
+    assert_true(value == expected);
+  }
+  else
+  {
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_ERROR_JSON_INVALID_STATE);
+  }
+
+  _az_split_buffers(json_object, buffers_half);
+
+  TEST_EXPECT_SUCCESS(az_json_reader_chunked_init(&reader, buffers_half, 2, NULL));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+
+  json_literal = reader.token;
+  assert_int_equal(json_literal.size, az_span_size(json));
+
+  if (json_literal.kind != AZ_JSON_TOKEN_NULL)
+  {
+    value = false;
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_OK);
+    assert_true(value == expected);
+  }
+  else
+  {
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_ERROR_JSON_INVALID_STATE);
+  }
+
+  _az_split_buffers_single_byte(json_object, _az_buffers64_one);
+
+  TEST_EXPECT_SUCCESS(
+      az_json_reader_chunked_init(&reader, _az_buffers64_one, az_span_size(json_object), NULL));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+  TEST_EXPECT_SUCCESS(az_json_reader_next_token(&reader));
+
+  json_literal = reader.token;
+  assert_int_equal(json_literal.size, az_span_size(json));
+
+  if (json_literal.kind != AZ_JSON_TOKEN_NULL)
+  {
+    value = false;
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_OK);
+    assert_true(value == expected);
+  }
+  else
+  {
+    assert_int_equal(az_json_token_get_boolean(&json_literal, &value), AZ_ERROR_JSON_INVALID_STATE);
+  }
+}
+
+static void test_az_json_token_literal(void** state)
+{
+  (void)state;
+
+  _az_json_token_literal_helper(AZ_SPAN_FROM_STR("true"), true);
+  _az_json_token_literal_helper(AZ_SPAN_FROM_STR("false"), false);
+  _az_json_token_literal_helper(AZ_SPAN_FROM_STR("null"), false);
+}
+
+static void test_az_json_token_copy(void** state)
+{
+  (void)state;
+
+  az_span json = AZ_SPAN_FROM_STR("abcdefghijkl");
+  uint8_t dest_buffer[128] = { 0 };
+  az_span destination = AZ_SPAN_FROM_BUFFER(dest_buffer);
+
+  az_json_token json_string = (az_json_token){
+    .slice = json,
+    .size = 12,
+  };
+
+  az_span remainder = az_json_token_copy_into_span(&json_string, destination);
+  assert_int_equal(az_span_size(remainder), 128 - 12);
+  assert_true(az_span_is_content_equal(json, az_span_slice(destination, 0, 12)));
+
+  // Split in 2
+  {
+    uint8_t split1[7] = { 0 };
+    uint8_t split2[13] = { 0 };
+    az_span buffers[2] = { AZ_SPAN_FROM_BUFFER(split1), AZ_SPAN_FROM_BUFFER(split2) };
+    az_span_copy(buffers[0], az_span_slice(json, 0, 7));
+    az_span_copy(buffers[1], az_span_slice_to_end(json, 7));
+
+    json_string = (az_json_token){
+      .slice = AZ_SPAN_NULL,
+      .size = 12,
+      ._internal = {
+        .pointer_to_first_buffer = buffers,
+        .start_buffer_index = 0,
+        .start_buffer_offset = 0,
+        .end_buffer_index = 1,
+        .end_buffer_offset = 5,
+      },
+    };
+
+    remainder = az_json_token_copy_into_span(&json_string, destination);
+    assert_int_equal(az_span_size(remainder), 128 - 12);
+    assert_true(az_span_is_content_equal(json, az_span_slice(destination, 0, 12)));
+  }
+  // Split in 3
+  {
+
+    uint8_t split1[7] = { 0 };
+    uint8_t split2[3] = { 0 };
+    uint8_t split3[5] = { 0 };
+    az_span buffers[3]
+        = { AZ_SPAN_FROM_BUFFER(split1), AZ_SPAN_FROM_BUFFER(split2), AZ_SPAN_FROM_BUFFER(split3) };
+    az_span_copy(az_span_slice_to_end(buffers[0], 1), az_span_slice(json, 0, 6));
+    az_span_copy(buffers[1], az_span_slice(json, 6, 9));
+    az_span_copy(buffers[2], az_span_slice_to_end(json, 9));
+
+    json_string = (az_json_token){
+      .slice = AZ_SPAN_NULL,
+      .size = 12,
+      ._internal = {
+        .pointer_to_first_buffer = buffers,
+        .start_buffer_index = 0,
+        .start_buffer_offset = 1,
+        .end_buffer_index = 2,
+        .end_buffer_offset = 3,
+      },
+    };
+
+    remainder = az_json_token_copy_into_span(&json_string, destination);
+    assert_int_equal(az_span_size(remainder), 128 - 12);
+    assert_true(az_span_is_content_equal(json, az_span_slice(destination, 0, 12)));
+  }
+  // Split in n
+  {
+    _az_split_buffers_single_byte(json, _az_buffers64_one);
+
+    json_string = (az_json_token){
+      .kind = AZ_JSON_TOKEN_STRING,
+      .slice = AZ_SPAN_NULL,
+      .size = 12,
+      ._internal = {
+        .string_has_escaped_chars = false,
+        .pointer_to_first_buffer = _az_buffers64_one,
+        .start_buffer_index = 0,
+        .start_buffer_offset = 0,
+        .end_buffer_index = az_span_size(json) - 1,
+        .end_buffer_offset = 1,
+      },
+    };
+
+    remainder = az_json_token_copy_into_span(&json_string, destination);
+    assert_int_equal(az_span_size(remainder), 128 - 12);
+    assert_true(az_span_is_content_equal(json, az_span_slice(destination, 0, 12)));
+  }
 }
 
 int test_az_json()
@@ -1919,6 +2483,10 @@ int test_az_json()
           cmocka_unit_test(test_json_skip_children),
           cmocka_unit_test(test_json_value),
           cmocka_unit_test(test_az_json_token_get_string_and_text_equal),
-          cmocka_unit_test(test_az_json_token_get_string_and_text_equal_discontiguous) };
+          cmocka_unit_test(test_az_json_token_get_string_and_text_equal_discontiguous),
+          cmocka_unit_test(test_az_json_reader_double),
+          cmocka_unit_test(test_az_json_token_number_too_large),
+          cmocka_unit_test(test_az_json_token_literal),
+          cmocka_unit_test(test_az_json_token_copy) };
   return cmocka_run_group_tests_name("az_core_json", tests, NULL, NULL);
 }

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -2019,8 +2019,6 @@ static void test_az_json_reader_double(void** state)
   az_span buffers_half[2] = { 0 };
 
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-0"), 0);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1024"), 1024);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1024"), -1024);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("2147483647"), 2147483647);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-2147483648"), -2147483647 - 1);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("4294967295"), 4294967295);
@@ -2030,22 +2028,15 @@ static void test_az_json_reader_double(void** state)
   _az_json_reader_double_helper(
       AZ_SPAN_FROM_STR("-9223372036854775808"), -2147483647 * (double)4294967298);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.23e3"), 1.23e3);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.23"), 1.23);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-123.456e-78"), -123.456e-78);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("123.456e+78"), 123.456e+78);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0"), 0);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0e0"), 0);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0e-0"), 0);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0e+0"), 0);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0e-1"), 0);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0e+1"), 0);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1"), -1);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.0"), 1);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1.0"), -1);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("123.123"), 123.123);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("123.1230"), 123.1230);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("123.0100"), 123.0100);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("123.01"), 123.01);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("123.001"), 123.001);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.000000000000001"), 0.000000000000001);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.0000000001"), 1.0000000001);
@@ -2059,25 +2050,12 @@ static void test_az_json_reader_double(void** state)
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.2e+4"), 1.2e+4);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1.2e4"), -1.2e4);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1.2e-4"), -1.2e-4);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.0001"), 0.0001);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.00102"), 0.00102);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.34567"), .34567);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-0.34567"), -.34567);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("9876.54321"), 9876.54321);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-9876.54321"), -9876.54321);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("987654.321"), 987654.321);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-987654.321"), -987654.321);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("987654.0000321"), 987654.0000321);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("4503599627370496"), 4503599627370496);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("9007199254740991"), 9007199254740991);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("4503599627370496.2"), 4503599627370496.2);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e15"), 1e15);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1e15"), -1e15);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.8e10"), 1.8e10);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1.8e10"), -1.8e10);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e-15"), 1e-15);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e-10"), 1e-10);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e-5"), 1e-5);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("0.1234567890123456"), 0.1234567890123456);
   _az_json_reader_double_helper(
       AZ_SPAN_FROM_STR("123456789012345.123456789012340000"), 123456789012345.123456789012340000);
@@ -2087,33 +2065,22 @@ static void test_az_json_reader_double(void** state)
       AZ_SPAN_FROM_STR("123456789012345.1234567890123400001"), 123456789012345.1234567890123400001);
   _az_json_reader_double_helper(
       AZ_SPAN_FROM_STR("1000000000000.1234567890123400001"), 1000000000000.1234567890123400001);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("12345.123e-15"), 12345.123e-15);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("12345.12300000010e5"), 12345.12300000010e5);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e-300"), 1e-300);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("9007199254740992"), 9007199254740992);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("9007199254740993"), (double)9007199254740993);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("45035996273704961"), (double)45035996273704961);
-  _az_json_reader_double_helper(
-      AZ_SPAN_FROM_STR("9223372036854775806"), (double)9223372036854775806);
-  _az_json_reader_double_helper(
-      AZ_SPAN_FROM_STR("-9223372036854775806"), (double)-9223372036854775806);
   _az_json_reader_double_helper(
       AZ_SPAN_FROM_STR("1844674407370955100"), (double)1844674407370955100);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.844674407370955e+19"), 1.844674407370955e+19);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.8446744073709551e+19"), 1.8446744073709551e+19);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.8446744073709552e+19"), 1.8446744073709552e+19);
   _az_json_reader_double_helper(
       AZ_SPAN_FROM_STR("18446744073709551615"), (double)18446744073709551615UL);
   _az_json_reader_double_helper(
       AZ_SPAN_FROM_STR("18446744073709551615.18446744073709551615"),
       18446744073709551615.18446744073709551615);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e16"), 1e16);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("12345.123e15"), 12345.123e15);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-12345.123e15"), -12345.123e15);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1e300"), 1e300);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1e300"), -1e300);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("1.7e308"), 1.7e308);
-  _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-1.7e308"), -1.7e308);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("2.22507e-308"), 2.22507e-308);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("-2.22507e-308"), -2.22507e-308);
   _az_json_reader_double_helper(AZ_SPAN_FROM_STR("4.94e-325"), 0);
@@ -2470,7 +2437,7 @@ static void test_az_json_token_copy(void** state)
   }
 }
 
-// Imagine your JSON input to parse is "{\"name\":\"some value string\", \"code\": 123456}"
+// Imagine your JSON input to parse is " { \"name\": \"some value string\" , \"code\" : 123456 } "
 // Either in one contiguous buffer, or split up within multiple non-contiguous ones.
 typedef struct
 {

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -15,7 +15,9 @@
 
 #define TEST_EXPECT_SUCCESS(exp) assert_true(az_succeeded(exp))
 
-az_result test_allocator(az_span_allocator_context* allocator_context, az_span* out_next_destination);
+az_result test_allocator(
+    az_span_allocator_context* allocator_context,
+    az_span* out_next_destination);
 
 az_result test_allocator_never_called(
     az_span_allocator_context* allocator_context,
@@ -29,14 +31,12 @@ az_result test_allocator_chunked(
     az_span_allocator_context* allocator_context,
     az_span* out_next_destination);
 
-static void test_json_token_helper(
-    az_json_token token,
-    az_json_token_kind expected_token_kind,
-    az_span expected_token_slice)
-{
-  assert_int_equal(token.kind, expected_token_kind);
-  assert_true(az_span_is_content_equal(token.slice, expected_token_slice));
-}
+#define test_json_token_helper(token, expected_token_kind, expected_token_slice) \
+  do \
+  { \
+    assert_int_equal(token.kind, expected_token_kind); \
+    assert_true(az_span_is_content_equal(token.slice, expected_token_slice)); \
+  } while (0)
 
 static void test_json_reader_init(void** state)
 {
@@ -235,7 +235,9 @@ typedef struct
   int32_t* current_index;
 } _az_user_context;
 
-az_result test_allocator(az_span_allocator_context* allocator_context, az_span* out_next_destination)
+az_result test_allocator(
+    az_span_allocator_context* allocator_context,
+    az_span* out_next_destination)
 {
   _az_user_context* user_context = (_az_user_context*)allocator_context->user_context;
   int32_t current_index = *user_context->current_index + allocator_context->bytes_used;
@@ -1321,7 +1323,6 @@ static void test_json_reader_invalid(void** state)
   test_json_reader_invalid_helper(AZ_SPAN_FROM_STR("trUe"), AZ_ERROR_UNEXPECTED_CHAR);
   test_json_reader_invalid_helper(AZ_SPAN_FROM_STR("False"), AZ_ERROR_UNEXPECTED_CHAR);
   test_json_reader_invalid_helper(AZ_SPAN_FROM_STR("age"), AZ_ERROR_UNEXPECTED_CHAR);
-  test_json_reader_invalid_helper(AZ_SPAN_FROM_STR("\""), AZ_ERROR_UNEXPECTED_CHAR);
   test_json_reader_invalid_helper(AZ_SPAN_FROM_STR("\"age\":"), AZ_ERROR_UNEXPECTED_CHAR);
 
   // Invalid numbers
@@ -1518,7 +1519,8 @@ static void test_json_value(void** state)
         az_span_is_content_equal(az_span_create_from_str(string_value), AZ_SPAN_FROM_STR("Hello")));
 
     TEST_EXPECT_SUCCESS(az_json_token_get_string(&json_property_name, string_value, 10, NULL));
-    assert_true(az_span_is_content_equal(az_span_create_from_str(string_value), AZ_SPAN_FROM_STR("Name")));
+    assert_true(
+        az_span_is_content_equal(az_span_create_from_str(string_value), AZ_SPAN_FROM_STR("Name")));
   }
   // string from boolean
   {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/826

**API Additions:**
```C
az_span az_json_token_copy_into_span(az_json_token const* json_token, az_span destination);

AZ_NODISCARD az_result az_json_reader_chunked_init(
    az_json_reader* json_reader,
    az_span json_buffers[],
    int32_t number_of_buffers,
    az_json_reader_options const* options);
```
Adding a public `int32_t size` field to `az_json_token`.

**Sample usage:**
```C
// Imagine your JSON input to parse is " { \"name\": \"some value string\" , \"code\" : 123456 } "
// Either in one contiguous buffer, or split up within multiple non-contiguous ones.
typedef struct
{
  char* name_string;
  int32_t name_length;
  az_span name_value_span; // optional, for demonstration purposes only
  int32_t code;
} model;

// optional, for demonstration purposes only
static uint8_t available_scratch[64] = { 0 };

static az_result _az_process_json(az_span* input, int32_t number_of_buffers, model* output)
{
  az_span scratch_span = AZ_SPAN_FROM_BUFFER(available_scratch);

  az_json_reader jr = { 0 };
  AZ_RETURN_IF_FAILED(az_json_reader_chunked_init(&jr, input, number_of_buffers, NULL));

  AZ_RETURN_IF_FAILED(az_json_reader_next_token(&jr));
  if (jr.token.kind != AZ_JSON_TOKEN_BEGIN_OBJECT)
  {
    return AZ_ERROR_UNEXPECTED_CHAR;
  }

  while (az_succeeded(az_json_reader_next_token(&jr)) && jr.token.kind != AZ_JSON_TOKEN_END_OBJECT)
  {
    if (az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("name")))
    {
      AZ_RETURN_IF_FAILED(az_json_reader_next_token(&jr));
      if (jr.token.kind != AZ_JSON_TOKEN_STRING)
      {
        return AZ_ERROR_ITEM_NOT_FOUND;
      }

      // optional, for demonstration purposes only
      az_json_token_copy_into_span(&jr.token, az_span_slice(scratch_span, 0, jr.token.size));
      output->name_value_span = az_span_slice(scratch_span, 0, jr.token.size);

      AZ_RETURN_IF_FAILED(az_json_token_get_string(
          &jr.token, output->name_string, output->name_length, &output->name_length));
    }
    else if (az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("code")))
    {
      AZ_RETURN_IF_FAILED(az_json_reader_next_token(&jr));
      if (jr.token.kind != AZ_JSON_TOKEN_NUMBER)
      {
        return AZ_ERROR_ITEM_NOT_FOUND;
      }
      AZ_RETURN_IF_FAILED(az_json_token_get_int32(&jr.token, &output->code));
    }
    else
    {
      // ignore other tokens
      AZ_RETURN_IF_FAILED(az_json_reader_skip_children(&jr));
    }
  }

  return AZ_OK;
}

static void test_az_json_reader_chunked(void** state)
{
  (void)state;

  char property_value[32] = { 0 };
  az_span expected = AZ_SPAN_FROM_STR("some value string");

  model original = (model){
    .name_string = property_value,
    .name_length = 32,
    .name_value_span = AZ_SPAN_NULL,
    .code = 0,
  };

  model m = original;
  az_span json = AZ_SPAN_FROM_STR(" { \"name\": \"some value string\" , \"code\" : 123456 } ");

  _az_process_json(&json, 1, &m);

  assert_int_equal(m.code, 123456);
  assert_int_equal(m.name_length, 17);
  assert_true(az_span_is_content_equal(expected, m.name_value_span));
  assert_true(az_span_is_content_equal(expected, az_span_create_from_str(m.name_string)));

  m = original;
  property_value[0] = 0;
  az_span buffers_half[2] = { 0 };
  _az_split_buffers(json, buffers_half);

  _az_process_json(buffers_half, 2, &m);

  assert_int_equal(m.code, 123456);
  assert_int_equal(m.name_length, 17);
  assert_true(az_span_is_content_equal(expected, m.name_value_span));
  assert_true(az_span_is_content_equal(expected, az_span_create_from_str(m.name_string)));

  m = original;
  property_value[0] = 0;
  _az_split_buffers_single_byte(json, _az_buffers64_one);

  _az_process_json(_az_buffers64_one, az_span_size(json), &m);

  assert_int_equal(m.code, 123456);
  assert_int_equal(m.name_length, 17);
  assert_true(az_span_is_content_equal(expected, m.name_value_span));
  assert_true(az_span_is_content_equal(expected, az_span_create_from_str(m.name_string)));
}
```

~**TODO:**~
- [x] Update` az_json_token` fields to capture all state information
- [x] Update all `az_json_token` APIs to handle dis-contiguous buffers
- [x] Implement `az_json_token_copy_into_span`
- [x] Update `az_json_reader` to return the complete `az_json_token` with the new fields
- [x] Add `az_json_reader` and `az_json_token` tests

**Subsequent PR:**
- [ ] Add more `az_json_reader` tests with invalid/incomplete JSON