### PR TITLE
Fix spacing on az_posix to satisfy clang format.

### DIFF
--- a/sdk/src/azure/platform/az_posix.c
+++ b/sdk/src/azure/platform/az_posix.c
@@ -14,10 +14,10 @@
 AZ_NODISCARD az_result az_platform_clock_msec(int64_t* out_clock_msec)
 {
   _az_PRECONDITION_NOT_NULL(out_clock_msec);
-  
+
   // NOLINTNEXTLINE(bugprone-misplaced-widening-cast)
   *out_clock_msec = (int64_t)((clock() / CLOCKS_PER_SEC) * _az_TIME_MILLISECONDS_PER_SECOND);
-  
+
   return AZ_OK;
 }
 


### PR DESCRIPTION
@antkmsft - this change slipped through between the clang format validation check PR and the recent PAL update.
https://github.com/Azure/azure-sdk-for-c/pull/1256

It is blocking CI for other PRs atm.