### PR TITLE
Reenable /analyze and fix all the warnings.

### DIFF
--- a/eng/cmake/global_compile_options.txt
+++ b/eng/cmake/global_compile_options.txt
@@ -4,7 +4,7 @@ if(MSVC)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /WX")
   endif()
 
-  add_compile_options(/W4 ${WARNINGS_AS_ERRORS_FLAG} /wd5031 /wd4668 /wd4820 /wd4255 /wd4710)
+  add_compile_options(/W4 ${WARNINGS_AS_ERRORS_FLAG} /wd5031 /wd4668 /wd4820 /wd4255 /wd4710 /analyze)
 elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
   if(WARNINGS_AS_ERRORS)
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")

--- a/sdk/inc/azure/core/_az_cfg.h
+++ b/sdk/inc/azure/core/_az_cfg.h
@@ -25,8 +25,10 @@
 // automatic variable '...'
 #pragma warning(disable : 4221)
 
-// warning C6011: Dereferencing NULL pointer. Using _az_PRECONDITION_NOT_NULL
-#pragma warning(disable : 6011)
+// warning C28278 : Function appears with no prototype in scope. Only limited analysis can be
+// performed. Include the appropriate header or add a prototype. This warning also occurs if
+// parameter or return types are omitted in a function definition.
+#pragma warning(disable : 28278)
 
 // Treat warnings as errors:
 // -------------------------

--- a/sdk/inc/azure/core/internal/az_precondition_internal.h
+++ b/sdk/inc/azure/core/internal/az_precondition_internal.h
@@ -59,7 +59,6 @@ az_precondition_failed_fn az_precondition_failed_get_callback();
 #endif
 
 #ifdef AZ_NO_PRECONDITION_CHECKING
-#define _az_PRECONDITION(condition)
 #define _az_PRECONDITION(condition) _az_ANALYSIS_ASSUME(condition)
 #else
 #define _az_PRECONDITION(condition) \

--- a/sdk/inc/azure/core/internal/az_precondition_internal.h
+++ b/sdk/inc/azure/core/internal/az_precondition_internal.h
@@ -43,12 +43,29 @@
 
 az_precondition_failed_fn az_precondition_failed_get_callback();
 
+// __analysis_assume() tells MSVC's code analysis tool about the assumptions we have, so it doesn't
+// emit warnings for the statements that we put into _az_PRECONDITION().
+// Code analysis starts to fail with this condition some time around version 19.27; but
+// __analysis_assume() does appear at least as early as version 1920 (The first "Visual Studio
+// 2019"). So, we do __analysis_assume() for MSVCs starting with 2019. We don't want to go much
+// earlier without verifying, because if __analysis_assume() is not available on earlier compiler
+// version, there will be a compilation error.
+// For more info, see
+// https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/using-the--analysis-assume-function-to-suppress-false-defects
+#if _MSC_VER >= 1920
+#define _az_ANALYSIS_ASSUME(statement) __analysis_assume(statement)
+#else
+#define _az_ANALYSIS_ASSUME(statement)
+#endif
+
 #ifdef AZ_NO_PRECONDITION_CHECKING
 #define _az_PRECONDITION(condition)
