### PR TITLE
Add the doxygen warning log to gitignore and remove --all when fetching.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -303,6 +303,7 @@ build/
 
 #Doxygen
 /[Dd]ocs/
+DoxygenWarningLog.txt
 
 # VS Code Files
 .vscode

--- a/eng/pipelines/templates/steps/vcpkg.yml
+++ b/eng/pipelines/templates/steps/vcpkg.yml
@@ -72,7 +72,7 @@ steps:
         git rev-parse --verify HEAD
 
         # Make sure to fetch all the tags to avoid failures on checkout.
-        git fetch --all --tags
+        git fetch --tags
 
         git checkout ${{ parameters.VcpkgVersion }}
         git status
@@ -113,7 +113,7 @@ steps:
         git pull origin master
 
         # Make sure to fetch all the tags to avoid failures on checkout.
-        git fetch --all --tags
+        git fetch --tags
 
         git checkout ${{ parameters.VcpkgVersion }}
 


### PR DESCRIPTION
Fixing based on @weshaggard recommmendation: https://github.com/Azure/azure-sdk-for-c/pull/1143#discussion_r477977213

@danieljurek - I can't move the warning log to `docs/` because that folder may not exists at the time of running doxygen, since it seems to be created near the end of the generation step. Because of that the file doesn't get written in that folder. So, just adding it to `.gitignore`.