### PR TITLE
Do not use a shared static scratch buffer for JSON token parsing. Instead use stack space.

### DIFF
--- a/sdk/src/azure/core/az_json_private.h
+++ b/sdk/src/azure/core/az_json_private.h
@@ -38,10 +38,8 @@ enum
   _az_MAX_UNESCAPED_STRING_SIZE
   = _az_MAX_ESCAPED_STRING_SIZE / _az_MAX_EXPANSION_FACTOR_WHILE_ESCAPING, // 166_666_666 bytes
 
-  _az_MAX_SIZE_FOR_INT32 = 11, // 10 + sign (i.e. -2147483648)
-
   // [-][0-9]{16}.[0-9]{15}, i.e. 1+16+1+15 since _az_MAX_SUPPORTED_FRACTIONAL_DIGITS is 15
-  _az_MAX_SIZE_FOR_DOUBLE = 33,
+  _az_MAX_SIZE_FOR_WRITING_DOUBLE = 33,
 
   // When writing large JSON strings in chunks, ask for at least 64 bytes, to avoid writing one
   // character at a time.

--- a/sdk/src/azure/core/az_json_token.c
+++ b/sdk/src/azure/core/az_json_token.c
@@ -7,11 +7,8 @@
 
 #include "az_json_private.h"
 
+#include "az_span_private.h"
 #include <azure/core/_az_cfg.h>
-
-// Used to copy discontiguous token values into a contiguous buffer, for number parsing.
-// All number types should fit within 99 bytes. Otherwise, they will overflow.
-static uint8_t _az_scratch_buffer[99] = { 0 };
 
 static az_span _az_json_token_copy_into_span_helper(
     az_json_token const* json_token,
@@ -451,7 +448,8 @@ az_json_token_get_uint64(az_json_token const* json_token, uint64_t* out_value)
   }
 
   // Token straddles more than one segment
-  az_span scratch = AZ_SPAN_FROM_BUFFER(_az_scratch_buffer);
+  uint8_t scratch_buffer[_az_MAX_SIZE_FOR_UINT64_T] = { 0 };
+  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 
   // Any number that won't fit in the scratch buffer, will overflow.
   if (az_span_size(scratch) < json_token->size)
@@ -484,7 +482,8 @@ az_json_token_get_uint32(az_json_token const* json_token, uint32_t* out_value)
   }
 
   // Token straddles more than one segment
-  az_span scratch = AZ_SPAN_FROM_BUFFER(_az_scratch_buffer);
+  uint8_t scratch_buffer[_az_MAX_SIZE_FOR_UINT32_T] = { 0 };
+  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 
   // Any number that won't fit in the scratch buffer, will overflow.
   if (az_span_size(scratch) < json_token->size)
@@ -516,7 +515,8 @@ AZ_NODISCARD az_result az_json_token_get_int64(az_json_token const* json_token, 
   }
 
   // Token straddles more than one segment
-  az_span scratch = AZ_SPAN_FROM_BUFFER(_az_scratch_buffer);
+  uint8_t scratch_buffer[_az_MAX_SIZE_FOR_INT64_T] = { 0 };
+  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 
   // Any number that won't fit in the scratch buffer, will overflow.
   if (az_span_size(scratch) < json_token->size)
@@ -548,7 +548,8 @@ AZ_NODISCARD az_result az_json_token_get_int32(az_json_token const* json_token, 
   }
 
   // Token straddles more than one segment
-  az_span scratch = AZ_SPAN_FROM_BUFFER(_az_scratch_buffer);
+  uint8_t scratch_buffer[_az_MAX_SIZE_FOR_INT32_T] = { 0 };
+  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 
   // Any number that won't fit in the scratch buffer, will overflow.
   if (az_span_size(scratch) < json_token->size)
@@ -580,7 +581,8 @@ AZ_NODISCARD az_result az_json_token_get_double(az_json_token const* json_token,
   }
 
   // Token straddles more than one segment
-  az_span scratch = AZ_SPAN_FROM_BUFFER(_az_scratch_buffer);
+  uint8_t scratch_buffer[99] = { 0 };
+  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 
   // Any number that won't fit in the scratch buffer, will overflow.
   if (az_span_size(scratch) < json_token->size)

--- a/sdk/src/azure/core/az_json_token.c
+++ b/sdk/src/azure/core/az_json_token.c
@@ -447,15 +447,15 @@ az_json_token_get_uint64(az_json_token const* json_token, uint64_t* out_value)
     return az_span_atou64(token_slice, out_value);
   }
 
-  // Token straddles more than one segment
-  uint8_t scratch_buffer[_az_MAX_SIZE_FOR_UINT64_T] = { 0 };
-  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
-
   // Any number that won't fit in the scratch buffer, will overflow.
