### PR TITLE
Do not differentiate between empty and null span - rename macro.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Rename `az_iot_hub_client_properties` to `az_iot_message_properties` and move it from `az_iot_hub_client.h` to `az_iot_common.h`.
 - Remove `az_pair` from `az_iot_message_properties_next()` in favor of individual name and value `az_span` parameters.
 - In `az_result.h`, rename `az_failed()` to `az_result_failed()` and `az_succeeded()` to `az_result_succeeded()`.
+- Renamed the macro `AZ_SPAN_NULL` to `AZ_SPAN_EMPTY`.
 
 ### Bug Fixes
 

--- a/sdk/docs/core/README.md
+++ b/sdk/docs/core/README.md
@@ -25,10 +25,10 @@ Our SDK passes `az_span` instances to functions to ensure that a buffer’s addr
 
 Since many of our SDK functions require `az_span` parameters, customers must know how to create `az_span` instances so that you can call functions in our SDK. Here are some examples.
 
-Create an empty (or NULL) `az_span`:
+Create an empty `az_span`:
 
 ```C
-az_span span_null = AZ_SPAN_NULL; // size = 0
+az_span empty_span = AZ_SPAN_EMPTY; // size = 0
 ```
 
 Create an `az_span` expression from a byte buffer:

--- a/sdk/inc/azure/core/az_credentials.h
+++ b/sdk/inc/azure/core/az_credentials.h
@@ -120,7 +120,7 @@ typedef struct
  * @param[in] tenant_id An Azure tenant ID.
  * @param[in] client_id An Azure client ID.
  * @param[in] client_secret An Azure client secret.
- * @param[in] authority Authentication authority URL to set. Passing #AZ_SPAN_NULL initializes
+ * @param[in] authority Authentication authority URL to set. Passing #AZ_SPAN_EMPTY initializes
  * credential with default authority (Azure AD global authority -
  * "https://login.microsoftonline.com/")
  *

--- a/sdk/inc/azure/core/az_http.h
+++ b/sdk/inc/azure/core/az_http.h
@@ -188,7 +188,7 @@ az_http_response_init(az_http_response* out_response, az_span buffer)
       .http_response = buffer,
       .written = 0,
       .parser = {
-        .remaining = AZ_SPAN_NULL,
+        .remaining = AZ_SPAN_EMPTY,
         .next_kind = _az_HTTP_RESPONSE_KIND_STATUS_LINE,
       },
     },

--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -73,9 +73,11 @@ typedef struct
 
   /// This read-only field gives access to the slice of the JSON text that represents the token
   /// value, and it shouldn't be modified by the caller.
-  /// If the token straddles non-contiguous buffers, this is set to #AZ_SPAN_EMPTY.
+  /// If the token straddles non-contiguous buffers, this is set to the partial token value
+  /// available in the last segment.
   /// The user can call #az_json_token_copy_into_span() to get the token value into a contiguous
-  /// buffer. In the case of JSON strings, the slice does not include the surrounding quotes.
+  /// buffer.
+  /// In the case of JSON strings, the slice does not include the surrounding quotes.
   az_span slice;
 
   /// This read-only field gives access to the size of the JSON text slice that represents the token

--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -73,7 +73,7 @@ typedef struct
 
   /// This read-only field gives access to the slice of the JSON text that represents the token
   /// value, and it shouldn't be modified by the caller.
-  /// If the token straddles non-contiguous buffers, this is set to #AZ_SPAN_NULL.
+  /// If the token straddles non-contiguous buffers, this is set to #AZ_SPAN_EMPTY.
   /// The user can call #az_json_token_copy_into_span() to get the token value into a contiguous
   /// buffer. In the case of JSON strings, the slice does not include the surrounding quotes.
   az_span slice;
@@ -91,7 +91,7 @@ typedef struct
     bool string_has_escaped_chars;
 
     /// This is the first segment in the entire JSON payload, if it was non-contiguous. Otherwise,
-    /// its set to #AZ_SPAN_NULL.
+    /// its set to #AZ_SPAN_EMPTY.
     az_span* pointer_to_first_buffer;
 
     /// The segment index within the non-contiguous JSON payload where this token starts.
@@ -385,7 +385,7 @@ az_json_writer_get_bytes_used_in_destination(az_json_writer const* json_writer)
  * @param[in] value The UTF-8 encoded value to be written as a JSON string. The value is escaped
  * before writing.
  *
- * @remarks If \p value is #AZ_SPAN_NULL, the empty JSON string value is written (i.e. "").
+ * @remarks If \p value is #AZ_SPAN_EMPTY, the empty JSON string value is written (i.e. "").
  *
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The string value was appended successfully.

--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -86,6 +86,11 @@ typedef struct
 
   struct
   {
+    /// A flag to indicate whether the JSON token straddles more than one buffer segment and is
+    /// split amongst non-contiguous buffers. For tokens created from input JSON payloads within a
+    /// contiguous buffer, this field is always false.
+    bool is_multisegment;
+
     /// A flag to indicate whether the JSON string contained any escaped characters, used as an
     /// optimization to avoid redundant checks. It is meaningless for any other token kind.
     bool string_has_escaped_chars;

--- a/sdk/inc/azure/core/az_span.h
+++ b/sdk/inc/azure/core/az_span.h
@@ -77,10 +77,13 @@ AZ_NODISCARD az_span az_span_create(uint8_t* ptr, int32_t size);
 
 /**
  * @brief An empty #az_span.
+ *
+ * @remark There is no guarantee that the pointer backing this span will be `NULL` and the caller
+ * shouldn't rely on it. However, the size will be 0.
  */
 // When updating this macro, also update AZ_PAIR_NULL, which should be using this macro, but can't
 // due to warnings, and so it is using an expansion of this macro instead.
-#define AZ_SPAN_NULL \
+#define AZ_SPAN_EMPTY \
   (az_span) \
   { \
     ._internal = {.ptr = NULL, .size = 0 } \
@@ -275,7 +278,7 @@ AZ_NODISCARD int32_t az_span_find(az_span source, az_span target);
  * source.
  *
  * @remarks This function copies all of \p source into the \p destination even if they overlap.
- * @remarks If \p source is an empty #az_span or #AZ_SPAN_NULL, this function will just return
+ * @remarks If \p source is an empty #az_span or #AZ_SPAN_EMPTY, this function will just return
  * \p destination.
  */
 az_span az_span_copy(az_span destination, az_span source);
@@ -536,7 +539,7 @@ typedef struct
 } az_pair;
 
 /**
- * @brief An #az_pair instance whose key and value fields are initialized to #AZ_SPAN_NULL.
+ * @brief An #az_pair instance whose key and value fields are initialized to #AZ_SPAN_EMPTY.
  */
 #define AZ_PAIR_NULL \
   (az_pair) \

--- a/sdk/inc/azure/core/internal/az_http_internal.h
+++ b/sdk/inc/azure/core/internal/az_http_internal.h
@@ -67,8 +67,8 @@ _az_http_policy_apiversion_options_default()
 {
   return (_az_http_policy_apiversion_options){
     ._internal = { .option_location = _az_http_policy_apiversion_option_location_header,
-                   .name = AZ_SPAN_NULL,
-                   .version = AZ_SPAN_NULL }
+                   .name = AZ_SPAN_EMPTY,
+                   .version = AZ_SPAN_EMPTY }
   };
 }
 
