### PR TITLE
Rename AZ_ERROR_EOF az_result to a more descriptive AZ_ERROR_UNEXPECTED_END.

### DIFF
--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -609,7 +609,7 @@ AZ_NODISCARD az_result az_json_reader_chunked_init(
  * @param json_reader A pointer to an #az_json_reader instance containing the JSON to read.
  *
  * @return AZ_OK if the token was read successfully.<br>
- *         AZ_ERROR_EOF when the end of the JSON document is reached.<br>
+ *         AZ_ERROR_UNEXPECTED_END when the end of the JSON document is reached.<br>
  *         AZ_ERROR_UNEXPECTED_CHAR when an invalid character is detected.
  */
 AZ_NODISCARD az_result az_json_reader_next_token(az_json_reader* json_reader);
@@ -620,7 +620,7 @@ AZ_NODISCARD az_result az_json_reader_next_token(az_json_reader* json_reader);
  * @param json_reader A pointer to an #az_json_reader instance containing the JSON to read.
  *
  * @return AZ_OK if the children of the current JSON token are skipped successfully.<br>
- *         AZ_ERROR_EOF when the end of the JSON document is reached.<br>
+ *         AZ_ERROR_UNEXPECTED_END when the end of the JSON document is reached.<br>
  *         AZ_ERROR_UNEXPECTED_CHAR when an invalid character is detected.
  *
  * @remarks If the current token kind is a property name, the reader first moves to the property

--- a/sdk/inc/azure/core/az_result.h
+++ b/sdk/inc/azure/core/az_result.h
@@ -95,7 +95,7 @@ typedef enum
   AZ_ERROR_UNEXPECTED_CHAR
   = _az_RESULT_MAKE_ERROR(_az_FACILITY_CORE, 5), ///< Input can't be successfully parsed.
 
-  AZ_ERROR_EOF = _az_RESULT_MAKE_ERROR(_az_FACILITY_CORE, 6), ///< Unexpected end of the input data.
+  AZ_ERROR_UNEXPECTED_END = _az_RESULT_MAKE_ERROR(_az_FACILITY_CORE, 6), ///< Unexpected end of the input data.
 
   AZ_ERROR_NOT_SUPPORTED = _az_RESULT_MAKE_ERROR(_az_FACILITY_CORE, 7),
 

--- a/sdk/src/azure/core/az_json_reader.c
+++ b/sdk/src/azure/core/az_json_reader.c
@@ -131,7 +131,7 @@ AZ_NODISCARD static az_result _az_json_reader_get_next_buffer(
   // If we only had one buffer, or we ran out of the set of discontiguous buffers, return error.
   if (json_reader->_internal.buffer_index >= json_reader->_internal.number_of_buffers - 1)
   {
-    return AZ_ERROR_EOF;
+    return AZ_ERROR_UNEXPECTED_END;
   }
 
   if (!skip_whitespace && json_reader->token._internal.start_buffer_index == -1)
@@ -151,7 +151,7 @@ AZ_NODISCARD static az_result _az_json_reader_get_next_buffer(
   // Found an empty segment in the json_buffers array, which isn't allowed.
   if (az_span_size(place_holder) < 1)
   {
-    return AZ_ERROR_EOF;
+    return AZ_ERROR_UNEXPECTED_END;
   }
 
   *remaining = place_holder;
@@ -365,7 +365,7 @@ AZ_NODISCARD static az_result _az_json_reader_process_property_name(az_json_read
   // either reached end of data or some other character, which is invalid.
   if (az_span_size(json) < 1)
   {
-    return AZ_ERROR_EOF;
+    return AZ_ERROR_UNEXPECTED_END;
   }
   if (az_span_ptr(json)[0] != ':')
   {
@@ -465,7 +465,7 @@ AZ_NODISCARD static az_result _az_json_reader_update_number_state_if_single_valu
 {
   if (json_reader->_internal.is_complex_json)
   {
-    return AZ_ERROR_EOF;
+    return AZ_ERROR_UNEXPECTED_END;
   }
 
   _az_json_reader_update_state(
@@ -809,7 +809,7 @@ AZ_NODISCARD static az_result _az_json_reader_process_next_byte(
     // Expected start of a property name or value, but instead reached end of data.
     if (az_span_size(json) < 1)
     {
-      return AZ_ERROR_EOF;
+      return AZ_ERROR_UNEXPECTED_END;
     }
 
     next_byte = az_span_ptr(json)[0];
@@ -854,7 +854,7 @@ AZ_NODISCARD az_result az_json_reader_next_token(az_json_reader* json_reader)
     if (json_reader->token.kind == AZ_JSON_TOKEN_NONE)
     {
       // An empty JSON payload is invalid.
-      return AZ_ERROR_EOF;
+      return AZ_ERROR_UNEXPECTED_END;
     }
     else
     {

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -854,7 +854,7 @@ AZ_NODISCARD az_result _az_is_expected_span(az_span* ref_span, az_span expected)
   // EOF because ref_span is smaller than the expected span
   if (expected_size > az_span_size(*ref_span))
   {
-    return AZ_ERROR_EOF;
+    return AZ_ERROR_UNEXPECTED_END;
   }
 
   actual_span = az_span_slice(*ref_span, 0, expected_size);

--- a/sdk/src/azure/iot/az_iot_hub_client.c
+++ b/sdk/src/azure/iot/az_iot_hub_client.c
@@ -276,7 +276,7 @@ az_iot_hub_client_properties_next(az_iot_hub_client_properties* properties, az_p
   if (index == prop_length)
   {
     *out = AZ_PAIR_NULL;
-    return AZ_ERROR_EOF;
+    return AZ_ERROR_UNEXPECTED_END;
   }
 
   az_span remainder;

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -824,7 +824,7 @@ static void test_json_reader(void** state)
   {
     az_json_reader reader = { 0 };
     TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, AZ_SPAN_FROM_STR("    "), NULL));
-    assert_true(az_json_reader_next_token(&reader) == AZ_ERROR_EOF);
+    assert_true(az_json_reader_next_token(&reader) == AZ_ERROR_UNEXPECTED_END);
     test_json_token_helper(reader.token, AZ_JSON_TOKEN_NONE, AZ_SPAN_NULL);
   }
   {
@@ -836,7 +836,7 @@ static void test_json_reader(void** state)
   {
     az_json_reader reader = { 0 };
     TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, AZ_SPAN_FROM_STR("  nul"), NULL));
-    assert_true(az_json_reader_next_token(&reader) == AZ_ERROR_EOF);
+    assert_true(az_json_reader_next_token(&reader) == AZ_ERROR_UNEXPECTED_END);
     test_json_token_helper(reader.token, AZ_JSON_TOKEN_NONE, AZ_SPAN_NULL);
   }
   {

--- a/sdk/tests/iot/hub/test_az_iot_hub_client.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client.c
@@ -898,7 +898,7 @@ static void test_az_iot_hub_client_properties_next_succeed(void** state)
       az_span_ptr(test_value_three),
       (size_t)az_span_size(test_value_three));
 
-  assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_ERROR_EOF);
+  assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_ERROR_UNEXPECTED_END);
 }
 
 static void test_az_iot_hub_client_properties_next_twice_succeed(void** state)
@@ -928,7 +928,7 @@ static void test_az_iot_hub_client_properties_next_twice_succeed(void** state)
       az_span_ptr(test_value_two),
       (size_t)az_span_size(test_value_two));
 
-  assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_ERROR_EOF);
+  assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_ERROR_UNEXPECTED_END);
 
   // Reset to beginning of span
   assert_int_equal(
@@ -950,7 +950,7 @@ static void test_az_iot_hub_client_properties_next_twice_succeed(void** state)
       az_span_ptr(test_value_two),
       (size_t)az_span_size(test_value_two));
 
-  assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_ERROR_EOF);
+  assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_ERROR_UNEXPECTED_END);
 }
 
 static void test_az_iot_hub_client_properties_next_empty_succeed(void** state)
@@ -962,7 +962,7 @@ static void test_az_iot_hub_client_properties_next_empty_succeed(void** state)
 
   az_pair pair_out;
 
-  assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_ERROR_EOF);
+  assert_int_equal(az_iot_hub_client_properties_next(&props, &pair_out), AZ_ERROR_UNEXPECTED_END);
 }
 
 int test_iot_hub_client()


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/894