### PR TITLE
[Unblock clean CI] Remove the CI step to restore vcpkg from the cache and remove the analyze flag for MSVC

### DIFF
--- a/eng/cmake/global_compile_options.txt
+++ b/eng/cmake/global_compile_options.txt
@@ -4,7 +4,7 @@ if(MSVC)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /WX")
   endif()
 
-  add_compile_options(/W4 ${WARNINGS_AS_ERRORS_FLAG} /wd5031 /wd4668 /wd4820 /wd4255 /wd4710 /analyze)
+  add_compile_options(/W4 ${WARNINGS_AS_ERRORS_FLAG} /wd5031 /wd4668 /wd4820 /wd4255 /wd4710)
 elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
   if(WARNINGS_AS_ERRORS)
     set(WARNINGS_AS_ERRORS_FLAG "-Werror")

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -61,24 +61,6 @@ steps:
         contains(variables['OSVmImage'], 'ubuntu')
       )
 
-  # Attempt to restore vcpkg from the cache
-  - task: Cache@2
-    inputs:
-      key: >-
-        $(Agent.JobName)
-        | "${{ parameters.VcpkgVersion }}"
-        | $(Agent.Os)
-        | $(${{ parameters.DependenciesVariableName }})
-      path: $(VCPKG_INSTALLATION_ROOT)
-      cacheHitVar: VcpkgRestoredFromCache
-    displayName: Vcpkg Cache
-    condition: >-
-      and(
-        succeeded(),
-        not(eq(variables['${{ parameters.DependenciesVariableName }}'], '')),
-        not(eq(variables['Skip.VcpkgCache'], 'true'))
-      )
-
   # Install vcpkg on MacOS
   - task: Bash@3
     inputs:

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -111,13 +111,28 @@ steps:
         git reset --hard HEAD
         echo git pull origin master
         git pull origin master
+
+        echo git fetch
+        git fetch
+
+        echo git tag
+        git tag
+
         echo git checkout ${{ parameters.VcpkgVersion }}
         git checkout ${{ parameters.VcpkgVersion }}
 
-        git log
+        echo git remote -v
         git remote -v
+        echo git status
         git status
+        echo git branch
         git branch
+        echo git tag
+        git tag
+
+        echo git fetch --all --tags
+        git fetch --all --tags
+        git tag
 
         echo ./bootstrap-vcpkg.sh
         ./bootstrap-vcpkg.sh

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -70,6 +70,10 @@ steps:
         git clone https://github.com/Microsoft/vcpkg.git
         cd vcpkg
         git rev-parse --verify HEAD
+
+        # Make sure to fetch all the tags to avoid failures on checkout.
+        git fetch --all --tags
+
         git checkout ${{ parameters.VcpkgVersion }}
         git status
 
@@ -101,39 +105,19 @@ steps:
     inputs:
       targetType: inline
       script: |
-        echo cd $VCPKG_INSTALLATION_ROOT
         cd $VCPKG_INSTALLATION_ROOT
-        pwd
 
         # Sometimes the image has changes in the git tree. Reset to HEAD and
         # then pull
-        echo git reset --hard HEAD
         git reset --hard HEAD
-        echo git pull origin master
         git pull origin master
 
-        echo git fetch
-        git fetch
-
-        echo git fetch --all --tags
+        # Make sure to fetch all the tags to avoid failures on checkout.
         git fetch --all --tags
-        git tag
 
-        echo git checkout ${{ parameters.VcpkgVersion }}
         git checkout ${{ parameters.VcpkgVersion }}
 
-        echo git remote -v
-        git remote -v
-        echo git status
-        git status
-        echo git branch
-        git branch
-        echo git tag
-        git tag
-
-        echo ./bootstrap-vcpkg.sh
         ./bootstrap-vcpkg.sh
-
     condition: >-
       and(
         succeeded(),

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -115,7 +115,8 @@ steps:
         echo git fetch
         git fetch
 
-        echo git tag
+        echo git fetch --all --tags
+        git fetch --all --tags
         git tag
 
         echo git checkout ${{ parameters.VcpkgVersion }}
@@ -128,10 +129,6 @@ steps:
         echo git branch
         git branch
         echo git tag
-        git tag
-
-        echo git fetch --all --tags
-        git fetch --all --tags
         git tag
 
         echo ./bootstrap-vcpkg.sh

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -101,15 +101,27 @@ steps:
     inputs:
       targetType: inline
       script: |
+        echo cd $VCPKG_INSTALLATION_ROOT
         cd $VCPKG_INSTALLATION_ROOT
+        pwd
 
         # Sometimes the image has changes in the git tree. Reset to HEAD and
         # then pull
+        echo git reset --hard HEAD
         git reset --hard HEAD
+        echo git pull origin master
         git pull origin master
+        echo git checkout ${{ parameters.VcpkgVersion }}
         git checkout ${{ parameters.VcpkgVersion }}
 
+        git log
+        git remote -v
+        git status
+        git branch
+
+        echo ./bootstrap-vcpkg.sh
         ./bootstrap-vcpkg.sh
+
     condition: >-
       and(
         succeeded(),


### PR DESCRIPTION
Testing out some stopgap solution to https://github.com/Azure/azure-sdk-for-c/issues/1142 by removing the restore from cache step.

Also, remove the analyze flag for MSVC to get clean CI to test out a stopgap which unblocks existing PRs while investigation is pending for https://github.com/Azure/azure-sdk-for-c/issues/1137