@@ -168,7 +168,7 @@ AZ_NODISCARD AZ_INLINE az_result _az_http_pipeline_nextpolicy(
  * @param[in] url_length The size of the initial url value within url #az_span.
  * @param[in] headers_buffer The #az_span to be used for storing headers for the request. The total
  * number of headers are calculated automatically based on the size of the buffer.
- * @param[in] body The #az_span buffer that contains a payload for the request. Use #AZ_SPAN_NULL
+ * @param[in] body The #az_span buffer that contains a payload for the request. Use #AZ_SPAN_EMPTY
  * for requests that don't have a body.
  *
  * @return

--- a/sdk/inc/azure/core/internal/az_span_internal.h
+++ b/sdk/inc/azure/core/internal/az_span_internal.h
@@ -69,7 +69,7 @@ AZ_NODISCARD int32_t _az_span_url_encode_calc_length(az_span source);
  *
  * @return The #az_span pointing to the token delimited by the beginning of `source` up to the first
  * occurrence of (but not including the) `delimiter`, or the end of `source` if `delimiter` is not
- * found. If `source` is empty, AZ_SPAN_EMPTY is returned instead.
+ * found. If `source` is empty, #AZ_SPAN_EMPTY is returned instead.
  */
 az_span _az_span_token(
     az_span source,

--- a/sdk/inc/azure/core/internal/az_span_internal.h
+++ b/sdk/inc/azure/core/internal/az_span_internal.h
@@ -66,7 +66,7 @@ AZ_NODISCARD int32_t _az_span_url_encode_calc_length(az_span source);
  * `out_remainder` is set to an empty #az_span.
  * @return The #az_span pointing to the token delimited by the beginning of `source` up to the first
  * occurrence of (but not including the) `delimiter`, or the end of `source` if `delimiter` is not
- * found. If `source` is empty, AZ_SPAN_NULL is returned instead.
+ * found. If `source` is empty, AZ_SPAN_EMPTY is returned instead.
  */
 AZ_NODISCARD az_span _az_span_token(az_span source, az_span delimiter, az_span* out_remainder);
 

--- a/sdk/inc/azure/core/internal/az_span_internal.h
+++ b/sdk/inc/azure/core/internal/az_span_internal.h
@@ -64,11 +64,18 @@ AZ_NODISCARD int32_t _az_span_url_encode_calc_length(az_span source);
  * @param[out] out_remainder The #az_span pointing to the remaining bytes in `source`, starting
  * after the occurrence of `delimiter`. If the position after `delimiter` is the end of `source`,
  * `out_remainder` is set to an empty #az_span.
+ * @param[out] out_index The position of \p delimiter in \p source if \p source contains the \p
+ * delimiter within it. Otherwise, it is set to -1.
+ *
  * @return The #az_span pointing to the token delimited by the beginning of `source` up to the first
  * occurrence of (but not including the) `delimiter`, or the end of `source` if `delimiter` is not
  * found. If `source` is empty, AZ_SPAN_EMPTY is returned instead.
  */
-AZ_NODISCARD az_span _az_span_token(az_span source, az_span delimiter, az_span* out_remainder);
+az_span _az_span_token(
+    az_span source,
+    az_span delimiter,
+    az_span* out_remainder,
+    int32_t* out_index);
 
 #include <azure/core/_az_cfg_suffix.h>
 

--- a/sdk/inc/azure/storage/az_storage_blobs.h
+++ b/sdk/inc/azure/storage/az_storage_blobs.h
@@ -128,7 +128,7 @@ AZ_NODISCARD AZ_INLINE az_storage_blobs_blob_upload_options
 az_storage_blobs_blob_upload_options_default()
 {
   return (az_storage_blobs_blob_upload_options){ .context = &az_context_application,
-                                                 ._internal = { .unused = AZ_SPAN_NULL } };
+                                                 ._internal = { .unused = AZ_SPAN_EMPTY } };
 }
 
 /**

--- a/sdk/samples/iot/aziot_esp8266/aziot_esp8266.ino
+++ b/sdk/samples/iot/aziot_esp8266/aziot_esp8266.ino
@@ -177,7 +177,7 @@ static int generateSasToken(char* sas_token, size_t size)
           &client,
           b64enc_hmacsha256_signature_span,
           expiration,
-          AZ_SPAN_NULL,
+          AZ_SPAN_EMPTY,
           sas_token,
           size,
           NULL)))

--- a/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
@@ -25,9 +25,9 @@
 #include <azure/core/az_span.h>
 #include <azure/iot/az_iot_hub_client.h>
 
-#include "pnp/pnp_protocol.h"
 #include "pnp/pnp_device_info_component.h"
 #include "pnp/pnp_mqtt_message.h"
+#include "pnp/pnp_protocol.h"
 #include "pnp/pnp_thermostat_component.h"
 
 #define SAMPLE_TYPE PAHO_IOT_HUB
@@ -962,7 +962,7 @@ static void property_callback(
   az_result rc;
   (void)user_context_callback;
 
-  if (az_span_ptr(component_name) == NULL || az_span_size(component_name) == 0)
+  if (az_span_size(component_name) == 0)
   {
     IOT_SAMPLE_LOG_ERROR(
         "Temperature Controller does not support writable property \"%.*s\". All writeable "

--- a/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
@@ -494,7 +494,7 @@ static void send_device_serial_number(void)
   // Build the serial number reported property message.
   rc = pnp_create_reported_property(
       mqtt_message.payload_span,
-      AZ_SPAN_NULL,
+      AZ_SPAN_EMPTY,
       reported_serial_num_property_name,
       append_string_callback,
       (void*)&reported_serial_num_property_value,
@@ -532,7 +532,7 @@ static void request_device_twin_document(void)
   }
 
   // Publish the twin document request.
-  mqtt_publish_message(mqtt_message.topic, AZ_SPAN_NULL, MQTT_PUBLISH_QOS);
+  mqtt_publish_message(mqtt_message.topic, AZ_SPAN_EMPTY, MQTT_PUBLISH_QOS);
   IOT_SAMPLE_LOG_SUCCESS("Client requested twin document.");
   IOT_SAMPLE_LOG(" "); // Formatting.
 
@@ -898,7 +898,7 @@ static az_result temp_controller_get_telemetry_message(pnp_mqtt_message* message
 
   // Get the Telemetry topic to publish the telemetry messages.
   rc = pnp_get_telemetry_topic(
-      &hub_client, NULL, AZ_SPAN_NULL, message->topic, message->topic_length, NULL);
+      &hub_client, NULL, AZ_SPAN_EMPTY, message->topic, message->topic_length, NULL);
   if (az_result_failed(rc))
   {
     IOT_SAMPLE_LOG_ERROR(

--- a/sdk/samples/iot/paho_iot_hub_pnp_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_pnp_sample.c
@@ -852,17 +852,18 @@ static az_result invoke_getMaxMinReport(
       command_start_time_value_buffer,
       sizeof(command_start_time_value_buffer),
       &incoming_since_value_len));
-  az_span start_time_span
-      = az_span_create((uint8_t*)command_start_time_value_buffer, incoming_since_value_len);
-
-  IOT_SAMPLE_LOG_AZ_SPAN("start time:", start_time_span);
 
   // Set the response payload to error if the "since" value was empty.
-  if (az_span_ptr(start_time_span) == NULL)
+  if (incoming_since_value_len == 0)
   {
     *out_response = command_empty_response_payload;
     return AZ_ERROR_ITEM_NOT_FOUND;
   }
+
+  az_span start_time_span
+      = az_span_create((uint8_t*)command_start_time_value_buffer, incoming_since_value_len);
+
+  IOT_SAMPLE_LOG_AZ_SPAN("start time:", start_time_span);
 
   // Get the current time as a string.
   time_t rawtime;

--- a/sdk/samples/iot/paho_iot_hub_pnp_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_pnp_sample.c
@@ -400,7 +400,7 @@ static void request_device_twin_document(void)
   }
 
   // Publish the twin document request.
-  mqtt_publish_message(twin_document_topic_buffer, AZ_SPAN_NULL, SAMPLE_PUBLISH_QOS);
+  mqtt_publish_message(twin_document_topic_buffer, AZ_SPAN_EMPTY, SAMPLE_PUBLISH_QOS);
 }
 
 static void receive_messages(void)

--- a/sdk/samples/iot/paho_iot_hub_sas_telemetry_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_sas_telemetry_sample.c
@@ -261,7 +261,7 @@ static void generate_sas_key(void)
       &hub_client,
       sas_base64_encoded_signed_signature,
       sas_duration,
-      AZ_SPAN_NULL,
+      AZ_SPAN_EMPTY,
       mqtt_password_buffer,
       sizeof(mqtt_password_buffer),
       &mqtt_password_length);

--- a/sdk/samples/iot/paho_iot_provisioning_sas_sample.c
+++ b/sdk/samples/iot/paho_iot_provisioning_sas_sample.c
@@ -430,7 +430,7 @@ static void generate_sas_key(void)
       &provisioning_client,
       sas_base64_encoded_signed_signature,
       sas_duration,
-      AZ_SPAN_NULL,
+      AZ_SPAN_EMPTY,
       mqtt_password_buffer,
       sizeof(mqtt_password_buffer),
       &mqtt_password_length);

--- a/sdk/samples/iot/pnp/pnp_protocol.c
+++ b/sdk/samples/iot/pnp/pnp_protocol.c
@@ -124,7 +124,7 @@ static az_result is_component_in_model(
 {
   int32_t index = 0;
 
-  if (az_span_ptr(component_name) == NULL || az_span_size(component_name) == 0)
+  if (az_span_size(component_name) == 0)
   {
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
@@ -154,7 +154,7 @@ az_result pnp_get_telemetry_topic(
 {
   az_iot_message_properties pnp_properties;
 
-  if (az_span_ptr(component_name) != NULL)
+  if (az_span_size(component_name) != 0)
   {
     if (properties == NULL)
     {
@@ -170,7 +170,7 @@ az_result pnp_get_telemetry_topic(
 
   AZ_RETURN_IF_FAILED(az_iot_hub_client_telemetry_get_publish_topic(
       client,
-      az_span_ptr(component_name) != NULL ? properties : NULL,
+      az_span_size(component_name) != 0 ? properties : NULL,
       mqtt_topic,
       mqtt_topic_size,
       out_mqtt_topic_length));
@@ -212,7 +212,7 @@ az_result pnp_create_reported_property(
 
   AZ_RETURN_IF_FAILED(az_json_writer_append_begin_object(&jw));
 
-  if (az_span_ptr(component_name) != NULL)
+  if (az_span_size(component_name) != 0)
   {
     AZ_RETURN_IF_FAILED(az_json_writer_append_property_name(&jw, component_name));
     AZ_RETURN_IF_FAILED(az_json_writer_append_begin_object(&jw));
@@ -223,7 +223,7 @@ az_result pnp_create_reported_property(
   AZ_RETURN_IF_FAILED(az_json_writer_append_property_name(&jw, property_name));
   AZ_RETURN_IF_FAILED(append_callback(&jw, context));
 
-  if (az_span_ptr(component_name) != NULL)
+  if (az_span_size(component_name) != 0)
   {
     AZ_RETURN_IF_FAILED(az_json_writer_append_end_object(&jw));
   }
@@ -251,7 +251,7 @@ az_result pnp_create_reported_property_with_status(
 
   AZ_RETURN_IF_FAILED(az_json_writer_init(&jw, json_buffer, NULL));
   AZ_RETURN_IF_FAILED(az_json_writer_append_begin_object(&jw));
-  if (az_span_ptr(component_name) != NULL)
+  if (az_span_size(component_name) != NULL)
   {
     AZ_RETURN_IF_FAILED(az_json_writer_append_property_name(&jw, component_name));
     AZ_RETURN_IF_FAILED(az_json_writer_append_begin_object(&jw));
@@ -268,7 +268,7 @@ az_result pnp_create_reported_property_with_status(
   AZ_RETURN_IF_FAILED(az_json_writer_append_property_name(&jw, desired_temp_ack_version_name));
   AZ_RETURN_IF_FAILED(az_json_writer_append_int32(&jw, ack_version));
 
-  if (az_span_ptr(ack_description) != NULL)
+  if (az_span_size(ack_description) != 0)
   {
     AZ_RETURN_IF_FAILED(
         az_json_writer_append_property_name(&jw, desired_temp_ack_description_name));
@@ -278,7 +278,7 @@ az_result pnp_create_reported_property_with_status(
   AZ_RETURN_IF_FAILED(az_json_writer_append_end_object(&jw));
   AZ_RETURN_IF_FAILED(az_json_writer_append_end_object(&jw));
 
-  if (az_span_ptr(component_name) != NULL)
+  if (az_span_size(component_name) != 0)
   {
     AZ_RETURN_IF_FAILED(az_json_writer_append_end_object(&jw));
   }

--- a/sdk/samples/iot/pnp/pnp_thermostat_component.c
+++ b/sdk/samples/iot/pnp/pnp_thermostat_component.c
@@ -7,9 +7,9 @@
 #pragma warning(disable : 4996)
 #endif
 
-#include <iot_sample_common.h>
-#include "pnp_protocol.h"
 #include "pnp_mqtt_message.h"
+#include "pnp_protocol.h"
+#include <iot_sample_common.h>
 
 #include "pnp_thermostat_component.h"
 
@@ -118,15 +118,16 @@ static az_result invoke_getMaxMinReport(
       incoming_since_value_buffer,
       sizeof(incoming_since_value_buffer),
       &incoming_since_value_buffer_len));
-  start_time_span
-      = az_span_create((uint8_t*)incoming_since_value_buffer, incoming_since_value_buffer_len);
 
   // Set the response payload to error if the "since" field was not sent
-  if (az_span_ptr(start_time_span) == NULL)
+  if (incoming_since_value_buffer_len == 0)
   {
     response = report_error_payload;
     return AZ_ERROR_ITEM_NOT_FOUND;
   }
+
+  start_time_span
+      = az_span_create((uint8_t*)incoming_since_value_buffer, incoming_since_value_buffer_len);
 
   // Get the current time as a string
   time_t rawtime;

--- a/sdk/samples/iot/sample_pnp.c
+++ b/sdk/samples/iot/sample_pnp.c
@@ -193,7 +193,7 @@ void pnp_parse_command_name(
   }
   else
   {
-    *component_name = AZ_SPAN_NULL;
+    *component_name = AZ_SPAN_EMPTY;
     *pnp_command_name = component_command;
   }
 }
@@ -356,7 +356,7 @@ az_result pnp_process_device_twin_message(
       }
       else
       {
-        property_callback(AZ_SPAN_NULL, &property_name, jr, version, context_ptr);
+        property_callback(AZ_SPAN_EMPTY, &property_name, jr, version, context_ptr);
       }
     }
     else if (jr.token.kind == AZ_JSON_TOKEN_BEGIN_OBJECT)

--- a/sdk/samples/iot/sample_pnp_thermostat_component.c
+++ b/sdk/samples/iot/sample_pnp_thermostat_component.c
@@ -108,7 +108,7 @@ static az_result invoke_getMaxMinReport(
 {
   // az_result result;
   // Parse the "since" field in the payload.
-  az_span start_time_span = AZ_SPAN_NULL;
+  az_span start_time_span = AZ_SPAN_EMPTY;
   az_json_reader jr;
   AZ_RETURN_IF_FAILED(az_json_reader_init(&jr, payload, NULL));
   AZ_RETURN_IF_FAILED(az_json_reader_next_token(&jr));

--- a/sdk/src/azure/core/az_json_reader.c
+++ b/sdk/src/azure/core/az_json_reader.c
@@ -25,6 +25,7 @@ AZ_NODISCARD az_result az_json_reader_init(
       .slice = AZ_SPAN_EMPTY,
       .size = 0,
       ._internal = {
+        .is_multisegment = false,
         .string_has_escaped_chars = false,
         .pointer_to_first_buffer = &AZ_SPAN_EMPTY,
         .start_buffer_index = -1,
@@ -63,6 +64,7 @@ AZ_NODISCARD az_result az_json_reader_chunked_init(
       .slice = AZ_SPAN_EMPTY,
       .size = 0,
       ._internal = {
+        .is_multisegment = false,
         .string_has_escaped_chars = false,
         .pointer_to_first_buffer = json_buffers,
         .start_buffer_index = -1,
@@ -111,16 +113,16 @@ static void _az_json_reader_update_state(
   ref_json_reader->token._internal.end_buffer_index = ref_json_reader->_internal.buffer_index;
   ref_json_reader->token._internal.end_buffer_offset = ref_json_reader->_internal.bytes_consumed;
 
+  ref_json_reader->token._internal.is_multisegment = false;
+
   // Token straddles more than one segment
   int32_t start_index = ref_json_reader->token._internal.start_buffer_index;
   if (start_index != -1 && start_index < ref_json_reader->token._internal.end_buffer_index)
   {
-    ref_json_reader->token.slice = AZ_SPAN_EMPTY;
+    ref_json_reader->token._internal.is_multisegment = true;
   }
-  else
-  {
-    ref_json_reader->token.slice = token_slice;
-  }
+
+  ref_json_reader->token.slice = token_slice;
 }
 
 AZ_NODISCARD static az_result _az_json_reader_get_next_buffer(

--- a/sdk/src/azure/core/az_json_reader.c
+++ b/sdk/src/azure/core/az_json_reader.c
@@ -22,11 +22,11 @@ AZ_NODISCARD az_result az_json_reader_init(
   *out_json_reader = (az_json_reader){
     .token = (az_json_token){
       .kind = AZ_JSON_TOKEN_NONE,
-      .slice = AZ_SPAN_NULL,
+      .slice = AZ_SPAN_EMPTY,
       .size = 0,
       ._internal = {
         .string_has_escaped_chars = false,
-        .pointer_to_first_buffer = &AZ_SPAN_NULL,
+        .pointer_to_first_buffer = &AZ_SPAN_EMPTY,
         .start_buffer_index = -1,
         .start_buffer_offset = -1,
         .end_buffer_index = -1,
@@ -35,7 +35,7 @@ AZ_NODISCARD az_result az_json_reader_init(
     },
     ._internal = {
       .json_buffer = json_buffer,
-      .json_buffers = &AZ_SPAN_NULL,
+      .json_buffers = &AZ_SPAN_EMPTY,
       .number_of_buffers = 1,
       .buffer_index = 0,
       .bytes_consumed = 0,
@@ -60,7 +60,7 @@ AZ_NODISCARD az_result az_json_reader_chunked_init(
   *out_json_reader = (az_json_reader){
     .token = (az_json_token){
       .kind = AZ_JSON_TOKEN_NONE,
-      .slice = AZ_SPAN_NULL,
+      .slice = AZ_SPAN_EMPTY,
       .size = 0,
       ._internal = {
         .string_has_escaped_chars = false,
@@ -115,7 +115,7 @@ static void _az_json_reader_update_state(
   int32_t start_index = ref_json_reader->token._internal.start_buffer_index;
   if (start_index != -1 && start_index < ref_json_reader->token._internal.end_buffer_index)
   {
-    ref_json_reader->token.slice = AZ_SPAN_NULL;
+    ref_json_reader->token.slice = AZ_SPAN_EMPTY;
   }
   else
   {

--- a/sdk/src/azure/core/az_json_token.c
+++ b/sdk/src/azure/core/az_json_token.c
@@ -130,21 +130,21 @@ AZ_NODISCARD static bool _az_json_token_is_text_equal_helper(
       // To do this, we need to encode UTF-16 codepoints (including surrogate pairs) into UTF-8.
       if (token_byte == 'u')
       {
-        *expected_text = AZ_SPAN_NULL;
+        *expected_text = AZ_SPAN_EMPTY;
         return false;
       }
     }
 
     if (token_byte != expected_ptr[i])
     {
-      *expected_text = AZ_SPAN_NULL;
+      *expected_text = AZ_SPAN_EMPTY;
       return false;
     }
 
     token_idx++;
   }
 
-  *expected_text = AZ_SPAN_NULL;
+  *expected_text = AZ_SPAN_EMPTY;
 
   // Only return true if the size of the unescaped token matches the expected size exactly.
   return token_idx == token_size;

--- a/sdk/src/azure/core/az_json_token.c
+++ b/sdk/src/azure/core/az_json_token.c
@@ -16,7 +16,7 @@ static az_span _az_json_token_copy_into_span_helper(
     az_json_token const* json_token,
     az_span destination)
 {
-  _az_PRECONDITION_IS_NULL(az_span_ptr(json_token->slice));
+  _az_PRECONDITION(json_token->_internal.is_multisegment);
 
   if (json_token->size == 0)
   {
@@ -49,7 +49,7 @@ az_span az_json_token_copy_into_span(az_json_token const* json_token, az_span de
   az_span token_slice = json_token->slice;
 
   // Contiguous token
-  if (az_span_ptr(token_slice) != NULL)
+  if (!json_token->_internal.is_multisegment)
   {
     return az_span_copy(destination, token_slice);
   }
@@ -168,7 +168,7 @@ AZ_NODISCARD bool az_json_token_is_text_equal(
   if (!json_token->_internal.string_has_escaped_chars)
   {
     // Contiguous token
-    if (az_span_ptr(token_slice) != NULL)
+    if (!json_token->_internal.is_multisegment)
     {
       return az_span_is_content_equal(token_slice, expected_text);
     }
@@ -214,7 +214,7 @@ AZ_NODISCARD bool az_json_token_is_text_equal(
   bool next_char_escaped = false;
 
   // Contiguous token
-  if (az_span_ptr(token_slice) != NULL)
+  if (!json_token->_internal.is_multisegment)
   {
     return _az_json_token_is_text_equal_helper(token_slice, &expected_text, &next_char_escaped);
   }
@@ -235,14 +235,14 @@ AZ_NODISCARD bool az_json_token_is_text_equal(
     }
 
     if (!_az_json_token_is_text_equal_helper(source, &expected_text, &next_char_escaped)
-        && az_span_ptr(expected_text) == NULL)
+        && az_span_size(expected_text) == 0)
     {
       return false;
     }
   }
 
   // Only return true if we have gone through and compared the entire expected_text.
-  return az_span_ptr(expected_text) == NULL;
+  return az_span_size(expected_text) == 0;
 }
 
 AZ_NODISCARD az_result az_json_token_get_boolean(az_json_token const* json_token, bool* out_value)
@@ -263,7 +263,7 @@ AZ_NODISCARD az_result az_json_token_get_boolean(az_json_token const* json_token
   az_span token_slice = json_token->slice;
 
   // Contiguous token
-  if (az_span_ptr(token_slice) != NULL)
+  if (!json_token->_internal.is_multisegment)
   {
     *out_value = az_span_size(token_slice) == _az_STRING_LITERAL_LEN("true");
   }
@@ -355,7 +355,7 @@ AZ_NODISCARD az_result az_json_token_get_string(
     }
 
     // Contiguous token
-    if (az_span_ptr(token_slice) != NULL)
+    if (!json_token->_internal.is_multisegment)
     {
       // This will add a null terminator.
       az_span_to_str(destination, destination_max_size, token_slice);
@@ -389,7 +389,7 @@ AZ_NODISCARD az_result az_json_token_get_string(
   bool next_char_escaped = false;
 
   // Contiguous token
-  if (az_span_ptr(token_slice) != NULL)
+  if (!json_token->_internal.is_multisegment)
   {
     AZ_RETURN_IF_FAILED(_az_json_token_get_string_helper(
         token_slice, destination, destination_max_size, &dest_idx, &next_char_escaped));
@@ -444,7 +444,7 @@ az_json_token_get_uint64(az_json_token const* json_token, uint64_t* out_value)
   az_span token_slice = json_token->slice;
 
   // Contiguous token
-  if (az_span_ptr(token_slice) != NULL)
+  if (!json_token->_internal.is_multisegment)
   {
     return az_span_atou64(token_slice, out_value);
   }
@@ -477,7 +477,7 @@ az_json_token_get_uint32(az_json_token const* json_token, uint32_t* out_value)
   az_span token_slice = json_token->slice;
 
   // Contiguous token
-  if (az_span_ptr(token_slice) != NULL)
+  if (!json_token->_internal.is_multisegment)
   {
     return az_span_atou32(token_slice, out_value);
   }
@@ -509,7 +509,7 @@ AZ_NODISCARD az_result az_json_token_get_int64(az_json_token const* json_token, 
   az_span token_slice = json_token->slice;
 
   // Contiguous token
-  if (az_span_ptr(token_slice) != NULL)
+  if (!json_token->_internal.is_multisegment)
   {
     return az_span_atoi64(token_slice, out_value);
   }
@@ -541,7 +541,7 @@ AZ_NODISCARD az_result az_json_token_get_int32(az_json_token const* json_token, 
   az_span token_slice = json_token->slice;
 
   // Contiguous token
-  if (az_span_ptr(token_slice) != NULL)
+  if (!json_token->_internal.is_multisegment)
   {
     return az_span_atoi32(token_slice, out_value);
   }
@@ -573,7 +573,7 @@ AZ_NODISCARD az_result az_json_token_get_double(az_json_token const* json_token,
   az_span token_slice = json_token->slice;
 
   // Contiguous token
-  if (az_span_ptr(token_slice) != NULL)
+  if (!json_token->_internal.is_multisegment)
   {
     return az_span_atod(token_slice, out_value);
   }

--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -81,7 +81,7 @@ _get_remaining_span(az_json_writer* ref_json_writer, int32_t required_size)
     // AZ_ERROR_INSUFFICIENT_SPAN_SIZE
     if (!az_result_succeeded(ref_json_writer->_internal.allocator_callback(&context, &remaining)))
     {
-      return AZ_SPAN_NULL;
+      return AZ_SPAN_EMPTY;
     }
     ref_json_writer->_internal.destination_buffer = remaining;
     ref_json_writer->_internal.bytes_written = 0;
@@ -555,7 +555,7 @@ az_json_writer_append_string_chunked(az_json_writer* ref_json_writer, az_span va
 AZ_NODISCARD az_result az_json_writer_append_string(az_json_writer* ref_json_writer, az_span value)
 {
   _az_PRECONDITION_NOT_NULL(ref_json_writer);
-  // A null span is allowed, and we write an empty JSON string for it.
+  // An empty span is allowed, and we write an empty JSON string for it.
   _az_PRECONDITION_VALID_SPAN(value, 0, true);
   _az_PRECONDITION(az_span_size(value) <= _az_MAX_UNESCAPED_STRING_SIZE);
   _az_PRECONDITION(_az_is_appending_value_valid(ref_json_writer));

--- a/sdk/src/azure/core/az_log.c
+++ b/sdk/src/azure/core/az_log.c
@@ -4,11 +4,11 @@
 #include "az_span_private.h"
 #include <azure/core/az_config.h>
 #include <azure/core/az_http.h>
-#include <azure/core/internal/az_http_internal.h>
 #include <azure/core/az_http_transport.h>
 #include <azure/core/az_log.h>
-#include <azure/core/internal/az_log_internal.h>
 #include <azure/core/az_span.h>
+#include <azure/core/internal/az_http_internal.h>
+#include <azure/core/internal/az_log_internal.h>
 
 #include <stddef.h>
 
@@ -78,7 +78,7 @@ static bool _az_log_write_engine(bool log_it, az_log_classification classificati
 // This function returns whether or not the passed-in message should be logged.
 bool _az_log_should_write(az_log_classification classification)
 {
-  return _az_log_write_engine(false, classification, AZ_SPAN_NULL);
+  return _az_log_write_engine(false, classification, AZ_SPAN_EMPTY);
 }
 
 // This function attempts to log the passed-in message.

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -42,7 +42,7 @@ AZ_NODISCARD az_span az_span_create_from_str(char* str)
   // Avoid passing in null pointer to strlen to avoid memory access violation.
   if (str == NULL)
   {
-    return AZ_SPAN_NULL;
+    return AZ_SPAN_EMPTY;
   }
 
   int32_t const length = (int32_t)strlen(str);
@@ -982,7 +982,7 @@ AZ_NODISCARD az_span _az_span_token(az_span source, az_span delimiter, az_span* 
 
   if (az_span_size(source) == 0)
   {
-    return AZ_SPAN_NULL;
+    return AZ_SPAN_EMPTY;
   }
 
   int32_t index = az_span_find(source, delimiter);
@@ -995,7 +995,7 @@ AZ_NODISCARD az_span _az_span_token(az_span source, az_span delimiter, az_span* 
   }
   else
   {
-    *out_remainder = AZ_SPAN_NULL;
+    *out_remainder = AZ_SPAN_EMPTY;
 
     return source;
   }

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -975,28 +975,26 @@ AZ_NODISCARD az_result _az_span_url_encode(az_span destination, az_span source, 
   return AZ_OK;
 }
 
-AZ_NODISCARD az_span _az_span_token(az_span source, az_span delimiter, az_span* out_remainder)
+az_span _az_span_token(
+    az_span source,
+    az_span delimiter,
+    az_span* out_remainder,
+    int32_t* out_index)
 {
+  _az_PRECONDITION_VALID_SPAN(source, 1, false);
   _az_PRECONDITION_VALID_SPAN(delimiter, 1, false);
   _az_PRECONDITION_NOT_NULL(out_remainder);
 
-  if (az_span_size(source) == 0)
+  *out_index = az_span_find(source, delimiter);
+
+  if (*out_index != -1)
   {
-    return AZ_SPAN_EMPTY;
+    *out_remainder
+        = az_span_slice(source, *out_index + az_span_size(delimiter), az_span_size(source));
+
+    return az_span_slice(source, 0, *out_index);
   }
 
-  int32_t index = az_span_find(source, delimiter);
-
-  if (index != -1)
-  {
-    *out_remainder = az_span_slice(source, index + az_span_size(delimiter), az_span_size(source));
-
-    return az_span_slice(source, 0, index);
-  }
-  else
-  {
-    *out_remainder = AZ_SPAN_EMPTY;
-
-    return source;
-  }
+  *out_remainder = AZ_SPAN_EMPTY;
+  return source;
 }

--- a/sdk/src/azure/iot/az_iot_common.c
+++ b/sdk/src/azure/iot/az_iot_common.c
@@ -113,8 +113,8 @@ AZ_NODISCARD az_result az_iot_message_properties_next(
 
   if (index == prop_length)
   {
-    *out_name = AZ_SPAN_NULL;
-    *out_value = AZ_SPAN_NULL;
+    *out_name = AZ_SPAN_EMPTY;
+    *out_value = AZ_SPAN_EMPTY;
     return AZ_ERROR_IOT_NO_MORE_PROPERTIES;
   }
 
@@ -149,7 +149,7 @@ AZ_NODISCARD int32_t az_iot_retry_calc_delay(
   _az_PRECONDITION_RANGE(0, max_retry_delay_msec, INT32_MAX - 1);
   _az_PRECONDITION_RANGE(0, random_msec, INT32_MAX - 1);
 
-  _az_LOG_WRITE(AZ_LOG_IOT_RETRY, AZ_SPAN_NULL);
+  _az_LOG_WRITE(AZ_LOG_IOT_RETRY, AZ_SPAN_EMPTY);
 
   int32_t delay = _az_retry_calc_delay(attempt, min_retry_delay_msec, max_retry_delay_msec);
 

--- a/sdk/src/azure/iot/az_iot_hub_client.c
+++ b/sdk/src/azure/iot/az_iot_hub_client.c
@@ -27,9 +27,9 @@ static const az_span client_sdk_version
 
 AZ_NODISCARD az_iot_hub_client_options az_iot_hub_client_options_default()
 {
-  return (az_iot_hub_client_options){ .module_id = AZ_SPAN_NULL,
+  return (az_iot_hub_client_options){ .module_id = AZ_SPAN_EMPTY,
                                       .user_agent = client_sdk_version,
-                                      .model_id = AZ_SPAN_NULL };
+                                      .model_id = AZ_SPAN_EMPTY };
 }
 
 AZ_NODISCARD az_result az_iot_hub_client_init(

--- a/sdk/src/azure/iot/az_iot_hub_client_c2d.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_c2d.c
@@ -3,10 +3,10 @@
 
 #include <stdint.h>
 
-#include <azure/iot/az_iot_hub_client.h>
 #include <azure/core/az_result.h>
 #include <azure/core/az_span.h>
 #include <azure/core/internal/az_span_internal.h>
+#include <azure/iot/az_iot_hub_client.h>
 
 #include <azure/core/internal/az_log_internal.h>
 #include <azure/core/internal/az_precondition_internal.h>
@@ -25,16 +25,20 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
   _az_PRECONDITION_NOT_NULL(out_request);
   (void)client;
 
-  az_span reminder;
-  az_span token = _az_span_token(received_topic, c2d_topic_suffix, &reminder);
-  if (az_span_ptr(reminder) == NULL)
+  int32_t index = 0;
+  az_span remainder;
+  az_span token = _az_span_token(received_topic, c2d_topic_suffix, &remainder, &index);
+  if (index == -1)
   {
     return AZ_ERROR_IOT_TOPIC_NO_MATCH;
   }
 
   _az_LOG_WRITE(AZ_LOG_MQTT_RECEIVED_TOPIC, received_topic);
 
-  token = _az_span_token(reminder, c2d_topic_suffix, &reminder);
+  token = az_span_size(remainder) == 0
+      ? AZ_SPAN_EMPTY
+      : _az_span_token(remainder, c2d_topic_suffix, &remainder, &index);
+
   AZ_RETURN_IF_FAILED(
       az_iot_message_properties_init(&out_request->properties, token, az_span_size(token)));
 

--- a/sdk/src/azure/iot/az_iot_hub_client_twin.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_twin.c
@@ -129,6 +129,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
         >= 0)
     {
       // Is a res case
+      int32_t index = 0;
       az_span remainder;
       az_span status_str = _az_span_token(
           az_span_slice(
@@ -136,12 +137,18 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
               twin_feature_index + az_span_size(az_iot_hub_twin_response_sub_topic),
               az_span_size(received_topic)),
           AZ_SPAN_FROM_STR("/"),
-          &remainder);
+          &remainder,
+          &index);
 
       // Get status and convert to enum
       uint32_t status_int;
       AZ_RETURN_IF_FAILED(az_span_atou32(status_str, &status_int));
       out_twin_response->status = (az_iot_status)status_int;
+
+      if (index == -1)
+      {
+        return AZ_ERROR_UNEXPECTED_END;
+      }
 
       // Get request id prop value
       az_iot_message_properties props;

--- a/sdk/src/azure/iot/az_iot_hub_client_twin.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_twin.c
@@ -162,7 +162,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
       {
         // Is a twin GET response
         out_twin_response->response_type = AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_GET;
-        out_twin_response->version = AZ_SPAN_NULL;
+        out_twin_response->version = AZ_SPAN_EMPTY;
       }
 
       result = AZ_OK;
@@ -184,7 +184,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
           &props, az_iot_hub_twin_version_prop, &out_twin_response->version));
 
       out_twin_response->response_type = AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES;
-      out_twin_response->request_id = AZ_SPAN_NULL;
+      out_twin_response->request_id = AZ_SPAN_EMPTY;
       out_twin_response->status = AZ_IOT_STATUS_OK;
 
       result = AZ_OK;

--- a/sdk/src/azure/iot/az_iot_provisioning_client.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client.c
@@ -39,7 +39,7 @@ AZ_INLINE az_span _az_iot_provisioning_get_str_dps_registrations()
 
 AZ_NODISCARD az_iot_provisioning_client_options az_iot_provisioning_client_options_default()
 {
-  return (az_iot_provisioning_client_options){ .user_agent = AZ_SPAN_NULL };
+  return (az_iot_provisioning_client_options){ .user_agent = AZ_SPAN_EMPTY };
 }
 
 AZ_NODISCARD az_result az_iot_provisioning_client_init(
@@ -222,13 +222,13 @@ AZ_NODISCARD az_result az_iot_provisioning_client_query_status_get_publish_topic
 AZ_INLINE az_iot_provisioning_client_registration_result
 _az_iot_provisioning_registration_result_default()
 {
-  return (az_iot_provisioning_client_registration_result){ .assigned_hub_hostname = AZ_SPAN_NULL,
-                                                           .device_id = AZ_SPAN_NULL,
+  return (az_iot_provisioning_client_registration_result){ .assigned_hub_hostname = AZ_SPAN_EMPTY,
+                                                           .device_id = AZ_SPAN_EMPTY,
                                                            .error_code = AZ_IOT_STATUS_UNKNOWN,
                                                            .extended_error_code = 0,
-                                                           .error_message = AZ_SPAN_NULL,
-                                                           .error_tracking_id = AZ_SPAN_NULL,
-                                                           .error_timestamp = AZ_SPAN_NULL };
+                                                           .error_message = AZ_SPAN_EMPTY,
+                                                           .error_tracking_id = AZ_SPAN_EMPTY,
+                                                           .error_timestamp = AZ_SPAN_EMPTY };
 }
 
 AZ_INLINE az_iot_status _az_iot_status_from_extended_status(uint32_t extended_status)
@@ -430,7 +430,7 @@ AZ_INLINE az_result az_iot_provisioning_client_parse_payload(
 
   if (!(found_operation_status && found_operation_id))
   {
-    out_response->operation_id = AZ_SPAN_NULL;
+    out_response->operation_id = AZ_SPAN_EMPTY;
     out_response->operation_status = AZ_SPAN_FROM_STR("failed");
 
     if (!found_error)

--- a/sdk/src/azure/iot/az_iot_provisioning_client.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client.c
@@ -492,7 +492,8 @@ AZ_NODISCARD az_result az_iot_provisioning_client_parse_received_topic_and_paylo
   // Parse the status.
   az_span remainder = az_span_slice_to_end(received_topic, az_span_size(str_dps_registrations_res));
 
-  az_span int_slice = _az_span_token(remainder, AZ_SPAN_FROM_STR("/"), &remainder);
+  int32_t index = 0;
+  az_span int_slice = _az_span_token(remainder, AZ_SPAN_FROM_STR("/"), &remainder, &index);
   AZ_RETURN_IF_FAILED(az_span_atou32(int_slice, (uint32_t*)(&out_response->status)));
 
   // Parse the optional retry-after= field.
@@ -501,7 +502,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_parse_received_topic_and_paylo
   if (idx != -1)
   {
     remainder = az_span_slice_to_end(remainder, idx + az_span_size(retry_after));
-    int_slice = _az_span_token(remainder, AZ_SPAN_FROM_STR("&"), &remainder);
+    int_slice = _az_span_token(remainder, AZ_SPAN_FROM_STR("&"), &remainder, &index);
 
     AZ_RETURN_IF_FAILED(az_span_atou32(int_slice, &out_response->retry_after_seconds));
   }

--- a/sdk/src/azure/platform/az_curl.c
+++ b/sdk/src/azure/platform/az_curl.c
@@ -32,7 +32,7 @@ static void _az_span_free(az_span* p)
     return;
   }
   free(az_span_ptr(*p));
-  *p = AZ_SPAN_NULL;
+  *p = AZ_SPAN_EMPTY;
 }
 
 /**

--- a/sdk/tests/core/test_az_credential_client_secret.c
+++ b/sdk/tests/core/test_az_credential_client_secret.c
@@ -36,7 +36,7 @@ static void test_credential_client_secret(void** state)
           AZ_SPAN_FROM_STR("TenantID"),
           AZ_SPAN_FROM_STR("ClientID"),
           AZ_SPAN_FROM_STR("ClientSecret"),
-          AZ_SPAN_NULL)));
+          AZ_SPAN_EMPTY)));
     }
     else
     {

--- a/sdk/tests/core/test_az_credential_client_secret.c
+++ b/sdk/tests/core/test_az_credential_client_secret.c
@@ -7,6 +7,7 @@
 #include <azure/core/az_span.h>
 #include <azure/core/internal/az_credentials_internal.h>
 #include <azure/core/internal/az_http_internal.h>
+#include <azure/core/internal/az_span_internal.h>
 
 #include <stddef.h>
 
@@ -155,7 +156,7 @@ az_result send_request(az_http_request const* request, az_http_response* respons
             = az_span_copy(auth_url_remainder, AZ_SPAN_FROM_STR("TenantID/oauth2/v2.0/token"));
 
         az_auth_url = az_span_slice(
-            az_auth_url, 0, (int32_t)(az_span_ptr(auth_url_remainder) - az_span_ptr(az_auth_url)));
+            az_auth_url, 0, (int32_t)(_az_span_diff(auth_url_remainder, az_auth_url)));
       }
       assert_true(az_span_is_content_equal(az_auth_url, request_url));
     }

--- a/sdk/tests/core/test_az_http.c
+++ b/sdk/tests/core/test_az_http.c
@@ -176,7 +176,7 @@ static void test_http_request(void** state)
 
     // Empty header
     assert_return_code(
-        az_http_request_append_header(&request, AZ_SPAN_FROM_STR("header"), AZ_SPAN_NULL), AZ_OK);
+        az_http_request_append_header(&request, AZ_SPAN_FROM_STR("header"), AZ_SPAN_EMPTY), AZ_OK);
   }
   { // Test adding duplicated query parameters
     uint8_t buf[100];
@@ -422,7 +422,7 @@ static void test_http_request(void** state)
 
     // Remove empty spaces from the left of header name
     assert_return_code(
-        az_http_request_append_header(&request, AZ_SPAN_FROM_STR(" \t\r\nheader"), AZ_SPAN_NULL),
+        az_http_request_append_header(&request, AZ_SPAN_FROM_STR(" \t\r\nheader"), AZ_SPAN_EMPTY),
         AZ_OK);
 
     az_pair header = { 0 };
@@ -581,7 +581,7 @@ static void test_http_request_removing_left_whitespace_chars(void** state)
 
   // Nothing but empty name - should hit precondion
   ASSERT_PRECONDITION_CHECKED(
-      az_http_request_append_header(&request, AZ_SPAN_FROM_STR(" \t\r"), AZ_SPAN_NULL));
+      az_http_request_append_header(&request, AZ_SPAN_FROM_STR(" \t\r"), AZ_SPAN_EMPTY));
 }
 
 static void test_http_request_header_validation(void** state)

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -2577,6 +2577,7 @@ static void test_az_json_token_copy(void** state)
       .slice = AZ_SPAN_EMPTY,
       .size = 12,
       ._internal = {
+        .is_multisegment = true,
         .pointer_to_first_buffer = buffers,
         .start_buffer_index = 0,
         .start_buffer_offset = 0,
@@ -2605,6 +2606,7 @@ static void test_az_json_token_copy(void** state)
       .slice = AZ_SPAN_EMPTY,
       .size = 12,
       ._internal = {
+        .is_multisegment = true,
         .pointer_to_first_buffer = buffers,
         .start_buffer_index = 0,
         .start_buffer_offset = 1,
@@ -2626,6 +2628,7 @@ static void test_az_json_token_copy(void** state)
       .slice = AZ_SPAN_EMPTY,
       .size = 12,
       ._internal = {
+        .is_multisegment = true,
         .string_has_escaped_chars = false,
         .pointer_to_first_buffer = _az_buffers64_one,
         .start_buffer_index = 0,

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -57,7 +57,7 @@ static void test_json_reader_init(void** state)
   assert_int_equal(az_json_reader_init(&reader, AZ_SPAN_FROM_STR("\""), NULL), AZ_OK);
   assert_int_equal(az_json_reader_init(&reader, AZ_SPAN_FROM_STR("\""), &options), AZ_OK);
 
-  test_json_token_helper(reader.token, AZ_JSON_TOKEN_NONE, AZ_SPAN_NULL);
+  test_json_token_helper(reader.token, AZ_JSON_TOKEN_NONE, AZ_SPAN_EMPTY);
 }
 
 /**  Json writer **/
@@ -223,7 +223,7 @@ static void test_json_writer(void** state)
   }
   {
     az_json_writer writer = { 0 };
-    TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_NULL, NULL));
+    TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_EMPTY, NULL));
     assert_int_equal(az_json_writer_append_int32(&writer, 1), AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
   }
 }
