### PR TITLE
Url encoding on http

### DIFF
--- a/sdk/inc/azure/core/internal/az_http_internal.h
+++ b/sdk/inc/azure/core/internal/az_http_internal.h
@@ -164,20 +164,25 @@ AZ_NODISCARD AZ_INLINE az_result _az_http_pipeline_nextpolicy(
 /**
  * @brief Format buffer as a http request containing URL and header spans.
  *
- * @param out_request HTTP request builder to initialize.
- * @param method HTTP verb: `"GET"`, `"POST"`, etc.
- * @param url Maximum URL length (see @ref az_http_request_set_query_parameter).
- * @param headers_buffer HTTP verb: `"GET"`, `"POST"`, etc.
- * @param body URL.
+ * @remark The initial URL is expected to be url-encoded.
+ *
+ * @param[out] out_request HTTP request to initialize.
+ * @param[in] context A pointer to an #az_context node.
+ * @param[in] method HTTP verb: `"GET"`, `"POST"`, etc.
+ * @param[in] url az_pan to be used for storing the url. An initial value is expected to be in the
+ * buffer containing url schema and the server address. It can contain query parameters (like
+ * https://service.azure.com?query=1). This value is expected to be url-encoded.
+ * @param[in] url_length The size of the initial url value within url az_span
+ * @param[in] headers_buffer az_span to be used for storing headers for the request. The total
+ * number of headers are calculated automatically based on the size of the buffer.
+ * @param[in] body az_span buffer that contains a payload for the request. Use AZ_SPAN_NULL for
+ * no-body requests.
  *
  * @return
  *   - *`AZ_OK`* success.
- *   - *`AZ_ERROR_INSUFFICIENT_SPAN_SIZE`* `buffer` does not have enough space to fit the
- * `max_url_size`.
  *   - *`AZ_ERROR_ARG`*
- *     - `ref_request` is _NULL_.
- *     - `buffer`, `method_verb`, or `initial_url` are invalid spans (see @ref _az_span_is_valid).
- *     - `max_url_size` is less than `initial_url.size`.
+ *     - `out_request` is _NULL_.
+ *     - `url`, `method`, or `headers_buffer` are invalid spans (see @ref _az_span_is_valid).
  */
 AZ_NODISCARD az_result az_http_request_init(
     az_http_request* out_request,
@@ -193,19 +198,39 @@ AZ_NODISCARD az_result az_http_request_init(
  * For instance, if url in request is `http://example.net?qp=1` and this function is called with
  * path equals to `test`, then request url will be updated to `http://example.net/test?qp=1`.
  *
+ * @remarks if \p is_path_url_encoded is set to false, before appending the path, it would be
+ * url-encoded.
  *
- * @param ref_request http request builder reference
- * @param path span to a path to be appended into url
- * @return AZ_NODISCARD az_http_request_append_path
+ *
+ * @param[out] ref_request http request reference
+ * @param[in] path span to a path to be appended into url
+ * @param[in] \p is_path_url_encoded boolean value that defines if the value to be appended is
+ * url-encoded or not.
+ * @return
+ *   - *`AZ_OK`* success.
+ *   - *`AZ_ERROR_INSUFFICIENT_SPAN_SIZE`* the `URL` would grow past the `max_url_size`, should
+ * the parameter get set.
+ *   - *`AZ_ERROR_ARG`*
+ *     - `ref_request` is _NULL_.
  */
-AZ_NODISCARD az_result az_http_request_append_path(az_http_request* ref_request, az_span path);
+AZ_NODISCARD az_result
+az_http_request_append_path(az_http_request* ref_request, az_span path, bool is_path_url_encoded);
 
 /**
- * @brief Set query parameter.
+ * @brief Set a query parameter at the end of url.
  *
- * @param ref_request HTTP request builder that holds the URL to set the query parameter to.
- * @param name URL parameter name.
- * @param value URL parameter value.
+ * @remark Since query parameters are storaged with url-encoding, this function will not check if
+ * the a query parameter already exists in the URL. Calling this function twice with same \p name
+ * would duplicate the query parameter.
+ *
+ * @param[out] ref_request HTTP request that holds the URL to set the query parameter to.
+ * @param[in] name URL parameter name.
+ * @param[in] value URL parameter value.
+ * @param[in] \p is_query_url_encoded boolean value that defines if the query parameter (name and
+ * value) is url-encoded or not.
+ *
+ * @remarks if \p is_query_url_encoded is set to false, before setting query parameter, it would be
+ * url-encoded.
  *
  * @return
  *   - *`AZ_OK`* success.
@@ -217,8 +242,11 @@ AZ_NODISCARD az_result az_http_request_append_path(az_http_request* ref_request,
  *     - `name` or `value` are empty.
  *     - `name`'s or `value`'s buffer overlap resulting `url`'s buffer.
  */
-AZ_NODISCARD az_result
-az_http_request_set_query_parameter(az_http_request* ref_request, az_span name, az_span value);
+AZ_NODISCARD az_result az_http_request_set_query_parameter(
+    az_http_request* ref_request,
+    az_span name,
+    az_span value,
+    bool is_query_url_encoded);
 
 /**
  * @brief Add a new HTTP header for the request.

--- a/sdk/src/azure/core/az_aad.c
+++ b/sdk/src/azure/core/az_aad.c
@@ -21,8 +21,11 @@ _az_aad_build_url(az_span url, az_span authority, az_span tenant_id, az_span* ou
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(url, az_span_size(authority));
   az_span remainder = az_span_copy(url, authority);
 
-  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(tenant_id));
-  remainder = az_span_copy(remainder, tenant_id);
+  {
+    int32_t url_length = 0;
+    AZ_RETURN_IF_FAILED(_az_span_url_encode(remainder, tenant_id, &url_length));
+    remainder = az_span_slice_to_end(remainder, url_length);
+  }
 
   az_span const oath_token = AZ_SPAN_FROM_STR("/oauth2/v2.0/token");
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(remainder, az_span_size(oath_token));

--- a/sdk/src/azure/core/az_http_policy.c
+++ b/sdk/src/azure/core/az_http_policy.c
@@ -31,7 +31,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_apiversion(
     case _az_http_policy_apiversion_option_location_queryparameter:
       // Add the version as a query parameter
       AZ_RETURN_IF_FAILED(az_http_request_set_query_parameter(
-          ref_request, options->_internal.name, options->_internal.version));
+          ref_request, options->_internal.name, options->_internal.version, true));
       break;
     default:
       return AZ_ERROR_ARG;

--- a/sdk/src/azure/core/az_http_request.c
+++ b/sdk/src/azure/core/az_http_request.c
@@ -91,7 +91,7 @@ az_http_request_append_path(az_http_request* ref_request, az_span path, bool is_
       query_start,
       query_start,
       path,
-      is_path_url_encoded,
+      !is_path_url_encoded,
       &path_size));
 
   query_start += path_size;

--- a/sdk/src/azure/core/az_http_request.c
+++ b/sdk/src/azure/core/az_http_request.c
@@ -10,6 +10,7 @@
 #include <azure/core/az_precondition.h>
 #include <azure/core/internal/az_http_internal.h>
 #include <azure/core/internal/az_precondition_internal.h>
+#include <azure/core/internal/az_span_internal.h>
 
 #include <assert.h>
 
@@ -57,7 +58,8 @@ AZ_NODISCARD az_result az_http_request_init(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_http_request_append_path(az_http_request* ref_request, az_span path)
+AZ_NODISCARD az_result
+az_http_request_append_path(az_http_request* ref_request, az_span path, bool is_path_url_encoded)
 {
   _az_PRECONDITION_NOT_NULL(ref_request);
 
@@ -67,27 +69,33 @@ AZ_NODISCARD az_result az_http_request_append_path(az_http_request* ref_request,
                                                : ref_request->_internal.url_length;
 
   /* use replace twice. Yes, we will have 2 right shift (one on each replace), but we rely on
-   * replace functionfor doing this movements only and avoid updating manually. We could also create
-   * a temp buffer to join "/" and path and then use replace. But that will cost us more stack
-   * memory.
+   * replace function for doing this movements only and avoid updating manually. We could also
+   * create a temp buffer to join "/" and path and then use replace. But that will cost us more
+   * stack memory.
    */
   AZ_RETURN_IF_FAILED(_az_span_replace(
       ref_request->_internal.url,
       ref_request->_internal.url_length,
       query_start,
       query_start,
-      AZ_SPAN_FROM_STR("/")));
+      AZ_SPAN_FROM_STR("/"),
+      false,
+      NULL));
   query_start += 1; // a size of "/"
   ++ref_request->_internal.url_length;
 
+  int32_t path_size = az_span_size(path);
   AZ_RETURN_IF_FAILED(_az_span_replace(
       ref_request->_internal.url,
       ref_request->_internal.url_length,
       query_start,
       query_start,
-      path));
-  query_start += az_span_size(path);
-  ref_request->_internal.url_length += az_span_size(path);
+      path,
+      is_path_url_encoded,
+      &path_size));
+
+  query_start += path_size;
+  ref_request->_internal.url_length += path_size;
 
   // update query start
   if (url_with_question_mark)
