### PR TITLE
Make sure no struct contains an enum as the first field to avoid IAR warning on { 0 } init.

### DIFF
--- a/sdk/inc/azure/core/az_http.h
+++ b/sdk/inc/azure/core/az_http.h
@@ -124,9 +124,6 @@ typedef enum
  */
 typedef struct
 {
-  /// An array of HTTP status codes to retry on, terminated by #AZ_HTTP_STATUS_CODE_END_OF_LIST.
-  az_http_status_code const* status_codes;
-
   /// The minimum time, in milliseconds, to wait before a retry.
   int32_t retry_delay_msec;
 
@@ -135,6 +132,12 @@ typedef struct
 
   /// Maximum number of retries.
   int32_t max_retries;
+
+  // Avoid using enum as the first field within structs, to allow for { 0 } initialization.
+  // This is a workaround for IAR compiler warning [Pe188]: enumerated type mixed with another type.
+
+  /// An array of HTTP status codes to retry on, terminated by #AZ_HTTP_STATUS_CODE_END_OF_LIST.
+  az_http_status_code const* status_codes;
 } az_http_policy_retry_options;
 
 typedef enum

--- a/sdk/inc/azure/core/internal/az_http_internal.h
+++ b/sdk/inc/azure/core/internal/az_http_internal.h
@@ -43,9 +43,14 @@ typedef struct
   // Services pass API versions in the header or in query parameters
   struct
   {
-    _az_http_policy_apiversion_option_location option_location;
     az_span name;
     az_span version;
+
+    // Avoid using enum as the first field within structs, to allow for { 0 } initialization.
+    // This is a workaround for IAR compiler warning [Pe188]: enumerated type mixed with another
+    // type.
+
+    _az_http_policy_apiversion_option_location option_location;
   } _internal;
 } _az_http_policy_apiversion_options;
 

--- a/sdk/inc/azure/iot/az_iot_hub_client.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client.h
@@ -384,10 +384,14 @@ typedef enum
  */
 typedef struct
 {
-  az_iot_hub_client_twin_response_type response_type; /**< Twin response type. */
-  az_iot_status status; /**< The operation status. */
   az_span
       request_id; /**< Request ID matches the ID specified when issuing a Get or Patch command. */
+
+  // Avoid using enum as the first field within structs, to allow for { 0 } initialization.
+  // This is a workaround for IAR compiler warning [Pe188]: enumerated type mixed with another type.
+
+  az_iot_hub_client_twin_response_type response_type; /**< Twin response type. */
+  az_iot_status status; /**< The operation status. */
   az_span version; /**< The Twin object version.
                     * @remark This is only returned when
                     * `response_type==AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES`

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -239,11 +239,15 @@ typedef enum
  */
 typedef struct
 {
+  az_span operation_id; /**< The id of the register operation. */
+
+  // Avoid using enum as the first field within structs, to allow for { 0 } initialization.
+  // This is a workaround for IAR compiler warning [Pe188]: enumerated type mixed with another type.
+
   az_iot_status status; /**< The current request status.
                          * @remark The authoritative response for the device registration operation
                          * (which may require several requests) is available only through
                          * #operation_status.  */
-  az_span operation_id; /**< The id of the register operation. */
   az_iot_provisioning_client_operation_status
       operation_status; /**< The status of the register operation. */
   uint32_t retry_after_seconds; /**< Recommended timeout before sending the next MQTT publish. */


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-sdk-for-c/pull/1304, with comment guidance, to make sure such intermittent issues don't come up again:
https://github.com/Azure/azure-sdk-for-c/issues/1276
https://github.com/Azure/azure-sdk-for-c/issues/303

Ideally, this would be fixed in IAR's compiler, or customers would disable such a warning.

cc @TiejunMS