### PR TITLE
update provisioning field name to registration state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-- Update provisioning client struct member name in `az_iot_provisioning_client_register_response` from `registration_result` to `registration_state` to match recent API naming updates.
+- Update provisioning client struct member name in `az_iot_provisioning_client_register_response` from `registration_result` to `registration_state`.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 1.0.0-preview.6 (Unreleased)
 
+### New Features
+
+### Breaking Changes
+
+- Update provisioning client struct member name in `az_iot_provisioning_client_register_response` from `registration_result` to `registration_state` to match recent API naming updates.
+
+### Bug Fixes
+
+### Other Changes and Improvements
+
 
 ## 1.0.0-preview.5 (2020-09-08)
 

--- a/sdk/docs/iot/mqtt_state_machine.md
+++ b/sdk/docs/iot/mqtt_state_machine.md
@@ -212,9 +212,9 @@ _Note 2_: To determine the parameters of the exponential with back-off retry str
 In the absence of modeling, we recommend the following default:
 
 ```C
-    min_retry_delay_msec =   1000;
-    max_retry_delay_msec = 100000;
-    max_random_jitter_msec      =   5000;
+    min_retry_delay_msec =     1000;
+    max_retry_delay_msec =   100000;
+    max_random_jitter_msec =   5000;
 ```
 
 For service-level errors, the Provisioning Service is providing a `retry-after` (in seconds) parameter:

--- a/sdk/docs/iot/mqtt_state_machine.md
+++ b/sdk/docs/iot/mqtt_state_machine.md
@@ -200,9 +200,9 @@ For connectivity issues at all layers (TCP, TLS, MQTT) as well as cases where th
 
 ```C
 // The previous operation took operation_msec.
-// The application calculates random_msec between 0 and max_random_msec.
+// The application calculates random_jitter_msec between 0 and max_random_jitter_msec.
 
-int32_t delay_msec = az_iot_calculate_retry_delay(operation_msec, attempt, min_retry_delay_msec, max_retry_delay_msec, random_msec);
+int32_t delay_msec = az_iot_calculate_retry_delay(operation_msec, attempt, min_retry_delay_msec, max_retry_delay_msec, random_jitter_msec);
 ```
 
 _Note 1_: The network stack may have used more time than the recommended delay before timing out. (e.g. The operation timed out after 2 minutes while the delay between operations is 1 second). In this case there is no need to delay the next operation.
@@ -214,7 +214,7 @@ In the absence of modeling, we recommend the following default:
 ```C
     min_retry_delay_msec =   1000;
     max_retry_delay_msec = 100000;
-    max_random_msec      =   5000;
+    max_random_jitter_msec      =   5000;
 ```
 
 For service-level errors, the Provisioning Service is providing a `retry-after` (in seconds) parameter:
@@ -229,7 +229,7 @@ if ( response.retry_after_seconds > 0 )
 }
 else
 {
-    delay_ms = az_iot_calculate_retry_delay(operation_msec, attempt, min_retry_delay_msec, max_retry_delay_msec, random_msec);
+    delay_ms = az_iot_calculate_retry_delay(operation_msec, attempt, min_retry_delay_msec, max_retry_delay_msec, random_jitter_msec);
 }
 ```
 

--- a/sdk/docs/iot/resources/iot_provisioning_flow.puml
+++ b/sdk/docs/iot/resources/iot_provisioning_flow.puml
@@ -68,7 +68,7 @@ az_iot_provisioning_client_register_response : - status
 az_iot_provisioning_client_register_response : - operation_id
 az_iot_provisioning_client_register_response : - operation_status
 az_iot_provisioning_client_register_response : - retry_after_seconds
-az_iot_provisioning_client_register_response : - registration_result:
+az_iot_provisioning_client_register_response : - registration_state:
 az_iot_provisioning_client_register_response : ..- assigned_hub_hostname
 az_iot_provisioning_client_register_response : ..- device_id
 az_iot_provisioning_client_register_response : ..- error_code

--- a/sdk/inc/azure/iot/az_iot_common.h
+++ b/sdk/inc/azure/iot/az_iot_common.h
@@ -215,7 +215,7 @@ AZ_NODISCARD AZ_INLINE bool az_iot_status_retriable(az_iot_status status)
  * @param[in] attempt The number of failed retry attempts.
  * @param[in] min_retry_delay_msec The minimum time, in milliseconds, to wait before a retry.
  * @param[in] max_retry_delay_msec The maximum time, in milliseconds, to wait before a retry.
- * @param[in] random_msec A random value between 0 and the maximum allowed jitter, in milliseconds.
+ * @param[in] random_jitter_msec A random value between 0 and the maximum allowed jitter, in milliseconds.
  * @return The recommended delay in milliseconds.
  */
 AZ_NODISCARD int32_t az_iot_calculate_retry_delay(
@@ -223,7 +223,7 @@ AZ_NODISCARD int32_t az_iot_calculate_retry_delay(
     int16_t attempt,
     int32_t min_retry_delay_msec,
     int32_t max_retry_delay_msec,
-    int32_t random_msec);
+    int32_t random_jitter_msec);
 
 #include <azure/core/_az_cfg_suffix.h>
 

--- a/sdk/inc/azure/iot/az_iot_hub_client.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client.h
@@ -395,10 +395,10 @@ typedef struct
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] received_topic An #az_span containing the received topic.
- * @param[out] out_twin_response If the message is twin-operation related, this will contain the
+ * @param[out] out_response If the message is twin-operation related, this will contain the
  *                         #az_iot_hub_client_twin_response.
  * @return An #az_result value indicating the result of the operation.
- * @retval #AZ_OK The topic is meant for this feature and the \p out_twin_response was populated
+ * @retval #AZ_OK The topic is meant for this feature and the \p out_response was populated
  * with relevant information.
  * @retval #AZ_ERROR_IOT_TOPIC_NO_MATCH The topic does not match the expected format. This could
  * be due to either a malformed topic OR the message which came in on this topic is not meant for
@@ -407,7 +407,7 @@ typedef struct
 AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
     az_iot_hub_client const* client,
     az_span received_topic,
-    az_iot_hub_client_twin_response* out_twin_response);
+    az_iot_hub_client_twin_response* out_response);
 
 /**
  * @brief Gets the MQTT topic that must be used to submit a Twin GET request.

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -236,7 +236,7 @@ typedef struct
                              * the #az_iot_provisioning_client_operation_status enum. */
   uint32_t retry_after_seconds; /**< Recommended timeout before sending the next MQTT publish. */
   az_iot_provisioning_client_registration_state
-      registration_result; /**< If the operation is complete (success or error), the
+      registration_state; /**< If the operation is complete (success or error), the
                                    registration state will contain the hub and device id in case of
                                    success. */
 } az_iot_provisioning_client_register_response;

--- a/sdk/samples/iot/paho_iot_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_provisioning_sample.c
@@ -352,8 +352,8 @@ static void handle_device_registration_status_message(
     {
       IOT_SAMPLE_LOG_SUCCESS("Device provisioned:");
       IOT_SAMPLE_LOG_AZ_SPAN(
-          "Hub Hostname:", register_response->registration_result.assigned_hub_hostname);
-      IOT_SAMPLE_LOG_AZ_SPAN("Device Id:", register_response->registration_result.device_id);
+          "Hub Hostname:", register_response->registration_state.assigned_hub_hostname);
+      IOT_SAMPLE_LOG_AZ_SPAN("Device Id:", register_response->registration_state.device_id);
       IOT_SAMPLE_LOG(" "); // Formatting
     }
     else // Unsuccessful assignment (unassigned, failed or disabled states)
@@ -362,14 +362,14 @@ static void handle_device_registration_status_message(
       IOT_SAMPLE_LOG_AZ_SPAN("Registration state:", register_response->operation_status);
       IOT_SAMPLE_LOG("Last operation status: %d", register_response->status);
       IOT_SAMPLE_LOG_AZ_SPAN("Operation ID:", register_response->operation_id);
-      IOT_SAMPLE_LOG("Error code: %u", register_response->registration_result.extended_error_code);
+      IOT_SAMPLE_LOG("Error code: %u", register_response->registration_state.extended_error_code);
       IOT_SAMPLE_LOG_AZ_SPAN(
-          "Error message:", register_response->registration_result.error_message);
+          "Error message:", register_response->registration_state.error_message);
       IOT_SAMPLE_LOG_AZ_SPAN(
-          "Error timestamp:", register_response->registration_result.error_timestamp);
+          "Error timestamp:", register_response->registration_state.error_timestamp);
       IOT_SAMPLE_LOG_AZ_SPAN(
-          "Error tracking ID:", register_response->registration_result.error_tracking_id);
-      exit((int)register_response->registration_result.extended_error_code);
+          "Error tracking ID:", register_response->registration_state.error_tracking_id);
+      exit((int)register_response->registration_state.extended_error_code);
     }
   }
 }

--- a/sdk/samples/iot/paho_iot_provisioning_sas_sample.c
+++ b/sdk/samples/iot/paho_iot_provisioning_sas_sample.c
@@ -361,8 +361,8 @@ static void handle_device_registration_status_message(
     {
       IOT_SAMPLE_LOG_SUCCESS("Device provisioned:");
       IOT_SAMPLE_LOG_AZ_SPAN(
-          "Hub Hostname:", register_response->registration_result.assigned_hub_hostname);
-      IOT_SAMPLE_LOG_AZ_SPAN("Device Id:", register_response->registration_result.device_id);
+          "Hub Hostname:", register_response->registration_state.assigned_hub_hostname);
+      IOT_SAMPLE_LOG_AZ_SPAN("Device Id:", register_response->registration_state.device_id);
       IOT_SAMPLE_LOG(" "); // Formatting
     }
     else // Unsuccessful assignment (unassigned, failed or disabled states)
@@ -371,14 +371,14 @@ static void handle_device_registration_status_message(
       IOT_SAMPLE_LOG_AZ_SPAN("Registration state:", register_response->operation_status);
       IOT_SAMPLE_LOG("Last operation status: %d", register_response->status);
       IOT_SAMPLE_LOG_AZ_SPAN("Operation ID:", register_response->operation_id);
-      IOT_SAMPLE_LOG("Error code: %u", register_response->registration_result.extended_error_code);
+      IOT_SAMPLE_LOG("Error code: %u", register_response->registration_state.extended_error_code);
       IOT_SAMPLE_LOG_AZ_SPAN(
-          "Error message:", register_response->registration_result.error_message);
+          "Error message:", register_response->registration_state.error_message);
       IOT_SAMPLE_LOG_AZ_SPAN(
-          "Error timestamp:", register_response->registration_result.error_timestamp);
+          "Error timestamp:", register_response->registration_state.error_timestamp);
       IOT_SAMPLE_LOG_AZ_SPAN(
-          "Error tracking ID:", register_response->registration_result.error_tracking_id);
-      exit((int)register_response->registration_result.extended_error_code);
+          "Error tracking ID:", register_response->registration_state.error_tracking_id);
+      exit((int)register_response->registration_state.extended_error_code);
     }
   }
 }

--- a/sdk/src/azure/iot/az_iot_common.c
+++ b/sdk/src/azure/iot/az_iot_common.c
@@ -146,13 +146,13 @@ AZ_NODISCARD int32_t az_iot_calculate_retry_delay(
     int16_t attempt,
     int32_t min_retry_delay_msec,
     int32_t max_retry_delay_msec,
-    int32_t random_msec)
+    int32_t random_jitter_msec)
 {
   _az_PRECONDITION_RANGE(0, operation_msec, INT32_MAX - 1);
   _az_PRECONDITION_RANGE(0, attempt, INT16_MAX - 1);
   _az_PRECONDITION_RANGE(0, min_retry_delay_msec, INT32_MAX - 1);
   _az_PRECONDITION_RANGE(0, max_retry_delay_msec, INT32_MAX - 1);
-  _az_PRECONDITION_RANGE(0, random_msec, INT32_MAX - 1);
+  _az_PRECONDITION_RANGE(0, random_jitter_msec, INT32_MAX - 1);
 
   _az_LOG_WRITE(AZ_LOG_IOT_RETRY, AZ_SPAN_EMPTY);
 
@@ -163,9 +163,9 @@ AZ_NODISCARD int32_t az_iot_calculate_retry_delay(
     delay = max_retry_delay_msec;
   }
 
-  if (max_retry_delay_msec - delay > random_msec)
+  if (max_retry_delay_msec - delay > random_jitter_msec)
   {
-    delay += random_msec;
+    delay += random_jitter_msec;
   }
 
   delay -= operation_msec;

--- a/sdk/src/azure/iot/az_iot_hub_client_twin.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_twin.c
@@ -108,11 +108,11 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_patch_get_publish_topic(
 AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
     az_iot_hub_client const* client,
     az_span received_topic,
-    az_iot_hub_client_twin_response* out_twin_response)
+    az_iot_hub_client_twin_response* out_response)
 {
   _az_PRECONDITION_NOT_NULL(client);
   _az_PRECONDITION_VALID_SPAN(received_topic, 1, false);
-  _az_PRECONDITION_NOT_NULL(out_twin_response);
+  _az_PRECONDITION_NOT_NULL(out_response);
   (void)client;
 
   az_result result;
@@ -145,7 +145,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
       // Get status and convert to enum
       uint32_t status_int;
       _az_RETURN_IF_FAILED(az_span_atou32(status_str, &status_int));
-      out_twin_response->status = (az_iot_status)status_int;
+      out_response->status = (az_iot_status)status_int;
 
       if (index == -1)
       {
@@ -158,20 +158,20 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
       _az_RETURN_IF_FAILED(
           az_iot_message_properties_init(&props, prop_span, az_span_size(prop_span)));
       _az_RETURN_IF_FAILED(az_iot_message_properties_find(
-          &props, az_iot_hub_client_request_id_span, &out_twin_response->request_id));
+          &props, az_iot_hub_client_request_id_span, &out_response->request_id));
 
-      if (out_twin_response->status == AZ_IOT_STATUS_NO_CONTENT)
+      if (out_response->status == AZ_IOT_STATUS_NO_CONTENT)
       {
         // Is a reported prop response
-        out_twin_response->response_type = AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES;
+        out_response->response_type = AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES;
         _az_RETURN_IF_FAILED(az_iot_message_properties_find(
-            &props, az_iot_hub_twin_version_prop, &out_twin_response->version));
+            &props, az_iot_hub_twin_version_prop, &out_response->version));
       }
       else
       {
         // Is a twin GET response
-        out_twin_response->response_type = AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_GET;
-        out_twin_response->version = AZ_SPAN_EMPTY;
+        out_response->response_type = AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_GET;
+        out_response->version = AZ_SPAN_EMPTY;
       }
 
       result = AZ_OK;
@@ -190,11 +190,11 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
       _az_RETURN_IF_FAILED(
           az_iot_message_properties_init(&props, prop_span, az_span_size(prop_span)));
       _az_RETURN_IF_FAILED(az_iot_message_properties_find(
-          &props, az_iot_hub_twin_version_prop, &out_twin_response->version));
+          &props, az_iot_hub_twin_version_prop, &out_response->version));
 
-      out_twin_response->response_type = AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES;
-      out_twin_response->request_id = AZ_SPAN_EMPTY;
-      out_twin_response->status = AZ_IOT_STATUS_OK;
+      out_response->response_type = AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES;
+      out_response->request_id = AZ_SPAN_EMPTY;
+      out_response->status = AZ_IOT_STATUS_OK;
 
       result = AZ_OK;
     }

--- a/sdk/src/azure/iot/az_iot_provisioning_client.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client.c
@@ -219,7 +219,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_query_status_get_publish_topic
 }
 
 AZ_INLINE az_iot_provisioning_client_registration_state
-_az_iot_provisioning_registration_result_default()
+_az_iot_provisioning_registration_state_default()
 {
   return (az_iot_provisioning_client_registration_state){ .assigned_hub_hostname = AZ_SPAN_EMPTY,
                                                            .device_id = AZ_SPAN_EMPTY,
@@ -265,7 +265,7 @@ AZ_INLINE az_result _az_iot_provisioning_client_parse_payload_error_code(
   return AZ_ERROR_ITEM_NOT_FOUND;
 }
 
-AZ_INLINE az_result _az_iot_provisioning_client_payload_registration_result_parse(
+AZ_INLINE az_result _az_iot_provisioning_client_payload_registration_state_parse(
     az_json_reader* jr,
     az_iot_provisioning_client_registration_state* out_state)
 {
@@ -353,7 +353,7 @@ AZ_INLINE az_result az_iot_provisioning_client_parse_payload(
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
 
-  out_response->registration_result = _az_iot_provisioning_registration_result_default();
+  out_response->registration_state = _az_iot_provisioning_registration_state_default();
 
   bool found_operation_id = false;
   bool found_operation_status = false;
@@ -385,8 +385,8 @@ AZ_INLINE az_result az_iot_provisioning_client_parse_payload(
     else if (az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("registrationState")))
     {
       _az_RETURN_IF_FAILED(az_json_reader_next_token(&jr));
-      _az_RETURN_IF_FAILED(_az_iot_provisioning_client_payload_registration_result_parse(
-          &jr, &out_response->registration_result));
+      _az_RETURN_IF_FAILED(_az_iot_provisioning_client_payload_registration_state_parse(
+          &jr, &out_response->registration_state));
     }
     else if (az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("trackingId")))
     {
@@ -395,7 +395,7 @@ AZ_INLINE az_result az_iot_provisioning_client_parse_payload(
       {
         return AZ_ERROR_ITEM_NOT_FOUND;
       }
-      out_response->registration_result.error_tracking_id = jr.token.slice;
+      out_response->registration_state.error_tracking_id = jr.token.slice;
     }
     else if (az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("message")))
     {
@@ -404,7 +404,7 @@ AZ_INLINE az_result az_iot_provisioning_client_parse_payload(
       {
         return AZ_ERROR_ITEM_NOT_FOUND;
       }
-      out_response->registration_result.error_message = jr.token.slice;
+      out_response->registration_state.error_message = jr.token.slice;
     }
     else if (az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("timestampUtc")))
     {
@@ -413,10 +413,10 @@ AZ_INLINE az_result az_iot_provisioning_client_parse_payload(
       {
         return AZ_ERROR_ITEM_NOT_FOUND;
       }
-      out_response->registration_result.error_timestamp = jr.token.slice;
+      out_response->registration_state.error_timestamp = jr.token.slice;
     }
     else if (az_result_succeeded(_az_iot_provisioning_client_parse_payload_error_code(
-                 &jr, &out_response->registration_result)))
+                 &jr, &out_response->registration_state)))
     {
       found_error = true;
     }

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
@@ -69,7 +69,7 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_topic_not_match
                                                             .retry_after_seconds = 0xBAADC0DE,
                                                             .operation_id = AZ_SPAN_EMPTY,
                                                             .operation_status = AZ_SPAN_EMPTY,
-                                                            .registration_result = { 0 } };
+                                                            .registration_state = { 0 } };
 
   az_result ret = az_iot_provisioning_client_parse_received_topic_and_payload(
       &client, received_topic, received_payload, &response);
@@ -140,15 +140,15 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_assigned_state_
   assert_memory_equal(
       az_span_ptr(response.operation_status), TEST_STATUS_ASSIGNED, strlen(TEST_STATUS_ASSIGNED));
   assert_memory_equal(
-      az_span_ptr(response.registration_result.assigned_hub_hostname),
+      az_span_ptr(response.registration_state.assigned_hub_hostname),
       TEST_HUB_HOSTNAME,
       strlen(TEST_HUB_HOSTNAME));
   assert_memory_equal(
-      az_span_ptr(response.registration_result.device_id), TEST_DEVICE_ID, strlen(TEST_DEVICE_ID));
+      az_span_ptr(response.registration_state.device_id), TEST_DEVICE_ID, strlen(TEST_DEVICE_ID));
 
-  assert_int_equal(0, response.registration_result.error_code);
-  assert_int_equal(0, response.registration_result.extended_error_code);
-  assert_int_equal(0, az_span_size(response.registration_result.error_message));
+  assert_int_equal(0, response.registration_state.error_code);
+  assert_int_equal(0, response.registration_state.extended_error_code);
+  assert_int_equal(0, az_span_size(response.registration_state.error_message));
 }
 
 static void
@@ -175,22 +175,22 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_invalid_certifi
   assert_memory_equal(
       az_span_ptr(response.operation_status), TEST_STATUS_FAILED, strlen(TEST_STATUS_FAILED));
 
-  assert_int_equal(0, az_span_size(response.registration_result.assigned_hub_hostname));
-  assert_int_equal(0, az_span_size(response.registration_result.device_id));
+  assert_int_equal(0, az_span_size(response.registration_state.assigned_hub_hostname));
+  assert_int_equal(0, az_span_size(response.registration_state.device_id));
 
-  assert_int_equal(AZ_IOT_STATUS_UNAUTHORIZED, response.registration_result.error_code);
-  assert_int_equal(401002, response.registration_result.extended_error_code);
+  assert_int_equal(AZ_IOT_STATUS_UNAUTHORIZED, response.registration_state.error_code);
+  assert_int_equal(401002, response.registration_state.extended_error_code);
 
   assert_memory_equal(
-      az_span_ptr(response.registration_result.error_message),
+      az_span_ptr(response.registration_state.error_message),
       TEST_ERROR_MESSAGE_INVALID_CERT,
       strlen(TEST_ERROR_MESSAGE_INVALID_CERT));
   assert_memory_equal(
-      az_span_ptr(response.registration_result.error_timestamp),
+      az_span_ptr(response.registration_state.error_timestamp),
       TEST_ERROR_TIMESTAMP,
       strlen(TEST_ERROR_TIMESTAMP));
   assert_memory_equal(
-      az_span_ptr(response.registration_result.error_tracking_id),
+      az_span_ptr(response.registration_state.error_tracking_id),
       TEST_ERROR_TRACKING_ID,
       strlen(TEST_ERROR_TRACKING_ID));
 }
@@ -250,22 +250,22 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_allocation_erro
   assert_memory_equal(
       az_span_ptr(response.operation_status), TEST_STATUS_FAILED, strlen(TEST_STATUS_FAILED));
 
-  assert_int_equal(0, az_span_size(response.registration_result.assigned_hub_hostname));
-  assert_int_equal(0, az_span_size(response.registration_result.device_id));
+  assert_int_equal(0, az_span_size(response.registration_state.assigned_hub_hostname));
+  assert_int_equal(0, az_span_size(response.registration_state.device_id));
 
-  assert_int_equal(AZ_IOT_STATUS_BAD_REQUEST, response.registration_result.error_code);
-  assert_int_equal(400207, response.registration_result.extended_error_code);
+  assert_int_equal(AZ_IOT_STATUS_BAD_REQUEST, response.registration_state.error_code);
+  assert_int_equal(400207, response.registration_state.extended_error_code);
 
   assert_memory_equal(
-      az_span_ptr(response.registration_result.error_message),
+      az_span_ptr(response.registration_state.error_message),
       TEST_ERROR_MESSAGE_ALLOCATION,
       strlen(TEST_ERROR_MESSAGE_ALLOCATION));
   assert_memory_equal(
-      az_span_ptr(response.registration_result.error_timestamp),
+      az_span_ptr(response.registration_state.error_timestamp),
       TEST_ERROR_TIMESTAMP,
       strlen(TEST_ERROR_TIMESTAMP));
 
-  assert_int_equal(0, az_span_size(response.registration_result.error_tracking_id));
+  assert_int_equal(0, az_span_size(response.registration_state.error_tracking_id));
 }
 
 static void
@@ -425,7 +425,7 @@ static void test_az_iot_provisioning_client_parse_operation_status_translate_suc
                                                             .retry_after_seconds = 0xBAADC0DE,
                                                             .operation_id = AZ_SPAN_EMPTY,
                                                             .operation_status = AZ_SPAN_EMPTY,
-                                                            .registration_result = { 0 } };
+                                                            .registration_state = { 0 } };
 
   az_iot_provisioning_client_operation_status operation_status = 0xBAADC0DE;
 


### PR DESCRIPTION
-updates naming from the API review
-also update the `random_msec` to `random_jitter_msec` 
-update `out_twin_response` to `out_response` to match other API's