@@ -408,7 +408,7 @@ az_result test_allocator_always_null(
     az_span* out_next_destination)
 {
   (void)allocator_context;
-  *out_next_destination = AZ_SPAN_NULL;
+  *out_next_destination = AZ_SPAN_EMPTY;
 
   return AZ_OK;
 }
@@ -423,7 +423,7 @@ static void test_json_writer_chunked(void** state)
     _az_user_context user_context = { .current_index = &previous };
 
     TEST_EXPECT_SUCCESS(
-        az_json_writer_chunked_init(&writer, AZ_SPAN_NULL, allocator, (void*)&user_context, NULL));
+        az_json_writer_chunked_init(&writer, AZ_SPAN_EMPTY, allocator, (void*)&user_context, NULL));
 
     // 0___________________________________________________________________________________________________1
     // 0_________1_________2_________3_________4_________5_________6_________7_________8_________9_________0
@@ -492,7 +492,7 @@ static void test_json_writer_chunked(void** state)
 
     {
       TEST_EXPECT_SUCCESS(az_json_writer_chunked_init(
-          &writer, AZ_SPAN_NULL, allocator, (void*)&user_context, NULL));
+          &writer, AZ_SPAN_EMPTY, allocator, (void*)&user_context, NULL));
 
       TEST_EXPECT_SUCCESS(az_json_writer_append_double(&writer, 0.000000000000001, 15));
 
