### PR TITLE
Add ability to append existing JSON text value to the JSON writer, with runtime validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+- Add `az_json_writer_append_json_text()` to support appending existing JSON with the JSON writer.
+
 ### Breaking Changes
 
 ### Bug Fixes

--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -386,23 +386,26 @@ AZ_NODISCARD az_result az_json_writer_append_string(az_json_writer* ref_json_wri
  * @param[in] json_writer A pointer to an #az_json_writer instance containing the buffer to append
  * the JSON text to.
  * @param[in] json_text A single, possibly nested, valid, UTF-8 encoded, JSON value to be written as
- * is. No modifications are made to this text, including escaping.
+ * is, without any formatting or spacing changes. No modifications are made to this text, including
+ * escaping.
  *
  * @remarks A single, possibly nested, JSON value is one that starts and ends with {} or [] or is a
  * single primitive token. The JSON cannot start with an end object or array, or a property name, or
  * be incomplete.
  *
- * @remarks The caller must make sure that the JSON to be appended provided by \p json_text is valid
- * and properly escaped.
+ * @remarks The function validates that the provided JSON to be appended is valid and properly
+ * escaped, and fails otherwise.
  *
- * @return An #az_result value indicating the result of the operation:
- *         - #AZ_OK if the JSON text value was appended successfully
- *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the buffer is too small
- *         - #AZ_ERROR_JSON_INVALID_STATE if the \p json_writer is in a state where the \p json_text
+ * @return An #az_result value indicating the result of the operation.
+ * @retval #AZ_OK The provided \p json_text was appended successfully.
+ * @retval #AZ_ERROR_INSUFFICIENT_SPAN_SIZE The destination is too small for the provided \p
+ * json_text.
+ * @retval #AZ_ERROR_JSON_INVALID_STATE The \p json_writer is in a state where the \p json_text
  * cannot be appended because it would result in invalid JSON.
- *         - #AZ_ERROR_UNEXPECTED_END when the JSON is invalid, because we reached the end of the
- * JSON document too early
- *         - #AZ_ERROR_UNEXPECTED_CHAR when the JSON is invalid, because of an invalid character
+ * @retval #AZ_ERROR_UNEXPECTED_END The provided \p json_text is invalid because it is incomplete
+ * and ends too early.
+ * @retval #AZ_ERROR_UNEXPECTED_CHAR The provided \p json_text is invalid because of an unexpected
+ * character.
  */
 AZ_NODISCARD az_result
 az_json_writer_append_json_text(az_json_writer* json_writer, az_span json_text);

--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -360,6 +360,34 @@ az_json_writer_get_bytes_used_in_destination(az_json_writer const* json_writer)
 AZ_NODISCARD az_result az_json_writer_append_string(az_json_writer* json_writer, az_span value);
 
 /**
+ * @brief Appends an existing UTF-8 encoded JSON text into the buffer, useful for appending nested
+ * JSON.
+ *
+ * @param[in] json_writer A pointer to an #az_json_writer instance containing the buffer to append
+ * the JSON text to.
+ * @param[in] json_text A single, possibly nested, valid, UTF-8 encoded, JSON value to be written as
+ * is. No modifications are made to this text, including escaping.
+ *
+ * @remarks A single, possibly nested, JSON value is one that starts and ends with {} or [] or is a
+ * single primitive value. The JSON cannot start with an end object or array, or a property name, or
+ * be incomplete.
+ *
+ * @remarks The caller must make sure that the JSON to be appended provided by \p json_text is valid
+ * and properly escaped.
+ *
+ * @return An #az_result value indicating the result of the operation:
+ *         - #AZ_OK if the JSON text value was appended successfully
+ *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the buffer is too small
+ *         - #AZ_ERROR_JSON_INVALID_STATE if the \p json_writer is in a state where the \p json_text
+ * cannot be appended because it would result in invalid JSON.
+ *         - #AZ_ERROR_UNEXPECTED_END when the JSON is invalid, because we reached the end of the
+ * JSON document too early
+ *         - #AZ_ERROR_UNEXPECTED_CHAR when the JSON is invalid, because of an invalid character
+ */
+AZ_NODISCARD az_result
+az_json_writer_append_json_text(az_json_writer* json_writer, az_span json_text);
+
+/**
  * @brief Appends the UTF-8 property name (as a JSON string) which is the first part of a name/value
  * pair of a JSON object.
  *

--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -369,7 +369,7 @@ AZ_NODISCARD az_result az_json_writer_append_string(az_json_writer* json_writer,
  * is. No modifications are made to this text, including escaping.
  *
  * @remarks A single, possibly nested, JSON value is one that starts and ends with {} or [] or is a
- * single primitive value. The JSON cannot start with an end object or array, or a property name, or
+ * single primitive token. The JSON cannot start with an end object or array, or a property name, or
  * be incomplete.
  *
  * @remarks The caller must make sure that the JSON to be appended provided by \p json_text is valid

--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -726,7 +726,8 @@ static AZ_NODISCARD az_result _az_validate_json(
   az_json_reader reader = { 0 };
   AZ_RETURN_IF_FAILED(az_json_reader_init(&reader, json_text, NULL));
 
-  AZ_RETURN_IF_FAILED(az_json_reader_next_token(&reader));
+  az_result result = az_json_reader_next_token(&reader);
+  AZ_RETURN_IF_FAILED(result);
 
   // This is guaranteed not to be a property name or end object/array.
   // The first token of a valid JSON must either be a value or start object/array.
@@ -734,14 +735,13 @@ static AZ_NODISCARD az_result _az_validate_json(
 
   // Keep reading until we have finished validating the entire JSON text and make sure it isn't
   // incomplete.
-  while (true)
+  while (az_succeeded(result = az_json_reader_next_token(&reader)))
   {
-    az_result result = az_json_reader_next_token(&reader);
-    if (result == AZ_ERROR_JSON_READER_DONE)
-    {
-      break;
-    }
-    AZ_RETURN_IF_FAILED(result);
+  }
+
+  if (result != AZ_ERROR_JSON_READER_DONE)
+  {
+    return result;
   }
 
   // This is guaranteed not to be a property name or start object/array.

--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -712,6 +712,86 @@ az_json_writer_append_property_name(az_json_writer* json_writer, az_span name)
   }
 }
 
+static AZ_NODISCARD az_result _az_validate_json(
+    az_span json_text,
+    az_json_token_kind* first_token_kind,
+    az_json_token_kind* last_token_kind)
+{
+  _az_PRECONDITION_NOT_NULL(first_token_kind);
+
+  az_json_reader reader = { 0 };
+  AZ_RETURN_IF_FAILED(az_json_reader_init(&reader, json_text, NULL));
+
+  AZ_RETURN_IF_FAILED(az_json_reader_next_token(&reader));
+
+  // This is guaranteed not to be a property name or end object/array.
+  // The  first token of a valid JSON must either be a value or start object/array.
+  *first_token_kind = reader.token.kind;
+
+  AZ_RETURN_IF_FAILED(az_json_reader_skip_children(&reader));
+  *last_token_kind = reader.token.kind;
+
+  return AZ_OK;
+}
+
+AZ_NODISCARD az_result
+az_json_writer_append_json_text(az_json_writer* json_writer, az_span json_text)
+{
+  _az_PRECONDITION_NOT_NULL(json_writer);
+  // A null or empty span is not allowed since that is invalid JSON.
+  _az_PRECONDITION_VALID_SPAN(json_text, 0, false);
+
+  az_json_token_kind first_token_kind = AZ_JSON_TOKEN_NONE;
+  az_json_token_kind last_token_kind = AZ_JSON_TOKEN_NONE;
+
+  // This runtime validation is necessary since the input could be user defined and malformed.
+  // This cannot be caught at dev time by a precondition, especially since they can be turned off.
+  AZ_RETURN_IF_FAILED(_az_validate_json(json_text, &first_token_kind, &last_token_kind));
+
+  // The JSON text is valid, but appending it to the the JSON writer at the current state still may
+  // not be valid.
+  if (first_token_kind == AZ_JSON_TOKEN_END_ARRAY
+      && !_az_is_appending_container_end_valid(json_writer, ']'))
+  {
+    return AZ_ERROR_JSON_INVALID_STATE;
+  }
+  else if (
+      first_token_kind == AZ_JSON_TOKEN_END_OBJECT
+      && !_az_is_appending_container_end_valid(json_writer, '}'))
+  {
+    return AZ_ERROR_JSON_INVALID_STATE;
+  }
+  else if (
+      first_token_kind == AZ_JSON_TOKEN_PROPERTY_NAME
+      && !_az_is_appending_property_name_valid(json_writer))
+  {
+    return AZ_ERROR_JSON_INVALID_STATE;
+  }
+  else if (!_az_is_appending_value_valid(json_writer))
+  {
+    // All other tokens, including start array and object are validated here.
+    // Also first_token_kind cannot be AZ_JSON_TOKEN_NONE at this point.
+    return AZ_ERROR_JSON_INVALID_STATE;
+  }
+
+  az_span remaining_json = _get_remaining_span(json_writer, _az_MINIMUM_STRING_CHUNK_SIZE);
+  AZ_RETURN_IF_NOT_ENOUGH_SIZE(remaining_json, _az_MINIMUM_STRING_CHUNK_SIZE);
+
+  AZ_RETURN_IF_FAILED(az_json_writer_span_copy_chunked(json_writer, &remaining_json, json_text));
+
+  // We only need to add a comma if the last token we append is a value or end of object/array.
+  // If the last token is a property name or the start of an object/array, we don't need to add a
+  // comma before appending subsequent tokens.
+  bool need_comma = !(
+      last_token_kind == AZ_JSON_TOKEN_PROPERTY_NAME || last_token_kind == AZ_JSON_TOKEN_BEGIN_ARRAY
+      || last_token_kind == AZ_JSON_TOKEN_BEGIN_OBJECT);
+
+  // We already tracked and updated bytes_written while writing, so no need to update it here.
+  _az_update_json_writer_state(
+      json_writer, 0, az_span_size(json_text), need_comma, last_token_kind);
+  return AZ_OK;
+}
+
 static AZ_NODISCARD az_result _az_json_writer_append_literal(
     az_json_writer* json_writer,
     az_span literal,

--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -732,7 +732,17 @@ static AZ_NODISCARD az_result _az_validate_json(
   // The first token of a valid JSON must either be a value or start object/array.
   *first_token_kind = reader.token.kind;
 
-  AZ_RETURN_IF_FAILED(az_json_reader_skip_children(&reader));
+  // Keep reading until we have finished validating the entire JSON text and make sure it isn't
+  // incomplete.
+  while (true)
+  {
+    az_result result = az_json_reader_next_token(&reader);
+    if (result == AZ_ERROR_JSON_READER_DONE)
+    {
+      break;
+    }
+    AZ_RETURN_IF_FAILED(result);
+  }
 
   // This is guaranteed not to be a property name or start object/array.
   // The last token of a valid JSON must either be a value or end object/array.

--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -779,7 +779,7 @@ az_json_writer_append_json_text(az_json_writer* json_writer, az_span json_text)
   // comma before appending subsequent tokens.
   // However, there is no valid, complete, single JSON value where the last token would be property
   // name, or start object/array.
-  // Therefore, need_comma must be true after apending the json_text.
+  // Therefore, need_comma must be true after appending the json_text.
 
   // We already tracked and updated bytes_written while writing, so no need to update it here.
   _az_update_json_writer_state(json_writer, 0, az_span_size(json_text), true, last_token_kind);

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -244,7 +244,6 @@ static void test_json_writer_append_nested(void** state)
           &writer, AZ_SPAN_FROM_STR("{\"name\":  \"f\\u0065o\", \"values\": [1, 2, 3,{}]}")));
 
       az_span_to_str((char*)array, 200, az_json_writer_get_bytes_used_in_destination(&writer));
-
       assert_string_equal(array, "{\"name\":  \"f\\u0065o\", \"values\": [1, 2, 3,{}]}");
     }
 
@@ -255,7 +254,6 @@ static void test_json_writer_append_nested(void** state)
       TEST_EXPECT_SUCCESS(az_json_writer_append_end_array(&writer));
 
       az_span_to_str((char*)array, 200, az_json_writer_get_bytes_used_in_destination(&writer));
-
       assert_string_equal(array, "[123  ]");
     }
 
@@ -264,15 +262,12 @@ static void test_json_writer_append_nested(void** state)
       TEST_EXPECT_SUCCESS(az_json_writer_append_begin_object(&writer));
       TEST_EXPECT_SUCCESS(az_json_writer_append_property_name(&writer, AZ_SPAN_FROM_STR("name")));
       TEST_EXPECT_SUCCESS(az_json_writer_append_bool(&writer, true));
-
       TEST_EXPECT_SUCCESS(az_json_writer_append_property_name(&writer, AZ_SPAN_FROM_STR("foo")));
       TEST_EXPECT_SUCCESS(az_json_writer_append_json_text(
           &writer, AZ_SPAN_FROM_STR("[\"bar\",null,0,-12,12,9007199254740991]")));
-
       TEST_EXPECT_SUCCESS(az_json_writer_append_end_object(&writer));
 
       az_span_to_str((char*)array, 200, az_json_writer_get_bytes_used_in_destination(&writer));
-
       assert_string_equal(
           array,
           "{"

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -332,12 +332,12 @@ static void test_json_writer_append_nested_invalid(void** state)
           az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("{\"name")),
           AZ_ERROR_UNEXPECTED_END);
     }
-    /*{
+    {
       TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
       assert_int_equal(
           az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("{\"name\":  ")),
           AZ_ERROR_UNEXPECTED_END);
-    }*/
+    }
     {
       TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
       TEST_EXPECT_SUCCESS(az_json_writer_append_begin_object(&writer));
@@ -1585,11 +1585,13 @@ static void test_json_reader_incomplete(void** state)
   test_json_reader_invalid_helper(AZ_SPAN_FROM_STR("{\"name\": 123 ,  "), AZ_ERROR_UNEXPECTED_END);
   test_json_reader_invalid_helper(AZ_SPAN_FROM_STR("{\"name\":\"value}"), AZ_ERROR_UNEXPECTED_END);
   test_json_reader_invalid_helper(AZ_SPAN_FROM_STR("{\"name\":\"value\""), AZ_ERROR_UNEXPECTED_END);
-  test_json_reader_invalid_helper(AZ_SPAN_FROM_STR("{\"name\":\"value\","), AZ_ERROR_UNEXPECTED_END);
+  test_json_reader_invalid_helper(
+      AZ_SPAN_FROM_STR("{\"name\":\"value\","), AZ_ERROR_UNEXPECTED_END);
   test_json_reader_invalid_helper(AZ_SPAN_FROM_STR("{\"name\":{}"), AZ_ERROR_UNEXPECTED_END);
   test_json_reader_invalid_helper(AZ_SPAN_FROM_STR("{\"name\":[]"), AZ_ERROR_UNEXPECTED_END);
   test_json_reader_invalid_helper(AZ_SPAN_FROM_STR("{\"name\":[[]"), AZ_ERROR_UNEXPECTED_END);
-  test_json_reader_invalid_helper(AZ_SPAN_FROM_STR("{\"name\":[1, 2, [], 3] "), AZ_ERROR_UNEXPECTED_END);
+  test_json_reader_invalid_helper(
+      AZ_SPAN_FROM_STR("{\"name\":[1, 2, [], 3] "), AZ_ERROR_UNEXPECTED_END);
 }
 
 static void test_json_skip_children(void** state)

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -228,6 +228,110 @@ static void test_json_writer(void** state)
   }
 }
 