+#define _az_PRECONDITION(condition) _az_ANALYSIS_ASSUME(condition)
 #else
 #define _az_PRECONDITION(condition) \
   do \
   { \
+    _az_ANALYSIS_ASSUME(condition); \
     if (!(condition)) \
     { \
       az_precondition_failed_get_callback()(); \

--- a/sdk/inc/azure/core/internal/az_precondition_internal.h
+++ b/sdk/inc/azure/core/internal/az_precondition_internal.h
@@ -59,7 +59,7 @@ az_precondition_failed_fn az_precondition_failed_get_callback();
 #endif
 
 #ifdef AZ_NO_PRECONDITION_CHECKING
-#define _az_PRECONDITION(condition) _az_ANALYSIS_ASSUME(condition)
+#define _az_PRECONDITION(condition)
 #else
 #define _az_PRECONDITION(condition) \
   do \

--- a/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
@@ -406,7 +406,8 @@ static void subscribe_mqtt_client_to_iot_hub_topics(void)
   if ((rc = MQTTClient_subscribe(mqtt_client, AZ_IOT_HUB_CLIENT_METHODS_SUBSCRIBE_TOPIC, 1))
       != MQTTCLIENT_SUCCESS)
   {
-    IOT_SAMPLE_LOG_ERROR("Failed to subscribe to the Methods topic: MQTTClient return code %d.", rc);
+    IOT_SAMPLE_LOG_ERROR(
+        "Failed to subscribe to the Methods topic: MQTTClient return code %d.", rc);
     exit(rc);
   }
 
@@ -414,7 +415,8 @@ static void subscribe_mqtt_client_to_iot_hub_topics(void)
   if ((rc = MQTTClient_subscribe(mqtt_client, AZ_IOT_HUB_CLIENT_TWIN_PATCH_SUBSCRIBE_TOPIC, 1))
       != MQTTCLIENT_SUCCESS)
   {
-    IOT_SAMPLE_LOG_ERROR("Failed to subscribe to the Twin Patch topic: MQTTClient return code %d.", rc);
+    IOT_SAMPLE_LOG_ERROR(
+        "Failed to subscribe to the Twin Patch topic: MQTTClient return code %d.", rc);
     exit(rc);
   }
 
@@ -422,7 +424,8 @@ static void subscribe_mqtt_client_to_iot_hub_topics(void)
   if ((rc = MQTTClient_subscribe(mqtt_client, AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_SUBSCRIBE_TOPIC, 1))
       != MQTTCLIENT_SUCCESS)
   {
-    IOT_SAMPLE_LOG_ERROR("Failed to subscribe to the Twin Response topic: MQTTClient return code %d.", rc);
+    IOT_SAMPLE_LOG_ERROR(
+        "Failed to subscribe to the Twin Response topic: MQTTClient return code %d.", rc);
     exit(rc);
   }
 }
@@ -435,14 +438,16 @@ static void initialize_components(void)
   if (az_failed(
           rc = pnp_thermostat_init(&thermostat_1, thermostat_1_name, DEFAULT_START_TEMP_CELSIUS)))
   {
-    IOT_SAMPLE_LOG_ERROR("Could not initialize Temperature Sensor 1: az_result return code 0x%08x.", rc);
+    IOT_SAMPLE_LOG_ERROR(
+        "Could not initialize Temperature Sensor 1: az_result return code 0x%08x.", rc);
     exit(rc);
   }
 
   if (az_failed(
           rc = pnp_thermostat_init(&thermostat_2, thermostat_2_name, DEFAULT_START_TEMP_CELSIUS)))
   {
-    IOT_SAMPLE_LOG_ERROR("Could not initialize Temperature Sensor 2: az_result return code 0x%08x.", rc);
+    IOT_SAMPLE_LOG_ERROR(
+        "Could not initialize Temperature Sensor 2: az_result return code 0x%08x.", rc);
     exit(rc);
   }
 }
@@ -480,19 +485,20 @@ static void send_device_serial_number(void)
           rc = az_iot_hub_client_twin_patch_get_publish_topic(
               &hub_client, get_request_id(), mqtt_message.topic, mqtt_message.topic_length, NULL)))
   {
-    IOT_SAMPLE_LOG_ERROR("Failed to get Twin Patch publish topic: az_result return code 0x%08x.", rc);
+    IOT_SAMPLE_LOG_ERROR(
+        "Failed to get Twin Patch publish topic: az_result return code 0x%08x.", rc);
     exit(rc);
   }
 
   // Build the serial number reported property message.
-  if (az_failed(
-          rc = pnp_create_reported_property(
-              mqtt_message.payload_span,
-              AZ_SPAN_NULL,
-              reported_serial_num_property_name,
-              append_string_callback,
-              (void*)&reported_serial_num_property_value,
-              &mqtt_message.out_payload_span)))
+  rc = pnp_create_reported_property(
+      mqtt_message.payload_span,
+      AZ_SPAN_NULL,
+      reported_serial_num_property_name,
+      append_string_callback,
+      (void*)&reported_serial_num_property_value,
+      &mqtt_message.out_payload_span);
+  if (az_failed(rc))
   {
     IOT_SAMPLE_LOG_ERROR(
         "Failed to build `serial number` reported property payload: az_result return code 0x%08x.",
@@ -519,7 +525,8 @@ static void request_device_twin_document(void)
           rc = az_iot_hub_client_twin_document_get_publish_topic(
               &hub_client, get_request_id(), mqtt_message.topic, mqtt_message.topic_length, NULL)))
   {
-    IOT_SAMPLE_LOG_ERROR("Failed to get Twin Document publish topic: az_result return code 0x%08x.", rc);
+    IOT_SAMPLE_LOG_ERROR(
+        "Failed to get Twin Document publish topic: az_result return code 0x%08x.", rc);
     exit(rc);
   }
 