@@ -510,7 +510,7 @@ static void test_json_writer_chunked(void** state)
     }
     {
       TEST_EXPECT_SUCCESS(az_json_writer_chunked_init(
-          &writer, AZ_SPAN_NULL, allocator, (void*)&user_context, NULL));
+          &writer, AZ_SPAN_EMPTY, allocator, (void*)&user_context, NULL));
 
       TEST_EXPECT_SUCCESS(az_json_writer_append_double(&writer, 1e-300, 15));
 
@@ -535,7 +535,7 @@ static void test_json_writer_chunked(void** state)
     _az_user_context user_context = { .current_index = &previous };
 
     TEST_EXPECT_SUCCESS(
-        az_json_writer_chunked_init(&writer, AZ_SPAN_NULL, allocator, (void*)&user_context, NULL));
+        az_json_writer_chunked_init(&writer, AZ_SPAN_EMPTY, allocator, (void*)&user_context, NULL));
 
     // this json { "span": "\" } would be scaped to { "span": "\\"" }
     uint8_t single_char[1] = { '\\' }; // char = '\'
@@ -572,7 +572,7 @@ static void test_json_writer_chunked(void** state)
     _az_user_context user_context = { .current_index = &previous };
 
     TEST_EXPECT_SUCCESS(
-        az_json_writer_chunked_init(&writer, AZ_SPAN_NULL, allocator, (void*)&user_context, NULL));
+        az_json_writer_chunked_init(&writer, AZ_SPAN_EMPTY, allocator, (void*)&user_context, NULL));
 
     // this json { "array": [1, 2, {}, 3, -12.3 ] }
     TEST_EXPECT_SUCCESS(az_json_writer_append_begin_object(&writer));
