### PR TITLE
Doc index generation

### DIFF
--- a/eng/docs/index/Generate-DocIndex.ps1
+++ b/eng/docs/index/Generate-DocIndex.ps1
@@ -8,6 +8,7 @@ Param (
 
 $ServiceMapping = @{
     "core"="Core";
+    "iot"="IoT";
     "storage"="Storage";
 }
 
@@ -24,7 +25,7 @@ Copy-Item "${DocGenDir}/templates/*" -Destination "${DocOutDir}/templates" -Forc
 Copy-Item "${DocGenDir}/docfx.json" -Destination "${DocOutDir}/" -Force
 
 Write-Verbose "Creating Index using service directory and package names from repo..."
-$ServiceList = Get-ChildItem "$($RepoRoot)/sdk" -Directory -Exclude eng, mgmtcommon, template | Sort-Object
+$ServiceList = Get-ChildItem "$($RepoRoot)/sdk/inc/azure" -Directory -Exclude eng, mgmtcommon, template | Sort-Object
 $YmlPath = "${DocOutDir}/api"
 New-Item -Path $YmlPath -Name "toc.yml" -Force
 
@@ -73,5 +74,7 @@ Copy-Item "$($RepoRoot)/CONTRIBUTING.md" -Destination "${DocOutDir}/api/CONTRIBU
 Write-Verbose "Building site..."
 & "${DocFxTool}" build "${DocOutDir}/docfx.json"
 
+Copy-Item "${DocGenDir}/assets/logo.svg" -Destination "${DocOutDir}/" -Force
+Copy-Item "${DocGenDir}/assets/toc.yml" -Destination "${DocOutDir}/" -Force
 Copy-Item "${DocGenDir}/assets/logo.svg" -Destination "${DocOutDir}/_site/" -Force
 Copy-Item "${DocGenDir}/assets/toc.yml" -Destination "${DocOutDir}/_site/" -Force

--- a/eng/docs/index/Generate-DocIndex.ps1
+++ b/eng/docs/index/Generate-DocIndex.ps1
@@ -28,7 +28,7 @@ $YmlPath = "${DocOutDir}/api"
 New-Item -Path $YmlPath -Name "toc.yml" -Force
 
 Write-Verbose "Creating Index for client packages..."
-foreach ($ServiceKey in $ServiceMapping.Keys)
+foreach ($ServiceKey in $ServiceMapping.Keys | Sort-Object)
 {
     # Generate a new top-level md file for the service
     New-Item -Path $YmlPath -Name "$($ServiceKey).md" -Force

--- a/eng/docs/index/Generate-DocIndex.ps1
+++ b/eng/docs/index/Generate-DocIndex.ps1
@@ -28,18 +28,18 @@ $YmlPath = "${DocOutDir}/api"
 New-Item -Path $YmlPath -Name "toc.yml" -Force
 
 Write-Verbose "Creating Index for client packages..."
-foreach ($Dir in $ServiceMapping.Keys)
+foreach ($ServiceKey in $ServiceMapping.Keys)
 {
     # Generate a new top-level md file for the service
-    New-Item -Path $YmlPath -Name "$($Dir).md" -Force
+    New-Item -Path $YmlPath -Name "$($ServiceKey).md" -Force
 
     # Add service to toc.yml
-    $ServiceName = $ServiceMapping[$Dir]
-    Add-Content -Path "$($YmlPath)/toc.yml" -Value "- name: $($ServiceName)`r`n  href: $($Dir.Name).md"
+    $ServiceName = $ServiceMapping[$ServiceKey]
+    Add-Content -Path "$($YmlPath)/toc.yml" -Value "- name: $($ServiceName)`r`n  href: $($ServiceKey).md"
 
-    Add-Content -Path "$($YmlPath)/$($Dir.Name).md" -Value "# Client"
-    Add-Content -Path "$($YmlPath)/$($Dir.Name).md" -Value "---"
-    Write-Verbose "Operating on Client Packages for $($Dir.Name)"
+    Add-Content -Path "$($YmlPath)/$($ServiceKey).md" -Value "# Client"
+    Add-Content -Path "$($YmlPath)/$($ServiceKey).md" -Value "---"
+    Write-Verbose "Operating on Client Packages for $($ServiceKey)"
 }
 
 Write-Verbose "Creating Site Title and Navigation..."

--- a/eng/docs/index/Generate-DocIndex.ps1
+++ b/eng/docs/index/Generate-DocIndex.ps1
@@ -35,11 +35,18 @@ foreach ($ServiceKey in $ServiceMapping.Keys | Sort-Object)
 
     # Add service to toc.yml
     $ServiceName = $ServiceMapping[$ServiceKey]
+    $CmakeContent = Get-Content "sdk/src/azure/$ServiceKey/CMakeLists.txt" -Raw
+    $ProjectName = if ($CmakeContent -match 'project\s.*\(([\w].*?)\s') {
+        $Matches[1]
+    } else {
+        "Azure SDK for Embedded C"
+    }
+
     Add-Content -Path "$($YmlPath)/toc.yml" -Value "- name: $($ServiceName)`r`n  href: $($ServiceKey).md"
 
     Add-Content -Path "$($YmlPath)/$($ServiceKey).md" -Value "# Client"
     Add-Content -Path "$($YmlPath)/$($ServiceKey).md" -Value "---"
-    Add-Content -Path "$($YmlPath)/$($ServiceKey).md" -Value "### Azure SDK for Embedded C"
+    Add-Content -Path "$($YmlPath)/$($ServiceKey).md" -Value "### $ProjectName"
     Write-Verbose "Operating on Client Packages for $($ServiceKey)"
 }
 

--- a/eng/docs/index/Generate-DocIndex.ps1
+++ b/eng/docs/index/Generate-DocIndex.ps1
@@ -39,6 +39,7 @@ foreach ($ServiceKey in $ServiceMapping.Keys | Sort-Object)
 
     Add-Content -Path "$($YmlPath)/$($ServiceKey).md" -Value "# Client"
     Add-Content -Path "$($YmlPath)/$($ServiceKey).md" -Value "---"
+    Add-Content -Path "$($YmlPath)/$($ServiceKey).md" -Value "### Azure SDK for Embedded C"
     Write-Verbose "Operating on Client Packages for $($ServiceKey)"
 }
 

