### PR TITLE
AZ_ERROR_DEPENDENCY_NOT_PROVIDED

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ By default, when building the project with no options, the following static libr
   - az_storage_blobs
     - Storage SDK blobs client.
   - az_noplatform
-    - A platform abstraction which will compile but returns `AZ_ERROR_NOT_IMPLEMENTED` for all platform calls. This ensures the project can be compiled without the need to provide any specific platform implementation. This is useful if you want to use az_core without platform specific functions like `mutex` or `time`.
+    - A platform abstraction which will compile but returns 0 or does nothing for all platform calls. This ensures the project can be compiled without the need to provide any specific platform implementation. This is useful if you want to use az_core without platform specific functions like `time` or `sleep`.
   - az_nohttp
     - Library that provides a basic returning error when calling HTTP stack. Similar to az_noplatform, this library ensures the project can be compiled without requiring any HTTP stack implementation. This is useful if you want to use `az_core` without `az_http` functionality.
 

--- a/sdk/docs/core/README.md
+++ b/sdk/docs/core/README.md
@@ -6,7 +6,7 @@ The library allows client libraries to expose common functionality in a consiste
 
 ## Porting the Azure SDK to Another Platform
 
-The `Azure Core` library requires you to implement a few functions to provide platform-specific features such as a clock, a thread sleep, and a mutual-exclusive thread synchronization lock. By default, `Azure Core` ships with no-op versions of these functions, all of which return `AZ_RESULT_NOT_IMPLEMENTED`. The no-op versions allow the Azure SDK to compile successfully so you can verify that your build tool chain is working properly; however, failures occur if you execute the code.
+The `Azure Core` library requires you to implement a few functions to provide platform-specific features such as a clock and thread sleep. By default, `Azure Core` ships with no-op versions of these functions, all of which return 0 or do no operations. The no-op versions allow the Azure SDK to compile successfully so you can verify that your build tool chain is working properly; however, failures may occur if you execute the code.
 
 ## Key Concepts
 

--- a/sdk/docs/platform/README.md
+++ b/sdk/docs/platform/README.md
@@ -22,7 +22,7 @@ Azure SDK provides one implementation for libcurl (`az_curl`). To consume this i
 
 The Azure SDK also provides empty HTTP adapter (`az_nohttp`). This transport allows you to build `az_core` without any specific HTTP adapter. Use this option when the application is not using HTTP based Azure SDK services.
 
->Note: An `AZ_ERROR_NOT_IMPLEMENTED` will be returned from the `az_nohttp` transport APIs.
+>Note: An `AZ_ERROR_DEPENDENCY_NOT_PROVIDED` will be returned from the `az_nohttp` transport APIs.
 
 You can also implement your own HTTP transport adapter and use it. This allows you to use a different HTTP stack other than `libcurl`. Follow the instructions on [using your own HTTP stack implementation](https://github.com/Azure/azure-sdk-for-c/blob/master/README.md#using-your-own-http-stack-implementation).
 

--- a/sdk/inc/azure/core/az_result.h
+++ b/sdk/inc/azure/core/az_result.h
@@ -80,7 +80,8 @@ typedef enum
   /// Not supported.
   AZ_ERROR_NOT_SUPPORTED = _az_RESULT_MAKE_ERROR(_az_FACILITY_CORE, 7),
 
-  /// An external dependency required to perform operation was is not provided.
+  /// An external dependency required to perform the operation was not provided. The operation needs
+  /// an implementation of the platform layer or an HTTP transport adapter.
   AZ_ERROR_DEPENDENCY_NOT_PROVIDED = _az_RESULT_MAKE_ERROR(_az_FACILITY_CORE, 8),
 
   // === Platform ===

--- a/sdk/inc/azure/core/az_result.h
+++ b/sdk/inc/azure/core/az_result.h
@@ -80,6 +80,9 @@ typedef enum
   /// Not supported.
   AZ_ERROR_NOT_SUPPORTED = _az_RESULT_MAKE_ERROR(_az_FACILITY_CORE, 7),
 
+  /// An external dependency required to perform operation was is not provided.
+  AZ_ERROR_DEPENDENCY_NOT_PROVIDED = _az_RESULT_MAKE_ERROR(_az_FACILITY_CORE, 8),
+
   // === Platform ===
   /// Dynamic memory allocation request was not successful.
   AZ_ERROR_OUT_OF_MEMORY = _az_RESULT_MAKE_ERROR(_az_FACILITY_PLATFORM, 1),

--- a/sdk/samples/storage/blobs/src/blobs_client_example.c
+++ b/sdk/samples/storage/blobs/src/blobs_client_example.c
@@ -92,7 +92,7 @@ int main()
 
   // This validation is only for the first time SDK client is used. API will return not implemented
   // if samples were built with no_http lib.
-  if (blob_upload_result == AZ_ERROR_NOT_IMPLEMENTED)
+  if (blob_upload_result == AZ_ERROR_DEPENDENCY_NOT_PROVIDED)
   {
     printf("Running sample with no_op HTTP implementation.\nRecompile az_core with an HTTP client "
            "implementation like CURL to see sample sending network requests.\n\n"

--- a/sdk/src/azure/platform/az_nohttp.c
+++ b/sdk/src/azure/platform/az_nohttp.c
@@ -19,5 +19,5 @@ az_http_client_send_request(az_http_request const* request, az_http_response* re
 {
   (void)request;
   (void)ref_response;
-  return AZ_ERROR_NOT_IMPLEMENTED;
+  return AZ_ERROR_DEPENDENCY_NOT_PROVIDED;
 }


### PR DESCRIPTION
This came up during API review meeting. Replace some instances of AZ_ERROR_NOT_IMPLEMENTED with AZ_ERROR_DEPENDENCY_NOT_PROVIDED, and update the docs.