@@ -616,7 +616,7 @@ static void test_json_writer_chunked(void** state)
     _az_user_context user_context = { .current_index = &previous };
 
     TEST_EXPECT_SUCCESS(az_json_writer_chunked_init(
-        &nested_object_builder, AZ_SPAN_NULL, allocator, (void*)&user_context, NULL));
+        &nested_object_builder, AZ_SPAN_EMPTY, allocator, (void*)&user_context, NULL));
 
     {
       // 0___________________________________________________________________________________________________1
@@ -654,7 +654,7 @@ static void test_json_writer_chunked(void** state)
     az_json_writer writer = { 0 };
     az_span_allocator_fn allocator = &test_allocator_always_null;
 
-    TEST_EXPECT_SUCCESS(az_json_writer_chunked_init(&writer, AZ_SPAN_NULL, allocator, NULL, NULL));
+    TEST_EXPECT_SUCCESS(az_json_writer_chunked_init(&writer, AZ_SPAN_EMPTY, allocator, NULL, NULL));
     assert_int_equal(az_json_writer_append_int32(&writer, 1), AZ_ERROR_INSUFFICIENT_SPAN_SIZE);
   }
 }
@@ -900,7 +900,7 @@ static void test_json_writer_large_string_chunked(void** state)
     _az_user_context user_context = { .current_index = &previous };
 
     TEST_EXPECT_SUCCESS(
-        az_json_writer_chunked_init(&writer, AZ_SPAN_NULL, allocator, (void*)&user_context, NULL));
+        az_json_writer_chunked_init(&writer, AZ_SPAN_EMPTY, allocator, (void*)&user_context, NULL));
 
     TEST_EXPECT_SUCCESS(az_json_writer_append_string(
         &writer, az_span_slice(AZ_SPAN_FROM_BUFFER(expected), 1, 1299)));
@@ -970,7 +970,7 @@ static void test_json_reader(void** state)
     az_json_reader reader = { 0 };
     TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, AZ_SPAN_FROM_STR("    "), NULL));
     assert_true(az_json_reader_next_token(&reader) == AZ_ERROR_UNEXPECTED_END);
-    test_json_token_helper(reader.token, AZ_JSON_TOKEN_NONE, AZ_SPAN_NULL);
+    test_json_token_helper(reader.token, AZ_JSON_TOKEN_NONE, AZ_SPAN_EMPTY);
   }
   {
     az_json_reader reader = { 0 };
@@ -982,7 +982,7 @@ static void test_json_reader(void** state)
     az_json_reader reader = { 0 };
     TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, AZ_SPAN_FROM_STR("  nul"), NULL));
     assert_true(az_json_reader_next_token(&reader) == AZ_ERROR_UNEXPECTED_END);
-    test_json_token_helper(reader.token, AZ_JSON_TOKEN_NONE, AZ_SPAN_NULL);
+    test_json_token_helper(reader.token, AZ_JSON_TOKEN_NONE, AZ_SPAN_EMPTY);
   }
   {
     az_json_reader reader = { 0 };
@@ -994,7 +994,7 @@ static void test_json_reader(void** state)
     az_json_reader reader = { 0 };
     TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, AZ_SPAN_FROM_STR("  falsx  "), NULL));
     assert_true(az_json_reader_next_token(&reader) == AZ_ERROR_UNEXPECTED_CHAR);
-    test_json_token_helper(reader.token, AZ_JSON_TOKEN_NONE, AZ_SPAN_NULL);
+    test_json_token_helper(reader.token, AZ_JSON_TOKEN_NONE, AZ_SPAN_EMPTY);
   }
   {
     az_json_reader reader = { 0 };
@@ -1012,7 +1012,7 @@ static void test_json_reader(void** state)
     az_json_reader reader = { 0 };
     TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, AZ_SPAN_FROM_STR("  123a"), NULL));
     assert_true(az_json_reader_next_token(&reader) == AZ_ERROR_UNEXPECTED_CHAR);
-    test_json_token_helper(reader.token, AZ_JSON_TOKEN_NONE, AZ_SPAN_NULL);
+    test_json_token_helper(reader.token, AZ_JSON_TOKEN_NONE, AZ_SPAN_EMPTY);
   }
   {
     az_span const s = AZ_SPAN_FROM_STR(" \"tr\\\"ue\\t\" ");
@@ -1788,7 +1788,7 @@ static void test_json_value(void** state)
 #define _az_json_token_is_text_equal_hello_helper(token) \
   do \
   { \
-    assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_NULL) == false); \
+    assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_EMPTY) == false); \
     assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_FROM_STR("")) == false); \
     assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_FROM_STR("a")) == false); \
     assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_FROM_STR("hello")) == false); \
@@ -1811,7 +1811,7 @@ static void test_json_value(void** state)
 #define _az_json_token_is_text_equal_name_helper(token) \
   do \
   { \
-    assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_NULL) == false); \
+    assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_EMPTY) == false); \
     assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_FROM_STR("")) == false); \
     assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_FROM_STR("a")) == false); \
     assert_true( \
@@ -1852,7 +1852,7 @@ static void test_az_json_token_get_string_and_text_equal(void** state)
   assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_FROM_STR("a")) == false);
   assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_FROM_STR("aaaaaa")) == false);
   assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_FROM_STR("       ")) == false);
-  assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_NULL));
+  assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_EMPTY));
   assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_FROM_STR("")));
 
   json_string.kind = AZ_JSON_TOKEN_PROPERTY_NAME;
@@ -1862,7 +1862,7 @@ static void test_az_json_token_get_string_and_text_equal(void** state)
   assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_FROM_STR("a")) == false);
   assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_FROM_STR("aaaaaa")) == false);
   assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_FROM_STR("       ")) == false);
-  assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_NULL));
+  assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_EMPTY));
   assert_true(az_json_token_is_text_equal(&json_string, AZ_SPAN_FROM_STR("")));
 
   json_string = (az_json_token){
@@ -2574,7 +2574,7 @@ static void test_az_json_token_copy(void** state)
     az_span_copy(buffers[1], az_span_slice_to_end(json, 7));
 
     json_string = (az_json_token){
-      .slice = AZ_SPAN_NULL,
+      .slice = AZ_SPAN_EMPTY,
       .size = 12,
       ._internal = {
         .pointer_to_first_buffer = buffers,
@@ -2602,7 +2602,7 @@ static void test_az_json_token_copy(void** state)
     az_span_copy(buffers[2], az_span_slice_to_end(json, 9));
 
     json_string = (az_json_token){
-      .slice = AZ_SPAN_NULL,
+      .slice = AZ_SPAN_EMPTY,
       .size = 12,
       ._internal = {
         .pointer_to_first_buffer = buffers,
@@ -2623,7 +2623,7 @@ static void test_az_json_token_copy(void** state)
 
     json_string = (az_json_token){
       .kind = AZ_JSON_TOKEN_STRING,
-      .slice = AZ_SPAN_NULL,
+      .slice = AZ_SPAN_EMPTY,
       .size = 12,
       ._internal = {
         .string_has_escaped_chars = false,
@@ -2712,7 +2712,7 @@ static void test_az_json_reader_chunked(void** state)
   model original = (model){
     .name_string = property_value,
     .name_length = 32,
-    .name_value_span = AZ_SPAN_NULL,
+    .name_value_span = AZ_SPAN_EMPTY,
     .code = 0,
   };
 

--- a/sdk/tests/core/test_az_pipeline.c
+++ b/sdk/tests/core/test_az_pipeline.c
@@ -57,7 +57,7 @@ void test_az_http_pipeline_process()
           url_span,
           3,
           header_span,
-          AZ_SPAN_NULL),
+          AZ_SPAN_EMPTY),
       AZ_OK);
 
   _az_http_pipeline pipeline = (_az_http_pipeline){

--- a/sdk/tests/core/test_az_policy.c
+++ b/sdk/tests/core/test_az_policy.c
@@ -84,7 +84,7 @@ void test_az_http_pipeline_policy_telemetry(void** state)
           url_span,
           3,
           header_span,
-          AZ_SPAN_NULL),
+          AZ_SPAN_EMPTY),
       AZ_OK);
 
   // Create policy options
@@ -126,7 +126,7 @@ void test_az_http_pipeline_policy_apiversion(void** state)
           url_span,
           3,
           header_span,
-          AZ_SPAN_NULL),
+          AZ_SPAN_EMPTY),
       AZ_OK);
 
   // Create policy options
@@ -242,7 +242,7 @@ void test_az_http_pipeline_policy_retry(void** state)
           url_span,
           3,
           header_span,
-          AZ_SPAN_NULL),
+          AZ_SPAN_EMPTY),
       AZ_OK);
 
   // Create policy options
@@ -287,7 +287,7 @@ void test_az_http_pipeline_policy_retry_with_header(void** state)
           url_span,
           3,
           header_span,
-          AZ_SPAN_NULL),
+          AZ_SPAN_EMPTY),
       AZ_OK);
 
   // Create policy options
@@ -334,7 +334,7 @@ void test_az_http_pipeline_policy_retry_with_header_2(void** state)
           url_span,
           3,
           header_span,
-          AZ_SPAN_NULL),
+          AZ_SPAN_EMPTY),
       AZ_OK);
 
   // Create policy options

--- a/sdk/tests/core/test_az_span.c
+++ b/sdk/tests/core/test_az_span.c
@@ -1718,9 +1718,11 @@ static void test_az_span_token_success(void** state)
   az_span delim = AZ_SPAN_FROM_STR("abc");
   az_span token;
   az_span out_span;
+  int32_t index = 0;
 
   // token: ""
-  token = _az_span_token(span, delim, &out_span);
+  token = _az_span_token(span, delim, &out_span, &index);
+  assert_int_equal(index, 0);
   assert_non_null(az_span_ptr(token));
   assert_true(az_span_size(token) == 0);
   assert_true(az_span_ptr(out_span) == (az_span_ptr(span) + az_span_size(delim)));
@@ -1729,7 +1731,8 @@ static void test_az_span_token_success(void** state)
   // token: "defg" (span+3)
   span = out_span;
 