--- a/eng/docs/index/assets/docfx.json
+++ b/eng/docs/index/assets/docfx.json
@@ -59,8 +59,8 @@
     "cleanupCacheHistory": false,
     "disableGitFeatures": false,
     "globalMetadata": {
-      "_appTitle": "Azure SDK for C",
-      "_appFooter": "Azure SDK for C",
+      "_appTitle": "Azure SDK for Embedded C",
+      "_appFooter": "Azure SDK for Embedded C",
       "_appFaviconPath": "https://c.s-microsoft.com/favicon.ico?v2",
       "_enableSearch": true,
       "_enableNewTab": true

--- a/eng/docs/index/templates/matthews/styles/main.js
+++ b/eng/docs/index/templates/matthews/styles/main.js
@@ -74,35 +74,8 @@ function httpGetAsync(targetUrl, callback) {
     xmlHttp.send(null);
 }
 
-function populateOptions(selector, packageName) {
-    var versionRequestUrl = BLOB_URI_PREFIX + packageName + "/versioning/versions"
-
-    httpGetAsync(versionRequestUrl, function (responseText) {
-        var versionselector = document.createElement("select")
-        versionselector.className = 'navbar-version-select'
-        if (responseText) {
-            options = responseText.match(/[^\r\n]+/g)
-
-            for (var i in options) {
-                $(versionselector).append('<option value="' + options[i] + '">' + options[i] + '</option>')
-            }
-        }
-        $(versionselector).val(WINDOW_CONTENTS[6]);
-        $(selector).append(versionselector)
-
-        $(versionselector).change(function () {
-            targetVersion = $(this).val()
-            url = WINDOW_CONTENTS.slice()
-            url[6] = targetVersion
-            window.location.href = url.join('/')
-        });
-
-    })
-}
-
-
 function populateIndexList(selector, packageName) {
-    url = BLOB_URI_PREFIX + packageName + "/versioning/versions"
+    url = BLOB_URI_PREFIX + "docs/versioning/versions"
 
     httpGetAsync(url, function (responseText) {
 
@@ -111,7 +84,7 @@ function populateIndexList(selector, packageName) {
             options = responseText.match(/[^\r\n]+/g)
 
             for (var i in options) {
-                $(publishedversions).append('<li><a href="' + getPackageUrl(SELECTED_LANGUAGE, packageName, options[i]) + '" target="_blank">' + options[i] + '</a></li>')
+                $(publishedversions).append('<li><a href="' + getPackageUrl(SELECTED_LANGUAGE, options[i]) + '" target="_blank">' + options[i] + '</a></li>')
             }
         }
         else {
@@ -121,23 +94,21 @@ function populateIndexList(selector, packageName) {
     })
 }
 
-function getPackageUrl(language, package, version) {
-    return "https://" + STORAGE_ACCOUNT_NAME + ".blob.core.windows.net/$web/" + language + "/" + package + "/" + version + "/index.html";
+function getPackageUrl(language, version) {
+    return "https://" + STORAGE_ACCOUNT_NAME + ".blob.core.windows.net/$web/" + language + "/docs/" + version + "/index.html";
 }
 
 // Populate Versions
 $(function () {
-    if (WINDOW_CONTENTS.length < 7 && WINDOW_CONTENTS[WINDOW_CONTENTS.length - 1] != 'index.html') {
+    // If this is not the index page (e.g. api/index.html) then it is an api
+    // page (e.g. /api/core.html) and we should populate the list of packge
+    // versions
+    if (WINDOW_CONTENTS[WINDOW_CONTENTS.length - 1] != 'index.html') {
         console.log("Run PopulateList")
 
-        $('h4').each(function () {
+        $('article.content > h1').each(function () {
             var pkgName = $(this).text()
             populateIndexList($(this), pkgName)
         })
-    }
-
-    if (WINDOW_CONTENTS.length > 7) {
-        var pkgName = WINDOW_CONTENTS[5]
-        populateOptions($('#navbar'), pkgName)
     }
 })

--- a/eng/docs/index/templates/matthews/styles/main.js
+++ b/eng/docs/index/templates/matthews/styles/main.js
@@ -106,7 +106,7 @@ $(function () {
     if (WINDOW_CONTENTS[WINDOW_CONTENTS.length - 1] != 'index.html') {
         console.log("Run PopulateList")
 
-        $('article.content > h1').each(function () {
+        $('article.content > h3').each(function () {
             var pkgName = $(this).text()
             populateIndexList($(this), pkgName)
         })


### PR DESCRIPTION
Example docs: https://djurekdocs.z5.web.core.windows.net/index/index.html

We discussed having the links go to the appropriate conceptual docs in each section, however, the URLs for IoT and Storage are different between the versions and it'd require more hand-built logic to generate these links appropriately. Fortunately I think our repo layout is stable at this time so perhaps we could do this for later versions? 

Core:
https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.4/md_sdk_docs_core__r_e_a_d_m_e.html
https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.3/md_sdk_docs_core__r_e_a_d_m_e.html
https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.2/md_sdk_core_core__r_e_a_d_m_e.html
https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.1/md_sdk_core_core__r_e_a_d_m_e.html

IoT:
https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.4/md_sdk_docs_iot__r_e_a_d_m_e.html
https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.3/md_sdk_docs_iot__r_e_a_d_m_e.html
https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.2/md_sdk_iot__r_e_a_d_m_e.html
https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.1/md_sdk_iot__r_e_a_d_m_e.html

Storage:
https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.4/md_sdk_docs_storage__r_e_a_d_m_e.html
https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.3/md_sdk_docs_storage__r_e_a_d_m_e.html
https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.2/md_sdk_storage_blobs__r_e_a_d_m_e.html
https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0-preview.1/md_sdk_storage_blobs__r_e_a_d_m_e.html

