### PR TITLE
update return value of az_iot_message_properties_next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `az_json_writer_append_json_text()` to support appending existing JSON with the JSON writer.
 - Add support for system properties for IoT Hub messages to `az_iot_common.h`.
+- Add new IoT result named `AZ_ERROR_IOT_NO_MORE_PROPERTIES` to designate the end of the properties iterated over by `az_iot_message_properties_next()`.
 
 ### Breaking Changes
 

--- a/sdk/inc/azure/core/az_result.h
+++ b/sdk/inc/azure/core/az_result.h
@@ -148,6 +148,9 @@ typedef enum
   // === IoT error codes ===
   /// The IoT topic is not matching the expected format.
   AZ_ERROR_IOT_TOPIC_NO_MATCH = _az_RESULT_MAKE_ERROR(_az_FACILITY_IOT, 1),
+
+  /// While iterating, there are no more properties to return.
+  AZ_ERROR_IOT_NO_MORE_PROPERTIES = _az_RESULT_MAKE_ERROR(_az_FACILITY_IOT, 2),
 } az_result;
 
 /**

--- a/sdk/inc/azure/iot/az_iot_common.h
+++ b/sdk/inc/azure/iot/az_iot_common.h
@@ -165,6 +165,8 @@ AZ_NODISCARD az_result az_iot_message_properties_find(
  * @param[out] out_name A pointer to an #az_span containing the name of the next property.
  * @param[out] out_value A pointer to an #az_span containing the value of the next property.
  * @return #az_result
+ *   @retval AZ_OK If properties were retrieved successfully.
+ *   @retval AZ_ERROR_IOT_NO_MORE_PROPERTIES If the API reached the end of the properties to retrieve.
  */
 AZ_NODISCARD az_result
 az_iot_message_properties_next(az_iot_message_properties* properties, az_span* out_name, az_span* out_value);

--- a/sdk/inc/azure/iot/az_iot_common.h
+++ b/sdk/inc/azure/iot/az_iot_common.h
@@ -165,8 +165,8 @@ AZ_NODISCARD az_result az_iot_message_properties_find(
  * @param[out] out_name A pointer to an #az_span containing the name of the next property.
  * @param[out] out_value A pointer to an #az_span containing the value of the next property.
  * @return An #az_result value indicating the result of the operation.
- *   @retval #AZ_OK A property was retrieved successfully.
- *   @retval #AZ_ERROR_IOT_NO_MORE_PROPERTIES The API reached the end of the properties to retrieve.
+ * @retval #AZ_OK A property was retrieved successfully.
+ * @retval #AZ_ERROR_IOT_NO_MORE_PROPERTIES The API reached the end of the properties to retrieve.
  */
 AZ_NODISCARD az_result
 az_iot_message_properties_next(az_iot_message_properties* properties, az_span* out_name, az_span* out_value);

--- a/sdk/inc/azure/iot/az_iot_common.h
+++ b/sdk/inc/azure/iot/az_iot_common.h
@@ -164,9 +164,9 @@ AZ_NODISCARD az_result az_iot_message_properties_find(
  * @param[in] properties The #az_iot_message_properties to use for this call
  * @param[out] out_name A pointer to an #az_span containing the name of the next property.
  * @param[out] out_value A pointer to an #az_span containing the value of the next property.
- * @return #az_result
- *   @retval AZ_OK If properties were retrieved successfully.
- *   @retval AZ_ERROR_IOT_NO_MORE_PROPERTIES If the API reached the end of the properties to retrieve.
+ * @return An #az_result value indicating the result of the operation.
+ *   @retval #AZ_OK A property was retrieved successfully.
+ *   @retval #AZ_ERROR_IOT_NO_MORE_PROPERTIES The API reached the end of the properties to retrieve.
  */
 AZ_NODISCARD az_result
 az_iot_message_properties_next(az_iot_message_properties* properties, az_span* out_name, az_span* out_value);

--- a/sdk/src/azure/iot/az_iot_common.c
+++ b/sdk/src/azure/iot/az_iot_common.c
@@ -115,7 +115,7 @@ AZ_NODISCARD az_result az_iot_message_properties_next(
   {
     *out_name = AZ_SPAN_NULL;
     *out_value = AZ_SPAN_NULL;
-    return AZ_ERROR_UNEXPECTED_END;
+    return AZ_ERROR_IOT_NO_MORE_PROPERTIES;
   }
 
   az_span remainder;

--- a/sdk/tests/iot/common/test_az_iot_common.c
+++ b/sdk/tests/iot/common/test_az_iot_common.c
@@ -613,6 +613,8 @@ static void test_az_iot_message_properties_next_succeed(void** state)
       (size_t)az_span_size(test_value_three));
 
   assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
+  //Call again to show subsequent calls do nothing
+  assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
 }
 
 static void test_az_iot_message_properties_next_twice_succeed(void** state)

--- a/sdk/tests/iot/common/test_az_iot_common.c
+++ b/sdk/tests/iot/common/test_az_iot_common.c
@@ -612,7 +612,7 @@ static void test_az_iot_message_properties_next_succeed(void** state)
       az_span_ptr(test_value_three),
       (size_t)az_span_size(test_value_three));
 
-  assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_UNEXPECTED_END);
+  assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
 }
 
 static void test_az_iot_message_properties_next_twice_succeed(void** state)
@@ -643,7 +643,7 @@ static void test_az_iot_message_properties_next_twice_succeed(void** state)
       az_span_ptr(test_value_two),
       (size_t)az_span_size(test_value_two));
 
-  assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_UNEXPECTED_END);
+  assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
 
   // Reset to beginning of span
   assert_int_equal(
@@ -665,7 +665,7 @@ static void test_az_iot_message_properties_next_twice_succeed(void** state)
       az_span_ptr(test_value_two),
       (size_t)az_span_size(test_value_two));
 
-  assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_UNEXPECTED_END);
+  assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
 }
 
 static void test_az_iot_message_properties_next_empty_succeed(void** state)
@@ -678,7 +678,7 @@ static void test_az_iot_message_properties_next_empty_succeed(void** state)
   az_span name;
   az_span value;
 
-  assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_UNEXPECTED_END);
+  assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
 }
 
 #ifdef _MSC_VER


### PR DESCRIPTION
The return value of `az_iot_message_properties_next()` in this case is expected and should have a return value to express that.