@@ -541,8 +548,9 @@ static void receive_messages(void)
     if (pnp_thermostat_get_max_temp_report(&hub_client, &thermostat_1, &mqtt_message))
     {
       mqtt_publish_message(mqtt_message.topic, mqtt_message.out_payload_span, MQTT_PUBLISH_QOS);
-      IOT_SAMPLE_LOG_SUCCESS("Client sent Temperature Sensor 1 the `maxTempSinceLastReboot` reported property "
-                  "message.");
+      IOT_SAMPLE_LOG_SUCCESS(
+          "Client sent Temperature Sensor 1 the `maxTempSinceLastReboot` reported property "
+          "message.");
       IOT_SAMPLE_LOG_AZ_SPAN("Payload:", mqtt_message.out_payload_span);
 
       // Receive the response from the server.
@@ -552,8 +560,9 @@ static void receive_messages(void)
     if (pnp_thermostat_get_max_temp_report(&hub_client, &thermostat_2, &mqtt_message))
     {
       mqtt_publish_message(mqtt_message.topic, mqtt_message.out_payload_span, MQTT_PUBLISH_QOS);
-      IOT_SAMPLE_LOG_SUCCESS("Client sent Temperature Sensor 2 the `maxTempSinceLastReboot` reported property "
-                  "message.");
+      IOT_SAMPLE_LOG_SUCCESS(
+          "Client sent Temperature Sensor 2 the `maxTempSinceLastReboot` reported property "
+          "message.");
       IOT_SAMPLE_LOG_AZ_SPAN("Payload:", mqtt_message.out_payload_span);
 
       // Receive the response from the server.
@@ -617,7 +626,8 @@ static void mqtt_receive_message(void)
     // Allow up to TIMEOUT_MQTT_RECEIVE_MAX_COUNT before disconnecting.
     if (++timeout_counter >= TIMEOUT_MQTT_RECEIVE_MAX_MESSAGE_COUNT)
     {
-      IOT_SAMPLE_LOG("Receive message timeout count of %d reached.", TIMEOUT_MQTT_RECEIVE_MAX_MESSAGE_COUNT);
+      IOT_SAMPLE_LOG(
+          "Receive message timeout count of %d reached.", TIMEOUT_MQTT_RECEIVE_MAX_MESSAGE_COUNT);
       is_device_operational = false;
     }
   }
@@ -773,7 +783,8 @@ static void handle_command_message(
                 mqtt_message.topic_length,
                 NULL)))
     {
-      IOT_SAMPLE_LOG_ERROR("Failed to get Methods response publish topic: az_result return code 0x%08x.", rc);
+      IOT_SAMPLE_LOG_ERROR(
+          "Failed to get Methods response publish topic: az_result return code 0x%08x.", rc);
       exit(rc);
     }
     command_response_payload = empty_response_payload;
@@ -813,7 +824,8 @@ static az_result temp_controller_process_command(
                 message->topic_length,
                 NULL)))
     {
-      IOT_SAMPLE_LOG_ERROR("Failed to get Methods response publish topic: az_result return code 0x%08x.", rc);
+      IOT_SAMPLE_LOG_ERROR(
+          "Failed to get Methods response publish topic: az_result return code 0x%08x.", rc);
       return rc;
     }
 
@@ -884,11 +896,12 @@ static az_result temp_controller_get_telemetry_message(pnp_mqtt_message* message
   az_result rc;
 
   // Get the Telemetry topic to publish the telemetry messages.
-  if (az_failed(
-          rc = pnp_get_telemetry_topic(
-              &hub_client, NULL, AZ_SPAN_NULL, message->topic, message->topic_length, NULL)))
+  rc = pnp_get_telemetry_topic(
+      &hub_client, NULL, AZ_SPAN_NULL, message->topic, message->topic_length, NULL);
+  if (az_failed(rc))
   {
-    IOT_SAMPLE_LOG_ERROR("Failed to get pnp Telemetry publish topic: az_result return code 0x%08x.", rc);
+    IOT_SAMPLE_LOG_ERROR(
+        "Failed to get pnp Telemetry publish topic: az_result return code 0x%08x.", rc);
     exit(rc);
   }
 
@@ -965,7 +978,8 @@ static void property_callback(
                 mqtt_message.topic_length,
                 NULL)))
     {
-      IOT_SAMPLE_LOG_ERROR("Failed to get Twin Patch publish topic: az_result return code 0x%08x.", rc);
+      IOT_SAMPLE_LOG_ERROR(
+          "Failed to get Twin Patch publish topic: az_result return code 0x%08x.", rc);
       exit(rc);
     }
 