-  token = _az_span_token(span, delim, &out_span);
+  token = _az_span_token(span, delim, &out_span, &index);
+  assert_int_equal(index, 4);
   assert_true(az_span_ptr(token) == az_span_ptr(span));
   assert_int_equal(az_span_size(token), 4);
   assert_true(
@@ -1740,7 +1743,8 @@ static void test_az_span_token_success(void** state)
   // token: "defg" (span+10)
   span = out_span;
 
-  token = _az_span_token(span, delim, &out_span);
+  token = _az_span_token(span, delim, &out_span, &index);
+  assert_int_equal(index, 4);
   assert_true(az_span_ptr(token) == az_span_ptr(span));
   assert_int_equal(az_span_size(token), 4);
   assert_true(
@@ -1751,17 +1755,11 @@ static void test_az_span_token_success(void** state)
   // token: "defg" (span+17)
   span = out_span;
 
-  token = _az_span_token(span, delim, &out_span);
+  token = _az_span_token(span, delim, &out_span, &index);
+  assert_int_equal(index, -1);
   assert_true(az_span_ptr(token) == az_span_ptr(span));
   assert_int_equal(az_span_size(token), 4);
-  assert_true(az_span_ptr(out_span) == NULL);
   assert_true(az_span_size(out_span) == 0);
-
-  // Out_span is empty.
-  span = out_span;
-
-  token = _az_span_token(span, delim, &out_span);
-  assert_true(az_span_is_content_equal(token, AZ_SPAN_EMPTY));
 }
 
 int test_az_span()

--- a/sdk/tests/core/test_az_span.c
+++ b/sdk/tests/core/test_az_span.c
@@ -116,17 +116,17 @@ static void test_az_span_is_content_equal(void** state)
   assert_true(az_span_is_content_equal(az_span_slice_to_end(d, 1), a));
 
   // Comparing empty to non-empty
-  assert_false(az_span_is_content_equal(a, AZ_SPAN_NULL));
-  assert_false(az_span_is_content_equal(AZ_SPAN_NULL, a));
+  assert_false(az_span_is_content_equal(a, AZ_SPAN_EMPTY));
+  assert_false(az_span_is_content_equal(AZ_SPAN_EMPTY, a));
 
   // Empty spans are equal
-  assert_true(az_span_is_content_equal(AZ_SPAN_NULL, AZ_SPAN_NULL));
+  assert_true(az_span_is_content_equal(AZ_SPAN_EMPTY, AZ_SPAN_EMPTY));
 
-  assert_true(az_span_is_content_equal(az_span_slice_to_end(a, 3), AZ_SPAN_NULL));
+  assert_true(az_span_is_content_equal(az_span_slice_to_end(a, 3), AZ_SPAN_EMPTY));
   assert_true(az_span_is_content_equal(az_span_slice_to_end(a, 3), az_span_slice_to_end(b, 3)));
 
   assert_true(az_span_is_content_equal(AZ_SPAN_FROM_STR(""), AZ_SPAN_FROM_STR("")));
-  assert_true(az_span_is_content_equal(AZ_SPAN_FROM_STR(""), AZ_SPAN_NULL));
+  assert_true(az_span_is_content_equal(AZ_SPAN_FROM_STR(""), AZ_SPAN_EMPTY));
   assert_true(az_span_is_content_equal(AZ_SPAN_FROM_STR(""), az_span_slice_to_end(a, 3)));
 }
 
@@ -850,9 +850,9 @@ static void az_span_find_error_cases_fail(void** state)
   az_span span = AZ_SPAN_FROM_STR("abcdefgabcdefg");
   az_span target = AZ_SPAN_FROM_STR("abd");
 
-  assert_int_equal(az_span_find(AZ_SPAN_NULL, AZ_SPAN_NULL), 0);
-  assert_int_equal(az_span_find(span, AZ_SPAN_NULL), 0);
-  assert_int_equal(az_span_find(AZ_SPAN_NULL, target), -1);
+  assert_int_equal(az_span_find(AZ_SPAN_EMPTY, AZ_SPAN_EMPTY), 0);
+  assert_int_equal(az_span_find(span, AZ_SPAN_EMPTY), 0);
+  assert_int_equal(az_span_find(AZ_SPAN_EMPTY, target), -1);
 }
 
 static void az_span_find_target_longer_than_source_fails(void** state)
@@ -1191,7 +1191,7 @@ static void az_span_u32toa_overflow_fails(void** state)
   do \
   { \
     az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer); \
-    az_span out_span = AZ_SPAN_NULL; \
+    az_span out_span = AZ_SPAN_EMPTY; \
     assert_true(az_result_succeeded(az_span_dtoa(buffer, v, fractional_digits, &out_span))); \
     az_span output = az_span_slice(buffer, 0, _az_span_diff(out_span, buffer)); \
     assert_memory_equal( \
@@ -1477,7 +1477,7 @@ static void az_span_dtoa_too_large(void** state)
   // [-][0-9]{16}.[0-9]{15}, i.e. 1+16+1+15
   uint8_t raw_buffer[33] = { 0 };
   az_span buff = AZ_SPAN_FROM_BUFFER(raw_buffer);
-  az_span o = AZ_SPAN_NULL;
+  az_span o = AZ_SPAN_EMPTY;
 
   assert_int_equal(az_span_dtoa(buff, 9007199254740992, 15, &o), AZ_ERROR_NOT_SUPPORTED);
   assert_int_equal(az_span_dtoa(buff, (double)9007199254740993, 15, &o), AZ_ERROR_NOT_SUPPORTED);
@@ -1511,7 +1511,7 @@ static void az_span_copy_empty(void** state)
   (void)state;
   uint8_t buff[10];
   az_span dst = AZ_SPAN_FROM_BUFFER(buff);
-  assert_true(az_span_is_content_equal(az_span_copy(dst, AZ_SPAN_NULL), dst));
+  assert_true(az_span_is_content_equal(az_span_copy(dst, AZ_SPAN_EMPTY), dst));
 }
 
 static void test_az_span_is_valid(void** state)
@@ -1524,12 +1524,12 @@ static void test_az_span_is_valid(void** state)
   assert_false(_az_span_is_valid((az_span){ 0 }, -1, true));
   assert_false(_az_span_is_valid((az_span){ 0 }, -1, false));
 
-  assert_true(_az_span_is_valid(AZ_SPAN_NULL, 0, true));
-  assert_false(_az_span_is_valid(AZ_SPAN_NULL, 0, false));
-  assert_false(_az_span_is_valid(AZ_SPAN_NULL, 1, true));
-  assert_false(_az_span_is_valid(AZ_SPAN_NULL, 1, false));
-  assert_false(_az_span_is_valid(AZ_SPAN_NULL, -1, true));
-  assert_false(_az_span_is_valid(AZ_SPAN_NULL, -1, false));
+  assert_true(_az_span_is_valid(AZ_SPAN_EMPTY, 0, true));
+  assert_false(_az_span_is_valid(AZ_SPAN_EMPTY, 0, false));
+  assert_false(_az_span_is_valid(AZ_SPAN_EMPTY, 1, true));
+  assert_false(_az_span_is_valid(AZ_SPAN_EMPTY, 1, false));
+  assert_false(_az_span_is_valid(AZ_SPAN_EMPTY, -1, true));
+  assert_false(_az_span_is_valid(AZ_SPAN_EMPTY, -1, false));
 
   assert_true(_az_span_is_valid(AZ_SPAN_FROM_STR(""), 0, true));
   assert_true(_az_span_is_valid(AZ_SPAN_FROM_STR(""), 0, false));
@@ -1658,14 +1658,14 @@ static void az_span_trim_zero(void** state)
 static void az_span_trim_null(void** state)
 {
   (void)state;
-  az_span source = _az_span_trim_whitespace(AZ_SPAN_NULL);
+  az_span source = _az_span_trim_whitespace(AZ_SPAN_EMPTY);
   assert_int_equal(az_span_size(source), 0);
 }
 
 static void az_span_trim_start(void** state)
 {
   (void)state;
-  az_span source = _az_span_trim_whitespace_from_start(AZ_SPAN_NULL);
+  az_span source = _az_span_trim_whitespace_from_start(AZ_SPAN_EMPTY);
   assert_int_equal(az_span_size(source), 0);
 }
 
@@ -1761,7 +1761,7 @@ static void test_az_span_token_success(void** state)
   span = out_span;
 
   token = _az_span_token(span, delim, &out_span);
-  assert_true(az_span_is_content_equal(token, AZ_SPAN_NULL));
+  assert_true(az_span_is_content_equal(token, AZ_SPAN_EMPTY));
 }
 
 int test_az_span()

--- a/sdk/tests/core/test_az_url_encode.c
+++ b/sdk/tests/core/test_az_url_encode.c
@@ -333,6 +333,9 @@ static void test_url_encode_preconditions(void** state)
 
     {
       // Input is empty, so the output is also empty BUT the output span is null.
+      // This precondition assert relies on the ptr of an empty span be null, which is not
+      // guaranteed. However, it is a reasonable assumption for tests as part of span validation,
+      // only for precondition checking.
       int32_t url_length = 0xFF;
       ASSERT_PRECONDITION_CHECKED(_az_span_url_encode(AZ_SPAN_EMPTY, AZ_SPAN_EMPTY, &url_length));
       assert_int_equal(url_length, 0xFF);

--- a/sdk/tests/core/test_az_url_encode.c
+++ b/sdk/tests/core/test_az_url_encode.c
@@ -30,7 +30,7 @@ static void test_url_encode_basic(void** state)
     az_span const buffer0 = az_span_slice(AZ_SPAN_FROM_BUFFER(buf20), 0, 0);
 
     int32_t url_length = 0xFF;
-    assert_true(az_result_succeeded(_az_span_url_encode(buffer0, AZ_SPAN_NULL, &url_length)));
+    assert_true(az_result_succeeded(_az_span_url_encode(buffer0, AZ_SPAN_EMPTY, &url_length)));
     assert_int_equal(url_length, 0);
     assert_true(az_span_is_content_equal(
         AZ_SPAN_FROM_BUFFER(buf20), AZ_SPAN_FROM_STR("********************")));
@@ -216,7 +216,7 @@ static void test_url_encode_basic(void** state)
   }
   {
     // Empty span
-    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_NULL);
+    int32_t url_length = _az_span_url_encode_calc_length(AZ_SPAN_EMPTY);
     assert_int_equal(url_length, 0);
     url_length = _az_span_url_encode_calc_length(AZ_SPAN_FROM_STR(""));
     assert_int_equal(url_length, 0);
@@ -274,7 +274,7 @@ static void test_url_encode_preconditions(void** state)
       // Input is empty, so the output is also empty BUT the output span is null.
       int32_t url_length = 0xFF;
       assert_true(
-          az_result_succeeded(_az_span_url_encode(AZ_SPAN_NULL, AZ_SPAN_NULL, &url_length)));
+          az_result_succeeded(_az_span_url_encode(AZ_SPAN_EMPTY, AZ_SPAN_EMPTY, &url_length)));
       assert_int_equal(url_length, 0);
     }
     { // Overlapping buffers, same pointer.
@@ -334,7 +334,7 @@ static void test_url_encode_preconditions(void** state)
     {
       // Input is empty, so the output is also empty BUT the output span is null.
       int32_t url_length = 0xFF;
-      ASSERT_PRECONDITION_CHECKED(_az_span_url_encode(AZ_SPAN_NULL, AZ_SPAN_NULL, &url_length));
+      ASSERT_PRECONDITION_CHECKED(_az_span_url_encode(AZ_SPAN_EMPTY, AZ_SPAN_EMPTY, &url_length));
       assert_int_equal(url_length, 0xFF);
     }
     {
@@ -377,7 +377,7 @@ static void test_url_encode_preconditions(void** state)
       // NULL out_size parameter.
       uint8_t buf1[1] = { '*' };
       az_span const buffer0 = az_span_slice(AZ_SPAN_FROM_BUFFER(buf1), 0, 0);
-      ASSERT_PRECONDITION_CHECKED(_az_span_url_encode(buffer0, AZ_SPAN_NULL, NULL));
+      ASSERT_PRECONDITION_CHECKED(_az_span_url_encode(buffer0, AZ_SPAN_EMPTY, NULL));
       assert_true(az_span_is_content_equal(AZ_SPAN_FROM_BUFFER(buf1), AZ_SPAN_FROM_STR("*")));
     }
     {

--- a/sdk/tests/iot/common/test_az_iot_common.c
+++ b/sdk/tests/iot/common/test_az_iot_common.c
@@ -237,7 +237,6 @@ static void _log_listener(az_log_classification classification, az_span message)
   {
     case AZ_LOG_IOT_RETRY:
       _log_retry++;
-      assert_ptr_equal(az_span_ptr(message), (void*)0);
       assert_int_equal(az_span_size(message), 0);
       break;
     default:

--- a/sdk/tests/iot/common/test_az_iot_common.c
+++ b/sdk/tests/iot/common/test_az_iot_common.c
@@ -73,7 +73,7 @@ static void test_az_iot_message_properties_append_NULL_name_span_fails(void** st
   az_iot_message_properties props;
 
   ASSERT_PRECONDITION_CHECKED(
-      az_iot_message_properties_append(&props, AZ_SPAN_NULL, test_value_one));
+      az_iot_message_properties_append(&props, AZ_SPAN_EMPTY, test_value_one));
 }
 
 static void test_az_iot_message_properties_append_NULL_value_span_fails(void** state)
@@ -82,7 +82,8 @@ static void test_az_iot_message_properties_append_NULL_value_span_fails(void** s
 
   az_iot_message_properties props;
 
-  ASSERT_PRECONDITION_CHECKED(az_iot_message_properties_append(&props, test_key_one, AZ_SPAN_NULL));
+  ASSERT_PRECONDITION_CHECKED(
+      az_iot_message_properties_append(&props, test_key_one, AZ_SPAN_EMPTY));
 }
 
 static void test_az_iot_message_properties_find_NULL_props_fail(void** state)
@@ -102,7 +103,7 @@ static void test_az_iot_message_properties_find_NULL_name_fail(void** state)
 
   az_span out_value;
 
-  ASSERT_PRECONDITION_CHECKED(az_iot_message_properties_find(&props, AZ_SPAN_NULL, &out_value));
+  ASSERT_PRECONDITION_CHECKED(az_iot_message_properties_find(&props, AZ_SPAN_EMPTY, &out_value));
 }
 
 static void test_az_iot_message_properties_find_NULL_value_fail(void** state)
@@ -342,7 +343,7 @@ static void test_az_iot_message_properties_append_empty_buffer_fail(void** state
   (void)state;
 
   az_iot_message_properties props;
-  assert_int_equal(az_iot_message_properties_init(&props, AZ_SPAN_NULL, 0), AZ_OK);
+  assert_int_equal(az_iot_message_properties_init(&props, AZ_SPAN_EMPTY, 0), AZ_OK);
 
   assert_int_equal(
       az_iot_message_properties_append(&props, test_key_one, test_value_one),
@@ -489,7 +490,7 @@ static void test_az_iot_message_properties_find_empty_buffer_fail(void** state)
 
   az_iot_message_properties props;
 
-  assert_int_equal(az_iot_message_properties_init(&props, AZ_SPAN_NULL, 0), AZ_OK);
+  assert_int_equal(az_iot_message_properties_init(&props, AZ_SPAN_EMPTY, 0), AZ_OK);
 
   az_span out_value;
   assert_int_equal(
@@ -592,29 +593,25 @@ static void test_az_iot_message_properties_next_succeed(void** state)
   assert_memory_equal(
       az_span_ptr(name), az_span_ptr(test_key_one), (size_t)az_span_size(test_key_one));
   assert_memory_equal(
-      az_span_ptr(value),
-      az_span_ptr(test_value_one),
-      (size_t)az_span_size(test_value_one));
+      az_span_ptr(value), az_span_ptr(test_value_one), (size_t)az_span_size(test_value_one));
 
   assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_OK);
   assert_memory_equal(
       az_span_ptr(name), az_span_ptr(test_key_two), (size_t)az_span_size(test_key_two));
   assert_memory_equal(
-      az_span_ptr(value),
-      az_span_ptr(test_value_two),
-      (size_t)az_span_size(test_value_two));
+      az_span_ptr(value), az_span_ptr(test_value_two), (size_t)az_span_size(test_value_two));
 
   assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_OK);
   assert_memory_equal(
       az_span_ptr(name), az_span_ptr(test_key_three), (size_t)az_span_size(test_key_three));
   assert_memory_equal(
-      az_span_ptr(value),
-      az_span_ptr(test_value_three),
-      (size_t)az_span_size(test_value_three));
+      az_span_ptr(value), az_span_ptr(test_value_three), (size_t)az_span_size(test_value_three));
 
