### PR TITLE
Increase package restore timeout.

### DIFF
--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -63,6 +63,7 @@ steps:
 
   # Attempt to restore vcpkg from the cache
   - task: Cache@2
+    timeoutInMinutes: 1
     inputs:
       key: >-
         $(Agent.JobName)
@@ -71,6 +72,7 @@ steps:
         | $(${{ parameters.DependenciesVariableName }})
       path: $(VCPKG_INSTALLATION_ROOT)
       cacheHitVar: VcpkgRestoredFromCache
+    
     displayName: Vcpkg Cache
     condition: >-
       and(


### PR DESCRIPTION
The cache restore task is running up against its default timeout. This should double it giving it a bit more headroom.