@@ -991,7 +1005,8 @@ static void property_callback(
 
     // Send error response to the updated property.
     mqtt_publish_message(mqtt_message.topic, mqtt_message.out_payload_span, MQTT_PUBLISH_QOS);
-    IOT_SAMPLE_LOG_SUCCESS("Client sent Temperature Controller error status reported property message:");
+    IOT_SAMPLE_LOG_SUCCESS(
+        "Client sent Temperature Controller error status reported property message:");
     IOT_SAMPLE_LOG_AZ_SPAN("Payload:", mqtt_message.out_payload_span);
 
     // Receive the response from the server.

--- a/sdk/samples/iot/paho_iot_hub_sas_telemetry_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_sas_telemetry_sample.c
@@ -256,15 +256,15 @@ static void generate_sas_key(void)
 
   // Get the resulting MQTT password, passing the base64 encoded, HMAC signed bytes
   size_t mqtt_password_length;
-  if (az_failed(
-          rc = az_iot_hub_client_sas_get_password(
-              &hub_client,
-              sas_base64_encoded_signed_signature,
-              sas_duration,
-              AZ_SPAN_NULL,
-              mqtt_password_buffer,
-              sizeof(mqtt_password_buffer),
-              &mqtt_password_length)))
+  rc = az_iot_hub_client_sas_get_password(
+      &hub_client,
+      sas_base64_encoded_signed_signature,
+      sas_duration,
+      AZ_SPAN_NULL,
+      mqtt_password_buffer,
+      sizeof(mqtt_password_buffer),
+      &mqtt_password_length);
+  if (az_failed(rc))
   {
     IOT_SAMPLE_LOG_ERROR("Could not get the password: az_result return code 0x%08x.", rc);
     exit(rc);

--- a/sdk/samples/iot/paho_iot_provisioning_sas_sample.c
+++ b/sdk/samples/iot/paho_iot_provisioning_sas_sample.c
@@ -117,7 +117,8 @@ static void create_and_configure_mqtt_client(void)
               env_vars.provisioning_registration_id,
               NULL)))
   {
-    IOT_SAMPLE_LOG_ERROR("Failed to initialize provisioning client: az_result return code 0x%08x.", rc);
+    IOT_SAMPLE_LOG_ERROR(
+        "Failed to initialize provisioning client: az_result return code 0x%08x.", rc);
     exit(rc);
   }
 
@@ -199,7 +200,8 @@ static void subscribe_mqtt_client_to_provisioning_service_topics(void)
        = MQTTClient_subscribe(mqtt_client, AZ_IOT_PROVISIONING_CLIENT_REGISTER_SUBSCRIBE_TOPIC, 1))
       != MQTTCLIENT_SUCCESS)
   {
-    IOT_SAMPLE_LOG_ERROR("Failed to subscribe to the register topic: MQTTClient return code %d.", rc);
+    IOT_SAMPLE_LOG_ERROR(
+        "Failed to subscribe to the register topic: MQTTClient return code %d.", rc);
     exit(rc);
   }
 }
@@ -289,7 +291,8 @@ static void receive_device_registration_status(void)
   if (operation_status == AZ_IOT_PROVISIONING_STATUS_ASSIGNED) // Successful assignment
   {
     IOT_SAMPLE_LOG_SUCCESS("Device provisioned:");
-    IOT_SAMPLE_LOG_AZ_SPAN("Hub Hostname:", register_response.registration_result.assigned_hub_hostname);
+    IOT_SAMPLE_LOG_AZ_SPAN(
+        "Hub Hostname:", register_response.registration_result.assigned_hub_hostname);
     IOT_SAMPLE_LOG_AZ_SPAN("Device Id:", register_response.registration_result.device_id);
   }
   else // Unsuccessful assignment (unassigned, failed or disabled states)
@@ -300,8 +303,10 @@ static void receive_device_registration_status(void)
     IOT_SAMPLE_LOG_AZ_SPAN("Operation ID:", register_response.operation_id);
     IOT_SAMPLE_LOG("Error code: %u", register_response.registration_result.extended_error_code);
     IOT_SAMPLE_LOG_AZ_SPAN("Error message:", register_response.registration_result.error_message);
-    IOT_SAMPLE_LOG_AZ_SPAN("Error timestamp:", register_response.registration_result.error_timestamp);
-    IOT_SAMPLE_LOG_AZ_SPAN("Error tracking ID:", register_response.registration_result.error_tracking_id);
+    IOT_SAMPLE_LOG_AZ_SPAN(
+        "Error timestamp:", register_response.registration_result.error_timestamp);
+    IOT_SAMPLE_LOG_AZ_SPAN(
+        "Error tracking ID:", register_response.registration_result.error_tracking_id);
     exit((int)register_response.registration_result.extended_error_code);
   }
 