-  assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
-  //Call again to show subsequent calls do nothing
-  assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
+  assert_int_equal(
+      az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
+  // Call again to show subsequent calls do nothing
+  assert_int_equal(
+      az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
 }
 
 static void test_az_iot_message_properties_next_twice_succeed(void** state)
@@ -633,19 +630,16 @@ static void test_az_iot_message_properties_next_twice_succeed(void** state)
   assert_memory_equal(
       az_span_ptr(name), az_span_ptr(test_key_one), (size_t)az_span_size(test_key_one));
   assert_memory_equal(
-      az_span_ptr(value),
-      az_span_ptr(test_value_one),
-      (size_t)az_span_size(test_value_one));
+      az_span_ptr(value), az_span_ptr(test_value_one), (size_t)az_span_size(test_value_one));
 
   assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_OK);
   assert_memory_equal(
       az_span_ptr(name), az_span_ptr(test_key_two), (size_t)az_span_size(test_key_two));
   assert_memory_equal(
-      az_span_ptr(value),
-      az_span_ptr(test_value_two),
-      (size_t)az_span_size(test_value_two));
+      az_span_ptr(value), az_span_ptr(test_value_two), (size_t)az_span_size(test_value_two));
 
-  assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
+  assert_int_equal(
+      az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
 
   // Reset to beginning of span
   assert_int_equal(
@@ -655,19 +649,16 @@ static void test_az_iot_message_properties_next_twice_succeed(void** state)
   assert_memory_equal(
       az_span_ptr(name), az_span_ptr(test_key_one), (size_t)az_span_size(test_key_one));
   assert_memory_equal(
-      az_span_ptr(value),
-      az_span_ptr(test_value_one),
-      (size_t)az_span_size(test_value_one));
+      az_span_ptr(value), az_span_ptr(test_value_one), (size_t)az_span_size(test_value_one));
 
   assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_OK);
   assert_memory_equal(
       az_span_ptr(name), az_span_ptr(test_key_two), (size_t)az_span_size(test_key_two));
   assert_memory_equal(
-      az_span_ptr(value),
-      az_span_ptr(test_value_two),
-      (size_t)az_span_size(test_value_two));
+      az_span_ptr(value), az_span_ptr(test_value_two), (size_t)az_span_size(test_value_two));
 
-  assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
+  assert_int_equal(
+      az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
 }
 
 static void test_az_iot_message_properties_next_empty_succeed(void** state)
@@ -675,12 +666,13 @@ static void test_az_iot_message_properties_next_empty_succeed(void** state)
   (void)state;
 
   az_iot_message_properties props;
-  assert_int_equal(az_iot_message_properties_init(&props, AZ_SPAN_NULL, 0), AZ_OK);
+  assert_int_equal(az_iot_message_properties_init(&props, AZ_SPAN_EMPTY, 0), AZ_OK);
 
   az_span name;
   az_span value;
 
-  assert_int_equal(az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
+  assert_int_equal(
+      az_iot_message_properties_next(&props, &name, &value), AZ_ERROR_IOT_NO_MORE_PROPERTIES);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/hub/test_az_iot_hub_client.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client.c
@@ -63,7 +63,7 @@ static void test_az_iot_hub_client_init_NULL_device_id_fails(void** state)
   az_iot_hub_client client;
 
   ASSERT_PRECONDITION_CHECKED(
-      az_iot_hub_client_init(&client, test_hub_hostname, AZ_SPAN_NULL, NULL));
+      az_iot_hub_client_init(&client, test_hub_hostname, AZ_SPAN_EMPTY, NULL));
 }
 
 static void test_az_iot_hub_client_init_NULL_hub_hostname_id_fails(void** state)
@@ -72,7 +72,7 @@ static void test_az_iot_hub_client_init_NULL_hub_hostname_id_fails(void** state)
 
   az_iot_hub_client client;
 
-  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_init(&client, AZ_SPAN_NULL, test_device_id, NULL));
+  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_init(&client, AZ_SPAN_EMPTY, test_device_id, NULL));
 }
 
 static void test_az_iot_hub_client_get_user_name_NULL_client_fails(void** state)
@@ -152,7 +152,7 @@ static void test_az_iot_hub_client_get_default_options_succeed(void** state)
   (void)state;
 
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  assert_true(az_span_is_content_equal(options.module_id, AZ_SPAN_NULL));
+  assert_true(az_span_is_content_equal(options.module_id, AZ_SPAN_EMPTY));
   assert_true(
       az_span_is_content_equal(options.user_agent, az_span_create_from_str(PLATFORM_USER_AGENT)));
 }

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_c2d.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_c2d.c
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 #include "test_az_iot_hub_client.h"
-#include <azure/iot/az_iot_hub_client.h>
-#include <azure/core/az_log.h>
-#include <azure/core/az_precondition.h>
-#include <azure/core/internal/az_precondition_internal.h>
-#include <azure/core/az_span.h>
 #include <az_test_log.h>
 #include <az_test_precondition.h>
 #include <az_test_span.h>
+#include <azure/core/az_log.h>
+#include <azure/core/az_precondition.h>
+#include <azure/core/az_span.h>
+#include <azure/core/internal/az_precondition_internal.h>
+#include <azure/iot/az_iot_hub_client.h>
 
 #include <setjmp.h>
 #include <stdarg.h>
@@ -53,7 +53,7 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_NULL_client_fail()
       az_iot_hub_client_c2d_parse_received_topic(NULL, received_topic, &out_request));
 }
 
-static void test_az_iot_hub_client_c2d_parse_received_topic_AZ_SPAN_NULL_received_topic_fail(
+static void test_az_iot_hub_client_c2d_parse_received_topic_AZ_SPAN_EMPTY_received_topic_fail(
     void** state)
 {
   (void)state;
@@ -63,7 +63,7 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_AZ_SPAN_NULL_receive
   assert_true(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
-  az_span received_topic = AZ_SPAN_NULL;
+  az_span received_topic = AZ_SPAN_EMPTY;
 
   az_iot_hub_client_c2d_request out_request;
 
@@ -104,8 +104,8 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_url_decoded_succeed(
   az_span value;
   assert_int_equal(az_iot_message_properties_next(&out_request.properties, &name, &value), AZ_OK);
   assert_true(az_span_is_content_equal(name, AZ_SPAN_FROM_STR("$.mid")));
-  assert_true(az_span_is_content_equal(
-      value, AZ_SPAN_FROM_STR("79eadb01-bd0d-472d-bd35-ccb76e70eab8")));
+  assert_true(
+      az_span_is_content_equal(value, AZ_SPAN_FROM_STR("79eadb01-bd0d-472d-bd35-ccb76e70eab8")));
 
   assert_int_equal(az_iot_message_properties_next(&out_request.properties, &name, &value), AZ_OK);
   assert_true(az_span_is_content_equal(name, AZ_SPAN_FROM_STR("$.to")));
@@ -148,8 +148,7 @@ static void test_az_iot_hub_client_c2d_parse_received_topic_url_encoded_succeed(
 
   assert_int_equal(az_iot_message_properties_next(&out_request.properties, &name, &value), AZ_OK);
   assert_true(az_span_is_content_equal(name, AZ_SPAN_FROM_STR("jkl")));
-  assert_true(
-      az_span_is_content_equal(value, AZ_SPAN_FROM_STR("%2Fsome%2Fthing%2F%3Fbla%3Dbla")));
+  assert_true(az_span_is_content_equal(value, AZ_SPAN_FROM_STR("%2Fsome%2Fthing%2F%3Fbla%3Dbla")));
 }
 
 static void test_az_iot_hub_client_c2d_parse_received_topic_no_props_succeed()
@@ -251,7 +250,7 @@ int test_az_iot_hub_client_c2d()
 #ifndef AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_NULL_client_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_c2d_parse_received_topic_AZ_SPAN_NULL_received_topic_fail),
+        test_az_iot_hub_client_c2d_parse_received_topic_AZ_SPAN_EMPTY_received_topic_fail),
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_NULL_out_request_fail),
 #endif // NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_c2d_parse_received_topic_url_decoded_succeed),

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_methods.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_methods.c
@@ -88,7 +88,8 @@ static void test_az_iot_hub_client_methods_response_get_publish_topic_EMPTY_requ
       &client, request_id, status, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_methods_response_get_publish_topic_AZ_SPAN_NULL_request_id_fail()
+static void
+test_az_iot_hub_client_methods_response_get_publish_topic_AZ_SPAN_EMPTY_request_id_fail()
 {
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
@@ -96,7 +97,7 @@ static void test_az_iot_hub_client_methods_response_get_publish_topic_AZ_SPAN_NU
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
-  az_span request_id = AZ_SPAN_NULL;
+  az_span request_id = AZ_SPAN_EMPTY;
   uint16_t status = 200;
 
   ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_methods_response_get_publish_topic(
@@ -126,12 +127,12 @@ static void test_az_iot_hub_client_methods_parse_received_topic_EMPTY_received_t
       az_iot_hub_client_methods_parse_received_topic(&client, received_topic, &out_request));
 }
 
-static void test_az_iot_hub_client_methods_parse_received_topic_AZ_SPAN_NULL_received_topic_fail()
+static void test_az_iot_hub_client_methods_parse_received_topic_AZ_SPAN_EMPTY_received_topic_fail()
 {
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
-  az_span received_topic = AZ_SPAN_NULL;
+  az_span received_topic = AZ_SPAN_EMPTY;
 
   az_iot_hub_client_method_request out_request;
 
@@ -425,11 +426,11 @@ int test_az_iot_hub_client_methods()
     cmocka_unit_test(
         test_az_iot_hub_client_methods_response_get_publish_topic_EMPTY_request_id_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_response_get_publish_topic_AZ_SPAN_NULL_request_id_fail),
+        test_az_iot_hub_client_methods_response_get_publish_topic_AZ_SPAN_EMPTY_request_id_fail),
     cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_NULL_client_fail),
     cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_EMPTY_received_topic_fail),
     cmocka_unit_test(
-        test_az_iot_hub_client_methods_parse_received_topic_AZ_SPAN_NULL_received_topic_fail),
+        test_az_iot_hub_client_methods_parse_received_topic_AZ_SPAN_EMPTY_received_topic_fail),
     cmocka_unit_test(test_az_iot_hub_client_methods_parse_received_topic_NULL_out_request_fail),
 #endif // AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_methods_response_get_publish_topic_succeed),

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_sas.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_sas.c
@@ -42,7 +42,7 @@ static void az_iot_hub_client_sas_get_signature_NULL_signature_fails()
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
-  az_span signature = AZ_SPAN_NULL;
+  az_span signature = AZ_SPAN_EMPTY;
 
   ASSERT_PRECONDITION_CHECKED(
       az_iot_hub_client_sas_get_signature(&client, test_sas_expiry_time_secs, signature, NULL));
@@ -53,7 +53,7 @@ static void az_iot_hub_client_sas_get_signature_NULL_signature_span_fails()
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
-  az_span signature = AZ_SPAN_NULL;
+  az_span signature = AZ_SPAN_EMPTY;
 
   ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_sas_get_signature(
       &client, test_sas_expiry_time_secs, signature, &signature));
