### PR TITLE
Sample update: includes and defines

### DIFF
--- a/sdk/samples/iot/CMakeLists.txt
+++ b/sdk/samples/iot/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 
 # Azure IoT Samples Library
 add_library (az_iot_samples_common
-  ${CMAKE_CURRENT_LIST_DIR}/iot_sample_foundation.c
+  ${CMAKE_CURRENT_LIST_DIR}/iot_samples_common.c
 )
 
 # Internal deps

--- a/sdk/samples/iot/iot_samples_common.c
+++ b/sdk/samples/iot/iot_samples_common.c
@@ -1,7 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include "iot_sample_foundation.h"
+#ifdef _MSC_VER
+// "'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead."
+#pragma warning(disable : 4996)
+#endif
+
+#ifdef _WIN32
+// Required for Sleep(DWORD)
+#include <Windows.h>
+#else
+// Required for sleep(unsigned int)
+#include <unistd.h>
+#endif
+
+#include "iot_samples_common.h"
+
+#include <time.h>
+#include <string.h>
+
+#include <openssl/bio.h>
+#include <openssl/buffer.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
 
 //
 // MQTT endpoints

--- a/sdk/samples/iot/iot_samples_common.c
+++ b/sdk/samples/iot/iot_samples_common.c
@@ -16,8 +16,8 @@
 
 #include "iot_samples_common.h"
 
-#include <time.h>
 #include <string.h>
+#include <time.h>
 
 #include <openssl/bio.h>
 #include <openssl/buffer.h>

--- a/sdk/samples/iot/iot_samples_common.c
+++ b/sdk/samples/iot/iot_samples_common.c
@@ -16,8 +16,16 @@
 
 #include "iot_samples_common.h"
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
+
+#include <azure/core/az_result.h>
+#include <azure/core/az_span.h>
 
 #include <openssl/bio.h>
 #include <openssl/buffer.h>

--- a/sdk/samples/iot/iot_samples_common.h
+++ b/sdk/samples/iot/iot_samples_common.h
@@ -1,44 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#ifndef SAMPLE_H
-#define SAMPLE_H
+#ifndef IOT_SAMPLES_COMMON_H
+#define IOT_SAMPLES_COMMON_H
 
-#ifdef _MSC_VER
-// warning C4201: nonstandard extension used: nameless struct/union
-#pragma warning(disable : 4201)
-// "'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead."
-#pragma warning(disable : 4996)
-#endif
-
-#ifdef _WIN32
-// Required for Sleep(DWORD)
-#include <Windows.h>
-#else
-// Required for sleep(unsigned int)
-#include <unistd.h>
-#endif
-
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <time.h>
 
-#include <azure/core/az_json.h>
 #include <azure/core/az_result.h>
 #include <azure/core/az_span.h>
-#include <azure/iot/az_iot_hub_client.h>
-#include <azure/iot/az_iot_provisioning_client.h>
-
-#include <openssl/bio.h>
-#include <openssl/buffer.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
-
-#include <paho-mqtt/MQTTClient.h>
 
 #define SAS_KEY_DURATION_TIME_DIGITS 4
-#define TIMEOUT_MQTT_DISCONNECT_MS (10 * 1000)
 
 //
 // Logging and Pre-condition Check
@@ -277,4 +252,4 @@ void sas_generate_encoded_signed_signature(
     const az_span* sas_signature,
     az_span* sas_b64_encoded_hmac256_signed_signature);
 
-#endif // SAMPLE_H
+#endif // IOT_SAMPLES_COMMON_H

--- a/sdk/samples/iot/paho_iot_hub_c2d_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_c2d_sample.c
@@ -1,13 +1,33 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include "iot_sample_foundation.h"
+#ifdef _MSC_VER
+// warning C4201: nonstandard extension used: nameless struct/union
+#pragma warning(disable : 4201)
+#endif
+#include <paho-mqtt/MQTTClient.h>
+#ifdef _MSC_VER
+#pragma warning(default : 4201)
+#endif
+
+#include "iot_samples_common.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <azure/core/az_result.h>
+#include <azure/core/az_span.h>
+#include <azure/iot/az_iot_hub_client.h>
 
 #define SAMPLE_TYPE PAHO_IOT_HUB
 #define SAMPLE_NAME PAHO_IOT_HUB_C2D_SAMPLE
 
 #define MAX_C2D_MESSAGE_COUNT 5
 #define TIMEOUT_MQTT_RECEIVE_MS (60 * 1000)
