### PR TITLE
Invoking functions from az_noplatform fails precondition.

### DIFF
--- a/sdk/docs/core/README.md
+++ b/sdk/docs/core/README.md
@@ -6,7 +6,7 @@ The library allows client libraries to expose common functionality in a consiste
 
 ## Porting the Azure SDK to Another Platform
 
-The `Azure Core` library requires you to implement a few functions to provide platform-specific features such as a clock and thread sleep. By default, `Azure Core` ships with no-op versions of these functions, all of which return 0 or do no operations. The no-op versions allow the Azure SDK to compile successfully so you can verify that your build tool chain is working properly; however, failures may occur if you execute the code.
+The `Azure Core` library requires you to implement a few functions to provide platform-specific features such as a clock and thread sleep. By default, `Azure Core` ships with no-op versions of these functions, all of which fail a precontition, and return 0 or do no operations. The no-op versions allow the Azure SDK to compile successfully so you can verify that your build tool chain is working properly; however, failures may occur if you execute the code.
 
 ## Key Concepts
 

--- a/sdk/docs/platform/README.md
+++ b/sdk/docs/platform/README.md
@@ -4,7 +4,7 @@ The Azure SDK platform layer provides abstractions for platform specific APIs wh
 
 ## Platform
 
-Azure SDK Core depends on some system-specific functions. These functions are not part of the C99 standard library and their implementation depends on system architecture (for example a clock, thread sleep, or interlock).
+Azure SDK Core depends on some system-specific functions. These functions are not part of the C99 standard library and their implementation depends on system architecture (for example, clock, or thread sleep).
 
 Azure SDK provides three platform implementations for you, one for Windows (`az_win32`), another for Linux and MacOS (`az_posix`) and an empty implementation (`az_noplatform`).
 

