### PR TITLE
Use gcc-5 

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -51,6 +51,11 @@ jobs:
         OSVmImage: 'ubuntu-18.04'
         vcpkg.deps: ''
         AZ_SDK_C_NO_SAMPLES: 'true'
+      Linux_x64_gcc5:
+        OSVmImage: 'ubuntu-16.04'
+        vcpkg.deps: ''
+        AZ_SDK_C_NO_SAMPLES: 'true'
+        CC: '/usr/bin/gcc-5'
       Win_x86:
         OSVmImage: 'windows-2019'
         vcpkg.deps: ''
@@ -77,13 +82,6 @@ jobs:
       # PRECONDITIONS               ON
       # LOGGING                     ON
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
-      Linux_x64_gcc5_with_samples:
-        OSVmImage: 'ubuntu-16.04'
-        vcpkg.deps: 'curl[ssl] paho-mqtt'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX'
-        CC: '/usr/bin/gcc-5'
-        CXX: '/usr/bin/g++-5'
       Linux_x64_with_samples:
         OSVmImage: 'ubuntu-18.04'
         vcpkg.deps: 'curl[ssl] paho-mqtt'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -78,7 +78,7 @@ jobs:
       # LOGGING                     ON
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
       Linux_x64_gcc5_with_samples:
-        OSVmImage: 'ubuntu-18.04'
+        OSVmImage: 'ubuntu-16.04'
         vcpkg.deps: 'curl[ssl] paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -83,6 +83,7 @@ jobs:
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX'
         CC: '/usr/bin/gcc-5'
+        CXX: '/usr/bin/g++-5'
       Linux_x64_with_samples:
         OSVmImage: 'ubuntu-18.04'
         vcpkg.deps: 'curl[ssl] paho-mqtt'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -6,12 +6,31 @@ jobs:
   condition: and(succeededOrFailed(), ne(variables['Skip.Test'], 'true'))
   strategy:
     matrix:
+      # Build with no dependencies at all (No samples) - PRECONDITIONS ON
+      # WARNINGS_AS_ERRORS          ON
+      # TRANSPORT_CURL              OFF
+      # UNIT_TESTING                OFF
+      # UNIT_TESTING_MOCKS          OFF
+      # TRANSPORT_PAHO              OFF
+      # PRECONDITIONS               ON
+      # LOGGING                     OFF
+      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
       Linux_ARM:
         OSVmImage: 'ubuntu-18.04'
         vcpkg.deps: ''
         AptDependencies: 'gcc-arm-none-eabi'
         build.args: '-DCMAKE_TOOLCHAIN_FILE=cmake-modules/gcc-arm-toolchain.cmake'
         AZ_SDK_C_NO_SAMPLES: 'true'
+
+      # Build with no dependencies at all (No samples) - PRECONDITIONS ON
+      # WARNINGS_AS_ERRORS          ON
+      # TRANSPORT_CURL              OFF
+      # UNIT_TESTING                OFF
+      # UNIT_TESTING_MOCKS          OFF
+      # TRANSPORT_PAHO              OFF
+      # PRECONDITIONS               OFF
+      # LOGGING                     OFF
+      # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_NONE
       Linux_ARM_no_preconditions:
         OSVmImage: 'ubuntu-18.04'
         vcpkg.deps: ''
@@ -58,6 +77,12 @@ jobs:
       # PRECONDITIONS               ON
       # LOGGING                     ON
       # AZ_PLATFORM_IMPL            AZ_PLATFORM_IMPL_POSIX / AZ_PLATFORM_IMPL_WIN32
+      Linux_x64_gcc5_with_samples:
+        OSVmImage: 'ubuntu-18.04'
+        vcpkg.deps: 'curl[ssl] paho-mqtt'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
+        build.args: ' -DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX'
+        CC: '/usr/bin/gcc-5'
       Linux_x64_with_samples:
         OSVmImage: 'ubuntu-18.04'
         vcpkg.deps: 'curl[ssl] paho-mqtt'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -22,7 +22,7 @@ jobs:
         build.args: '-DCMAKE_TOOLCHAIN_FILE=cmake-modules/gcc-arm-toolchain.cmake'
         AZ_SDK_C_NO_SAMPLES: 'true'
 
-      # Build with no dependencies at all (No samples) - PRECONDITIONS ON
+      # Build with no dependencies at all (No samples) - PRECONDITIONS OFF
       # WARNINGS_AS_ERRORS          ON
       # TRANSPORT_CURL              OFF
       # UNIT_TESTING                OFF


### PR DESCRIPTION
Add a matrix entry that uses gcc 5. Ubuntu 18.04 already uses gcc 7 by default so no additional action is required here. 

gcc 5 version: 

```
-- The C compiler identification is GNU 5.5.0
```

gcc 7 version (already in use): 

```
-- The C compiler identification is GNU 7.5.0
```