+#define TIMEOUT_MQTT_DISCONNECT_MS (10 * 1000)
 
 static sample_environment_variables env_vars;
 static az_iot_hub_client hub_client;

--- a/sdk/samples/iot/paho_iot_hub_methods_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_methods_sample.c
@@ -1,13 +1,33 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include "iot_sample_foundation.h"
+#ifdef _MSC_VER
+// warning C4201: nonstandard extension used: nameless struct/union
+#pragma warning(disable : 4201)
+#endif
+#include <paho-mqtt/MQTTClient.h>
+#ifdef _MSC_VER
+#pragma warning(default : 4201)
+#endif
+
+#include "iot_samples_common.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <azure/core/az_result.h>
+#include <azure/core/az_span.h>
+#include <azure/iot/az_iot_hub_client.h>
 
 #define SAMPLE_TYPE PAHO_IOT_HUB
 #define SAMPLE_NAME PAHO_IOT_HUB_METHODS_SAMPLE
 
 #define MAX_METHOD_MESSAGE_COUNT 5
 #define TIMEOUT_MQTT_RECEIVE_MS (60 * 1000)
+#define TIMEOUT_MQTT_DISCONNECT_MS (10 * 1000)
 
 static const az_span ping_method_name = AZ_SPAN_LITERAL_FROM_STR("ping");
 static const az_span ping_response = AZ_SPAN_LITERAL_FROM_STR("{\"response\": \"pong\"}");

--- a/sdk/samples/iot/paho_iot_hub_sas_telemetry_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_sas_telemetry_sample.c
@@ -1,13 +1,33 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include "iot_sample_foundation.h"
+#ifdef _MSC_VER
+// warning C4201: nonstandard extension used: nameless struct/union
+#pragma warning(disable : 4201)
+#endif
+#include <paho-mqtt/MQTTClient.h>
+#ifdef _MSC_VER
+#pragma warning(default : 4201)
+#endif
+
+#include "iot_samples_common.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <azure/core/az_result.h>
+#include <azure/core/az_span.h>
+#include <azure/iot/az_iot_hub_client.h>
 
 #define SAMPLE_TYPE PAHO_IOT_HUB
 #define SAMPLE_NAME PAHO_IOT_HUB_SAS_TELEMETRY_SAMPLE
 
 #define TELEMETRY_SEND_INTERVAL_SEC 1
 #define TELEMETRY_NUMBER_OF_MESSAGES 5
+#define TIMEOUT_MQTT_DISCONNECT_MS (10 * 1000)
 
 static sample_environment_variables env_vars;
 static az_iot_hub_client hub_client;
@@ -166,7 +186,7 @@ void send_telemetry_messages_to_iot_hub()
   };
 
   // Publish # of telemetry messages.