@@ -98,70 +106,11 @@ AZ_NODISCARD az_result az_http_request_append_path(az_http_request* ref_request,
   return AZ_OK;
 }
 
-// returns the query parameter value from a query parameter name.
-// Or returns AZ_SPAN_NULL if query parameter name is not found
-static AZ_NODISCARD az_span _az_http_request_find_query_parameter(
+AZ_NODISCARD az_result az_http_request_set_query_parameter(
     az_http_request* ref_request,
-    az_span query_parameter_name,
-    int32_t* out_query_parameter_index)
-{
-  if (ref_request->_internal.query_start == 0)
-  {
-    return AZ_SPAN_NULL;
-  }
-
-  az_span url = ref_request->_internal.url;
-  uint8_t* query_params_ptr = az_span_ptr(url);
-  uint8_t* new_qp_name_ptr = az_span_ptr(query_parameter_name);
-  int32_t new_qp_name_size = az_span_size(query_parameter_name);
-
-  // will be set to the start of the value of a qp equal to the new qp
-  *out_query_parameter_index = -1;
-
-  for (int32_t is_query_start = 1, index = ref_request->_internal.query_start; // +1 to jump `?`
-       index < ref_request->_internal.url_length - new_qp_name_size;
-       index++)
-  {
-    if (query_params_ptr[index] == '&')
-    {
-      is_query_start = 1; // set next index to be queryStart
-      if (*out_query_parameter_index > 0)
-      { // if this was set before, it means we found the end of the value we want to return
-        return az_span_slice(url, *out_query_parameter_index, index);
-      }
-      continue;
-    }
-    if (is_query_start == 1 && query_params_ptr[index] == new_qp_name_ptr[0])
-    { // at this point, a qp name start with the same letter as the new qp
-      // Check if they have same size before comparing content by checking if
-      // adding the size of the new qp we get to the `=` delimiter
-      if (query_params_ptr[index + new_qp_name_size] == '=')
-      { // at this point, we know size is the same, now check the contents
-        az_span existing_pq = az_span_slice(url, index, index + new_qp_name_size);
-        if (az_span_is_content_equal(existing_pq, query_parameter_name))
-        {
-          // advance index to value start
-          index = index + new_qp_name_size + 1; // +1 to jump '='
-          // set qp value start
-          *out_query_parameter_index = index;
-        }
-      }
-    }
-    is_query_start = 0;
-  }
-
-  if (*out_query_parameter_index > 0)
-  { // getting here means we found the qp at the last position of url, so the value goes to the end
-    // of url
-    return az_span_slice(url, *out_query_parameter_index, ref_request->_internal.url_length);
-  }
-
-  // didn't find the query parameter, return null
-  return AZ_SPAN_NULL;
-}
-
-AZ_NODISCARD az_result
-az_http_request_set_query_parameter(az_http_request* ref_request, az_span name, az_span value)
+    az_span name,
+    az_span value,
+    bool is_query_url_encoded)
 {
   _az_PRECONDITION_NOT_NULL(ref_request);
   _az_PRECONDITION_VALID_SPAN(name, 1, false);
@@ -170,55 +119,16 @@ az_http_request_set_query_parameter(az_http_request* ref_request, az_span name, 
   // name or value can't be empty
   _az_PRECONDITION(az_span_size(name) > 0 && az_span_size(value) > 0);
 
-  // check if query parameter is already in url
-  int32_t pre_existing_query_parameter_start_index = 0;
-  az_span pre_existing_query_parameter_value = _az_http_request_find_query_parameter(
-      ref_request, name, &pre_existing_query_parameter_start_index);
   az_span url_remainder
       = az_span_slice_to_end(ref_request->_internal.url, ref_request->_internal.url_length);
 
-  if (pre_existing_query_parameter_start_index > 0)
-  { // a negative difference means shifting left and no required length.
-    // a positive difference means new value will require shifting right.
-    int32_t pre_existing_query_parameter_value_size
-        = az_span_size(pre_existing_query_parameter_value);
-    int32_t difference = az_span_size(value) - pre_existing_query_parameter_value_size;
-    int32_t required_length = difference > 0 ? difference : 0;
-    AZ_RETURN_IF_NOT_ENOUGH_SIZE(url_remainder, required_length);
-
-    // There is already a query parameter name. update the value if different
-    if (az_span_is_content_equal(value, pre_existing_query_parameter_value))
-    {
-      // No need to do anything, existing value is equal to the new one
-      return AZ_OK;
-    }
-
-    // Replace the value content. This might shift right or left the url contents.
-    // No need to check
-    AZ_RETURN_IF_FAILED(_az_span_replace(
-        ref_request->_internal.url,
-        ref_request->_internal.url_length,
-        pre_existing_query_parameter_start_index,
-        pre_existing_query_parameter_start_index + pre_existing_query_parameter_value_size,
-        value));
-    ref_request->_internal.url_length += difference;
-    if (difference < 0)
-    {
-      // clear anything after a left shift
-      difference *= -1;
-      az_span_fill(
-          az_span_slice(
-              az_span_slice_to_end(ref_request->_internal.url, ref_request->_internal.url_length),
-              0,
-              difference),
-          0);
-    }
-    return AZ_OK;
-  }
-
-  // Adding new query parameter. Adding +2 to required length to include extra required symbols `=`
+  // Adding query parameter. Adding +2 to required length to include extra required symbols `=`
   // and `?` or `&`.
-  int32_t required_length = az_span_size(name) + az_span_size(value) + 2;
+  int32_t required_length
+      = (is_query_url_encoded
+             ? (az_span_size(name) + az_span_size(value))
+             : (_az_span_url_encode_calc_length(name) + _az_span_url_encode_calc_length(value)))
+      + 2;
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(url_remainder, required_length);
 
   // Append either '?' or '&'
@@ -237,14 +147,30 @@ az_http_request_set_query_parameter(az_http_request* ref_request, az_span name, 
 
   url_remainder = az_span_copy_u8(url_remainder, separator);
 
+  int32_t encoding_size = 0;
   // Append parameter name
-  url_remainder = az_span_copy(url_remainder, name);
+  if (is_query_url_encoded)
+  {
+    url_remainder = az_span_copy(url_remainder, name);
+  }
+  else
+  {
+    AZ_RETURN_IF_FAILED(_az_span_url_encode(url_remainder, name, &encoding_size));
+    url_remainder = az_span_slice_to_end(url_remainder, encoding_size);
+  }
 
   // Append equal sym
   url_remainder = az_span_copy_u8(url_remainder, '=');
 
   // Parameter value
-  url_remainder = az_span_copy(url_remainder, value);
+  if (is_query_url_encoded)
+  {
+    url_remainder = az_span_copy(url_remainder, value);
+  }
+  else
+  {
+    AZ_RETURN_IF_FAILED(_az_span_url_encode(url_remainder, value, &encoding_size));
+  }
 
   ref_request->_internal.url_length += required_length;
 

--- a/sdk/src/azure/core/az_span_private.h
+++ b/sdk/src/azure/core/az_span_private.h
@@ -63,7 +63,9 @@ AZ_NODISCARD az_result _az_span_replace(
     int32_t current_size,
     int32_t start,
     int32_t end,
-    az_span replacement);
+    az_span replacement,
+    bool url_encode,
+    int32_t* out_url_encode_size);
 
 typedef bool (*_az_predicate)(uint8_t next_byte);
 

--- a/sdk/src/azure/platform/az_curl.c
+++ b/sdk/src/azure/platform/az_curl.c
@@ -233,11 +233,6 @@ _az_http_client_curl_build_headers(az_http_request const* request, struct curl_s
 static AZ_NODISCARD az_result
 _az_http_client_curl_append_url(az_span writable_buffer, az_span url_from_request)
 {
-  /*
-  TODO: url-encode query parameters only. Not all the url
-  int32_t length;
-  AZ_RETURN_IF_FAILED(_az_span_url_encode(writable_buffer, url_from_request, &length));
-   */
   AZ_RETURN_IF_NOT_ENOUGH_SIZE(writable_buffer, az_span_size(url_from_request) + 1);
   az_span remainder = az_span_copy(writable_buffer, url_from_request);
   az_span_copy_u8(remainder, 0);
@@ -469,8 +464,7 @@ _az_http_client_curl_setup_url(CURL* ref_curl, az_http_request const* request)
   az_span request_url = { 0 };
   // get request_url. It will have the size of what it has written in it only
   AZ_RETURN_IF_FAILED(az_http_request_get_url(request, &request_url));
-  // TODO: url-encode, encode only query parameters.
-  // int32_t request_url_size = _az_span_url_encode_calc_length(request_url);
+  // Note: the url from request is already url-encoded.
   int32_t request_url_size = az_span_size(request_url);
 
   az_span writable_buffer;

--- a/sdk/tests/core/test_az_http.c
+++ b/sdk/tests/core/test_az_http.c
@@ -369,6 +369,70 @@ static void test_http_request(void** state)
     assert_return_code(az_http_request_get_url(&request, &url_result), AZ_OK);
     assert_true(az_span_is_content_equal(url_result, expected_url));
   }
+  { // Test setting query parameter url-encode
+    uint8_t buf[100];
+    uint8_t header_buf[(2 * sizeof(az_pair))];
+    memset(buf, 0, sizeof(buf));
+    memset(header_buf, 0, sizeof(header_buf));
+
+    az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
+    az_span initial_url = AZ_SPAN_FROM_STR("http://example.com");
+    az_span remainder = az_span_copy(url_span, initial_url);
+    assert_int_equal(az_span_size(remainder), 100 - az_span_size(initial_url));
+    az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
+    az_http_request request;
+
+    TEST_EXPECT_SUCCESS(az_http_request_init(
+        &request,
+        &az_context_application,
+        az_http_method_get(),
+        url_span,
+        az_span_size(initial_url),
+        header_span,
+        AZ_SPAN_FROM_STR("body")));
+
+    assert_return_code(
+        az_http_request_set_query_parameter(
+            &request, AZ_SPAN_FROM_STR("q\n1"), AZ_SPAN_FROM_STR("space here"), false),
+        AZ_OK);
+
+    az_span expected_url = AZ_SPAN_FROM_STR("http://example.com?q%0A1=space%20here");
+    uint8_t result[100];
+    az_span url_result = AZ_SPAN_FROM_BUFFER(result);
+    assert_return_code(az_http_request_get_url(&request, &url_result), AZ_OK);
+    assert_true(az_span_is_content_equal(url_result, expected_url));
+  }
+  { // Test append path url encode
+    uint8_t buf[100];
+    uint8_t header_buf[(2 * sizeof(az_pair))];
+    memset(buf, 0, sizeof(buf));
+    memset(header_buf, 0, sizeof(header_buf));
+
+    az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
+    az_span initial_url = AZ_SPAN_FROM_STR("http://example.com");
+    az_span remainder = az_span_copy(url_span, initial_url);
+    assert_int_equal(az_span_size(remainder), 100 - az_span_size(initial_url));
+    az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
+    az_http_request request;
+
+    TEST_EXPECT_SUCCESS(az_http_request_init(
+        &request,
+        &az_context_application,
+        az_http_method_get(),
+        url_span,
+        az_span_size(initial_url),
+        header_span,
+        AZ_SPAN_FROM_STR("body")));
+
+    assert_return_code(
+        az_http_request_append_path(&request, AZ_SPAN_FROM_STR("path with space"), false), AZ_OK);
+
+    az_span expected_url = AZ_SPAN_FROM_STR("http://example.com/path%20with%20space");
+    uint8_t result[100];
+    az_span url_result = AZ_SPAN_FROM_BUFFER(result);
+    assert_return_code(az_http_request_get_url(&request, &url_result), AZ_OK);
+    assert_true(az_span_is_content_equal(url_result, expected_url));
+  }
   {
     uint8_t buf[100];
     uint8_t header_buf[(2 * sizeof(az_pair))];

--- a/sdk/tests/core/test_az_span.c
+++ b/sdk/tests/core/test_az_span.c
@@ -948,7 +948,8 @@ static void test_az_span_replace(void** state)
     assert_int_equal(az_span_size(remainder), expected_remainder_size);
 
     assert_true(
-        _az_span_replace(builder, az_span_size(initial_state), 1, 6, AZ_SPAN_FROM_STR("X"))
+        _az_span_replace(
+            builder, az_span_size(initial_state), 1, 6, AZ_SPAN_FROM_STR("X"), false, NULL)
         == AZ_OK);
 
     az_span const result = az_span_slice(builder, 0, 4);
@@ -964,7 +965,8 @@ static void test_az_span_replace(void** state)
     assert_int_equal(az_span_size(remainder), 200 - az_span_size(initial_state));
 
     assert_true(
-        _az_span_replace(builder, az_span_size(initial_state), 2, 2, AZ_SPAN_FROM_STR("X"))
+        _az_span_replace(
+            builder, az_span_size(initial_state), 2, 2, AZ_SPAN_FROM_STR("X"), false, NULL)
         == AZ_OK);
 
     az_span const result = az_span_slice(builder, 0, 9);
@@ -980,7 +982,8 @@ static void test_az_span_replace(void** state)
     assert_int_equal(az_span_size(remainder), 200 - az_span_size(initial_state));
 
     assert_true(
-        _az_span_replace(builder, az_span_size(initial_state), 8, 8, AZ_SPAN_FROM_STR("90"))
+        _az_span_replace(
+            builder, az_span_size(initial_state), 8, 8, AZ_SPAN_FROM_STR("90"), false, NULL)
         == AZ_OK);
 
     az_span const result = az_span_slice(builder, 0, 10);
@@ -996,7 +999,8 @@ static void test_az_span_replace(void** state)
     assert_int_equal(az_span_size(remainder), 200 - az_span_size(initial_state));
 
     assert_true(
-        _az_span_replace(builder, az_span_size(initial_state), 0, 8, AZ_SPAN_FROM_STR("X"))
+        _az_span_replace(
+            builder, az_span_size(initial_state), 0, 8, AZ_SPAN_FROM_STR("X"), false, NULL)
         == AZ_OK);
 
     az_span const result = az_span_slice(builder, 0, 1);
@@ -1012,7 +1016,8 @@ static void test_az_span_replace(void** state)
     assert_int_equal(az_span_size(remainder), 200 - az_span_size(initial_state));
 
     assert_true(
-        _az_span_replace(builder, az_span_size(initial_state), 0, 8, AZ_SPAN_FROM_STR("X12345678X"))
+        _az_span_replace(
+            builder, az_span_size(initial_state), 0, 8, AZ_SPAN_FROM_STR("X12345678X"), false, NULL)
         == AZ_OK);
 
     az_span const result = az_span_slice(builder, 0, 10);
@@ -1028,7 +1033,8 @@ static void test_az_span_replace(void** state)
     assert_int_equal(az_span_size(remainder), 200 - az_span_size(initial_state));
 
     assert_true(
-        _az_span_replace(builder, az_span_size(initial_state), 0, 0, AZ_SPAN_FROM_STR("XXX"))
+        _az_span_replace(
+            builder, az_span_size(initial_state), 0, 0, AZ_SPAN_FROM_STR("XXX"), false, NULL)
         == AZ_OK);
 
     az_span const result = az_span_slice(builder, 0, 11);
@@ -1044,7 +1050,8 @@ static void test_az_span_replace(void** state)
     assert_int_equal(az_span_size(remainder), 200 - az_span_size(initial_state));
 
     assert_true(
-        _az_span_replace(builder, az_span_size(initial_state), 0, 1, AZ_SPAN_FROM_STR("2"))
+        _az_span_replace(
+            builder, az_span_size(initial_state), 0, 1, AZ_SPAN_FROM_STR("2"), false, NULL)
         == AZ_OK);
 
     az_span const result = az_span_slice(builder, 0, 1);
@@ -1060,7 +1067,8 @@ static void test_az_span_replace(void** state)
     assert_int_equal(az_span_size(remainder), 4 - az_span_size(initial_state));
 
     assert_true(
-        _az_span_replace(builder, az_span_size(initial_state), 0, 4, AZ_SPAN_FROM_STR("4321"))
+        _az_span_replace(
+            builder, az_span_size(initial_state), 0, 4, AZ_SPAN_FROM_STR("4321"), false, NULL)
         == AZ_OK);
 
     az_span const result = az_span_slice(builder, 0, 4);
@@ -1075,8 +1083,8 @@ static void test_az_span_replace(void** state)
     az_span remainder = az_span_copy(builder, initial_state);
     assert_int_equal(az_span_size(remainder), 10 - az_span_size(initial_state));
 
-    TEST_EXPECT_SUCCESS(
-        _az_span_replace(builder, az_span_size(initial_state), 1, 2, AZ_SPAN_FROM_STR("X")));
+    TEST_EXPECT_SUCCESS(_az_span_replace(
+        builder, az_span_size(initial_state), 1, 2, AZ_SPAN_FROM_STR("X"), false, NULL));
 
     remainder = az_span_copy(remainder, AZ_SPAN_FROM_STR("AB"));
 
@@ -1097,8 +1105,8 @@ static void test_az_span_replace(void** state)
     az_span remainder = az_span_copy(builder, initial_state);
     assert_int_equal(az_span_size(remainder), 4 - az_span_size(initial_state));
 
-    TEST_EXPECT_SUCCESS(
-        _az_span_replace(builder, az_span_size(initial_state), 3, 3, AZ_SPAN_FROM_STR("4")));
+    TEST_EXPECT_SUCCESS(_az_span_replace(
+        builder, az_span_size(initial_state), 3, 3, AZ_SPAN_FROM_STR("4"), false, NULL));
 
     az_span const result = az_span_slice(builder, 0, 4);
     assert_true(az_span_is_content_equal(result, expected));
@@ -1112,20 +1120,22 @@ static void test_az_span_replace(void** state)
     assert_int_equal(az_span_size(remainder), 4 - az_span_size(initial_state));
 
     assert_true(
-        _az_span_replace(builder, az_span_size(initial_state), 0, 4, AZ_SPAN_FROM_STR("4321X"))
+        _az_span_replace(
+            builder, az_span_size(initial_state), 0, 4, AZ_SPAN_FROM_STR("4321X"), false, NULL)
         == AZ_ERROR_ARG);
   }
   {
     // Fail on builder empty -> try to replace content from empty builder
     uint8_t array[200];
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
-    assert_true(_az_span_replace(builder, 0, 0, 1, AZ_SPAN_FROM_STR("2")) == AZ_ERROR_ARG);
+    assert_true(
+        _az_span_replace(builder, 0, 0, 1, AZ_SPAN_FROM_STR("2"), false, NULL) == AZ_ERROR_ARG);
   }
   {
     // Replace content on empty builder -> insert at the end
     uint8_t array[200];
     az_span builder = AZ_SPAN_FROM_BUFFER(array);
-    assert_true(_az_span_replace(builder, 0, 0, 0, AZ_SPAN_FROM_STR("2")) == AZ_OK);
+    assert_true(_az_span_replace(builder, 0, 0, 0, AZ_SPAN_FROM_STR("2"), false, NULL) == AZ_OK);
     az_span const result = az_span_slice(builder, 0, 1);
     az_span const expected = AZ_SPAN_FROM_STR("2");
     assert_true(az_span_is_content_equal(result, expected));
@@ -1139,7 +1149,8 @@ static void test_az_span_replace(void** state)
     assert_int_equal(az_span_size(remainder), 400 - az_span_size(initial_state));
 
     assert_true(
-        _az_span_replace(builder, az_span_size(initial_state), 30, 31, AZ_SPAN_FROM_STR("4321X"))
+        _az_span_replace(
+            builder, az_span_size(initial_state), 30, 31, AZ_SPAN_FROM_STR("4321X"), false, NULL)
         == AZ_ERROR_ARG);
   }
   {
@@ -1151,7 +1162,8 @@ static void test_az_span_replace(void** state)
     assert_int_equal(az_span_size(remainder), 40 - az_span_size(initial_state));
 
     assert_true(
-        _az_span_replace(builder, az_span_size(initial_state), 4, 5, AZ_SPAN_FROM_STR("4321X"))
+        _az_span_replace(
+            builder, az_span_size(initial_state), 4, 5, AZ_SPAN_FROM_STR("4321X"), false, NULL)
         == AZ_ERROR_ARG);
   }
   {
@@ -1163,7 +1175,8 @@ static void test_az_span_replace(void** state)
     assert_int_equal(az_span_size(remainder), 40 - az_span_size(initial_state));
 
     assert_true(
-        _az_span_replace(builder, az_span_size(initial_state), 3, 1, AZ_SPAN_FROM_STR("4321X"))
+        _az_span_replace(
+            builder, az_span_size(initial_state), 3, 1, AZ_SPAN_FROM_STR("4321X"), false, NULL)
         == AZ_ERROR_ARG);
   }
 }


### PR DESCRIPTION
Adding documentation about HTTP Request as:
-  initial url is expected to be url-encoded

Then, for append_path and set_query_parameters, adding support for customers to tell if the values are already url-encoded or not.
If values are not url-encoded, it will be encoded before updating the url.

>Note:  The side effect of this feature is that we need to remove the feature that was preventing duplicating a query parameter.  Since query parameters are now recorded with encoding, we would need to decode them for doing a lineal search. Duplication behavior is documented so any service client creating an HTTP Request knows and prevent the duplication on their end

fixes: https://github.com/Azure/azure-sdk-for-c/issues/1049