### PR TITLE
Remove unused internal method since it has no callers: 'az_http_request_append_path'

### DIFF
--- a/sdk/inc/azure/core/internal/az_http_internal.h
+++ b/sdk/inc/azure/core/internal/az_http_internal.h
@@ -187,27 +187,6 @@ AZ_NODISCARD az_result az_http_request_init(
     az_span body);
 
 /**
- * @brief Adds path to url request.
- * For instance, if url in request is `http://example.net?qp=1` and this function is called with
- * path equals to `test`, then request url will be updated to `http://example.net/test?qp=1`.
- *
- * @remarks If \p is_path_url_encoded is set to false, before appending the path, it would be
- * url-encoded.
- *
- *
- * @param[out] ref_request A reference to an HTTP request.
- * @param[in] path The #az_span to a path to be appended into the URL.
- * @param[in] is_path_url_encoded The boolean value that defines if the value to be appended is
- * url-encoded or not.
- * @return An #az_result value indicating the result of the operation:
- *         - #AZ_OK if successful
- *         - #AZ_ERROR_INSUFFICIENT_SPAN_SIZE if the \p path wouldn't fit into the URL buffer
- * provided.
- */
-AZ_NODISCARD az_result
-az_http_request_append_path(az_http_request* ref_request, az_span path, bool is_path_url_encoded);
-
-/**
  * @brief Set a query parameter at the end of url.
  *
  * @remark Query parameters are stored url-encoded. This function will not check if

--- a/sdk/src/azure/core/az_http_request.c
+++ b/sdk/src/azure/core/az_http_request.c
@@ -62,64 +62,6 @@ AZ_NODISCARD az_result az_http_request_init(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result
-az_http_request_append_path(az_http_request* ref_request, az_span path, bool is_path_url_encoded)
-{
-  _az_PRECONDITION_NOT_NULL(ref_request);
-
-  int32_t const initial_url_length = ref_request->_internal.url_length;
-  int32_t const initial_query_start = ref_request->_internal.query_start;
-  az_span const url = ref_request->_internal.url;
-
-  int32_t const path_size
-      = is_path_url_encoded ? az_span_size(path) : _az_span_url_encode_calc_length(path);
-
-  // Add 1 for the /.
-  int32_t const size_after_insert = initial_url_length + 1 + path_size;
-  if (az_span_size(url) < size_after_insert)
-  {
-    return AZ_ERROR_INSUFFICIENT_SPAN_SIZE;
-  }
-
-  // To begin, assume we are appending at the end of the url.
-  int32_t query_start = initial_url_length;
-
-  // There is an existing query parameter (i.e. URL with a question mark).
-  if (initial_query_start > 0)
-  {
-    // We are appending in the middle of the URL, so, we will need to shift some existing content to
-    // the right.
-    query_start = initial_query_start - 1;
-
-    // Get the span where to move the content, leaving enough room for the path and /.
-    az_span shifted_dst = az_span_slice_to_end(url, query_start + 1 + path_size);
-    // Get the span slice needed to be moved before appending the path.
-    az_span shifted_src = az_span_slice(url, query_start, initial_url_length);
-    // Move content left or right so there is room for path to be added.
-    az_span_copy(shifted_dst, shifted_src);
-
-    // Move past the /, path, and ? since that will be the new start of the next query.
-    ref_request->_internal.query_start = query_start + 2 + path_size;
-  }
-
-  // Add the path delimiter.
-  az_span destination = az_span_copy_u8(az_span_slice_to_end(url, query_start), '/');
-
-  // Copy the path, after url encoding it, if necessary.
-  if (is_path_url_encoded)
-  {
-    az_span_copy(destination, path);
-  }
-  else
-  {
-    int32_t ignored = 0;
-    AZ_RETURN_IF_FAILED(_az_span_url_encode(destination, path, &ignored));
-  }
-
-  ref_request->_internal.url_length = size_after_insert;
-  return AZ_OK;
-}
-
 AZ_NODISCARD az_result az_http_request_set_query_parameter(
     az_http_request* ref_request,
     az_span name,

--- a/sdk/tests/core/test_az_http.c
+++ b/sdk/tests/core/test_az_http.c
@@ -140,9 +140,6 @@ static void test_http_request(void** state)
       assert_true(az_span_is_content_equal(header.value, expected_headers2[i].value));
     }
 
-    assert_return_code(
-        az_http_request_append_path(&request, AZ_SPAN_FROM_STR("path"), true), AZ_OK);
-
     az_http_method method;
     az_span body;
     az_span url;
@@ -153,8 +150,8 @@ static void test_http_request(void** state)
     assert_string_equal(az_span_ptr(body), az_span_ptr(AZ_SPAN_FROM_STR("body")));
     assert_string_equal(
         az_span_ptr(url),
-        az_span_ptr(AZ_SPAN_FROM_STR("https://antk-keyvault.vault.azure.net/secrets/Password/"
-                                     "path?api-version=7.0&test-param=token")));
+        az_span_ptr(AZ_SPAN_FROM_STR("https://antk-keyvault.vault.azure.net/secrets/Password"
+                                     "?api-version=7.0&test-param=token")));
   }
   {
     uint8_t buf[100];
@@ -397,37 +394,6 @@ static void test_http_request(void** state)
         AZ_OK);
 
     az_span expected_url = AZ_SPAN_FROM_STR("http://example.com?q1=space%20here");
-    uint8_t result[100];
-    az_span url_result = AZ_SPAN_FROM_BUFFER(result);
-    assert_return_code(az_http_request_get_url(&request, &url_result), AZ_OK);
-    assert_true(az_span_is_content_equal(url_result, expected_url));
-  }
-  { // Test append path url encode
-    uint8_t buf[100];
-    uint8_t header_buf[(2 * sizeof(az_pair))];
-    memset(buf, 0, sizeof(buf));
-    memset(header_buf, 0, sizeof(header_buf));
-
-    az_span url_span = AZ_SPAN_FROM_BUFFER(buf);
-    az_span initial_url = AZ_SPAN_FROM_STR("http://example.com");
-    az_span remainder = az_span_copy(url_span, initial_url);
-    assert_int_equal(az_span_size(remainder), 100 - az_span_size(initial_url));
-    az_span header_span = AZ_SPAN_FROM_BUFFER(header_buf);
-    az_http_request request;
-
-    TEST_EXPECT_SUCCESS(az_http_request_init(
-        &request,
-        &az_context_application,
-        az_http_method_get(),
-        url_span,
-        az_span_size(initial_url),
-        header_span,
-        AZ_SPAN_FROM_STR("body")));
-
-    assert_return_code(
-        az_http_request_append_path(&request, AZ_SPAN_FROM_STR("path with space"), false), AZ_OK);
-
-    az_span expected_url = AZ_SPAN_FROM_STR("http://example.com/path%20with%20space");
     uint8_t result[100];
     az_span url_result = AZ_SPAN_FROM_BUFFER(result);
     assert_return_code(az_http_request_get_url(&request, &url_result), AZ_OK);


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/1108