### PR TITLE
Replace ==/!= AZ_OK with az_result_succeeded()/failed()

### DIFF
--- a/sdk/docs/iot/README.md
+++ b/sdk/docs/iot/README.md
@@ -298,15 +298,15 @@ void handle_iot_message(mqtt_client_message* msg)
   az_iot_hub_client_method_request method_request;
   az_iot_hub_client_c2d_request c2d_request;
   az_iot_hub_client_twin_response twin_response;
-  if (az_iot_hub_client_methods_parse_received_topic(&client, incoming_topic, &method_request) == AZ_OK)
+  if (az_result_succeeded(az_iot_hub_client_methods_parse_received_topic(&client, incoming_topic, &method_request)))
   {
     //Handle the method request
   }
-  else if (az_iot_hub_client_c2d_parse_received_topic(&client, incoming_topic, &c2d_request) == AZ_OK)
+  else if (az_result_succeeded(az_iot_hub_client_c2d_parse_received_topic(&client, incoming_topic, &c2d_request)))
   {
     //Handle the c2d message
   }
-  else if (az_iot_hub_client_twin_parse_received_topic(&client, incoming_topic, &twin_response) == AZ_OK)
+  else if (az_result_succeeded(az_iot_hub_client_twin_parse_received_topic(&client, incoming_topic, &twin_response)))
   {
     //Handle the twin message
   }

--- a/sdk/samples/iot/pnp/pnp_thermostat_component.c
+++ b/sdk/samples/iot/pnp/pnp_thermostat_component.c
@@ -353,7 +353,7 @@ az_result pnp_thermostat_process_command(
         command_payload,
         mqtt_message->payload_span,
         &mqtt_message->out_payload_span);
-    if (response != AZ_OK)
+    if (az_result_failed(response)
     {
       *status = AZ_IOT_STATUS_BAD_REQUEST;
     }

--- a/sdk/samples/iot/pnp/pnp_thermostat_component.c
+++ b/sdk/samples/iot/pnp/pnp_thermostat_component.c
@@ -353,7 +353,7 @@ az_result pnp_thermostat_process_command(
         command_payload,
         mqtt_message->payload_span,
         &mqtt_message->out_payload_span);
-    if (az_result_failed(response)
+    if (az_result_failed(response))
     {
       *status = AZ_IOT_STATUS_BAD_REQUEST;
     }

--- a/sdk/samples/storage/blobs/src/blobs_client_example.c
+++ b/sdk/samples/storage/blobs/src/blobs_client_example.c
@@ -68,9 +68,8 @@ int main()
   az_storage_blobs_blob_client client;
   az_storage_blobs_blob_client_options options = az_storage_blobs_blob_client_options_default();
 
-  if (az_storage_blobs_blob_client_init(
-          &client, az_span_create_from_str(getenv(URI_ENV)), AZ_CREDENTIAL_ANONYMOUS, &options)
-      != AZ_OK)
+  if (az_result_failed(az_storage_blobs_blob_client_init(
+          &client, az_span_create_from_str(getenv(URI_ENV)), AZ_CREDENTIAL_ANONYMOUS, &options)))
   {
     printf("\nFailed to init blob client\n");
     return 1;
@@ -79,7 +78,7 @@ int main()
   /******* 2) Create a buffer for response (will be reused for all requests)   *****/
   uint8_t response_buffer[1024 * 4] = { 0 };
   az_http_response http_response;
-  if (az_http_response_init(&http_response, AZ_SPAN_FROM_BUFFER(response_buffer)) != AZ_OK)
+  if (az_result_failed(az_http_response_init(&http_response, AZ_SPAN_FROM_BUFFER(response_buffer))))
   {
     printf("\nFailed to init http response\n");
     return 1;
@@ -100,7 +99,7 @@ int main()
 
     return 1;
   }
-  else if (blob_upload_result != AZ_OK) // Any other error would terminate sample
+  else if (az_result_failed(blob_upload_result)) // Any other error would terminate sample
   {
     printf("\nFailed to upload blob\n");
     return 1;
@@ -109,7 +108,7 @@ int main()
   // 4) get response and parse it
   az_http_response_status_line status_line;
 
-  if (az_http_response_get_status_line(&http_response, &status_line) != AZ_OK)
+  if (az_result_failed(az_http_response_get_status_line(&http_response, &status_line)))
   {
     printf("\nFailed to get status line\n");
     return 1;
@@ -133,7 +132,7 @@ int main()
     {
       break;
     }
-    else if (header_get_result != AZ_OK)
+    else if (az_result_failed(header_get_result))
     {
       printf("\nFailed to get header\n");
       return 1;

--- a/sdk/src/azure/core/az_http_policy_retry.c
+++ b/sdk/src/azure/core/az_http_policy_retry.c
@@ -105,7 +105,8 @@ AZ_INLINE AZ_NODISCARD az_result _az_http_policy_retry_get_retry_after(
 
     az_span header_name = { 0 };
     az_span header_value = { 0 };
-    while (az_http_response_get_next_header(ref_response, &header_name, &header_value) == AZ_OK)
+    while (az_result_succeeded(
+        az_http_response_get_next_header(ref_response, &header_name, &header_value)))
     {
       if (az_span_is_content_equal_ignoring_case(header_name, AZ_SPAN_FROM_STR("retry-after-ms"))
           || az_span_is_content_equal_ignoring_case(

--- a/sdk/src/azure/core/az_http_response.c
+++ b/sdk/src/azure/core/az_http_response.c
@@ -292,7 +292,7 @@ AZ_NODISCARD az_result az_http_response_get_body(az_http_response* ref_response,
     {
       // Parse and ignore all remaining headers
       for (az_span n = { 0 }, v = { 0 };
-           az_http_response_get_next_header(ref_response, &n, &v) == AZ_OK;)
+           az_result_succeeded(az_http_response_get_next_header(ref_response, &n, &v));)
       {
         // ignoring header
       }

--- a/sdk/src/azure/core/az_json_reader.c
+++ b/sdk/src/azure/core/az_json_reader.c
@@ -544,7 +544,7 @@ AZ_NODISCARD static az_result _az_json_reader_process_number(az_json_reader* ref
     az_result result = AZ_OK;
     if (_az_finished_consuming_json_number(next_byte, AZ_SPAN_FROM_STR(".eE"), &result))
     {
-      if (result == AZ_OK)
+      if (az_result_succeeded(result))
       {
         _az_json_reader_update_state(
             ref_json_reader,
@@ -583,7 +583,7 @@ AZ_NODISCARD static az_result _az_json_reader_process_number(az_json_reader* ref
     az_result result = AZ_OK;
     if (_az_finished_consuming_json_number(next_byte, AZ_SPAN_FROM_STR(".eE"), &result))
     {
-      if (result == AZ_OK)
+      if (az_result_succeeded(result))
       {
         _az_json_reader_update_state(
             ref_json_reader,
@@ -628,7 +628,7 @@ AZ_NODISCARD static az_result _az_json_reader_process_number(az_json_reader* ref
     az_result result = AZ_OK;
     if (_az_finished_consuming_json_number(next_byte, AZ_SPAN_FROM_STR("eE"), &result))
     {
-      if (result == AZ_OK)
+      if (az_result_succeeded(result))
       {
         _az_json_reader_update_state(
             ref_json_reader,


### PR DESCRIPTION
I noticed this during the API review meeting.
I am updating our SDK code, samples, and docs. I am not updating tests, so they are more specifically ckeck for `AZ_OK` so any possible future update would be more intentional.