### PR TITLE
Remove validating precondition in 'az_log_set_classifications'

### DIFF
--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -33,8 +33,6 @@
 /**
  * @brief Identifies the classifications of log messages produced by the SDK.
  */
-// Make sure to update #_az_log_classifications_are_valid() whenever a new value is added to this
-// enum.
 typedef enum
 {
   AZ_LOG_END_OF_LIST

--- a/sdk/src/azure/core/az_log.c
+++ b/sdk/src/azure/core/az_log.c
@@ -19,40 +19,8 @@
 static az_log_classification const* volatile _az_log_classifications = NULL;
 static az_log_message_fn volatile _az_log_message_callback = NULL;
 
-// Verifies that the classification that the user provided is one of the valid possibilties and
-// guards against looping past the end of the classification array.
-// Make sure to update the switch statement whenever new classifications are added.
-#ifndef AZ_NO_PRECONDITION_CHECKING
-AZ_INLINE bool _az_log_classifications_are_valid(az_log_classification const* classifications)
-{
-  if (classifications == NULL)
-  {
-    return true;
-  }
-  for (az_log_classification const* cls = classifications; *cls != AZ_LOG_END_OF_LIST; ++cls)
-  {
-    switch (*cls)
-    {
-      case AZ_LOG_HTTP_REQUEST:
-      case AZ_LOG_HTTP_RESPONSE:
-      case AZ_LOG_HTTP_RETRY:
-      case AZ_LOG_MQTT_RECEIVED_TOPIC:
-      case AZ_LOG_MQTT_RECEIVED_PAYLOAD:
-      case AZ_LOG_IOT_RETRY:
-      case AZ_LOG_IOT_SAS_TOKEN:
-      case AZ_LOG_IOT_AZURERTOS:
-        continue;
-      default:
-        return false;
-    }
-  }
-  return true;
-}
-#endif // AZ_NO_PRECONDITION_CHECKING
-
 void az_log_set_classifications(az_log_classification const classifications[])
 {
-  _az_PRECONDITION(_az_log_classifications_are_valid(classifications));
   _az_log_classifications = classifications;
 }
 


### PR DESCRIPTION
Undoing most of https://github.com/Azure/azure-sdk-for-c/pull/1174 which was intended to put a band-aid over https://github.com/Azure/azure-sdk-for-c/issues/1172 but keeping the tests 

It is potentially useful to allow user-defined log classifications.

The downside is, developer bugs or misuse will result in undefined behavior, including AVs. We need to resolve this with better/more explicit documentation and code snippets - see https://github.com/Azure/azure-sdk-for-c/issues/1192

cc @JeffreyRichter 