### PR TITLE
Bump branch coverage test metric threshold from 65 to 70.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -273,8 +273,8 @@ jobs:
       checkCoverage: true
       coverageFailOption: fixed
       coverageType: branch
-      # 65% minimum branch coverage
-      coverageThreshold: 65
+      # 70% minimum branch coverage
+      coverageThreshold: 70
     condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
 - job: GenerateReleaseArtifacts


### PR DESCRIPTION
Even though we are above 90% line coverage already, I think 95% is a good line coverage bar to settle on. Anything higher as a CI blocking bar has diminishing returns.

Bumping branch coverage to 70%, and we should keep incrementing that one, to reach a goal of at least 90%.

**Current snapshot:**
![image](https://user-images.githubusercontent.com/6527137/89854335-842ea880-db48-11ea-8712-0fd3e7020199.png)