-  if (az_span_size(scratch) < json_token->size)
+  if (json_token->size > _az_MAX_SIZE_FOR_UINT64)
   {
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
+
+  // Token straddles more than one segment
+  uint8_t scratch_buffer[_az_MAX_SIZE_FOR_UINT64] = { 0 };
+  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 
   az_span remainder = _az_json_token_copy_into_span_helper(json_token, scratch);
 
@@ -481,15 +481,15 @@ az_json_token_get_uint32(az_json_token const* json_token, uint32_t* out_value)
     return az_span_atou32(token_slice, out_value);
   }
 
-  // Token straddles more than one segment
-  uint8_t scratch_buffer[_az_MAX_SIZE_FOR_UINT32_T] = { 0 };
-  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
-
   // Any number that won't fit in the scratch buffer, will overflow.
-  if (az_span_size(scratch) < json_token->size)
+  if (json_token->size > _az_MAX_SIZE_FOR_UINT32)
   {
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
+
+  // Token straddles more than one segment
+  uint8_t scratch_buffer[_az_MAX_SIZE_FOR_UINT32] = { 0 };
+  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 
   az_span remainder = _az_json_token_copy_into_span_helper(json_token, scratch);
 
@@ -514,15 +514,15 @@ AZ_NODISCARD az_result az_json_token_get_int64(az_json_token const* json_token, 
     return az_span_atoi64(token_slice, out_value);
   }
 
-  // Token straddles more than one segment
-  uint8_t scratch_buffer[_az_MAX_SIZE_FOR_INT64_T] = { 0 };
-  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
-
   // Any number that won't fit in the scratch buffer, will overflow.
-  if (az_span_size(scratch) < json_token->size)
+  if (json_token->size > _az_MAX_SIZE_FOR_INT64)
   {
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
+
+  // Token straddles more than one segment
+  uint8_t scratch_buffer[_az_MAX_SIZE_FOR_INT64] = { 0 };
+  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 
   az_span remainder = _az_json_token_copy_into_span_helper(json_token, scratch);
 
@@ -547,15 +547,15 @@ AZ_NODISCARD az_result az_json_token_get_int32(az_json_token const* json_token, 
     return az_span_atoi32(token_slice, out_value);
   }
 
-  // Token straddles more than one segment
-  uint8_t scratch_buffer[_az_MAX_SIZE_FOR_INT32_T] = { 0 };
-  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
-
   // Any number that won't fit in the scratch buffer, will overflow.
-  if (az_span_size(scratch) < json_token->size)
+  if (json_token->size > _az_MAX_SIZE_FOR_INT32)
   {
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
+
+  // Token straddles more than one segment
+  uint8_t scratch_buffer[_az_MAX_SIZE_FOR_INT32] = { 0 };
+  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 
   az_span remainder = _az_json_token_copy_into_span_helper(json_token, scratch);
 
@@ -580,15 +580,15 @@ AZ_NODISCARD az_result az_json_token_get_double(az_json_token const* json_token,
     return az_span_atod(token_slice, out_value);
   }
 
-  // Token straddles more than one segment
-  uint8_t scratch_buffer[99] = { 0 };
-  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
-
   // Any number that won't fit in the scratch buffer, will overflow.
-  if (az_span_size(scratch) < json_token->size)
+  if (json_token->size > _az_MAX_SIZE_FOR_PARSING_DOUBLE)
   {
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
+
+  // Token straddles more than one segment
+  uint8_t scratch_buffer[_az_MAX_SIZE_FOR_PARSING_DOUBLE] = { 0 };
+  az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 
   az_span remainder = _az_json_token_copy_into_span_helper(json_token, scratch);
 

--- a/sdk/src/azure/core/az_json_token.c
+++ b/sdk/src/azure/core/az_json_token.c
@@ -453,7 +453,8 @@ az_json_token_get_uint64(az_json_token const* json_token, uint64_t* out_value)
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
 
-  // Token straddles more than one segment
+  // Token straddles more than one segment.
+  // Used to copy discontiguous token values into a contiguous buffer, for number parsing.
   uint8_t scratch_buffer[_az_MAX_SIZE_FOR_UINT64] = { 0 };
   az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 
@@ -487,7 +488,8 @@ az_json_token_get_uint32(az_json_token const* json_token, uint32_t* out_value)
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
 
-  // Token straddles more than one segment
+  // Token straddles more than one segment.
+  // Used to copy discontiguous token values into a contiguous buffer, for number parsing.
   uint8_t scratch_buffer[_az_MAX_SIZE_FOR_UINT32] = { 0 };
   az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 
@@ -520,7 +522,8 @@ AZ_NODISCARD az_result az_json_token_get_int64(az_json_token const* json_token, 
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
 
-  // Token straddles more than one segment
+  // Token straddles more than one segment.
+  // Used to copy discontiguous token values into a contiguous buffer, for number parsing.
   uint8_t scratch_buffer[_az_MAX_SIZE_FOR_INT64] = { 0 };
   az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 
@@ -553,7 +556,8 @@ AZ_NODISCARD az_result az_json_token_get_int32(az_json_token const* json_token, 
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
 
-  // Token straddles more than one segment
+  // Token straddles more than one segment.
+  // Used to copy discontiguous token values into a contiguous buffer, for number parsing.
   uint8_t scratch_buffer[_az_MAX_SIZE_FOR_INT32] = { 0 };
   az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 
@@ -586,7 +590,8 @@ AZ_NODISCARD az_result az_json_token_get_double(az_json_token const* json_token,
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
 
-  // Token straddles more than one segment
+  // Token straddles more than one segment.
+  // Used to copy discontiguous token values into a contiguous buffer, for number parsing.
   uint8_t scratch_buffer[_az_MAX_SIZE_FOR_PARSING_DOUBLE] = { 0 };
   az_span scratch = AZ_SPAN_FROM_BUFFER(scratch_buffer);
 

--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -904,7 +904,8 @@ AZ_NODISCARD az_result az_json_writer_append_double(
   _az_PRECONDITION(_az_isfinite(value));
   _az_PRECONDITION_RANGE(0, fractional_digits, _az_MAX_SUPPORTED_FRACTIONAL_DIGITS);
 
-  int32_t required_size = _az_MAX_SIZE_FOR_DOUBLE; // Need enough space to write any double number.
+  // Need enough space to write any double number.
+  int32_t required_size = _az_MAX_SIZE_FOR_WRITING_DOUBLE;
 
   if (ref_json_writer->_internal.need_comma)
   {
@@ -928,7 +929,7 @@ AZ_NODISCARD az_result az_json_writer_append_double(
   // We already accounted for the maximum size needed in required_size, so subtract that to get the
   // actual bytes written.
   int32_t written
-      = required_size + _az_span_diff(leftover, remaining_json) - _az_MAX_SIZE_FOR_DOUBLE;
+      = required_size + _az_span_diff(leftover, remaining_json) - _az_MAX_SIZE_FOR_WRITING_DOUBLE;
   _az_update_json_writer_state(ref_json_writer, written, written, true, AZ_JSON_TOKEN_NUMBER);
   return AZ_OK;
 }

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -370,7 +370,7 @@ AZ_NODISCARD az_result az_span_atod(az_span source, double* out_number)
 
   int32_t size = az_span_size(source);
 
-  _az_PRECONDITION_RANGE(1, size, 99);
+  _az_PRECONDITION_RANGE(1, size, _az_MAX_SIZE_FOR_PARSING_DOUBLE);
 
   // This check is necessary to prevent sscanf from reading bytes past the end of the span, when the
   // span might contain whitespace or other invalid bytes at the start.

--- a/sdk/src/azure/core/az_span_private.h
+++ b/sdk/src/azure/core/az_span_private.h
@@ -23,10 +23,20 @@ enum
   // _az_MAX_SAFE_INTEGER.
   _az_MAX_SUPPORTED_FRACTIONAL_DIGITS = 15,
 
-  _az_MAX_SIZE_FOR_INT32_T = 11,
-  _az_MAX_SIZE_FOR_UINT32_T = 10,
-  _az_MAX_SIZE_FOR_INT64_T = 20,
-  _az_MAX_SIZE_FOR_UINT64_T = 20,
+  // 10 + sign (i.e. -2,147,483,648)
+  _az_MAX_SIZE_FOR_INT32 = 11,
+
+  // For example: 2,147,483,648
+  _az_MAX_SIZE_FOR_UINT32 = 10,
+
+  // 19 + sign (i.e. -9,223,372,036,854,775,808)
+  _az_MAX_SIZE_FOR_INT64 = 20,
+
+  // For example: 18,446,744,073,709,551,615
+  _az_MAX_SIZE_FOR_UINT64 = 20,
+
+  // Two digit length to create the "format" passed to sscanf.
+  _az_MAX_SIZE_FOR_PARSING_DOUBLE = 99,
 };
 
 /**

--- a/sdk/src/azure/core/az_span_private.h
+++ b/sdk/src/azure/core/az_span_private.h
@@ -22,6 +22,11 @@ enum
   // or causing integer overflow. We can't choose 16, because 9999999999999999 is larger than
   // _az_MAX_SAFE_INTEGER.
   _az_MAX_SUPPORTED_FRACTIONAL_DIGITS = 15,
+
+  _az_MAX_SIZE_FOR_INT32_T = 11,
+  _az_MAX_SIZE_FOR_UINT32_T = 10,
+  _az_MAX_SIZE_FOR_INT64_T = 20,
+  _az_MAX_SIZE_FOR_UINT64_T = 20,
 };
 
 /**


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/1079

cc @hihigupt 