### PR TITLE
IoT Sample Readme Updates

### DIFF
--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -246,7 +246,7 @@ The following samples use SAS authentication to connect to Azure IoT Hub or Azur
 
 1. Compile the code:
 
-    - Enter the directory `/azure-sdk-for-c/cmake`. If it does not exist, please create it.
+    - From the sdk root, create a build directory (eg `/build`). Change directory into your build directory.
     - Build the directory structure and the samples:
 
       ```bash

--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -153,22 +153,28 @@ To run the samples, ensure you have the following programs or tools installed on
 
 Samples use environment variables for a variety of purposes, including filepaths and connection parameters. Please keep in mind, **every time a new terminal is opened, the environment variables will have to be reset**. Setting a variable will take the following form:
 
-Linux:
+**Linux**:
 
 ```bash
 export ENV_VARIABLE_NAME=VALUE
 ```
 
-Windows:
+**Windows (CMD)**:
 
 ```cmd
 set ENV_VARIABLE_NAME=VALUE
 ```
 
+**Windows (Powershell)**:
+
+```powershell
+$env:ENV_VARIABLE_NAME=NAME
+```
+
 Set the following environment variables for all samples:
 
 - `VCPKG_DEFAULT_TRIPLET` and `VCPKG_ROOT`: Refer to these [directions](https://github.com/Azure/azure-sdk-for-c#development-environment).
-- `AZ_IOT_DEVICE_X509_TRUST_PEM_FILE_PATH`: **Only for Windows or if required by OS.** Download [BaltimoreCyberTrustRoot.crt.pem](https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem) to `\azure-sdk-for-c\sdk\samples\iot\`. Copy the full filepath to this downloaded .pem file, e.g. `C:\azure-sdk-for-c\sdk\samples\iot\BaltimoreCyberTrustRoot.crt.pem`.
+- `AZ_IOT_DEVICE_X509_TRUST_PEM_FILE_PATH`: **Only for Windows or if required by OS.** Download [BaltimoreCyberTrustRoot.crt.pem](https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem) to `\azure-sdk-for-c\sdk\samples\iot\`. Copy the full filepath to this downloaded .pem file, e.g. `C:\<FULL PATH TO REPO>\sdk\samples\iot\BaltimoreCyberTrustRoot.crt.pem`.
 
 ### Certificate Samples
 
@@ -194,9 +200,9 @@ The following samples use x509 authentication to connect to Azure IoT Hub or Azu
 
 #### IoT Hub Certificate Samples
 
-*Executables:* `paho_iot_hub_c2d_sample`, `paho_iot_hub_methods_sample`, `paho_iot_hub_telemetry_sample`, `paho_iot_hub_twin_sample`, `paho_iot_hub_pnp_sample`
+*Executables:* `paho_iot_hub_c2d_sample`, `paho_iot_hub_methods_sample`, `paho_iot_hub_telemetry_sample`, `paho_iot_hub_twin_sample`, `paho_iot_hub_pnp_sample`, `paho_iot_hub_pnp_component_sample`
 
-1. In your Azure IoT Hub, add a new device using a self-signed certificate.  See [here](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-security-x509-get-started#create-an-x509-device-for-your-iot-hub) for further instruction, with one exception--**do NOT** select X.509 CA Signed as the authentication type. Select **X.509 Self-Signed**. For the Thumbprint, use the recently generated fingerprint noted at the bottom of the generate_certificate output. (It is also placed in a file named `fingerprint.txt` for your convenience).
+1. In your Azure IoT Hub, add a new device using a self-signed certificate.  See [here](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-security-x509-get-started#create-an-x509-device-for-your-iot-hub) for further instruction, with one exception--**DO NOT** select X.509 CA Signed as the authentication type. Select **X.509 Self-Signed**. For the Thumbprint, use the recently generated fingerprint noted at the bottom of the `generate_certificate.ps1` output. (It is also placed in a file named `fingerprint.txt` for your convenience).
 
 2. Set the following environment variables:
 
@@ -275,7 +281,7 @@ The following samples use SAS authentication to connect to Azure IoT Hub or Azur
 
 ## Next Steps and Additional Documentation
 
-Start using the IoT Provisioning Client in your solutions!
+Start using the IoT Clients in your solutions!
 
 - A general overview of the Embedded C SDK and additional background on running samples can be found in the [Azure SDK for Embedded C README](https://github.com/Azure/azure-sdk-for-c#azure-sdk-for-embedded-c).
 - More SDK details pertaining to the Azure IoT Client library can be found in the [Azure IoT Client README](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot#azure-iot-clients).

--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -153,19 +153,19 @@ To run the samples, ensure you have the following programs or tools installed on
 
 Samples use environment variables for a variety of purposes, including filepaths and connection parameters. Please keep in mind, **every time a new terminal is opened, the environment variables will have to be reset**. Setting a variable will take the following form:
 
-**Linux**:
+#### Linux
 
 ```bash
 export ENV_VARIABLE_NAME=VALUE
 ```
 
-**Windows (CMD)**:
+#### Windows (CMD)
 
 ```cmd
 set ENV_VARIABLE_NAME=VALUE
 ```
 
-**Windows (Powershell)**:
+#### Windows (Powershell)
 
 ```powershell
 $env:ENV_VARIABLE_NAME=NAME
@@ -174,7 +174,7 @@ $env:ENV_VARIABLE_NAME=NAME
 Set the following environment variables for all samples:
 
 - `VCPKG_DEFAULT_TRIPLET` and `VCPKG_ROOT`: Refer to these [directions](https://github.com/Azure/azure-sdk-for-c#development-environment).
-- `AZ_IOT_DEVICE_X509_TRUST_PEM_FILE_PATH`: **Only for Windows or if required by OS.** Download [BaltimoreCyberTrustRoot.crt.pem](https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem) to `\azure-sdk-for-c\sdk\samples\iot\`. Copy the full filepath to this downloaded .pem file, e.g. `C:\<FULL PATH TO REPO>\sdk\samples\iot\BaltimoreCyberTrustRoot.crt.pem`.
+- `AZ_IOT_DEVICE_X509_TRUST_PEM_FILE_PATH`: **Only for Windows or if required by OS.** Download [BaltimoreCyberTrustRoot.crt.pem](https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem) to `<FULL PATH TO azure-sdk-for-c REPO>\sdk\samples\iot\`. Copy the full filepath to this downloaded .pem file, e.g. `<FULL PATH TO azure-sdk-for-c REPO>\sdk\samples\iot\BaltimoreCyberTrustRoot.crt.pem`.
 
 ### Certificate Samples
 
@@ -281,7 +281,7 @@ The following samples use SAS authentication to connect to Azure IoT Hub or Azur
 
 ## Next Steps and Additional Documentation
 
-Start using the IoT Clients in your solutions!
+Start using the Azure Embedded C SDK IoT Clients in your solutions!
 
 - A general overview of the Embedded C SDK and additional background on running samples can be found in the [Azure SDK for Embedded C README](https://github.com/Azure/azure-sdk-for-c#azure-sdk-for-embedded-c).
 - More SDK details pertaining to the Azure IoT Client library can be found in the [Azure IoT Client README](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot#azure-iot-clients).


### PR DESCRIPTION
- Adding the pnp component sample to Cert executable list.
- Change directions for building from creating a `cmake` directory to a `build` directory. As a default, `build` should be preferred over `cmake` since many projects use `cmake` as a directory to store extra `.cmake` files. `cmake` also is not in our `.gitignore`.
- Add instructions for setting env vars in powershell.
- Small typo type stuff.