### PR TITLE
remove struct name to align with core

### DIFF
--- a/sdk/inc/azure/iot/az_iot_hub_client.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client.h
@@ -41,7 +41,7 @@ enum
  * @brief Azure IoT Hub Client options.
  *
  */
-typedef struct az_iot_hub_client_options
+typedef struct
 {
   az_span module_id; /**< The module name (if a module identity is used). */
   az_span user_agent; /**< The user-agent is a formatted string that will be used for Azure IoT
@@ -54,7 +54,7 @@ typedef struct az_iot_hub_client_options
  * @brief Azure IoT Hub Client.
  *
  */
-typedef struct az_iot_hub_client
+typedef struct
 {
   struct
   {
@@ -223,7 +223,7 @@ AZ_NODISCARD az_result az_iot_hub_client_sas_get_password(
  * @brief Telemetry or C2D properties.
  *
  */
-typedef struct az_iot_hub_client_properties
+typedef struct
 {
   struct
   {
@@ -349,7 +349,7 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
  * @brief The Cloud-To-Device Request.
  *
  */
-typedef struct az_iot_hub_client_c2d_request
+typedef struct
 {
   az_iot_hub_client_properties properties; /**< The properties associated with this C2D request. */
 } az_iot_hub_client_c2d_request;
@@ -385,7 +385,7 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
  * @brief A method request received from IoT Hub.
  *
  */
-typedef struct az_iot_hub_client_method_request
+typedef struct
 {
   az_span request_id; /**< The request id.
                        * @note The application must match the method request and method response. */
@@ -463,7 +463,7 @@ typedef enum
  * @brief Twin response.
  *
  */
-typedef struct az_iot_hub_client_twin_response
+typedef struct
 {
   az_iot_hub_client_twin_response_type response_type; /**< Twin response type. */
   az_iot_status status; /**< The operation status. */

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -32,7 +32,7 @@
  * @brief Azure IoT Provisioning Client options.
  *
  */
-typedef struct az_iot_provisioning_client_options
+typedef struct
 {
   az_span user_agent; /**< The user-agent is a formatted string that will be used for Azure IoT
                          usage statistics. */
@@ -42,7 +42,7 @@ typedef struct az_iot_provisioning_client_options
  * @brief Azure IoT Provisioning Client.
  *
  */
-typedef struct az_iot_provisioning_client
+typedef struct
 {
   struct
   {
@@ -201,7 +201,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_sas_get_password(
  * @remark This is returned only when the operation completed.
  *
  */
-typedef struct az_iot_provisioning_client_registration_result
+typedef struct
 {
   az_span assigned_hub_hostname; /**< Assigned Azure IoT Hub hostname. @remark This is only
                                     available if error_code is success. */
@@ -218,7 +218,7 @@ typedef struct az_iot_provisioning_client_registration_result
  * @brief Register or query operation response.
  *
  */
-typedef struct az_iot_provisioning_client_register_response
+typedef struct
 {
   az_iot_status status; /**< The current request status.
                          * @remark The authoritative response for the device registration operation

--- a/sdk/samples/iot/sample_pnp_component_mqtt.h
+++ b/sdk/samples/iot/sample_pnp_component_mqtt.h
@@ -8,7 +8,7 @@
 
 #include <azure/core/az_span.h>
 
-typedef struct sample_pnp_mqtt_message_tag
+typedef struct
 {
   char* topic;
   size_t topic_length;

--- a/sdk/samples/iot/sample_pnp_thermostat_component.h
+++ b/sdk/samples/iot/sample_pnp_thermostat_component.h
@@ -13,7 +13,7 @@
 
 #include "sample_pnp_component_mqtt.h"
 
-typedef struct sample_pnp_thermostat_component_tag
+typedef struct
 {
   az_span component_name;
   double current_temperature;


### PR DESCRIPTION
The rest of the SDK doesn't have the struct name and the typedef. This removes the struct name for IoT to align to core.