+static void test_json_writer_append_nested(void** state)
+{
+  (void)state;
+  {
+    uint8_t array[200] = { 0 };
+    az_json_writer writer = { 0 };
+
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+
+      // Intentionally include non-normalized spacing and character escaping to validate
+      // the data is copied as is, after validation.
+      TEST_EXPECT_SUCCESS(az_json_writer_append_json_text(
+          &writer, AZ_SPAN_FROM_STR("{\"name\":  \"f\\u0065o\", \"values\": [1, 2, 3,{}]}")));
+
+      az_span_to_str((char*)array, 200, az_json_writer_get_bytes_used_in_destination(&writer));
+
+      assert_string_equal(array, "{\"name\":  \"f\\u0065o\", \"values\": [1, 2, 3,{}]}");
+    }
+
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_begin_object(&writer));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_property_name(&writer, AZ_SPAN_FROM_STR("name")));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_bool(&writer, true));
+
+      TEST_EXPECT_SUCCESS(az_json_writer_append_property_name(&writer, AZ_SPAN_FROM_STR("foo")));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_json_text(
+          &writer, AZ_SPAN_FROM_STR("[\"bar\",null,0,-12,12,9007199254740991]")));
+
+      TEST_EXPECT_SUCCESS(az_json_writer_append_end_object(&writer));
+
+      az_span_to_str((char*)array, 200, az_json_writer_get_bytes_used_in_destination(&writer));
+
+      assert_string_equal(
+          array,
+          "{"
+          "\"name\":true,"
+          "\"foo\":[\"bar\",null,0,-12,12,9007199254740991]"
+          "}");
+    }
+  }
+}
+
+static void test_json_writer_append_nested_invalid(void** state)
+{
+  (void)state;
+  {
+    uint8_t array[200] = { 0 };
+    az_json_writer writer = { 0 };
+
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      assert_int_equal(
+          az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("\"name\":  \"f\\u0065o\"")),
+          AZ_ERROR_UNEXPECTED_CHAR);
+    }
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      assert_int_equal(
+          az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("{]")),
+          AZ_ERROR_UNEXPECTED_CHAR);
+    }
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_begin_object(&writer));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_property_name(&writer, AZ_SPAN_FROM_STR("name")));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_bool(&writer, true));
+
+      TEST_EXPECT_SUCCESS(az_json_writer_append_property_name(&writer, AZ_SPAN_FROM_STR("foo")));
+      assert_int_equal(
+          az_json_writer_append_json_text(
+              &writer, AZ_SPAN_FROM_STR("\"bar\",null,0,-12,12,9007199254740991")),
+          AZ_ERROR_UNEXPECTED_CHAR);
+    }
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      assert_int_equal(
+          az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("{\"name")),
+          AZ_ERROR_UNEXPECTED_END);
+    }
+    /*{
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      assert_int_equal(
+          az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("{\"name\":  ")),
+          AZ_ERROR_UNEXPECTED_END);
+    }*/
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_begin_object(&writer));
+      assert_int_equal(
+          az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("{}")),
+          AZ_ERROR_JSON_INVALID_STATE);
+    }
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_begin_object(&writer));
+      assert_int_equal(
+          az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("1")),
+          AZ_ERROR_JSON_INVALID_STATE);
+    }
+  }
+}
+
 static uint8_t json_array[200] = { 0 };
 
 typedef struct
