### PR TITLE
Proposal: assert(false) in the default precondition failed handler

### DIFF
--- a/sdk/src/azure/core/az_precondition.c
+++ b/sdk/src/azure/core/az_precondition.c
@@ -10,7 +10,7 @@
 
 static void az_precondition_failed_default()
 {
-  assert(false);
+  assert(0);
   /* By default, when a precondition fails the calling thread spins forever */
   while (1)
   {

--- a/sdk/src/azure/core/az_precondition.c
+++ b/sdk/src/azure/core/az_precondition.c
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: MIT
 
 #include <azure/core/internal/az_precondition_internal.h>
+
+#include <assert.h>
 #include <stdint.h>
 
 #include <azure/core/_az_cfg.h>
 
 static void az_precondition_failed_default()
 {
+  assert(false);
   /* By default, when a precondition fails the calling thread spins forever */
   while (1)
   {

--- a/sdk/src/azure/core/az_precondition.c
+++ b/sdk/src/azure/core/az_precondition.c
@@ -10,7 +10,9 @@
 
 static void az_precondition_failed_default()
 {
+  // When assert() fails, some platforms would break into debugger, print callstack info, etc.
   assert(0);
+
   /* By default, when a precondition fails the calling thread spins forever */
   while (1)
   {


### PR DESCRIPTION
Currently, if precondition fails, your program ends up spinning in the endless loop. Maybe it is the only thing that can be done on an IoT device, I think that if we also do `assert(false)`, nothing will change for the IoT device, but on the desktop systems at least, you will break into debugger/program will abort with console message immediately - no need to wait until you figure out it is not doing anything, plus if you break into debugger, you get callstack. And if our unit tests fail, you get results immediately instead of being terminated by timeout at an unknown place, especially useful in CI/CD, I think.

Note that I am not even doing `assert(!"Precondition failed!")`, or try to include file and line information: so that it does not contribute as much to the binary size (all these would be strings need to be stored somewhere in the binary).

Update: to make would be message on assert failure even smaller, I changed `assert(false)` to `assert(0)`, so if the implementation choses to store "false" or "0" as a message, "0" is shorter, but carries the same information (little).