### PR TITLE
Avoid using !az_result_succeeded or failed, and instead use the appropriate function.

### DIFF
--- a/sdk/inc/azure/core/az_span.h
+++ b/sdk/inc/azure/core/az_span.h
@@ -517,7 +517,7 @@ typedef struct
  * This function must never return an empty #az_span, unless the requested buffer size is not
  * available. In which case, it must return an error #az_result.
  *
- * @remarks The caller must check the return value using #az_result_succeeded() before continuing to
+ * @remarks The caller must check the return value using #az_result_failed() before continuing to
  * use the \p out_next_destination.
  */
 typedef az_result (*az_span_allocator_fn)(

--- a/sdk/src/azure/core/az_http_policy_retry.c
+++ b/sdk/src/azure/core/az_http_policy_retry.c
@@ -75,12 +75,12 @@ AZ_INLINE void _az_http_policy_retry_log(int32_t attempt, int32_t delay_msec)
 AZ_INLINE AZ_NODISCARD int32_t _az_uint32_span_to_int32(az_span span)
 {
   uint32_t value = 0;
-  if (az_result_succeeded(az_span_atou32(span, &value)))
+  if (az_result_failed(az_span_atou32(span, &value)))
   {
-    return value < INT32_MAX ? (int32_t)value : INT32_MAX;
+    return -1;
   }
 
-  return -1;
+  return value < INT32_MAX ? (int32_t)value : INT32_MAX;
 }
 
 AZ_INLINE AZ_NODISCARD az_result _az_http_policy_retry_get_retry_after(

--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -80,7 +80,7 @@ _get_remaining_span(az_json_writer* ref_json_writer, int32_t required_size)
     };
 
     // No more space left in the destination, let the caller fail with AZ_ERROR_NOT_ENOUGH_SPACE.
-    if (!az_result_succeeded(ref_json_writer->_internal.allocator_callback(&context, &remaining)))
+    if (az_result_failed(ref_json_writer->_internal.allocator_callback(&context, &remaining)))
     {
       return AZ_SPAN_EMPTY;
     }


### PR DESCRIPTION
Minor fixes to close https://github.com/Azure/azure-sdk-for-c/issues/1104

From https://github.com/Azure/azure-sdk-for-c/issues/1104#issuecomment-679417234
> Let me see what some of the coding patterns and samples look like without using `az_succeeded` and get back to you. I would be surprised if it looks less clean/readable or becomes too cumbersome, but if that's the case, I will leave them as is.

Leaving `az_result_succeeded` as is, since it is useful in certain places and that coding pattern isn't as clean if we are forced to use `az_result_failed` only, without changing the logic/if blocks more than I would like.