@@ -372,7 +377,8 @@ static void send_operation_query_message(
               sizeof(query_status_topic_buffer),
               NULL)))
   {
-    IOT_SAMPLE_LOG_ERROR("Unable to get query status publish topic: az_result return code 0x%08x.", rc);
+    IOT_SAMPLE_LOG_ERROR(
+        "Unable to get query status publish topic: az_result return code 0x%08x.", rc);
     exit(rc);
   }
 
@@ -394,7 +400,8 @@ static void generate_sas_key(void)
   az_result rc;
 
   // Create the POSIX expiration time from input minutes.
-  uint64_t sas_duration = iot_sample_get_epoch_expiration_time_from_minutes(env_vars.sas_key_duration_minutes);
+  uint64_t sas_duration
+      = iot_sample_get_epoch_expiration_time_from_minutes(env_vars.sas_key_duration_minutes);
 
   // Get the signature which will be signed with the decoded key
   az_span sas_signature = AZ_SPAN_FROM_BUFFER(sas_signature_buffer);
@@ -402,12 +409,14 @@ static void generate_sas_key(void)
           rc = az_iot_provisioning_client_sas_get_signature(
               &provisioning_client, sas_duration, sas_signature, &sas_signature)))
   {
-    IOT_SAMPLE_LOG_ERROR("Could not get the signature for SAS key: az_result return code 0x%08x.", rc);
+    IOT_SAMPLE_LOG_ERROR(
+        "Could not get the signature for SAS key: az_result return code 0x%08x.", rc);
     exit(rc);
   }
 
   // Generate the encoded, signed signature (b64 encoded, HMAC-SHA256 signing)
-  az_span sas_base64_encoded_signed_signature = AZ_SPAN_FROM_BUFFER(sas_base64_encoded_signed_signature_buffer);
+  az_span sas_base64_encoded_signed_signature
+      = AZ_SPAN_FROM_BUFFER(sas_base64_encoded_signed_signature_buffer);
   iot_sample_generate_sas_base64_encoded_signed_signature(
       env_vars.provisioning_sas_key,
       sas_signature,
@@ -416,15 +425,15 @@ static void generate_sas_key(void)
 
   // Get the resulting MQTT password, passing the base64 encoded, HMAC signed bytes
   size_t mqtt_password_length;
-  if (az_failed(
-          rc = az_iot_provisioning_client_sas_get_password(
-              &provisioning_client,
-              sas_base64_encoded_signed_signature,
-              sas_duration,
-              AZ_SPAN_NULL,
-              mqtt_password_buffer,
-              sizeof(mqtt_password_buffer),
-              &mqtt_password_length)))
+  rc = az_iot_provisioning_client_sas_get_password(
+      &provisioning_client,
+      sas_base64_encoded_signed_signature,
+      sas_duration,
+      AZ_SPAN_NULL,
+      mqtt_password_buffer,
+      sizeof(mqtt_password_buffer),
+      &mqtt_password_length);
+  if (az_failed(rc))
   {
     IOT_SAMPLE_LOG_ERROR("Could not get the password: az_result return code 0x%08x.", rc);
     exit(rc);


### PR DESCRIPTION
Yes, we state that dereferencing null should never happen, but code analysis does not see that. It sees that we invoke `precondition_failed()` function, and that's it. So to a code analysis tool, after invoking that function, execution continues, and the code would go and dereference NULL pointer. Which, to us, is fine, but we have to explain it to a code analysis tool. `__analysis_assume` does that.

For the IoT samples, I **_had_** to rewrite some `if` statements (the ones that contain `AZ_SPAN_NULL`) to remove assignment from them. I tried a few less invasive methods (pragma warning disable, redefine AZ_SPAN_NULL as `(az_span) { 0 }` for MSVC), but it didn't work.
So modifying all the instances is the simplest fix (and maybe the only fix available; at least for now, because I do believe there's a bug in the analyze - both in the fact that it doesn't like our assignments in ifs() when AZ_SPAN_NULL is used, and that the warning can't be disabled).

If you want to give it another shot, now or later - feel free. I am not a fan of this solution as well. I like the `if(az_failed(rc = ...))` form. It is common for C to do this. It is unfortunate that `/analyze` does complain about it. What we do is clearly distinctive from the potential error when you write `if(i = get_int())` - in our case, we do pass a result of the assignment to a function that takes az_result, and it  returns bool, and that bool goes to the if().
`/analyze` did not find a bug. If you follow it's advice and replace `=` with `==` - you will actually make a bug, but the tool will be silent. And I hate we have to change our code not to make the code better, but to make the tool happy.

In the future, if it comes to that, it should be relatively easy to undo this: to find all instances, search for `if(az_failed(rc))`.