### PR TITLE
Run clang-tidy linter tool on the repo and fix all warnings

### DIFF
--- a/sdk/inc/azure/core/_az_cfg.h
+++ b/sdk/inc/azure/core/_az_cfg.h
@@ -86,6 +86,6 @@
 #endif // _MSC_VER
 
 // Get the number of elements in an array
-#define _az_COUNTOF(array) (sizeof(array) / sizeof(array[0]))
+#define _az_COUNTOF(array) (sizeof(array) / sizeof((array)[0]))
 
 #endif // _az_CFG_H

--- a/sdk/inc/azure/core/_az_cfg_suffix.h
+++ b/sdk/inc/azure/core/_az_cfg_suffix.h
@@ -18,7 +18,7 @@
 #elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) // !_MSC_VER
 #pragma GCC diagnostic pop
 #elif defined(__clang__) // !_MSC_VER !__GNUC__
-#pragma clang diagnostic pop
+#pragma clang diagnostic pop // NOLINT(clang-diagnostic-unknown-pragmas)
 #endif
 
 #ifdef __cplusplus

--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -28,7 +28,7 @@
 #include <azure/core/_az_cfg_prefix.h>
 
 #define _az_LOG_MAKE_CLASSIFICATION(facility, code) \
-  ((int32_t)((uint32_t)(facility) << 16) | (uint32_t)(code))
+  (((uint32_t)(facility) << 16U) | (uint32_t)(code))
 
 /**
  * @brief Identifies the classifications of log messages produced by the SDK.

--- a/sdk/inc/azure/core/az_result.h
+++ b/sdk/inc/azure/core/az_result.h
@@ -36,10 +36,9 @@ enum
 };
 
 #define _az_RESULT_MAKE_ERROR(facility, code) \
-  ((int32_t)(_az_ERROR_FLAG | ((int32_t)(facility) << 16) | (int32_t)(code)))
+  ((uint32_t)_az_ERROR_FLAG | ((uint32_t)(facility) << 16U) | (uint32_t)(code))
 
-#define _az_RESULT_MAKE_SUCCESS(facility, code) \
-  ((int32_t)(((int32_t)(facility) << 16) | (int32_t)(code)))
+#define _az_RESULT_MAKE_SUCCESS(facility, code) (((uint32_t)(facility) << 16U) | (uint32_t)(code))
 
 // az_result Bits:
 //   - 31 Severity (0 - success, 1 - failure).
@@ -145,7 +144,7 @@ typedef enum
  */
 AZ_NODISCARD AZ_INLINE bool az_result_failed(az_result result)
 {
-  return ((int32_t)result & (int32_t)_az_ERROR_FLAG) != 0;
+  return ((uint32_t)result & (uint32_t)_az_ERROR_FLAG) != 0;
 }
 
 /**

--- a/sdk/inc/azure/core/az_result.h
+++ b/sdk/inc/azure/core/az_result.h
@@ -36,7 +36,7 @@ enum
 };
 
 #define _az_RESULT_MAKE_ERROR(facility, code) \
-  ((uint32_t)_az_ERROR_FLAG | ((uint32_t)(facility) << 16U) | (uint32_t)(code))
+  ((int32_t)((uint32_t)_az_ERROR_FLAG | ((uint32_t)(facility) << 16U) | (uint32_t)(code)))
 
 #define _az_RESULT_MAKE_SUCCESS(facility, code) (((uint32_t)(facility) << 16U) | (uint32_t)(code))
 

--- a/sdk/inc/azure/core/az_span.h
+++ b/sdk/inc/azure/core/az_span.h
@@ -105,7 +105,7 @@ AZ_NODISCARD az_span az_span_create(uint8_t* ptr, int32_t size);
 #define AZ_SPAN_LITERAL_FROM_STR(STRING_LITERAL)      \
   {                                                   \
     ._internal = {                                    \
-      .ptr = (uint8_t*)STRING_LITERAL,                \
+      .ptr = (uint8_t*)(STRING_LITERAL),              \
       .size = _az_STRING_LITERAL_LEN(STRING_LITERAL), \
     },                                                \
   }
@@ -126,12 +126,12 @@ AZ_NODISCARD az_span az_span_create(uint8_t* ptr, int32_t size);
 
 // Returns 1 if the address of the array is equal to the address of its 1st element.
 // Returns 0 for anything that is not an array (for example any arbitrary pointer).
-#define _az_IS_ARRAY(array) (((void*)&(array)) == ((void*)(&array[0])))
+#define _az_IS_ARRAY(array) (((void*)&(array)) == ((void*)(&(array)[0])))
 
 // Returns 1 if the element size of the array is 1 (which is only true for byte arrays such as
 // uint8_t[] and char[]).
 // Returns 0 for any other element size (for example int32_t[]).
-#define _az_IS_BYTE_ARRAY(array) ((sizeof(array[0]) == 1) && _az_IS_ARRAY(array))
+#define _az_IS_BYTE_ARRAY(array) ((sizeof((array)[0]) == 1) && _az_IS_ARRAY(array))
 
 /**
  * @brief Returns an #az_span expression over an uninitialized byte buffer.
@@ -148,7 +148,7 @@ AZ_NODISCARD az_span az_span_create(uint8_t* ptr, int32_t size);
 // Force a division by 0 that gets detected by compilers for anything that isn't a byte array.
 #define AZ_SPAN_FROM_BUFFER(BYTE_BUFFER) \
   az_span_create(                        \
-      (uint8_t*)BYTE_BUFFER, (sizeof(BYTE_BUFFER) / (_az_IS_BYTE_ARRAY(BYTE_BUFFER) ? 1 : 0)))
+      (uint8_t*)(BYTE_BUFFER), (sizeof(BYTE_BUFFER) / (_az_IS_BYTE_ARRAY(BYTE_BUFFER) ? 1 : 0)))
 
 /**
  * @brief Returns an #az_span from a 0-terminated array of bytes (chars).

--- a/sdk/inc/azure/core/az_span.h
+++ b/sdk/inc/azure/core/az_span.h
@@ -303,6 +303,7 @@ az_span az_span_copy_u8(az_span destination, uint8_t byte);
  */
 AZ_INLINE void az_span_fill(az_span destination, uint8_t value)
 {
+  // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
   memset(az_span_ptr(destination), value, (size_t)az_span_size(destination));
 }
 

--- a/sdk/inc/azure/core/internal/az_http_internal.h
+++ b/sdk/inc/azure/core/internal/az_http_internal.h
@@ -11,6 +11,12 @@
 
 #include <azure/core/_az_cfg_prefix.h>
 