@@ -73,8 +73,8 @@ static void az_iot_hub_client_sas_get_password_EMPTY_signature_fails()
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
-  az_span key_name = AZ_SPAN_NULL;
-  az_span signature = AZ_SPAN_NULL;
+  az_span key_name = AZ_SPAN_EMPTY;
+  az_span signature = AZ_SPAN_EMPTY;
 
   char password[TEST_SPAN_BUFFER_SIZE];
   size_t length = 0;
@@ -94,7 +94,7 @@ static void az_iot_hub_client_sas_get_password_NULL_password_span_fails()
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
-  az_span key_name = AZ_SPAN_NULL;
+  az_span key_name = AZ_SPAN_EMPTY;
   char password[TEST_SPAN_BUFFER_SIZE];
   size_t length = 0;
 
@@ -113,7 +113,7 @@ static void az_iot_hub_client_sas_get_password_empty_password_buffer_span_fails(
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
-  az_span key_name = AZ_SPAN_NULL;
+  az_span key_name = AZ_SPAN_EMPTY;
   char password[TEST_SPAN_BUFFER_SIZE];
   size_t length = 0;
 
@@ -182,7 +182,7 @@ static void az_iot_hub_client_sas_get_password_device_succeeds()
       = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "%2Fdevices%2F" TEST_DEVICE_ID_STR
         "&sig=" TEST_URL_ENC_SIG "&se=" TEST_EXPIRATION_STR;
 
-  az_span key_name = AZ_SPAN_NULL;
+  az_span key_name = AZ_SPAN_EMPTY;
 
   char password[TEST_SPAN_BUFFER_SIZE];
   size_t length = 0;
@@ -209,7 +209,7 @@ static void az_iot_hub_client_sas_get_password_device_no_out_length_succeeds()
       = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "%2Fdevices%2F" TEST_DEVICE_ID_STR
         "&sig=" TEST_URL_ENC_SIG "&se=" TEST_EXPIRATION_STR;
 
-  az_span key_name = AZ_SPAN_NULL;
+  az_span key_name = AZ_SPAN_EMPTY;
 
   char password[TEST_SPAN_BUFFER_SIZE];
 
@@ -238,7 +238,7 @@ static void az_iot_hub_client_sas_get_password_module_succeeds()
       = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "%2Fdevices%2F" TEST_DEVICE_ID_STR
         "%2Fmodules%2F" TEST_MODULE_ID_STR "&sig=" TEST_URL_ENC_SIG "&se=" TEST_EXPIRATION_STR;
 
-  az_span key_name = AZ_SPAN_NULL;
+  az_span key_name = AZ_SPAN_EMPTY;
 
   char password[TEST_SPAN_BUFFER_SIZE];
   size_t length = 0;
@@ -268,7 +268,7 @@ static void az_iot_hub_client_sas_get_password_module_no_length_succeeds()
       = "SharedAccessSignature sr=" TEST_DEVICE_HOSTNAME_STR "%2Fdevices%2F" TEST_DEVICE_ID_STR
         "%2Fmodules%2F" TEST_MODULE_ID_STR "&sig=" TEST_URL_ENC_SIG "&se=" TEST_EXPIRATION_STR;
 
-  az_span key_name = AZ_SPAN_NULL;
+  az_span key_name = AZ_SPAN_EMPTY;
 
   char password[TEST_SPAN_BUFFER_SIZE];
 
@@ -348,7 +348,7 @@ static void az_iot_hub_client_sas_get_password_device_overflow_fails()
   az_iot_hub_client client;
   assert_true(az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL) == AZ_OK);
 
-  az_span key_name = AZ_SPAN_NULL;
+  az_span key_name = AZ_SPAN_EMPTY;
 
   char password[132];
   size_t length = 0;
@@ -373,7 +373,7 @@ static void az_iot_hub_client_sas_get_password_module_overflow_fails()
   assert_true(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options) == AZ_OK);
 
-  az_span key_name = AZ_SPAN_NULL;
+  az_span key_name = AZ_SPAN_EMPTY;
 
   char password[150];
   size_t length = 0;

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
@@ -165,7 +165,7 @@ static void test_az_iot_hub_client_twin_parse_received_topic_NULL_rec_topic_fail
   az_iot_hub_client_twin_response response;
 
   ASSERT_PRECONDITION_CHECKED(
-      az_iot_hub_client_twin_parse_received_topic(&client, AZ_SPAN_NULL, &response));
+      az_iot_hub_client_twin_parse_received_topic(&client, AZ_SPAN_EMPTY, &response));
 }
 
 static void test_az_iot_hub_client_twin_parse_received_topic_NULL_response_fails()
@@ -257,7 +257,7 @@ static void test_az_iot_hub_client_twin_parse_received_topic_desired_found_succe
           &client, test_twin_received_topic_desired_success, &response),
       AZ_OK);
   assert_true(az_span_is_content_equal((response.version), test_device_request_id));
-  assert_true(az_span_is_content_equal(response.request_id, AZ_SPAN_NULL));
+  assert_true(az_span_is_content_equal(response.request_id, AZ_SPAN_EMPTY));
   assert_int_equal(response.status, AZ_IOT_STATUS_OK);
   assert_int_equal(response.response_type, AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES);
 }
@@ -274,7 +274,7 @@ static void test_az_iot_hub_client_twin_parse_received_topic_get_response_found_
           &client, test_twin_received_get_response, &response),
       AZ_OK);
   assert_true(az_span_is_content_equal(response.request_id, test_device_request_id));
-  assert_true(az_span_is_content_equal(response.version, AZ_SPAN_NULL));
+  assert_true(az_span_is_content_equal(response.version, AZ_SPAN_EMPTY));
   assert_int_equal(response.status, AZ_IOT_STATUS_OK);
   assert_int_equal(response.response_type, AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_GET);
 }

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
@@ -27,6 +27,8 @@ static const az_span test_twin_received_topic_desired_success
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/PATCH/properties/desired/?$version=id_one");
 static const az_span test_twin_received_topic_fail
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/rez/200");
+static const az_span test_twin_received_topic_incomplete_fail
+    = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/200");
 static const az_span test_twin_received_topic_prefix_fail
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/contoso/res/200");
 
@@ -309,6 +311,19 @@ static void test_az_iot_hub_client_twin_parse_received_topic_not_found_fails()
       AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
+static void test_az_iot_hub_client_twin_parse_received_topic_not_found_incomplete_fails()
+{
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
+  az_iot_hub_client_twin_response response;
+
+  assert_int_equal(
+      az_iot_hub_client_twin_parse_received_topic(
+          &client, test_twin_received_topic_incomplete_fail, &response),
+      AZ_ERROR_UNEXPECTED_END);
+}
+
 static void test_az_iot_hub_client_twin_parse_received_topic_not_found_prefix_fails()
 {
   az_iot_hub_client client;
@@ -398,6 +413,7 @@ int test_az_iot_hub_client_twin()
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_get_response_found_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_reported_props_found_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_not_found_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_not_found_incomplete_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_not_found_prefix_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_logging_succeed),
   };

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client.c
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "test_az_iot_provisioning_client.h"
-#include <azure/iot/az_iot_provisioning_client.h>
-#include <azure/core/az_span.h>
 #include <az_test_span.h>
+#include <azure/core/az_span.h>
+#include <azure/iot/az_iot_provisioning_client.h>
 
 #include <setjmp.h>
 #include <stdarg.h>
@@ -28,7 +28,7 @@ static const az_span test_global_device_endpoint
 static void test_az_iot_provisioning_client_options_default_succeed()
 {
   az_iot_provisioning_client_options options = az_iot_provisioning_client_options_default();
-  assert_true(az_span_is_content_equal(options.user_agent, AZ_SPAN_NULL));
+  assert_true(az_span_is_content_equal(options.user_agent, AZ_SPAN_EMPTY));
 }
 
 static void test_az_iot_provisioning_client_default_options_get_connect_info_succeed()
@@ -58,7 +58,7 @@ static void test_az_iot_provisioning_client_default_options_get_connect_info_suc
   assert_int_equal(strlen(TEST_REGISTRATION_ID), client_id_len);
 
   char expected_username[] = TEST_ID_SCOPE "/registrations/" TEST_REGISTRATION_ID
-                                          "/api-version=" AZ_IOT_PROVISIONING_SERVICE_VERSION;
+                                           "/api-version=" AZ_IOT_PROVISIONING_SERVICE_VERSION;
 
   char user_name[sizeof(expected_username) + 1];
   memset(user_name, 0xCC, sizeof(user_name));

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
@@ -67,8 +67,8 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_topic_not_match
 
   az_iot_provisioning_client_register_response response = { .status = AZ_IOT_STATUS_FORBIDDEN,
                                                             .retry_after_seconds = 0xBAADC0DE,
-                                                            .operation_id = AZ_SPAN_NULL,
-                                                            .operation_status = AZ_SPAN_NULL,
+                                                            .operation_id = AZ_SPAN_EMPTY,
+                                                            .operation_status = AZ_SPAN_EMPTY,
                                                             .registration_result = { 0 } };
 
   az_result ret = az_iot_provisioning_client_parse_received_topic_and_payload(
@@ -423,8 +423,8 @@ static void test_az_iot_provisioning_client_parse_operation_status_translate_suc
 {
   az_iot_provisioning_client_register_response response = { .status = AZ_IOT_STATUS_FORBIDDEN,
                                                             .retry_after_seconds = 0xBAADC0DE,
-                                                            .operation_id = AZ_SPAN_NULL,
-                                                            .operation_status = AZ_SPAN_NULL,
+                                                            .operation_id = AZ_SPAN_EMPTY,
+                                                            .operation_status = AZ_SPAN_EMPTY,
                                                             .registration_result = { 0 } };
 
   az_iot_provisioning_client_operation_status operation_status = 0xBAADC0DE;

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_sas.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_sas.c
@@ -47,7 +47,7 @@ static void az_iot_provisioning_client_sas_get_signature_NULL_signature_fails()
           &client, test_global_device_endpoint, test_id_scope, test_registration_id, NULL),
       AZ_OK);
 
-  az_span signature = AZ_SPAN_NULL;
+  az_span signature = AZ_SPAN_EMPTY;
 
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_sas_get_signature(
       &client, test_sas_expiry_time_secs, signature, NULL));
@@ -61,7 +61,7 @@ static void az_iot_provisioning_client_sas_get_signature_NULL_signature_span_fai
           &client, test_global_device_endpoint, test_id_scope, test_registration_id, NULL),
       AZ_OK);
 
-  az_span signature = AZ_SPAN_NULL;
+  az_span signature = AZ_SPAN_EMPTY;
 
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_sas_get_signature(
       &client, test_sas_expiry_time_secs, signature, &signature));
@@ -84,8 +84,8 @@ static void az_iot_provisioning_client_sas_get_password_EMPTY_signature_fails()
           &client, test_global_device_endpoint, test_id_scope, test_registration_id, NULL),
       AZ_OK);
 
-  az_span key_name = AZ_SPAN_NULL;
-  az_span signature = AZ_SPAN_NULL;
+  az_span key_name = AZ_SPAN_EMPTY;
+  az_span signature = AZ_SPAN_EMPTY;
 
   char password[TEST_SPAN_BUFFER_SIZE];
   size_t length = 0;
@@ -108,7 +108,7 @@ static void az_iot_provisioning_client_sas_get_password_NULL_password_span_fails
           &client, test_global_device_endpoint, test_id_scope, test_registration_id, NULL),
       AZ_OK);
 
-  az_span key_name = AZ_SPAN_NULL;
+  az_span key_name = AZ_SPAN_EMPTY;
   size_t length = 0;
   char password[TEST_SPAN_BUFFER_SIZE];
 
@@ -130,7 +130,7 @@ static void az_iot_provisioning_client_sas_get_password_empty_password_buffer_fa
           &client, test_global_device_endpoint, test_id_scope, test_registration_id, NULL),
       AZ_OK);
 
-  az_span key_name = AZ_SPAN_NULL;
+  az_span key_name = AZ_SPAN_EMPTY;
 
   char password[TEST_SPAN_BUFFER_SIZE];
   size_t length = 0;
@@ -177,7 +177,7 @@ static void az_iot_provisioning_client_sas_get_password_device_succeeds()
   const char expected_password[] = "SharedAccessSignature sr=" TEST_URL_ENCODED_RESOURCE_URI
                                    "&sig=" TEST_URL_ENC_SIG "&se=" TEST_EXPIRATION_STR;
 
-  az_span key_name = AZ_SPAN_NULL;
+  az_span key_name = AZ_SPAN_EMPTY;
 
   char password[TEST_SPAN_BUFFER_SIZE];
   size_t length = 0;
@@ -233,7 +233,7 @@ static void az_iot_provisioning_client_sas_get_password_device_overflow_fails()
           &client, test_global_device_endpoint, test_id_scope, test_registration_id, NULL),
       AZ_OK);
 
-  az_span key_name = AZ_SPAN_NULL;
+  az_span key_name = AZ_SPAN_EMPTY;
 
   char password[132];
   size_t length = 0;


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/1082

Also fixes https://github.com/Azure/azure-sdk-for-c/issues/1171