--- a/sdk/inc/azure/core/az_http_transport.h
+++ b/sdk/inc/azure/core/az_http_transport.h
@@ -226,6 +226,8 @@ AZ_NODISCARD int32_t az_http_request_headers_count(az_http_request const* reques
  * @retval #AZ_ERROR_HTTP_RESPONSE_COULDNT_RESOLVE_HOST The URL from \p ref_request can't be
  * resolved by the HTTP stack and the request was not sent.
  * @retval #AZ_ERROR_HTTP_ADAPTER Any other issue from the transport adapter layer.
+ * @retval #AZ_ERROR_DEPENDENCY_NOT_PROVIDED No platform implementation was supplied to support this
+ * function.
  */
 AZ_NODISCARD az_result
 az_http_client_send_request(az_http_request const* request, az_http_response* ref_response);

--- a/sdk/src/azure/core/az_http_policy_logging.c
+++ b/sdk/src/azure/core/az_http_policy_logging.c
@@ -110,8 +110,7 @@ static az_result _az_http_policy_logging_append_http_request_msg(
     remainder = az_span_copy(remainder, new_line_tab_string);
     remainder = az_span_copy(remainder, header_name);
 
-    if (az_span_size(header_value) > 0
-        && !az_span_is_content_equal(header_name, auth_header_name))
+    if (az_span_size(header_value) > 0 && !az_span_is_content_equal(header_name, auth_header_name))
     {
       remainder = az_span_copy(remainder, colon_separator_string);
       remainder = _az_http_policy_logging_copy_lengthy_value(remainder, header_value);

--- a/sdk/src/azure/platform/az_curl.c
+++ b/sdk/src/azure/platform/az_curl.c
@@ -590,13 +590,6 @@ static AZ_NODISCARD az_result _az_http_client_curl_send_request_impl_process(
   return result;
 }
 
-/**
- * @brief uses AZ_HTTP_BUILDER to set up CURL request and perform it.
- *
- * @param request an internal http builder with data to build and send http request
- * @param ref_response pre-allocated buffer where http response will be written
- * @return az_result
- */
 AZ_NODISCARD az_result
 az_http_client_send_request(az_http_request const* request, az_http_response* ref_response)
 {

--- a/sdk/src/azure/platform/az_nohttp.c
+++ b/sdk/src/azure/platform/az_nohttp.c
@@ -5,15 +5,6 @@
 
 #include <azure/core/_az_cfg.h>
 
-/**
- * @brief Provides no HTTP support.
- *
- * @param request An internal HTTP builder with data to build and send HTTP request.
- * @param ref_response A pre-allocated buffer where the HTTP response will be written.
- * @return An #az_result value indicating the result of the operation.
- * @retval #AZ_OK Success.
- * @retval other Failure.
- */
 AZ_NODISCARD az_result
 az_http_client_send_request(az_http_request const* request, az_http_response* ref_response)
 {

--- a/sdk/src/azure/platform/az_noplatform.c
+++ b/sdk/src/azure/platform/az_noplatform.c
@@ -2,9 +2,24 @@
 // SPDX-License-Identifier: MIT
 
 #include <azure/core/az_platform.h>
+#include <azure/core/internal/az_precondition_internal.h>
 
 #include <azure/core/_az_cfg.h>
 
-AZ_NODISCARD int64_t az_platform_clock_msec() { return 0; }
+AZ_NODISCARD int64_t az_platform_clock_msec()
+{
+  // This function does not have meaningful implementation to be called and its return value being
+  // relied upon.
+  _az_PRECONDITION(false);
 
-void az_platform_sleep_msec(int32_t milliseconds) { (void)milliseconds; }
+  return 0;
+}
+
+void az_platform_sleep_msec(int32_t milliseconds)
+{
+  (void)milliseconds;
+
+  // This function does not have meaningful implementation to be called and its behavior being
+  // relied upon.
+  _az_PRECONDITION(false);
+}

--- a/sdk/src/azure/platform/az_posix.c
+++ b/sdk/src/azure/platform/az_posix.c
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/core/internal/az_config_internal.h>
 #include <azure/core/az_platform.h>
+#include <azure/core/internal/az_config_internal.h>
 
 #include <time.h>
 

--- a/sdk/tests/core/CMakeLists.txt
+++ b/sdk/tests/core/CMakeLists.txt
@@ -11,7 +11,7 @@ include(AddTestCMocka)
 
 # -ld link option is only available for gcc
 if(UNIT_TESTING_MOCKS)
-    set(WRAP_FUNCTIONS "-Wl,--wrap=az_platform_clock_msec")
+    set(WRAP_FUNCTIONS "-Wl,--wrap=az_platform_clock_msec -Wl,--wrap=az_platform_sleep_msec")
 else()
     set(WRAP_FUNCTIONS "")
 endif()

--- a/sdk/tests/core/test_az_policy.c
+++ b/sdk/tests/core/test_az_policy.c
@@ -361,8 +361,8 @@ void test_az_http_pipeline_policy_retry_with_header_2(void** state)
 int64_t __wrap_az_platform_clock_msec();
 int64_t __wrap_az_platform_clock_msec() { return (int64_t)mock(); }
 
-void __wrap_az_platform_sleep_msec(int32_t);
-void __wrap_az_platform_sleep_msec(int32_t) {}
+void __wrap_az_platform_sleep_msec(int32_t milliseconds);
+void __wrap_az_platform_sleep_msec(int32_t milliseconds) { (void)milliseconds; }
 
 #endif // _az_MOCK_ENABLED
 

--- a/sdk/tests/core/test_az_policy.c
+++ b/sdk/tests/core/test_az_policy.c
@@ -361,6 +361,9 @@ void test_az_http_pipeline_policy_retry_with_header_2(void** state)
 int64_t __wrap_az_platform_clock_msec();
 int64_t __wrap_az_platform_clock_msec() { return (int64_t)mock(); }
 
+int64_t __wrap_az_platform_sleep_msec(int32_t);
+int64_t __wrap_az_platform_sleep_msec(int32_t) {}
+
 #endif // _az_MOCK_ENABLED
 
 int test_az_policy()

--- a/sdk/tests/core/test_az_policy.c
+++ b/sdk/tests/core/test_az_policy.c
@@ -90,7 +90,7 @@ void test_az_http_pipeline_policy_telemetry(void** state)
   // Create policy options
   _az_http_policy_telemetry_options telemetry = _az_http_policy_telemetry_options_default();
 
-  _az_http_policy policies[1] = {            
+  _az_http_policy policies[1] = {
             {
               ._internal = {
                 .process = test_policy_transport,
@@ -135,7 +135,7 @@ void test_az_http_pipeline_policy_apiversion(void** state)
   api_version._internal.name = AZ_SPAN_FROM_STR("name");
   api_version._internal.version = AZ_SPAN_FROM_STR("version");
 
-  _az_http_policy policies[1] = {            
+  _az_http_policy policies[1] = {
             {
               ._internal = {
                 .process = test_policy_transport,
@@ -248,7 +248,7 @@ void test_az_http_pipeline_policy_retry(void** state)
   // Create policy options
   az_http_policy_retry_options retry_options = _az_http_policy_retry_options_default();
 
-  _az_http_policy policies[1] = {            
+  _az_http_policy policies[1] = {
             {
               ._internal = {
                 .process = test_policy_transport_retry_response,
@@ -295,7 +295,7 @@ void test_az_http_pipeline_policy_retry_with_header(void** state)
   // make just one retry
   retry_options.max_retries = 1;
 
-  _az_http_policy policies[1] = {            
+  _az_http_policy policies[1] = {
             {
               ._internal = {
                 .process = test_policy_transport_retry_response_with_header,
@@ -342,7 +342,7 @@ void test_az_http_pipeline_policy_retry_with_header_2(void** state)
   // make just one retry
   retry_options.max_retries = 1;
 
-  _az_http_policy policies[1] = {            
+  _az_http_policy policies[1] = {
             {
               ._internal = {
                 .process = test_policy_transport_retry_response_with_header_2,
@@ -361,8 +361,8 @@ void test_az_http_pipeline_policy_retry_with_header_2(void** state)
 int64_t __wrap_az_platform_clock_msec();
 int64_t __wrap_az_platform_clock_msec() { return (int64_t)mock(); }
 
-int64_t __wrap_az_platform_sleep_msec(int32_t);
-int64_t __wrap_az_platform_sleep_msec(int32_t) {}
+void __wrap_az_platform_sleep_msec(int32_t);
+void __wrap_az_platform_sleep_msec(int32_t) {}
 
 #endif // _az_MOCK_ENABLED
 


### PR DESCRIPTION
This is variant B of the proposed behavior. Variant A: https://github.com/Azure/azure-sdk-for-c/pull/1256

Closes #1226