+enum
+{
+  /// The maximum number of HTTP pipeline policies allowed.
+  _az_MAXIMUM_NUMBER_OF_POLICIES = 10,
+};
+
 /**
  * @brief Internal definition of an HTTP pipeline.
  * Defines the number of policies inside a pipeline.
@@ -19,7 +25,7 @@ typedef struct
 {
   struct
   {
-    _az_http_policy policies[10];
+    _az_http_policy policies[_az_MAXIMUM_NUMBER_OF_POLICIES];
   } _internal;
 } _az_http_pipeline;
 

--- a/sdk/inc/azure/core/internal/az_precondition_internal.h
+++ b/sdk/inc/azure/core/internal/az_precondition_internal.h
@@ -117,7 +117,7 @@ AZ_NODISCARD AZ_INLINE bool _az_span_is_valid(az_span span, int32_t min_size, bo
   // left until the theoretical end of the address space, it is not a valid span.
   // Example: (az_span) { .ptr = (uint8_t*)(~0 - 5), .size = 10 } is not a valid span, because most
   // likely you end up pointing to 0x0000 at .ptr[6], &.ptr[7] is 0x...0001, etc.
-  uint8_t* const max_ptr = (uint8_t*)~0U;
+  uint8_t* const max_ptr = (uint8_t*)-1;
   result = result && ((size_t)span_size <= (size_t)(max_ptr - ptr));
 
   return result && min_size <= span_size;

--- a/sdk/inc/azure/core/internal/az_precondition_internal.h
+++ b/sdk/inc/azure/core/internal/az_precondition_internal.h
@@ -117,7 +117,7 @@ AZ_NODISCARD AZ_INLINE bool _az_span_is_valid(az_span span, int32_t min_size, bo
   // left until the theoretical end of the address space, it is not a valid span.
   // Example: (az_span) { .ptr = (uint8_t*)(~0 - 5), .size = 10 } is not a valid span, because most
   // likely you end up pointing to 0x0000 at .ptr[6], &.ptr[7] is 0x...0001, etc.
-  uint8_t* const max_ptr = (uint8_t*)-1;
+  uint8_t* const max_ptr = (uint8_t*)~0U;
   result = result && ((size_t)span_size <= (size_t)(max_ptr - ptr));
 
   return result && min_size <= span_size;

--- a/sdk/inc/azure/core/internal/az_precondition_internal.h
+++ b/sdk/inc/azure/core/internal/az_precondition_internal.h
@@ -117,7 +117,7 @@ AZ_NODISCARD AZ_INLINE bool _az_span_is_valid(az_span span, int32_t min_size, bo
   // left until the theoretical end of the address space, it is not a valid span.
   // Example: (az_span) { .ptr = (uint8_t*)(~0 - 5), .size = 10 } is not a valid span, because most
   // likely you end up pointing to 0x0000 at .ptr[6], &.ptr[7] is 0x...0001, etc.
-  uint8_t* const max_ptr = (uint8_t*)~0U;
+  uint8_t* const max_ptr = (uint8_t*)~(uint8_t)0;
   result = result && ((size_t)span_size <= (size_t)(max_ptr - ptr));
 
   return result && min_size <= span_size;

--- a/sdk/inc/azure/core/internal/az_precondition_internal.h
+++ b/sdk/inc/azure/core/internal/az_precondition_internal.h
@@ -117,8 +117,8 @@ AZ_NODISCARD AZ_INLINE bool _az_span_is_valid(az_span span, int32_t min_size, bo
   // left until the theoretical end of the address space, it is not a valid span.
   // Example: (az_span) { .ptr = (uint8_t*)(~0 - 5), .size = 10 } is not a valid span, because most
   // likely you end up pointing to 0x0000 at .ptr[6], &.ptr[7] is 0x...0001, etc.
-  uint8_t* const max_ptr = (uint8_t*)~0;
-  result &= ((size_t)span_size <= (size_t)(max_ptr - ptr));
+  uint8_t* const max_ptr = (uint8_t*)~0U;
+  result = result && ((size_t)span_size <= (size_t)(max_ptr - ptr));
 
   return result && min_size <= span_size;
 }

--- a/sdk/inc/azure/core/internal/az_retry_internal.h
+++ b/sdk/inc/azure/core/internal/az_retry_internal.h
@@ -14,7 +14,7 @@ AZ_NODISCARD AZ_INLINE int32_t _az_retry_calc_delay(
     int32_t max_retry_delay_msec)
 {
   int32_t const exponential_retry_after
-      = retry_delay_msec * (attempt <= 30 ? (1 << attempt) : INT32_MAX); // scale exponentially
+      = retry_delay_msec * (attempt <= 30 ? (1U << (uint32_t)attempt) : INT32_MAX); // scale exponentially
 
   return exponential_retry_after > max_retry_delay_msec ? max_retry_delay_msec
                                                         : exponential_retry_after;

--- a/sdk/inc/azure/core/internal/az_retry_internal.h
+++ b/sdk/inc/azure/core/internal/az_retry_internal.h
@@ -13,7 +13,7 @@ _az_retry_calc_delay(int32_t attempt, int32_t retry_delay_msec, int32_t max_retr
 {
   // scale exponentially
   int32_t const exponential_retry_after
-      = retry_delay_msec * (attempt <= 30 ? (1U << (uint32_t)attempt) : INT32_MAX);
+      = retry_delay_msec * (attempt <= 30 ? (int32_t)(1U << (uint32_t)attempt) : INT32_MAX);
 
   return exponential_retry_after > max_retry_delay_msec ? max_retry_delay_msec
                                                         : exponential_retry_after;

--- a/sdk/inc/azure/core/internal/az_retry_internal.h
+++ b/sdk/inc/azure/core/internal/az_retry_internal.h
@@ -8,13 +8,12 @@
 
 #include <azure/core/_az_cfg_prefix.h>
 
-AZ_NODISCARD AZ_INLINE int32_t _az_retry_calc_delay(
-    int32_t attempt,
-    int32_t retry_delay_msec,
-    int32_t max_retry_delay_msec)
+AZ_NODISCARD AZ_INLINE int32_t
+_az_retry_calc_delay(int32_t attempt, int32_t retry_delay_msec, int32_t max_retry_delay_msec)
 {
+  // scale exponentially
   int32_t const exponential_retry_after
-      = retry_delay_msec * (attempt <= 30 ? (1U << (uint32_t)attempt) : INT32_MAX); // scale exponentially
+      = retry_delay_msec * (attempt <= 30 ? (1U << (uint32_t)attempt) : INT32_MAX);
 
   return exponential_retry_after > max_retry_delay_msec ? max_retry_delay_msec
                                                         : exponential_retry_after;

--- a/sdk/inc/azure/core/internal/az_span_internal.h
+++ b/sdk/inc/azure/core/internal/az_span_internal.h
@@ -13,7 +13,7 @@
 #include <azure/core/_az_cfg_prefix.h>
 
 // The smallest number that has the same number of digits as _az_MAX_SIZE_FOR_UINT64 (i.e. 10^19).
-#define _az_SMALLEST_20_DIGIT_NUMBER 10000000000000000000ull
+#define _az_SMALLEST_20_DIGIT_NUMBER 10000000000000000000ULL
 
 enum
 {

--- a/sdk/inc/azure/core/internal/az_span_internal.h
+++ b/sdk/inc/azure/core/internal/az_span_internal.h
@@ -12,6 +12,24 @@
 
 #include <azure/core/_az_cfg_prefix.h>
 
+// The smallest number that has the same number of digits as _az_MAX_SIZE_FOR_UINT64 (i.e. 10^19).
+#define _az_SMALLEST_20_DIGIT_NUMBER 10000000000000000000ull
+
+enum
+{
+  // For example: 2,147,483,648
+  _az_MAX_SIZE_FOR_UINT32 = 10,
+
+  // For example: 18,446,744,073,709,551,615
+  _az_MAX_SIZE_FOR_UINT64 = 20,
+
+  // The number of unique values in base 10 (decimal).
+  _az_NUMBER_OF_DECIMAL_VALUES = 10,
+
+  // The smallest number that has the same number of digits as _az_MAX_SIZE_FOR_UINT32 (i.e. 10^9).
+  _az_SMALLEST_10_DIGIT_NUMBER = 1000000000,
+};
+
 // Use this helper to figure out how much the sliced_span has moved in comparison to the
 // original_span while writing and slicing a copy of the original.
 // The \p sliced_span must be some slice of the \p original_span (and have the same backing memory).

--- a/sdk/inc/azure/iot/az_iot_common.h
+++ b/sdk/inc/azure/iot/az_iot_common.h
@@ -215,7 +215,8 @@ AZ_NODISCARD AZ_INLINE bool az_iot_status_retriable(az_iot_status status)
  * @param[in] attempt The number of failed retry attempts.
  * @param[in] min_retry_delay_msec The minimum time, in milliseconds, to wait before a retry.
  * @param[in] max_retry_delay_msec The maximum time, in milliseconds, to wait before a retry.
- * @param[in] random_jitter_msec A random value between 0 and the maximum allowed jitter, in milliseconds.
+ * @param[in] random_jitter_msec A random value between 0 and the maximum allowed jitter, in
+ * milliseconds.
  * @return The recommended delay in milliseconds.
  */
 AZ_NODISCARD int32_t az_iot_calculate_retry_delay(

--- a/sdk/inc/azure/iot/az_iot_common.h
+++ b/sdk/inc/azure/iot/az_iot_common.h
@@ -227,4 +227,4 @@ AZ_NODISCARD int32_t az_iot_calculate_retry_delay(
 
 #include <azure/core/_az_cfg_suffix.h>
 
-#endif //!_az_IOT_CORE_H
+#endif // _az_IOT_CORE_H

--- a/sdk/inc/azure/iot/az_iot_hub_client.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client.h
@@ -461,4 +461,4 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_patch_get_publish_topic(
 
 #include <azure/core/_az_cfg_suffix.h>
 
-#endif //!_az_IOT_HUB_CLIENT_H
+#endif // _az_IOT_HUB_CLIENT_H

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -331,4 +331,4 @@ AZ_NODISCARD az_result az_iot_provisioning_client_query_status_get_publish_topic
 
 #include <azure/core/_az_cfg_suffix.h>
 
-#endif //!_az_IOT_PROVISIONING_CLIENT_H
+#endif // _az_IOT_PROVISIONING_CLIENT_H

--- a/sdk/inc/azure/iot/internal/az_iot_common_internal.h
+++ b/sdk/inc/azure/iot/internal/az_iot_common_internal.h
@@ -53,4 +53,4 @@ AZ_NODISCARD az_result _az_span_copy_url_encode(az_span destination, az_span sou
 
 #include <azure/core/_az_cfg_suffix.h>
 
-#endif //!_az_IOT_CORE_INTERNAL_H
+#endif // _az_IOT_CORE_INTERNAL_H

--- a/sdk/inc/azure/iot/internal/az_iot_common_internal.h
+++ b/sdk/inc/azure/iot/internal/az_iot_common_internal.h
@@ -42,14 +42,17 @@ AZ_NODISCARD int32_t _az_iot_u32toa_size(uint32_t number);
 AZ_NODISCARD int32_t _az_iot_u64toa_size(uint64_t number);
 
 /**
- * @brief Copies the url-encoded content of `source` span into `destination`, returning the free remaining of `destination`.
+ * @brief Copies the url-encoded content of `source` span into `destination`, returning the free
+ * remaining of `destination`.
  *
  * @param[in] destination The span where the `source` is url-encoded to.
  * @param[in] source The span to url-encode and copy the content from.
- * @param[out] out_remainder A slice of `destination` with the non-used buffer portion of `destination`.
+ * @param[out] out_remainder A slice of `destination` with the non-used buffer portion of
+ * `destination`.
  * @return An `az_result` value.
  */
-AZ_NODISCARD az_result _az_span_copy_url_encode(az_span destination, az_span source, az_span* out_remainder);
+AZ_NODISCARD az_result
+_az_span_copy_url_encode(az_span destination, az_span source, az_span* out_remainder);
 
 #include <azure/core/_az_cfg_suffix.h>
 

--- a/sdk/src/azure/core/az_context.c
+++ b/sdk/src/azure/core/az_context.c
@@ -25,7 +25,9 @@ AZ_NODISCARD int64_t az_context_get_expiration(az_context const* context)
   for (; context != NULL; context = context->_internal.parent)
   {
     if (context->_internal.expiration < expiration)
+    {
       expiration = context->_internal.expiration;
+    }
   }
   return expiration;
 }

--- a/sdk/src/azure/core/az_hex_private.h
+++ b/sdk/src/azure/core/az_hex_private.h
@@ -19,6 +19,9 @@ enum
  */
 AZ_NODISCARD AZ_INLINE uint8_t _az_number_to_upper_hex(uint8_t number)
 {
+  // The 10 is one more than the last non-alphabetic digit of the hex values (0-9, A-F).
+  // Every value under 10 is a single digit, whereas values 10 and above are hex letters.
+
   // NOLINTNEXTLINE(readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers)
   return (uint8_t)(number + (number < 10 ? '0' : _az_HEX_UPPER_OFFSET));
 }

--- a/sdk/src/azure/core/az_hex_private.h
+++ b/sdk/src/azure/core/az_hex_private.h
@@ -19,6 +19,7 @@ enum
  */
 AZ_NODISCARD AZ_INLINE uint8_t _az_number_to_upper_hex(uint8_t number)
 {
+  // NOLINTNEXTLINE(readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers)
   return (uint8_t)(number + (number < 10 ? '0' : _az_HEX_UPPER_OFFSET));
 }
 

--- a/sdk/src/azure/core/az_http_request.c
+++ b/sdk/src/azure/core/az_http_request.c
@@ -105,7 +105,7 @@ AZ_NODISCARD az_result az_http_request_set_query_parameter(
   // Parameter value
   if (is_value_url_encoded)
   {
-    url_remainder = az_span_copy(url_remainder, value);
+    az_span_copy(url_remainder, value);
   }
   else
   {

--- a/sdk/src/azure/core/az_http_response.c
+++ b/sdk/src/azure/core/az_http_response.c
@@ -329,7 +329,7 @@ AZ_NODISCARD az_result az_http_response_append(az_http_response* ref_response, a
   int32_t write_size = az_span_size(source);
   _az_RETURN_IF_NOT_ENOUGH_SIZE(remaining, write_size);
 
-  remaining = az_span_copy(remaining, source);
+  az_span_copy(remaining, source);
   ref_response->_internal.written += write_size;
 
   return AZ_OK;

--- a/sdk/src/azure/core/az_json_private.h
+++ b/sdk/src/azure/core/az_json_private.h
@@ -75,7 +75,7 @@ AZ_INLINE _az_json_stack_item _az_json_stack_pop(_az_json_bit_stack* ref_json_st
   // Don't do the right bit shift if we are at the last bit in the stack.
   if (ref_json_stack->_internal.current_depth != 0)
   {
-    ref_json_stack->_internal.az_json_stack >>= 1;
+    ref_json_stack->_internal.az_json_stack >>= 1U;
 
     // We don't want current_depth to become negative, in case preconditions are off, and if
     // append_container_end is called before append_X_start.
@@ -83,8 +83,8 @@ AZ_INLINE _az_json_stack_item _az_json_stack_pop(_az_json_bit_stack* ref_json_st
   }
 
   // true (i.e. 1) means _az_JSON_STACK_OBJECT, while false (i.e. 0) means _az_JSON_STACK_ARRAY
-  return (ref_json_stack->_internal.az_json_stack & 1) != 0 ? _az_JSON_STACK_OBJECT
-                                                            : _az_JSON_STACK_ARRAY;
+  return (ref_json_stack->_internal.az_json_stack & 1U) != 0 ? _az_JSON_STACK_OBJECT
+                                                             : _az_JSON_STACK_ARRAY;
 }
 
 AZ_INLINE void _az_json_stack_push(_az_json_bit_stack* ref_json_stack, _az_json_stack_item item)
@@ -94,8 +94,8 @@ AZ_INLINE void _az_json_stack_push(_az_json_bit_stack* ref_json_stack, _az_json_
       && ref_json_stack->_internal.current_depth < _az_MAX_JSON_STACK_SIZE);
 
   ref_json_stack->_internal.current_depth++;
-  ref_json_stack->_internal.az_json_stack <<= 1;
-  ref_json_stack->_internal.az_json_stack |= item;
+  ref_json_stack->_internal.az_json_stack <<= 1U;
+  ref_json_stack->_internal.az_json_stack |= (uint32_t)item;
 }
 
 AZ_NODISCARD AZ_INLINE _az_json_stack_item _az_json_stack_peek(_az_json_bit_stack const* json_stack)
@@ -105,8 +105,8 @@ AZ_NODISCARD AZ_INLINE _az_json_stack_item _az_json_stack_peek(_az_json_bit_stac
       && json_stack->_internal.current_depth <= _az_MAX_JSON_STACK_SIZE);
 
   // true (i.e. 1) means _az_JSON_STACK_OBJECT, while false (i.e. 0) means _az_JSON_STACK_ARRAY
-  return (json_stack->_internal.az_json_stack & 1) != 0 ? _az_JSON_STACK_OBJECT
-                                                        : _az_JSON_STACK_ARRAY;
+  return (json_stack->_internal.az_json_stack & 1U) != 0 ? _az_JSON_STACK_OBJECT
+                                                         : _az_JSON_STACK_ARRAY;
 }
 
 #include <azure/core/_az_cfg_suffix.h>

--- a/sdk/src/azure/core/az_json_private.h
+++ b/sdk/src/azure/core/az_json_private.h
@@ -55,6 +55,9 @@ enum
   // strings are guaranteed to fit into a single 64 byte chunk, if all 10 needed to be escaped (i.e.
   // multiply by 6). 10 * 6 + 4 = 64, and that fits within _az_MINIMUM_STRING_CHUNK_SIZE
   _az_MAX_UNESCAPED_STRING_SIZE_PER_CHUNK = 10,
+
+  // The number of unique values in base 16 (hexadecimal).
+  _az_NUMBER_OF_HEX_VALUES = 16,
 };
 
 typedef enum

--- a/sdk/src/azure/core/az_json_reader.c
+++ b/sdk/src/azure/core/az_json_reader.c
@@ -271,7 +271,8 @@ AZ_NODISCARD static az_result _az_json_reader_process_string(az_json_reader* ref
     {
       break;
     }
-    else if (next_byte == '\\')
+
+    if (next_byte == '\\')
     {
       ref_json_reader->token._internal.string_has_escaped_chars = true;
       current_index++;
@@ -750,25 +751,31 @@ AZ_NODISCARD static az_result _az_json_reader_process_value(
 {
   if (next_byte == '"')
     return _az_json_reader_process_string(ref_json_reader);
-  else if (next_byte == '{')
+
+  if (next_byte == '{')
     return _az_json_reader_process_container_start(
         ref_json_reader, AZ_JSON_TOKEN_BEGIN_OBJECT, _az_JSON_STACK_OBJECT);
-  else if (next_byte == '[')
+
+  if (next_byte == '[')
     return _az_json_reader_process_container_start(
         ref_json_reader, AZ_JSON_TOKEN_BEGIN_ARRAY, _az_JSON_STACK_ARRAY);
-  else if (isdigit(next_byte) || next_byte == '-')
+
+  if (isdigit(next_byte) || next_byte == '-')
     return _az_json_reader_process_number(ref_json_reader);
-  else if (next_byte == 'f')
+
+  if (next_byte == 'f')
     return _az_json_reader_process_literal(
         ref_json_reader, AZ_SPAN_FROM_STR("false"), AZ_JSON_TOKEN_FALSE);
-  else if (next_byte == 't')
+
+  if (next_byte == 't')
     return _az_json_reader_process_literal(
         ref_json_reader, AZ_SPAN_FROM_STR("true"), AZ_JSON_TOKEN_TRUE);
-  else if (next_byte == 'n')
+
+  if (next_byte == 'n')
     return _az_json_reader_process_literal(
         ref_json_reader, AZ_SPAN_FROM_STR("null"), AZ_JSON_TOKEN_NULL);
-  else
-    return AZ_ERROR_UNEXPECTED_CHAR;
+
+  return AZ_ERROR_UNEXPECTED_CHAR;
 }
 
 AZ_NODISCARD static az_result _az_json_reader_read_first_token(
@@ -786,7 +793,8 @@ AZ_NODISCARD static az_result _az_json_reader_read_first_token(
     ref_json_reader->_internal.is_complex_json = true;
     return AZ_OK;
   }
-  else if (first_byte == '[')
+
+  if (first_byte == '[')
   {
     _az_json_stack_push(&ref_json_reader->_internal.bit_stack, _az_JSON_STACK_ARRAY);
 
@@ -796,10 +804,8 @@ AZ_NODISCARD static az_result _az_json_reader_read_first_token(
     ref_json_reader->_internal.is_complex_json = true;
     return AZ_OK;
   }
-  else
-  {
-    return _az_json_reader_process_value(ref_json_reader, first_byte);
-  }
+
+  return _az_json_reader_process_value(ref_json_reader, first_byte);
 }
 
 AZ_NODISCARD static az_result _az_json_reader_process_next_byte(
@@ -839,24 +845,22 @@ AZ_NODISCARD static az_result _az_json_reader_process_next_byte(
       }
       return _az_json_reader_process_property_name(ref_json_reader);
     }
-    else
-    {
-      return _az_json_reader_process_value(ref_json_reader, next_byte);
-    }
+
+    return _az_json_reader_process_value(ref_json_reader, next_byte);
   }
-  else if (next_byte == '}')
+
+  if (next_byte == '}')
   {
     return _az_json_reader_process_container_end(ref_json_reader, AZ_JSON_TOKEN_END_OBJECT);
   }
-  else if (next_byte == ']')
+
+  if (next_byte == ']')
   {
     return _az_json_reader_process_container_end(ref_json_reader, AZ_JSON_TOKEN_END_ARRAY);
   }
-  else
-  {
-    // No other character is a valid token delimiter within JSON.
-    return AZ_ERROR_UNEXPECTED_CHAR;
-  }
+
+  // No other character is a valid token delimiter within JSON.
+  return AZ_ERROR_UNEXPECTED_CHAR;
 }
 
 AZ_NODISCARD az_result az_json_reader_next_token(az_json_reader* ref_json_reader)
@@ -873,11 +877,9 @@ AZ_NODISCARD az_result az_json_reader_next_token(az_json_reader* ref_json_reader
       // An empty JSON payload is invalid.
       return AZ_ERROR_UNEXPECTED_END;
     }
-    else
-    {
-      // No more JSON text left to process, we are done.
-      return AZ_ERROR_JSON_READER_DONE;
-    }
+
+    // No more JSON text left to process, we are done.
+    return AZ_ERROR_JSON_READER_DONE;
   }
 
   // Clear the internal state of any previous token.
@@ -900,16 +902,14 @@ AZ_NODISCARD az_result az_json_reader_next_token(az_json_reader* ref_json_reader
       {
         return _az_json_reader_process_container_end(ref_json_reader, AZ_JSON_TOKEN_END_OBJECT);
       }
-      else
+
+      // We expect the start of a property name as the first non-whitespace character within a
+      // JSON object.
+      if (first_byte != '"')
       {
-        // We expect the start of a property name as the first non-whitespace character within a
-        // JSON object.
-        if (first_byte != '"')
-        {
-          return AZ_ERROR_UNEXPECTED_CHAR;
-        }
-        return _az_json_reader_process_property_name(ref_json_reader);
+        return AZ_ERROR_UNEXPECTED_CHAR;
       }
+      return _az_json_reader_process_property_name(ref_json_reader);
     }
     case AZ_JSON_TOKEN_BEGIN_ARRAY:
     {
@@ -917,10 +917,8 @@ AZ_NODISCARD az_result az_json_reader_next_token(az_json_reader* ref_json_reader
       {
         return _az_json_reader_process_container_end(ref_json_reader, AZ_JSON_TOKEN_END_ARRAY);
       }
-      else
-      {
-        return _az_json_reader_process_value(ref_json_reader, first_byte);
-      }
+
+      return _az_json_reader_process_value(ref_json_reader, first_byte);
     }
     case AZ_JSON_TOKEN_PROPERTY_NAME:
       return _az_json_reader_process_value(ref_json_reader, first_byte);

--- a/sdk/src/azure/core/az_json_reader.c
+++ b/sdk/src/azure/core/az_json_reader.c
@@ -164,7 +164,7 @@ AZ_NODISCARD static az_result _az_json_reader_get_next_buffer(
 
 AZ_NODISCARD static az_span _az_json_reader_skip_whitespace(az_json_reader* ref_json_reader)
 {
-  az_span json = { 0 };
+  az_span json;
   az_span remaining = _get_remaining_json(ref_json_reader);
 
   while (true)

--- a/sdk/src/azure/core/az_json_reader.c
+++ b/sdk/src/azure/core/az_json_reader.c
@@ -327,7 +327,7 @@ AZ_NODISCARD static az_result _az_json_reader_process_string(az_json_reader* ref
     else
     {
       // Control characters are invalid within a JSON string and should be correctly escaped.
-      if (next_byte < 0x20)
+      if (next_byte < _az_ASCII_SPACE_CHARACTER)
       {
         return AZ_ERROR_UNEXPECTED_CHAR;
       }

--- a/sdk/src/azure/core/az_json_reader.c
+++ b/sdk/src/azure/core/az_json_reader.c
@@ -750,30 +750,44 @@ AZ_NODISCARD static az_result _az_json_reader_process_value(
     uint8_t const next_byte)
 {
   if (next_byte == '"')
+  {
     return _az_json_reader_process_string(ref_json_reader);
+  }
 
   if (next_byte == '{')
+  {
     return _az_json_reader_process_container_start(
         ref_json_reader, AZ_JSON_TOKEN_BEGIN_OBJECT, _az_JSON_STACK_OBJECT);
+  }
 
   if (next_byte == '[')
+  {
     return _az_json_reader_process_container_start(
         ref_json_reader, AZ_JSON_TOKEN_BEGIN_ARRAY, _az_JSON_STACK_ARRAY);
+  }
 
   if (isdigit(next_byte) || next_byte == '-')
+  {
     return _az_json_reader_process_number(ref_json_reader);
+  }
 
   if (next_byte == 'f')
+  {
     return _az_json_reader_process_literal(
         ref_json_reader, AZ_SPAN_FROM_STR("false"), AZ_JSON_TOKEN_FALSE);
+  }
 
   if (next_byte == 't')
+  {
     return _az_json_reader_process_literal(
         ref_json_reader, AZ_SPAN_FROM_STR("true"), AZ_JSON_TOKEN_TRUE);
+  }
 
   if (next_byte == 'n')
+  {
     return _az_json_reader_process_literal(
         ref_json_reader, AZ_SPAN_FROM_STR("null"), AZ_JSON_TOKEN_NULL);
+  }
 
   return AZ_ERROR_UNEXPECTED_CHAR;
 }

--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -241,9 +241,9 @@ static int32_t _az_json_writer_escaped_length(
       default:
       {
         // Check if the character has to be escaped as a UNICODE escape sequence.
-        if (ch < 0x20)
+        if (ch < _az_ASCII_SPACE_CHARACTER)
         {
-          escaped_length += 6;
+          escaped_length += _az_MAX_EXPANSION_FACTOR_WHILE_ESCAPING;
         }
         else
         {
@@ -325,19 +325,19 @@ static int32_t _az_json_writer_escape_next_byte_and_copy(
     default:
     {
       // Check if the character has to be escaped as a UNICODE escape sequence.
-      if (next_byte < 0x20)
+      if (next_byte < _az_ASCII_SPACE_CHARACTER)
       {
         // TODO: Consider moving this array outside the loop.
-        uint8_t array[6] = {
+        uint8_t array[_az_MAX_EXPANSION_FACTOR_WHILE_ESCAPING] = {
           '\\',
           'u',
           '0',
           '0',
-          _az_number_to_upper_hex((uint8_t)(next_byte / 16)),
-          _az_number_to_upper_hex((uint8_t)(next_byte % 16)),
+          _az_number_to_upper_hex((uint8_t)(next_byte / _az_NUMBER_OF_HEX_VALUES)),
+          _az_number_to_upper_hex((uint8_t)(next_byte % _az_NUMBER_OF_HEX_VALUES)),
         };
         *remaining_destination = az_span_copy(*remaining_destination, AZ_SPAN_FROM_BUFFER(array));
-        written += 6;
+        written += _az_MAX_EXPANSION_FACTOR_WHILE_ESCAPING;
       }
       else
       {

--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -565,10 +565,8 @@ AZ_NODISCARD az_result az_json_writer_append_string(az_json_writer* ref_json_wri
   {
     return az_json_writer_append_string_small(ref_json_writer, value);
   }
-  else
-  {
-    return az_json_writer_append_string_chunked(ref_json_writer, value);
-  }
+
+  return az_json_writer_append_string_chunked(ref_json_writer, value);
 }
 
 static AZ_NODISCARD az_result
@@ -712,10 +710,8 @@ az_json_writer_append_property_name(az_json_writer* ref_json_writer, az_span nam
   {
     return az_json_writer_append_property_name_small(ref_json_writer, name);
   }
-  else
-  {
-    return az_json_writer_append_property_name_chunked(ref_json_writer, name);
-  }
+
+  return az_json_writer_append_property_name_chunked(ref_json_writer, name);
 }
 
 static AZ_NODISCARD az_result _az_validate_json(

--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -833,18 +833,10 @@ static AZ_NODISCARD az_result _az_json_writer_append_literal(
 
 AZ_NODISCARD az_result az_json_writer_append_bool(az_json_writer* ref_json_writer, bool value)
 {
-  az_result result;
-  if (value)
-  {
-    result = _az_json_writer_append_literal(
-        ref_json_writer, AZ_SPAN_FROM_STR("true"), AZ_JSON_TOKEN_TRUE);
-  }
-  else
-  {
-    result = _az_json_writer_append_literal(
-        ref_json_writer, AZ_SPAN_FROM_STR("false"), AZ_JSON_TOKEN_FALSE);
-  }
-  return result;
+  return value ? _az_json_writer_append_literal(
+             ref_json_writer, AZ_SPAN_FROM_STR("true"), AZ_JSON_TOKEN_TRUE)
+               : _az_json_writer_append_literal(
+                   ref_json_writer, AZ_SPAN_FROM_STR("false"), AZ_JSON_TOKEN_FALSE);
 }
 
 AZ_NODISCARD az_result az_json_writer_append_null(az_json_writer* ref_json_writer)

--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -612,7 +612,7 @@ az_json_writer_append_property_name_small(az_json_writer* ref_json_writer, az_sp
   }
 
   remaining_json = az_span_copy_u8(remaining_json, '"');
-  remaining_json = az_span_copy_u8(remaining_json, ':');
+  az_span_copy_u8(remaining_json, ':');
 
   _az_update_json_writer_state(
       ref_json_writer, required_size, required_size, false, AZ_JSON_TOKEN_PROPERTY_NAME);
@@ -825,7 +825,7 @@ static AZ_NODISCARD az_result _az_json_writer_append_literal(
     remaining_json = az_span_copy_u8(remaining_json, ',');
   }
 
-  remaining_json = az_span_copy(remaining_json, literal);
+  az_span_copy(remaining_json, literal);
 
   _az_update_json_writer_state(ref_json_writer, required_size, required_size, true, literal_kind);
   return AZ_OK;
@@ -961,7 +961,7 @@ static AZ_NODISCARD az_result _az_json_writer_append_container_start(
     remaining_json = az_span_copy_u8(remaining_json, ',');
   }
 
-  remaining_json = az_span_copy_u8(remaining_json, byte);
+  az_span_copy_u8(remaining_json, byte);
 
   _az_update_json_writer_state(
       ref_json_writer, required_size, required_size, false, container_kind);
@@ -1002,7 +1002,7 @@ static AZ_NODISCARD az_result az_json_writer_append_container_end(
   az_span remaining_json = _get_remaining_span(ref_json_writer, required_size);
   _az_RETURN_IF_NOT_ENOUGH_SIZE(remaining_json, required_size);
 
-  remaining_json = az_span_copy_u8(remaining_json, byte);
+  az_span_copy_u8(remaining_json, byte);
 
   _az_update_json_writer_state(ref_json_writer, required_size, required_size, true, container_kind);
   _az_json_stack_pop(&ref_json_writer->_internal.bit_stack);

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -448,11 +448,11 @@ AZ_NODISCARD int32_t az_span_find(az_span source, az_span target)
     if (source_ptr[i] == target_ptr[0])
     {
       // The condition in step 2. has been satisfied.
-      int32_t j;
+      int32_t j = 1;
       // This is the loop defined in step 3.
       // The loop must be broken if it reaches the ends of `target` (step 3.) OR `source`
       // (step 5.).
-      for (j = 1; j < target_size && (i + j) < source_size; j++)
+      for (; j < target_size && (i + j) < source_size; j++)
       {
         // Condition defined in step 5.
         if (source_ptr[i + j] != target_ptr[j])

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -783,8 +783,6 @@ az_span_dtoa(az_span destination, double source, int32_t fractional_digits, az_s
 // TODO: pass az_span by value
 AZ_NODISCARD az_result _az_is_expected_span(az_span* ref_span, az_span expected)
 {
-  az_span actual_span = { 0 };
-
   int32_t expected_size = az_span_size(expected);
 
   // EOF because ref_span is smaller than the expected span
@@ -793,7 +791,7 @@ AZ_NODISCARD az_result _az_is_expected_span(az_span* ref_span, az_span expected)
     return AZ_ERROR_UNEXPECTED_END;
   }
 
-  actual_span = az_span_slice(*ref_span, 0, expected_size);
+  az_span actual_span = az_span_slice(*ref_span, 0, expected_size);
 
   if (!az_span_is_content_equal(actual_span, expected))
   {

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -390,6 +390,7 @@ AZ_NODISCARD az_result az_span_atod(az_span source, double* out_number)
   format[2] = (char)((size % _az_NUMBER_OF_DECIMAL_VALUES) + '0');
 
   int32_t chars_consumed = 0;
+  // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
   int32_t n = sscanf((char*)source_ptr, format, out_number, &chars_consumed);
 
   // Success if the entire source was consumed by sscanf and it set the out_number argument.
@@ -496,6 +497,7 @@ az_span az_span_copy(az_span destination, az_span source)
   }
 
   uint8_t* ptr = az_span_ptr(destination);
+  // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
   memmove((void*)ptr, (void const*)az_span_ptr(source), (size_t)src_size);
 
   return az_span_slice_to_end(destination, src_size);
@@ -551,6 +553,7 @@ void az_span_to_str(char* destination, int32_t destination_max_size, az_span sou
 
   _az_PRECONDITION(size_to_write >= 0);
 
+  // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
   memmove((void*)destination, (void const*)az_span_ptr(source), (size_t)size_to_write);
   destination[size_to_write] = 0;
 }

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -78,7 +78,7 @@ AZ_NODISCARD AZ_INLINE uint8_t _az_tolower(uint8_t value)
   // return 'A' <= value && value <= 'Z' ? value + AZ_ASCII_LOWER_DIF : value;
   if ((uint8_t)(int8_t)(value - 'A') <= ('Z' - 'A'))
   {
-    value = (uint8_t)((value + _az_ASCII_LOWER_DIF) & UINT8_MAX);
+    value = (uint8_t)((uint32_t)(value + _az_ASCII_LOWER_DIF) & (uint8_t)UINT8_MAX);
   }
   return value;
 }
@@ -555,7 +555,10 @@ void az_span_to_str(char* destination, int32_t destination_max_size, az_span sou
   destination[size_to_write] = 0;
 }
 
-AZ_INLINE uint8_t _az_decimal_to_ascii(uint8_t d) { return (uint8_t)(('0' + d) & UINT8_MAX); }
+AZ_INLINE uint8_t _az_decimal_to_ascii(uint8_t d)
+{
+  return (uint8_t)((uint32_t)('0' + d) & (uint8_t)UINT8_MAX);
+}
 
 static AZ_NODISCARD az_result _az_span_builder_append_uint64(az_span* ref_span, uint64_t n)
 {
@@ -883,7 +886,7 @@ AZ_NODISCARD AZ_INLINE bool _az_span_is_byte_letter(uint8_t c)
 {
   // This is equivalent to ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z')
   // This works because upper case and lower case letters are 0x20 away from each other.
-  return ((uint32_t)(c - 'A') & ~_az_ASCII_SPACE_CHARACTER) <= 'Z' - 'A';
+  return ((uint32_t)(c - 'A') & ~(uint32_t)_az_ASCII_SPACE_CHARACTER) <= 'Z' - 'A';
 }
 
 AZ_NODISCARD AZ_INLINE bool _az_span_url_should_encode(uint8_t c)
@@ -964,8 +967,8 @@ AZ_NODISCARD az_result _az_span_url_encode(az_span destination, az_span source, 
       }
 
       dest_ptr[0] = '%';
-      dest_ptr[1] = _az_number_to_upper_hex(c >> 4);
-      dest_ptr[2] = _az_number_to_upper_hex(c & _az_LARGEST_HEX_VALUE);
+      dest_ptr[1] = _az_number_to_upper_hex(c >> 4U);
+      dest_ptr[2] = _az_number_to_upper_hex(c & (uint32_t)_az_LARGEST_HEX_VALUE);
       dest_ptr += 3;
     }
   }

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -825,8 +825,9 @@ AZ_NODISCARD AZ_INLINE bool _az_is_whitespace(uint8_t c)
     case '\n':
     case '\r':
       return true;
+    default:
+      return false;
   }
-  return false;
 }
 
 typedef enum

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -430,43 +430,42 @@ AZ_NODISCARD int32_t az_span_find(az_span source, az_span target)
   {
     return 0;
   }
-  else if (source_size < target_size)
+
+  if (source_size < target_size)
   {
     return target_not_found;
   }
-  else
+
+  uint8_t* source_ptr = az_span_ptr(source);
+  uint8_t* target_ptr = az_span_ptr(target);
+
+  // This loop traverses `source` position by position (step 1.)
+  for (int32_t i = 0; i < (source_size - target_size + 1); i++)
   {
-    uint8_t* source_ptr = az_span_ptr(source);
-    uint8_t* target_ptr = az_span_ptr(target);
-
-    // This loop traverses `source` position by position (step 1.)
-    for (int32_t i = 0; i < (source_size - target_size + 1); i++)
+    // This is the check done in step 1. above.
+    if (source_ptr[i] == target_ptr[0])
     {
-      // This is the check done in step 1. above.
-      if (source_ptr[i] == target_ptr[0])
+      // The condition in step 2. has been satisfied.
+      int32_t j;
+      // This is the loop defined in step 3.
+      // The loop must be broken if it reaches the ends of `target` (step 3.) OR `source`
+      // (step 5.).
+      for (j = 1; j < target_size && (i + j) < source_size; j++)
       {
-        // The condition in step 2. has been satisfied.
-        int32_t j;
-        // This is the loop defined in step 3.
-        // The loop must be broken if it reaches the ends of `target` (step 3.) OR `source`
-        // (step 5.).
-        for (j = 1; j < target_size && (i + j) < source_size; j++)
+        // Condition defined in step 5.
+        if (source_ptr[i + j] != target_ptr[j])
         {
-          // Condition defined in step 5.
-          if (source_ptr[i + j] != target_ptr[j])
-          {
-            break;
-          }
+          break;
         }
+      }
 
-        if (j == target_size)
-        {
-          // All bytes in `target` have been checked and matched the corresponding bytes in `source`
-          // (from the start point `i`), so this is indeed an instance of `target` in that position
-          // of `source` (step 4.).
+      if (j == target_size)
+      {
+        // All bytes in `target` have been checked and matched the corresponding bytes in `source`
+        // (from the start point `i`), so this is indeed an instance of `target` in that position
+        // of `source` (step 4.).
 
-          return i;
-        }
+        return i;
       }
     }
   }

--- a/sdk/src/azure/core/az_span_private.h
+++ b/sdk/src/azure/core/az_span_private.h
@@ -13,6 +13,10 @@
 
 #include <azure/core/_az_cfg_prefix.h>
 
+// In IEEE 754, +inf is represented as 0 for the sign bit, all 1s for the biased exponent, and 0s
+// for the fraction bits.
+#define _az_BINARY_VALUE_OF_POSITIVE_INFINITY 0x7FF0000000000000ULL
+
 enum
 {
   _az_ASCII_LOWER_DIF = 'a' - 'A',
@@ -64,7 +68,8 @@ AZ_NODISCARD AZ_INLINE bool _az_isfinite(double value)
   // This is equivalent to checking the following ranges, condensed into a single check:
   // (binary_value < 0x7FF0000000000000 ||
   //   (binary_value > 0x7FFFFFFFFFFFFFFF && binary_value < 0xFFF0000000000000))
-  return ((binary_value & 0x7FF0000000000000) != 0x7FF0000000000000);
+  return (binary_value & _az_BINARY_VALUE_OF_POSITIVE_INFINITY)
+      != _az_BINARY_VALUE_OF_POSITIVE_INFINITY;
 }
 
 AZ_NODISCARD az_result _az_is_expected_span(az_span* ref_span, az_span expected);

--- a/sdk/src/azure/core/az_span_private.h
+++ b/sdk/src/azure/core/az_span_private.h
@@ -26,17 +26,17 @@ enum
   // 10 + sign (i.e. -2,147,483,648)
   _az_MAX_SIZE_FOR_INT32 = 11,
 
-  // For example: 2,147,483,648
-  _az_MAX_SIZE_FOR_UINT32 = 10,
-
   // 19 + sign (i.e. -9,223,372,036,854,775,808)
   _az_MAX_SIZE_FOR_INT64 = 20,
 
-  // For example: 18,446,744,073,709,551,615
-  _az_MAX_SIZE_FOR_UINT64 = 20,
-
   // Two digit length to create the "format" passed to sscanf.
   _az_MAX_SIZE_FOR_PARSING_DOUBLE = 99,
+
+  // The number value of the ASCII space character ' '.
+  _az_ASCII_SPACE_CHARACTER = 0x20,
+
+  // The largest digit in base 16 (hexadecimal).
+  _az_LARGEST_HEX_VALUE = 0xF,
 };
 
 /**

--- a/sdk/src/azure/core/az_span_private.h
+++ b/sdk/src/azure/core/az_span_private.h
@@ -57,6 +57,7 @@ AZ_NODISCARD AZ_INLINE bool _az_isfinite(double value)
 
   // Workaround for strict-aliasing rules.
   // Get the 8-byte binary representation of the double value, by re-interpreting it as an uint64_t.
+  // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
   memcpy(&binary_value, &value, sizeof(binary_value));
 
   // These are the binary representations of the various non-finite value ranges,

--- a/sdk/src/azure/iot/az_iot_common.c
+++ b/sdk/src/azure/iot/az_iot_common.c
@@ -181,11 +181,11 @@ AZ_NODISCARD int32_t _az_iot_u32toa_size(uint32_t number)
     return 1;
   }
 
-  uint32_t div = 1000000000;
-  int32_t digit_count = 10;
+  uint32_t div = _az_SMALLEST_10_DIGIT_NUMBER;
+  int32_t digit_count = _az_MAX_SIZE_FOR_UINT32;
   while (number / div == 0)
   {
-    div /= 10;
+    div /= _az_NUMBER_OF_DECIMAL_VALUES;
     digit_count--;
   }
 
@@ -199,11 +199,11 @@ AZ_NODISCARD int32_t _az_iot_u64toa_size(uint64_t number)
     return 1;
   }
 
-  uint64_t div = 10000000000000000000ul;
-  int32_t digit_count = 20;
+  uint64_t div = _az_SMALLEST_20_DIGIT_NUMBER;
+  int32_t digit_count = _az_MAX_SIZE_FOR_UINT64;
   while (number / div == 0)
   {
-    div /= 10;
+    div /= _az_NUMBER_OF_DECIMAL_VALUES;
     digit_count--;
   }
 

--- a/sdk/src/azure/iot/az_iot_common.c
+++ b/sdk/src/azure/iot/az_iot_common.c
@@ -93,10 +93,8 @@ AZ_NODISCARD az_result az_iot_message_properties_find(
         *out_value = _az_span_token(remaining, hub_client_param_separator_span, &remaining, &index);
         return AZ_OK;
       }
-      else
-      {
-        _az_span_token(remaining, hub_client_param_separator_span, &remaining, &index);
-      }
+
+      _az_span_token(remaining, hub_client_param_separator_span, &remaining, &index);
     }
   }
 
@@ -182,18 +180,16 @@ AZ_NODISCARD int32_t _az_iot_u32toa_size(uint32_t number)
   {
     return 1;
   }
-  else
-  {
-    uint32_t div = 1000000000;
-    int32_t digit_count = 10;
-    while (number / div == 0)
-    {
-      div /= 10;
-      digit_count--;
-    }
 
-    return digit_count;
+  uint32_t div = 1000000000;
+  int32_t digit_count = 10;
+  while (number / div == 0)
+  {
+    div /= 10;
+    digit_count--;
   }
+
+  return digit_count;
 }
 
 AZ_NODISCARD int32_t _az_iot_u64toa_size(uint64_t number)
@@ -202,18 +198,16 @@ AZ_NODISCARD int32_t _az_iot_u64toa_size(uint64_t number)
   {
     return 1;
   }
-  else
-  {
-    uint64_t div = 10000000000000000000ul;
-    int32_t digit_count = 20;
-    while (number / div == 0)
-    {
-      div /= 10;
-      digit_count--;
-    }
 
-    return digit_count;
+  uint64_t div = 10000000000000000000ul;
+  int32_t digit_count = 20;
+  while (number / div == 0)
+  {
+    div /= 10;
+    digit_count--;
   }
+
+  return digit_count;
 }
 
 AZ_NODISCARD az_result

--- a/sdk/src/azure/iot/az_iot_common.c
+++ b/sdk/src/azure/iot/az_iot_common.c
@@ -213,7 +213,7 @@ AZ_NODISCARD int32_t _az_iot_u64toa_size(uint64_t number)
 AZ_NODISCARD az_result
 _az_span_copy_url_encode(az_span destination, az_span source, az_span* out_remainder)
 {
-  int32_t length;
+  int32_t length = 0;
   _az_RETURN_IF_FAILED(_az_span_url_encode(destination, source, &length));
   *out_remainder = az_span_slice(destination, length, az_span_size(destination));
   return AZ_OK;

--- a/sdk/src/azure/iot/az_iot_hub_client_c2d.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_c2d.c
@@ -28,7 +28,7 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
 
   int32_t index = 0;
   az_span remainder;
-  az_span token = _az_span_token(received_topic, c2d_topic_suffix, &remainder, &index);
+  _az_span_token(received_topic, c2d_topic_suffix, &remainder, &index);
   if (index == -1)
   {
     return AZ_ERROR_IOT_TOPIC_NO_MATCH;
@@ -39,7 +39,7 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
     _az_LOG_WRITE(AZ_LOG_MQTT_RECEIVED_TOPIC, received_topic);
   }
 
-  token = az_span_size(remainder) == 0
+  az_span token = az_span_size(remainder) == 0
       ? AZ_SPAN_EMPTY
       : _az_span_token(remainder, c2d_topic_suffix, &remainder, &index);
 

--- a/sdk/src/azure/iot/az_iot_hub_client_twin.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_twin.c
@@ -115,15 +115,15 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
   _az_PRECONDITION_NOT_NULL(out_response);
   (void)client;
 
-  az_result result;
+  az_result result = AZ_OK;
 
-  int32_t twin_index;
+  int32_t twin_index = az_span_find(received_topic, az_iot_hub_twin_topic_prefix);
   // Check if is related to twin or not
-  if ((twin_index = az_span_find(received_topic, az_iot_hub_twin_topic_prefix)) >= 0)
+  if (twin_index >= 0)
   {
     _az_LOG_WRITE(AZ_LOG_MQTT_RECEIVED_TOPIC, received_topic);
 
-    int32_t twin_feature_index;
+    int32_t twin_feature_index = -1;
     az_span twin_feature_span
         = az_span_slice(received_topic, twin_index, az_span_size(received_topic));
 
@@ -143,7 +143,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
           &index);
 
       // Get status and convert to enum
-      uint32_t status_int;
+      uint32_t status_int = 0;
       _az_RETURN_IF_FAILED(az_span_atou32(status_str, &status_int));
       out_response->status = (az_iot_status)status_int;
 

--- a/sdk/src/azure/iot/az_iot_provisioning_client.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client.c
@@ -107,7 +107,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_get_user_name(
     remainder = az_span_copy(remainder, *user_agent);
   }
 
-  remainder = az_span_copy_u8(remainder, '\0');
+  az_span_copy_u8(remainder, '\0');
 
   if (out_mqtt_user_name_length)
   {
@@ -137,7 +137,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_get_client_id(
       mqtt_client_id_span, required_length + (int32_t)sizeof((uint8_t)'\0'));
 
   az_span remainder = az_span_copy(mqtt_client_id_span, client->_internal.registration_id);
-  remainder = az_span_copy_u8(remainder, '\0');
+  az_span_copy_u8(remainder, '\0');
 
   if (out_mqtt_client_id_length)
   {
@@ -170,7 +170,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_get_publish_topic(
 
   az_span remainder = az_span_copy(mqtt_topic_span, str_dps_registrations);
   remainder = az_span_copy(remainder, str_put_iotdps_register);
-  remainder = az_span_copy_u8(remainder, '\0');
+  az_span_copy_u8(remainder, '\0');
 
   if (out_mqtt_topic_length)
   {
@@ -200,15 +200,14 @@ AZ_NODISCARD az_result az_iot_provisioning_client_query_status_get_publish_topic
   az_span str_dps_registrations = _az_iot_provisioning_get_str_dps_registrations();
 
   int32_t required_length = az_span_size(str_dps_registrations)
-      + az_span_size(str_get_iotdps_get_operationstatus)
-      + az_span_size(operation_id);
+      + az_span_size(str_get_iotdps_get_operationstatus) + az_span_size(operation_id);
 
   _az_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_span, required_length + (int32_t)sizeof((uint8_t)'\0'));
 
   az_span remainder = az_span_copy(mqtt_topic_span, str_dps_registrations);
   remainder = az_span_copy(remainder, str_get_iotdps_get_operationstatus);
   remainder = az_span_copy(remainder, operation_id);
-  remainder = az_span_copy_u8(remainder, '\0');
+  az_span_copy_u8(remainder, '\0');
 
   if (out_mqtt_topic_length)
   {
@@ -222,12 +221,12 @@ AZ_INLINE az_iot_provisioning_client_registration_state
 _az_iot_provisioning_registration_state_default()
 {
   return (az_iot_provisioning_client_registration_state){ .assigned_hub_hostname = AZ_SPAN_EMPTY,
-                                                           .device_id = AZ_SPAN_EMPTY,
-                                                           .error_code = AZ_IOT_STATUS_UNKNOWN,
-                                                           .extended_error_code = 0,
-                                                           .error_message = AZ_SPAN_EMPTY,
-                                                           .error_tracking_id = AZ_SPAN_EMPTY,
-                                                           .error_timestamp = AZ_SPAN_EMPTY };
+                                                          .device_id = AZ_SPAN_EMPTY,
+                                                          .error_code = AZ_IOT_STATUS_UNKNOWN,
+                                                          .extended_error_code = 0,
+                                                          .error_message = AZ_SPAN_EMPTY,
+                                                          .error_tracking_id = AZ_SPAN_EMPTY,
+                                                          .error_timestamp = AZ_SPAN_EMPTY };
 }
 
 AZ_INLINE az_iot_status _az_iot_status_from_extended_status(uint32_t extended_status)
@@ -415,8 +414,7 @@ AZ_INLINE az_result az_iot_provisioning_client_parse_payload(
         return AZ_ERROR_ITEM_NOT_FOUND;
       }
       _az_RETURN_IF_FAILED(_az_iot_provisioning_client_parse_operation_status(
-          jr.token.slice,
-          &out_response->operation_status));
+          jr.token.slice, &out_response->operation_status));
 
       found_operation_status = true;
     }
@@ -552,5 +550,3 @@ AZ_NODISCARD az_result az_iot_provisioning_client_parse_received_topic_and_paylo
 
   return AZ_OK;
 }
-
-

--- a/sdk/src/azure/iot/az_iot_provisioning_client.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client.c
@@ -22,18 +22,22 @@ static const az_span str_get_iotdps_get_operationstatus
 AZ_INLINE az_span _az_iot_provisioning_get_dps_registrations_res()
 {
   az_span sub_topic = AZ_SPAN_LITERAL_FROM_STR(AZ_IOT_PROVISIONING_CLIENT_REGISTER_SUBSCRIBE_TOPIC);
+
+  // NOLINTNEXTLINE(readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers)
   return az_span_slice(sub_topic, 0, 23);
 }
 
 // /registrations/
 AZ_INLINE az_span _az_iot_provisioning_get_str_registrations()
 {
+  // NOLINTNEXTLINE(readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers)
   return az_span_slice(_az_iot_provisioning_get_dps_registrations_res(), 4, 19);
 }
 
 // $dps/registrations/
 AZ_INLINE az_span _az_iot_provisioning_get_str_dps_registrations()
 {
+  // NOLINTNEXTLINE(readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers)
   return az_span_slice(_az_iot_provisioning_get_dps_registrations_res(), 0, 19);
 }
 
@@ -231,6 +235,7 @@ _az_iot_provisioning_registration_state_default()
 
 AZ_INLINE az_iot_status _az_iot_status_from_extended_status(uint32_t extended_status)
 {
+  // NOLINTNEXTLINE(readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers)
   return (az_iot_status)(extended_status / 1000);
 }
 

--- a/sdk/src/azure/iot/az_iot_provisioning_client_sas.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client_sas.c
@@ -150,8 +150,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_sas_get_password(
   if (out_mqtt_password_length != NULL)
   {
     *out_mqtt_password_length
-        = ((size_t)mqtt_password_size - (size_t)az_span_size(mqtt_password_span)
-           - 1 /* NULL TERMINATOR */);
+        = (mqtt_password_size - (size_t)az_span_size(mqtt_password_span) - 1 /* NULL TERMINATOR */);
   }
 
   return AZ_OK;

--- a/sdk/src/azure/platform/az_curl.c
+++ b/sdk/src/azure/platform/az_curl.c
@@ -372,13 +372,17 @@ static int32_t _az_http_client_curl_upload_read_callback(
 
   // Terminate the upload if the destination buffer is too small
   if (dst_buffer_size < 1)
+  {
     return CURL_READFUNC_ABORT;
+  }
 
   int32_t userdata_length = az_span_size(*upload_content);
 
   // Return if nothing to copy
   if (userdata_length < 1)
+  {
     return CURLE_OK; // Success, all bytes copied
+  }
 
   // Calculate how many bytes can we copy from customer data (upload_content)
   // Curl provides dst buffer with a max size of dest_buffer_size, if customer data size is less

--- a/sdk/src/azure/platform/az_curl.c
+++ b/sdk/src/azure/platform/az_curl.c
@@ -391,6 +391,7 @@ static int32_t _az_http_client_curl_upload_read_callback(
   // copy a next chunk of data
   int32_t size_of_copy = (userdata_length < dst_buffer_size) ? userdata_length : dst_buffer_size;
 
+  // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
   memcpy(dst, az_span_ptr(*upload_content), (size_t)size_of_copy);
 
   // Update the userdata span. If we already copied all content, slice will set upload_content with
@@ -501,6 +502,7 @@ _az_http_client_curl_setup_url(CURL* ref_curl, az_http_request const* request)
   }
 
   // free used buffer before anything else
+  // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
   memset(az_span_ptr(writable_buffer), 0, (size_t)az_span_size(writable_buffer));
   _az_span_free(&writable_buffer);
 

--- a/sdk/src/azure/platform/az_posix.c
+++ b/sdk/src/azure/platform/az_posix.c
@@ -12,6 +12,7 @@
 
 AZ_NODISCARD int64_t az_platform_clock_msec()
 {
+  // NOLINTNEXTLINE(bugprone-misplaced-widening-cast)
   return (int64_t)((clock() / CLOCKS_PER_SEC) * _az_TIME_MILLISECONDS_PER_SECOND);
 }
 

--- a/sdk/src/azure/platform/az_posix.c
+++ b/sdk/src/azure/platform/az_posix.c
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/core/internal/az_config_internal.h>
 #include <azure/core/az_platform.h>
+#include <azure/core/internal/az_config_internal.h>
 
 #include <time.h>
 

--- a/sdk/src/azure/storage/az_storage_blobs_blob_client.c
+++ b/sdk/src/azure/storage/az_storage_blobs_blob_client.c
@@ -47,8 +47,12 @@ AZ_NODISCARD az_storage_blobs_blob_client_options az_storage_blobs_blob_client_o
     .retry_options = _az_http_policy_retry_options_default(),
   };
 
+  // NOLINTNEXTLINE(readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers)
   options.retry_options.max_retries = 5;
+
   options.retry_options.retry_delay_msec = 1 * _az_TIME_MILLISECONDS_PER_SECOND;
+
+  // NOLINTNEXTLINE(readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers)
   options.retry_options.max_retry_delay_msec = 30 * _az_TIME_MILLISECONDS_PER_SECOND;
 
   return options;


### PR DESCRIPTION
Related to https://github.com/Azure/azure-sdk-for-c/issues/155, https://github.com/Azure/azure-sdk-for-c/issues/453, and follow up to https://github.com/Azure/azure-sdk-for-c/pull/492

https://clang.llvm.org/extra/clang-tidy/

This PR is broken down into commits that can be reviewed individually, where each commit fixes a particular type of warning, either in the header files (under `/inc`) or in the source files (`/src`).

The check `readability-inconsistent-declaration-parameter-name` is useful for catching parameter naming differences between the header and source files.

Ran on both Windows and Ubuntu 18.04 (to get platform coverage), excluding two rules: `llvm-header-guard` and `google-readability-todo`

For certain warnings, suppressed them with inline comments in source.

> clang-tidy -p . --header-filter='.*' src/azure/core/az_span.c --checks='*,-llvm-header-guard,-google-readability-todo' --list-checks -- -Iinc
```text
Enabled checks:
    abseil-duration-addition
    abseil-duration-comparison
    abseil-duration-conversion-cast
    abseil-duration-division
    abseil-duration-factory-float
    abseil-duration-factory-scale
    abseil-duration-subtraction
    abseil-duration-unnecessary-conversion
    abseil-faster-strsplit-delimiter
    abseil-no-internal-dependencies
    abseil-no-namespace
    abseil-redundant-strcat-calls
    abseil-str-cat-append
    abseil-string-find-startswith
    abseil-time-comparison
    abseil-time-subtraction
    abseil-upgrade-duration-conversions
    android-cloexec-accept
    android-cloexec-accept4
    android-cloexec-creat
    android-cloexec-dup
    android-cloexec-epoll-create
    android-cloexec-epoll-create1
    android-cloexec-fopen
    android-cloexec-inotify-init
    android-cloexec-inotify-init1
    android-cloexec-memfd-create
    android-cloexec-open
    android-cloexec-pipe
    android-cloexec-pipe2
    android-cloexec-socket
    android-comparison-in-temp-failure-retry
    boost-use-to-string
    bugprone-argument-comment
    bugprone-assert-side-effect
    bugprone-bad-signal-to-kill-thread
    bugprone-bool-pointer-implicit-conversion
    bugprone-branch-clone
    bugprone-copy-constructor-init
    bugprone-dangling-handle
    bugprone-dynamic-static-initializers
    bugprone-exception-escape
    bugprone-fold-init-type
    bugprone-forward-declaration-namespace
    bugprone-forwarding-reference-overload
    bugprone-inaccurate-erase
    bugprone-incorrect-roundings
    bugprone-infinite-loop
    bugprone-integer-division
    bugprone-lambda-function-name
    bugprone-macro-parentheses
    bugprone-macro-repeated-side-effects
    bugprone-misplaced-operator-in-strlen-in-alloc
    bugprone-misplaced-widening-cast
    bugprone-move-forwarding-reference
    bugprone-multiple-statement-macro
    bugprone-narrowing-conversions
    bugprone-not-null-terminated-result
    bugprone-parent-virtual-call
    bugprone-posix-return
    bugprone-signed-char-misuse
    bugprone-sizeof-container
    bugprone-sizeof-expression
    bugprone-string-constructor
    bugprone-string-integer-assignment
    bugprone-string-literal-with-embedded-nul
    bugprone-suspicious-enum-usage
    bugprone-suspicious-memset-usage
    bugprone-suspicious-missing-comma
    bugprone-suspicious-semicolon
    bugprone-suspicious-string-compare
    bugprone-swapped-arguments
    bugprone-terminating-continue
    bugprone-throw-keyword-missing
    bugprone-too-small-loop-variable
    bugprone-undefined-memory-manipulation
    bugprone-undelegated-constructor
    bugprone-unhandled-self-assignment
    bugprone-unused-raii
    bugprone-unused-return-value
    bugprone-use-after-move
    bugprone-virtual-near-miss
    cert-dcl03-c
    cert-dcl16-c
    cert-dcl21-cpp
    cert-dcl50-cpp
    cert-dcl54-cpp
    cert-dcl58-cpp
    cert-dcl59-cpp
    cert-env33-c
    cert-err09-cpp
    cert-err34-c
    cert-err52-cpp
    cert-err58-cpp
    cert-err60-cpp
    cert-err61-cpp
    cert-fio38-c
    cert-flp30-c
    cert-mem57-cpp
    cert-msc30-c
    cert-msc32-c
    cert-msc50-cpp
    cert-msc51-cpp
    cert-oop11-cpp
    cert-oop54-cpp
    cert-oop58-cpp
    cert-pos44-c
    clang-analyzer-apiModeling.StdCLibraryFunctions
    clang-analyzer-apiModeling.TrustNonnull
    clang-analyzer-apiModeling.google.GTest
    clang-analyzer-apiModeling.llvm.CastValue
    clang-analyzer-apiModeling.llvm.ReturnValue
    clang-analyzer-core.CallAndMessage
    clang-analyzer-core.DivideZero
    clang-analyzer-core.DynamicTypePropagation
    clang-analyzer-core.NonNullParamChecker
    clang-analyzer-core.NonnilStringConstants
    clang-analyzer-core.NullDereference
    clang-analyzer-core.StackAddrEscapeBase
    clang-analyzer-core.StackAddressEscape
    clang-analyzer-core.UndefinedBinaryOperatorResult
    clang-analyzer-core.VLASize
    clang-analyzer-core.builtin.BuiltinFunctions
    clang-analyzer-core.builtin.NoReturnFunctions
    clang-analyzer-core.uninitialized.ArraySubscript
    clang-analyzer-core.uninitialized.Assign
    clang-analyzer-core.uninitialized.Branch
    clang-analyzer-core.uninitialized.CapturedBlockVariable
    clang-analyzer-core.uninitialized.UndefReturn
    clang-analyzer-cplusplus.InnerPointer
    clang-analyzer-cplusplus.Move
    clang-analyzer-cplusplus.NewDelete
    clang-analyzer-cplusplus.NewDeleteLeaks
    clang-analyzer-cplusplus.PureVirtualCall
    clang-analyzer-cplusplus.SelfAssignment
    clang-analyzer-cplusplus.SmartPtr
    clang-analyzer-cplusplus.VirtualCallModeling
    clang-analyzer-deadcode.DeadStores
    clang-analyzer-fuchsia.HandleChecker
    clang-analyzer-nullability.NullPassedToNonnull
    clang-analyzer-nullability.NullReturnedFromNonnull
    clang-analyzer-nullability.NullabilityBase
    clang-analyzer-nullability.NullableDereferenced
    clang-analyzer-nullability.NullablePassedToNonnull
    clang-analyzer-nullability.NullableReturnedFromNonnull
    clang-analyzer-optin.cplusplus.UninitializedObject
    clang-analyzer-optin.cplusplus.VirtualCall
    clang-analyzer-optin.mpi.MPI-Checker
    clang-analyzer-optin.osx.OSObjectCStyleCast
    clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker
    clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker
    clang-analyzer-optin.performance.GCDAntipattern
    clang-analyzer-optin.performance.Padding
    clang-analyzer-optin.portability.UnixAPI
    clang-analyzer-osx.API
    clang-analyzer-osx.MIG
    clang-analyzer-osx.NSOrCFErrorDerefChecker
    clang-analyzer-osx.NumberObjectConversion
    clang-analyzer-osx.OSObjectRetainCount
    clang-analyzer-osx.ObjCProperty
    clang-analyzer-osx.SecKeychainAPI
    clang-analyzer-osx.cocoa.AtSync
    clang-analyzer-osx.cocoa.AutoreleaseWrite
    clang-analyzer-osx.cocoa.ClassRelease
    clang-analyzer-osx.cocoa.Dealloc
    clang-analyzer-osx.cocoa.IncompatibleMethodTypes
    clang-analyzer-osx.cocoa.Loops
    clang-analyzer-osx.cocoa.MissingSuperCall
    clang-analyzer-osx.cocoa.NSAutoreleasePool
    clang-analyzer-osx.cocoa.NSError
    clang-analyzer-osx.cocoa.NilArg
    clang-analyzer-osx.cocoa.NonNilReturnValue
    clang-analyzer-osx.cocoa.ObjCGenerics
    clang-analyzer-osx.cocoa.RetainCount
    clang-analyzer-osx.cocoa.RetainCountBase
    clang-analyzer-osx.cocoa.RunLoopAutoreleaseLeak
    clang-analyzer-osx.cocoa.SelfInit
    clang-analyzer-osx.cocoa.SuperDealloc
    clang-analyzer-osx.cocoa.UnusedIvars
    clang-analyzer-osx.cocoa.VariadicMethodTypes
    clang-analyzer-osx.coreFoundation.CFError
    clang-analyzer-osx.coreFoundation.CFNumber
    clang-analyzer-osx.coreFoundation.CFRetainRelease
    clang-analyzer-osx.coreFoundation.containers.OutOfBounds
    clang-analyzer-osx.coreFoundation.containers.PointerSizedValues
    clang-analyzer-security.FloatLoopCounter
    clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
    clang-analyzer-security.insecureAPI.SecuritySyntaxChecker
    clang-analyzer-security.insecureAPI.UncheckedReturn
    clang-analyzer-security.insecureAPI.bcmp
    clang-analyzer-security.insecureAPI.bcopy
    clang-analyzer-security.insecureAPI.bzero
    clang-analyzer-security.insecureAPI.decodeValueOfObjCType
    clang-analyzer-security.insecureAPI.getpw
    clang-analyzer-security.insecureAPI.gets
    clang-analyzer-security.insecureAPI.mkstemp
    clang-analyzer-security.insecureAPI.mktemp
    clang-analyzer-security.insecureAPI.rand
    clang-analyzer-security.insecureAPI.strcpy
    clang-analyzer-security.insecureAPI.vfork
    clang-analyzer-unix.API
    clang-analyzer-unix.DynamicMemoryModeling
    clang-analyzer-unix.Malloc
    clang-analyzer-unix.MallocSizeof
    clang-analyzer-unix.MismatchedDeallocator
    clang-analyzer-unix.Vfork
    clang-analyzer-unix.cstring.BadSizeArg
    clang-analyzer-unix.cstring.CStringModeling
    clang-analyzer-unix.cstring.NullArg
    clang-analyzer-valist.CopyToSelf
    clang-analyzer-valist.Uninitialized
    clang-analyzer-valist.Unterminated
    clang-analyzer-valist.ValistBase
    cppcoreguidelines-avoid-c-arrays
    cppcoreguidelines-avoid-goto
    cppcoreguidelines-avoid-magic-numbers
    cppcoreguidelines-c-copy-assignment-signature
    cppcoreguidelines-explicit-virtual-functions
    cppcoreguidelines-init-variables
    cppcoreguidelines-interfaces-global-init
    cppcoreguidelines-macro-usage
    cppcoreguidelines-narrowing-conversions
    cppcoreguidelines-no-malloc
    cppcoreguidelines-non-private-member-variables-in-classes
    cppcoreguidelines-owning-memory
    cppcoreguidelines-pro-bounds-array-to-pointer-decay
    cppcoreguidelines-pro-bounds-constant-array-index
    cppcoreguidelines-pro-bounds-pointer-arithmetic
    cppcoreguidelines-pro-type-const-cast
    cppcoreguidelines-pro-type-cstyle-cast
    cppcoreguidelines-pro-type-member-init
    cppcoreguidelines-pro-type-reinterpret-cast
    cppcoreguidelines-pro-type-static-cast-downcast
    cppcoreguidelines-pro-type-union-access
    cppcoreguidelines-pro-type-vararg
    cppcoreguidelines-slicing
    cppcoreguidelines-special-member-functions
    darwin-avoid-spinlock
    darwin-dispatch-once-nonstatic
    fuchsia-default-arguments-calls
    fuchsia-default-arguments-declarations
    fuchsia-header-anon-namespaces
    fuchsia-multiple-inheritance
    fuchsia-overloaded-operator
    fuchsia-restrict-system-includes
    fuchsia-statically-constructed-objects
    fuchsia-trailing-return
    fuchsia-virtual-inheritance
    google-build-explicit-make-pair
    google-build-namespaces
    google-build-using-namespace
    google-default-arguments
    google-explicit-constructor
    google-global-names-in-headers
    google-objc-avoid-nsobject-new
    google-objc-avoid-throwing-exception
    google-objc-function-naming
    google-objc-global-variable-declaration
    google-readability-avoid-underscore-in-googletest-name
    google-readability-braces-around-statements
    google-readability-casting
    google-readability-function-size
    google-readability-namespace-comments
    google-runtime-int
    google-runtime-operator
    google-runtime-references
    google-upgrade-googletest-case
    hicpp-avoid-c-arrays
    hicpp-avoid-goto
    hicpp-braces-around-statements
    hicpp-deprecated-headers
    hicpp-exception-baseclass
    hicpp-explicit-conversions
    hicpp-function-size
    hicpp-invalid-access-moved
    hicpp-member-init
    hicpp-move-const-arg
    hicpp-multiway-paths-covered
    hicpp-named-parameter
    hicpp-new-delete-operators
    hicpp-no-array-decay
    hicpp-no-assembler
    hicpp-no-malloc
    hicpp-noexcept-move
    hicpp-signed-bitwise
    hicpp-special-member-functions
    hicpp-static-assert
    hicpp-undelegated-constructor
    hicpp-uppercase-literal-suffix
    hicpp-use-auto
    hicpp-use-emplace
    hicpp-use-equals-default
    hicpp-use-equals-delete
    hicpp-use-noexcept
    hicpp-use-nullptr
    hicpp-use-override
    hicpp-vararg
    linuxkernel-must-check-errs
    llvm-include-order
    llvm-namespace-comment
    llvm-prefer-isa-or-dyn-cast-in-conditionals
    llvm-prefer-register-over-unsigned
    llvm-qualified-auto
    llvm-twine-local
    misc-definitions-in-headers
    misc-misplaced-const
    misc-new-delete-overloads
    misc-non-copyable-objects
    misc-non-private-member-variables-in-classes
    misc-redundant-expression
    misc-static-assert
    misc-throw-by-value-catch-by-reference
    misc-unconventional-assign-operator
    misc-uniqueptr-reset-release
    misc-unused-alias-decls
    misc-unused-parameters
    misc-unused-using-decls
    modernize-avoid-bind
    modernize-avoid-c-arrays
    modernize-concat-nested-namespaces
    modernize-deprecated-headers
    modernize-deprecated-ios-base-aliases
    modernize-loop-convert
    modernize-make-shared
    modernize-make-unique
    modernize-pass-by-value
    modernize-raw-string-literal
    modernize-redundant-void-arg
    modernize-replace-auto-ptr
    modernize-replace-random-shuffle
    modernize-return-braced-init-list
    modernize-shrink-to-fit
    modernize-unary-static-assert
    modernize-use-auto
    modernize-use-bool-literals
    modernize-use-default-member-init
    modernize-use-emplace
    modernize-use-equals-default
    modernize-use-equals-delete
    modernize-use-nodiscard
    modernize-use-noexcept
    modernize-use-nullptr
    modernize-use-override
    modernize-use-trailing-return-type
    modernize-use-transparent-functors
    modernize-use-uncaught-exceptions
    modernize-use-using
    mpi-buffer-deref
    mpi-type-mismatch
    objc-avoid-nserror-init
    objc-forbidden-subclassing
    objc-missing-hash
    objc-property-declaration
    objc-super-self
    openmp-exception-escape
    openmp-use-default-none
    performance-faster-string-find
    performance-for-range-copy
    performance-implicit-conversion-in-loop
    performance-inefficient-algorithm
    performance-inefficient-string-concatenation
    performance-inefficient-vector-operation
    performance-move-const-arg
    performance-move-constructor-init
    performance-no-automatic-move
    performance-noexcept-move-constructor
    performance-trivially-destructible
    performance-type-promotion-in-math-fn
    performance-unnecessary-copy-initialization
    performance-unnecessary-value-param
    portability-simd-intrinsics
    readability-avoid-const-params-in-decls
    readability-braces-around-statements
    readability-const-return-type
    readability-container-size-empty
    readability-convert-member-functions-to-static
    readability-delete-null-pointer
    readability-deleted-default
    readability-else-after-return
    readability-function-size
    readability-identifier-naming
    readability-implicit-bool-conversion
    readability-inconsistent-declaration-parameter-name
    readability-isolate-declaration
    readability-magic-numbers
    readability-make-member-function-const
    readability-misleading-indentation
    readability-misplaced-array-index
    readability-named-parameter
    readability-non-const-parameter
    readability-qualified-auto
    readability-redundant-access-specifiers
    readability-redundant-control-flow
    readability-redundant-declaration
    readability-redundant-function-ptr-dereference
    readability-redundant-member-init
    readability-redundant-preprocessor
    readability-redundant-smartptr-get
    readability-redundant-string-cstr
    readability-redundant-string-init
    readability-simplify-boolean-expr
    readability-simplify-subscript-expr
    readability-static-accessed-through-instance
    readability-static-definition-in-anonymous-namespace
    readability-string-compare
    readability-uniqueptr-delete-release
    readability-uppercase-literal-suffix
    zircon-temporary-objects
```

On Ubuntu (using clang-tidy v9), from the `<repo root>/sdk/` directory:
```bash
find inc/ -name '*.h' -exec clang-tidy-9 -p . {} --checks='*,-llvm-header-guard,-google-readability-todo' -- -Iinc \; > output_header_filtered.txt
find src/ -name '*.c' -exec clang-tidy-9 -p . {} --checks='*,-llvm-header-guard,-google-readability-todo' -- -Iinc \; > output_source_filtered.txt
find src/ -name '*.c' -exec clang-tidy-9 -p . --header-filter='.*' {} --checks='*,-llvm-header-guard,-google-readability-todo' -- -Iinc \; > output_with_header_filter_star.txt
```

On Windows (using clang-tidy v10), from the `<repo root>/sdk/` directory:
```bash
find inc/ -name '*.h' -exec clang-tidy -p . {} --checks='*,-llvm-header-guard,-google-readability-todo' -- -Iinc \; > output_header_filtered-windows.txt
find src/ -name '*.c' -exec clang-tidy -p . {} --checks='*,-llvm-header-guard,-google-readability-todo' -- -Iinc \; > output_source_filtered-windows.txt
find src/ -name '*.c' -exec clang-tidy -p . --header-filter='.*' {} --checks='*,-llvm-header-guard,-google-readability-todo' -- -Iinc \; > output_with_header_filter_star-windows.txt
```