### PR TITLE
Small Dox correction: verbatim semver.org

### DIFF
--- a/sdk/inc/azure/core/az_http_transport.h
+++ b/sdk/inc/azure/core/az_http_transport.h
@@ -113,7 +113,7 @@ typedef AZ_NODISCARD az_result (*_az_http_policy_process_fn)(
 
 /**
  * @brief HTTP policy.
- * An HTTP pipeline inside SDK clients is an array of http policies.
+ * An HTTP pipeline inside SDK clients is an array of HTTP policies.
  */
 struct _az_http_policy
 {

--- a/sdk/inc/azure/core/az_version.h
+++ b/sdk/inc/azure/core/az_version.h
@@ -15,7 +15,7 @@
 #ifndef _az_VERSION_H
 #define _az_VERSION_H
 
-/// The version in string format used for telemetry following the semver.org standard
+/// The version in string format used for telemetry following the `semver.org` standard
 /// (https://semver.org).
 #define AZ_SDK_VERSION_STRING "1.0.0-preview.5"
 


### PR DESCRIPTION
A proposal, but I think we should verbatim the site-name.
Plus I capitalized HTTP in one instance.