### PR TITLE
Docs: More details about az_log_set_classifications()

### DIFF
--- a/sdk/docs/core/README.md
+++ b/sdk/docs/core/README.md
@@ -106,10 +106,11 @@ Log classifications allow your application to select which specific log messages
       printf("%.*s\n", az_span_size(message), az_span_ptr(message));
    }
 
+   az_log_classification const log_classifications[] = { AZ_LOG_HTTP_REQUEST, AZ_LOG_HTTP_RESPONSE, AZ_LOG_END_OF_LIST };
+
    int main()
    {
-      az_log_classification const classifications[] = { AZ_LOG_HTTP_REQUEST, AZ_LOG_HTTP_RESPONSE, AZ_LOG_END_OF_LIST };
-      az_log_set_classifications(classifications);
+      az_log_set_classifications(log_classifications);
       az_log_set_callback(test_log_func);
 
       // More code goes here...

--- a/sdk/docs/core/README.md
+++ b/sdk/docs/core/README.md
@@ -101,12 +101,12 @@ Now, whenever our SDK wants to send a log message, it will invoke your callback 
 Log classifications allow your application to select which specific log messages it wants to receive. Here is a complete example that logs HTTP request and response messages to standard output:
 
    ```C
-   void test_log_func(az_log_classification classification, az_span message)
+   static void test_log_func(az_log_classification classification, az_span message)
    {
       printf("%.*s\n", az_span_size(message), az_span_ptr(message));
    }
 
-   az_log_classification const log_classifications[] = { AZ_LOG_HTTP_REQUEST, AZ_LOG_HTTP_RESPONSE, AZ_LOG_END_OF_LIST };
+   static az_log_classification const log_classifications[] = { AZ_LOG_HTTP_REQUEST, AZ_LOG_HTTP_RESPONSE, AZ_LOG_END_OF_LIST };
 
    int main()
    {

--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -83,11 +83,11 @@ typedef void (*az_log_message_fn)(az_log_classification classification, az_span 
  * receive log messages for all #az_log_classification values.
  * @details If \p classifications is not `NULL`, it must point to an array of
  * #az_log_classification, terminated by #AZ_LOG_END_OF_LIST.
- * @details In constrast to \p classifications being `NULL`, \p classifications pointing to an empty
- * array (which still should be terminated by #AZ_LOG_END_OF_LIST), states that an aplication is not
- * interested in receiving any message, regardless of classification.
+ * @details In contrast to \p classifications being `NULL`, \p classifications pointing to an empty
+ * array (which still should be terminated by #AZ_LOG_END_OF_LIST), states that an application is
+ * not interested in receiving any log messages.
  *
- * @warning Users should not change the \p classifications array elements, once it is passed to this
+ * @warning Users must not change the \p classifications array elements, once it is passed to this
  * function. If \p classifications array is allocated on a stack, program behavior in multi-threaded
  * environment is undefined.
  */

--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -79,11 +79,11 @@ typedef void (*az_log_message_fn)(az_log_classification classification, az_span 
  * @param[in] classifications __[nullable]__ An array of #az_log_classification values, terminated
  * by #AZ_LOG_END_OF_LIST.
  *
- * @detail If no classifications are set (\p classifications is `NULL`), the application will
+ * @details If no classifications are set (\p classifications is `NULL`), the application will
  * receive log messages for all #az_log_classification values.
- * @detail If \p classifications is not `NULL`, it must point to an array of #az_log_classification,
- * terminated by #AZ_LOG_END_OF_LIST.
- * @detail In constrast to \p classifications being `NULL`, \p classifications pointing to an empty
+ * @details If \p classifications is not `NULL`, it must point to an array of
+ * #az_log_classification, terminated by #AZ_LOG_END_OF_LIST.
+ * @details In constrast to \p classifications being `NULL`, \p classifications pointing to an empty
  * array (which still should be terminated by #AZ_LOG_END_OF_LIST), states that an aplication is not
  * interested in receiving any message, regardless of classification.
  *

--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -78,7 +78,7 @@ typedef void (*az_log_message_fn)(az_log_classification classification, az_span 
  *
  * @param[in] classifications __[nullable]__ An array of #az_log_classification values, terminated
  * by #AZ_LOG_END_OF_LIST.
- * 
+ *
  * @detail If no classifications are set (\p classifications is `NULL`), the application will
  * receive log messages for all #az_log_classification values.
  * @detail If \p classifications is not `NULL`, it must point to an array of #az_log_classification,

--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -76,11 +76,16 @@ typedef void (*az_log_message_fn)(az_log_classification classification, az_span 
  * @brief Allows the application to specify which #az_log_classification types it is interested in
  * receiving.
  *
- * @details If no classifications are set (`NULL`), the application will receive log messages for
- * all #az_log_classification values.
- *
- * @param[in] classifications __[nullable]__ An array of az_log_classification values, terminated by
- * #AZ_LOG_END_OF_LIST.
+ * @param[in] classifications __[nullable]__ An array of #az_log_classification values, terminated
+ * by #AZ_LOG_END_OF_LIST.
+ * 
+ * @detail If no classifications are set (\p classifications is `NULL`), the application will
+ * receive log messages for all #az_log_classification values.
+ * @detail If \p classifications is not `NULL`, it must point to an array of #az_log_classification,
+ * terminated by #AZ_LOG_END_OF_LIST.
+ * @detail In constrast to \p classifications being `NULL`, \p classifications pointing to an empty
+ * array (which still should be terminated by #AZ_LOG_END_OF_LIST), states that an aplication is not
+ * interested in receiving any message, regardless of classification.
  *
  * @warning Users should not change the \p classifications array elements, once it is passed to this
  * function. If \p classifications array is allocated on a stack, program behavior in multi-threaded

--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -81,6 +81,10 @@ typedef void (*az_log_message_fn)(az_log_classification classification, az_span 
  *
  * @param[in] classifications __[nullable]__ An array of az_log_classification values, terminated by
  * #AZ_LOG_END_OF_LIST.
+ *
+ * @warning Users should not change the \p classifications array elements, once it is passed to this
+ * function. If \p classifications array is allocated on a stack, program behavior in multi-threaded
+ * environment is undefined.
  */
 #ifndef AZ_NO_LOGGING
 void az_log_set_classifications(az_log_classification const classifications[]);

--- a/sdk/samples/storage/blobs/src/blobs_client_example.c
+++ b/sdk/samples/storage/blobs/src/blobs_client_example.c
@@ -37,14 +37,14 @@ static az_span content_to_upload = AZ_SPAN_LITERAL_FROM_STR("Some test content")
 #endif
 
 // Enable logging
-az_log_classification const log_classifications[]
-    = { AZ_LOG_HTTP_REQUEST, AZ_LOG_HTTP_RESPONSE, AZ_LOG_END_OF_LIST };
-
 static void test_log_func(az_log_classification classification, az_span message)
 {
   (void)classification;
   printf("%.*s\n", az_span_size(message), az_span_ptr(message));
 }
+
+static az_log_classification const log_classifications[]
+    = { AZ_LOG_HTTP_REQUEST, AZ_LOG_HTTP_RESPONSE, AZ_LOG_END_OF_LIST };
 
 int main()
 {

--- a/sdk/samples/storage/blobs/src/blobs_client_example.c
+++ b/sdk/samples/storage/blobs/src/blobs_client_example.c
@@ -37,6 +37,9 @@ static az_span content_to_upload = AZ_SPAN_LITERAL_FROM_STR("Some test content")
 #endif
 
 // Enable logging
+az_log_classification const log_classifications[]
+    = { AZ_LOG_HTTP_REQUEST, AZ_LOG_HTTP_RESPONSE, AZ_LOG_END_OF_LIST };
+
 static void test_log_func(az_log_classification classification, az_span message)
 {
   (void)classification;
@@ -58,9 +61,7 @@ int main()
   */
 
   // enable logging
-  az_log_classification const classifications[]
-      = { AZ_LOG_HTTP_REQUEST, AZ_LOG_HTTP_RESPONSE, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(log_classifications);
   az_log_set_callback(test_log_func);
 
   // 1) Init client.


### PR DESCRIPTION
Closes #1227.
Closes #1192.

I don't think there is much more we can do for #1227.  We still can - maybe we can have a local copy of an array of some finite size, and copy elements there, but besides that I don't see much options. az_log_set_classifications() would need to return az_result in this case, if the limit is exceeded. Then, if you want more than the predefined limit, one of the options is to pass NULL to receive all classifications, and filter them out in log callback, which does receive classification in addition to message.

I had two solutions in mind:
1. Use mutex, and lock it when setting classifications, and while iterating over them. I do not think it is possible, given that az_log is used by IoT, and mutex is in PAL, and we don't want the dependency on PAL for the IoT scenarios.

2. If we know all the possible classifications, make some sort of a map of `classification -> bool is_enabled`, and use that internal copy; this would also have some perf benefits as side effect. But given that we now extracted IoT classifications from core into a file in the iot directory, I do not see a realistic good and simple way of doing this anymore.