-  for (int i = 0; i < TELEMETRY_NUMBER_OF_MESSAGES; ++i)
+  for (uint8_t i = 0; i < TELEMETRY_NUMBER_OF_MESSAGES; ++i)
   {
     LOG("Sending message %d.", i + 1);
     if ((rc = MQTTClient_publish(

--- a/sdk/samples/iot/paho_iot_hub_telemetry_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_telemetry_sample.c
@@ -1,13 +1,33 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include "iot_sample_foundation.h"
+#ifdef _MSC_VER
+// warning C4201: nonstandard extension used: nameless struct/union
+#pragma warning(disable : 4201)
+#endif
+#include <paho-mqtt/MQTTClient.h>
+#ifdef _MSC_VER
+#pragma warning(default : 4201)
+#endif
+
+#include "iot_samples_common.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <azure/core/az_result.h>
+#include <azure/core/az_span.h>
+#include <azure/iot/az_iot_hub_client.h>
 
 #define SAMPLE_TYPE PAHO_IOT_HUB
 #define SAMPLE_NAME PAHO_IOT_HUB_TELEMETRY_SAMPLE
 
 #define TELEMETRY_SEND_INTERVAL_SEC 1
 #define TELEMETRY_NUMBER_OF_MESSAGES 5
+#define TIMEOUT_MQTT_DISCONNECT_MS (10 * 1000)
 
 static sample_environment_variables env_vars;
 static az_iot_hub_client hub_client;
@@ -157,7 +177,7 @@ void send_telemetry_messages_to_iot_hub()
   };
 
   // Publish # of telemetry messages.
-  for (int i = 0; i < TELEMETRY_NUMBER_OF_MESSAGES; ++i)
+  for (uint8_t i = 0; i < TELEMETRY_NUMBER_OF_MESSAGES; ++i)
   {
     LOG("Sending message %d.", i + 1);
     if ((rc = MQTTClient_publish(

--- a/sdk/samples/iot/paho_iot_hub_twin_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_twin_sample.c
@@ -1,13 +1,34 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include "iot_sample_foundation.h"
+#ifdef _MSC_VER
+// warning C4201: nonstandard extension used: nameless struct/union
+#pragma warning(disable : 4201)
+#endif
+#include <paho-mqtt/MQTTClient.h>
+#ifdef _MSC_VER
+#pragma warning(default : 4201)
+#endif
+
+#include "iot_samples_common.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <azure/core/az_json.h>
+#include <azure/core/az_result.h>
+#include <azure/core/az_span.h>
+#include <azure/iot/az_iot_hub_client.h>
 
 #define SAMPLE_TYPE PAHO_IOT_HUB
 #define SAMPLE_NAME PAHO_IOT_HUB_TWIN_SAMPLE
 
 #define MAX_TWIN_MESSAGE_COUNT 5
 #define TIMEOUT_MQTT_RECEIVE_MS (60 * 1000)
+#define TIMEOUT_MQTT_DISCONNECT_MS (10 * 1000)
 
 static const az_span twin_document_topic_request_id = AZ_SPAN_LITERAL_FROM_STR("get_twin");
 static const az_span twin_patch_topic_request_id = AZ_SPAN_LITERAL_FROM_STR("reported_prop");

--- a/sdk/samples/iot/paho_iot_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_provisioning_sample.c
@@ -1,12 +1,32 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include "iot_sample_foundation.h"
+#ifdef _MSC_VER
+// warning C4201: nonstandard extension used: nameless struct/union
+#pragma warning(disable : 4201)
+#endif
+#include <paho-mqtt/MQTTClient.h>
+#ifdef _MSC_VER
+#pragma warning(default : 4201)
+#endif
+
+#include "iot_samples_common.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <azure/core/az_result.h>
+#include <azure/core/az_span.h>
+#include <azure/iot/az_iot_provisioning_client.h>
 
 #define SAMPLE_TYPE PAHO_IOT_PROVISIONING
 #define SAMPLE_NAME PAHO_IOT_PROVISIONING_SAMPLE
 
 #define TIMEOUT_MQTT_RECEIVE_MS (60 * 1000)
+#define TIMEOUT_MQTT_DISCONNECT_MS (10 * 1000)
 
 static sample_environment_variables env_vars;
 static az_iot_provisioning_client provisioning_client;

--- a/sdk/samples/iot/paho_iot_provisioning_sas_sample.c
+++ b/sdk/samples/iot/paho_iot_provisioning_sas_sample.c
@@ -1,12 +1,32 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include "iot_sample_foundation.h"
+#ifdef _MSC_VER
+// warning C4201: nonstandard extension used: nameless struct/union
+#pragma warning(disable : 4201)
+#endif
+#include <paho-mqtt/MQTTClient.h>
+#ifdef _MSC_VER
+#pragma warning(default : 4201)
+#endif
+
+#include "iot_samples_common.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <azure/core/az_result.h>
+#include <azure/core/az_span.h>
+#include <azure/iot/az_iot_provisioning_client.h>
 
 #define SAMPLE_TYPE PAHO_IOT_PROVISIONING
 #define SAMPLE_NAME PAHO_IOT_PROVISIONING_SAS_SAMPLE
 
 #define TIMEOUT_MQTT_RECEIVE_MS (60 * 1000)
+#define TIMEOUT_MQTT_DISCONNECT_MS (10 * 1000)
 
 static sample_environment_variables env_vars;
 static az_iot_provisioning_client provisioning_client;


### PR DESCRIPTION
iot_samples_common.c only adds to the includes already specified in iot_samples_common.h. It does not replicate the includes.

all other sample.c files include all header files associated with content.