@@ -2550,6 +2654,8 @@ int test_az_json()
   const struct CMUnitTest tests[]
       = { cmocka_unit_test(test_json_reader_init),
           cmocka_unit_test(test_json_writer),
+          cmocka_unit_test(test_json_writer_append_nested),
+          cmocka_unit_test(test_json_writer_append_nested_invalid),
           cmocka_unit_test(test_json_writer_chunked),
           cmocka_unit_test(test_json_writer_chunked_no_callback),
           cmocka_unit_test(test_json_writer_large_string_chunked),

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -250,6 +250,17 @@ static void test_json_writer_append_nested(void** state)
 
     {
       TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_begin_array(&writer));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("123  ")));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_end_array(&writer));
+
+      az_span_to_str((char*)array, 200, az_json_writer_get_bytes_used_in_destination(&writer));
+
+      assert_string_equal(array, "[123  ]");
+    }
+
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
       TEST_EXPECT_SUCCESS(az_json_writer_append_begin_object(&writer));
       TEST_EXPECT_SUCCESS(az_json_writer_append_property_name(&writer, AZ_SPAN_FROM_STR("name")));
       TEST_EXPECT_SUCCESS(az_json_writer_append_bool(&writer, true));
@@ -306,6 +317,18 @@ static void test_json_writer_append_nested_invalid(void** state)
     {
       TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
       assert_int_equal(
+          az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("fals ")),
+          AZ_ERROR_UNEXPECTED_CHAR);
+    }
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      assert_int_equal(
+          az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("  ")),
+          AZ_ERROR_UNEXPECTED_END);
+    }
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      assert_int_equal(
           az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("{\"name")),
           AZ_ERROR_UNEXPECTED_END);
     }
@@ -327,6 +350,29 @@ static void test_json_writer_append_nested_invalid(void** state)
       TEST_EXPECT_SUCCESS(az_json_writer_append_begin_object(&writer));
       assert_int_equal(
           az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("1")),
+          AZ_ERROR_JSON_INVALID_STATE);
+    }
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_int32(&writer, 123));
+      assert_int_equal(
+          az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("123")),
+          AZ_ERROR_JSON_INVALID_STATE);
+    }
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_begin_object(&writer));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_end_object(&writer));
+      assert_int_equal(
+          az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("123")),
+          AZ_ERROR_JSON_INVALID_STATE);
+    }
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_begin_array(&writer));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_end_array(&writer));
+      assert_int_equal(
+          az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("true")),
           AZ_ERROR_JSON_INVALID_STATE);
     }
   }


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/934

~**TODO:**~
- [x] Add tests
- [x] Update changelog

cc @danewalton, @hihigupt, @amih90 