### PR TITLE
Update changelog for preview 4 to include the sscanf related bug fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 - Remove support for non-finite double values while parsing/formatting.
 - Use custom, portable implementation of IEEE 754 compliant `isfinite()` since some embedded platforms don't have it.
+- Limit use of `sscanf` only to double parsing, using a custom implementation for {u}int{32|64} parsing because of incompatibility with `sscanf` format and the `GCC newlib-nano` implementation.
 
 ### Other Changes and Improvements
 


### PR DESCRIPTION
I missed this change when going through the commit history.

This fix is important enough to call out in the changelog for preview 4, since it impacted certain IoT consumers, and also update the release notes with.

@RickWinter thoughts?