### PR TITLE
Turn the log classifications array used for registration into a bit flag.

### DIFF
--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -31,8 +31,8 @@
  * @brief Identifies the classifications of log messages produced by the SDK.
  *
  * @note See the following `az_log_classification` values from various headers:
- * - #az_log_classification_core
- * - #az_log_classification_iot
+ * - #az_log_classification_bit_flags_core
+ * - #az_log_classification_bit_flags_iot
  */
 typedef int32_t az_log_classification;
 

--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -36,21 +36,28 @@
  */
 typedef int32_t az_log_classification;
 
-// All zeroes and all ones are reserved.
+// All zeroes is reserved for NONE.
+// All ones is reserved for ALL.
+// Bit 31 is reserved to avoid negative classification values.
 // Valid bit values are ones that are unused by other components, between 1 to 30, inclusive.
 #define _az_LOG_MAKE_CLASSIFICATION(bit) ((az_log_classification)(1U << (uint32_t)(bit)))
 
+// Bits 0 to 10 and are reserved for core, and 11 to 30 can be used by service client components.
 /**
  * @brief Identifies the #az_log_classification produced by the SDK Core.
  */
 enum az_log_classification_bit_flags_core
 {
-  AZ_LOG_HTTP_REQUEST = _az_LOG_MAKE_CLASSIFICATION(1), ///< HTTP request is about to be sent.
+  AZ_LOG_NONE = 0, ///< Sentinel value which lets the SDK know to log nothing (this is the default).
 
-  AZ_LOG_HTTP_RESPONSE = _az_LOG_MAKE_CLASSIFICATION(2), ///< HTTP response was received.
+  AZ_LOG_ALL = -1, ///< Sentinel value which lets the SDK know to log all classifications.
+
+  AZ_LOG_HTTP_REQUEST = _az_LOG_MAKE_CLASSIFICATION(0), ///< HTTP request is about to be sent.
+
+  AZ_LOG_HTTP_RESPONSE = _az_LOG_MAKE_CLASSIFICATION(1), ///< HTTP response was received.
 
   AZ_LOG_HTTP_RETRY
-  = _az_LOG_MAKE_CLASSIFICATION(3), ///< First HTTP request did not succeed and will be retried.
+  = _az_LOG_MAKE_CLASSIFICATION(2), ///< First HTTP request did not succeed and will be retried.
 };
 
 /**
@@ -66,16 +73,16 @@ typedef void (*az_log_message_fn)(az_log_classification classification, az_span 
  * @brief Allows the application to specify which #az_log_classification types it is interested in
  * receiving.
  *
- * @details If no classifications are set (`NULL`), the application will receive log messages for
- * all #az_log_classification values.
+ * @details If no classifications are set (i.e. #AZ_LOG_ALL, or 0), the application will receive log
+ * messages for all #az_log_classification values.
  *
- * @param[in] classifications __[nullable]__ An array of az_log_classification values, terminated by
- * #AZ_LOG_END_OF_LIST.
+ * @param[in] classifications A bit-flag of log classification values that the caller is interested
+ * in receiving.
  */
 #ifndef AZ_NO_LOGGING
-void az_log_set_classifications(az_log_classification const classification);
+void az_log_set_classifications(az_log_classification const classifications);
 #else
-AZ_INLINE void az_log_set_classifications(az_log_classification const classification)
+AZ_INLINE void az_log_set_classifications(az_log_classification const classifications)
 {
   (void)classifications;
 }
@@ -85,8 +92,8 @@ AZ_INLINE void az_log_set_classifications(az_log_classification const classifica
  * @brief Sets the function that will be invoked to report an SDK log message.
  *
  * @param[in] az_log_message_callback __[nullable]__ A pointer to the function that will be invoked
- * when the SDK reports a log message matching one of the #az_log_classification passed to
- * #az_log_set_classifications(). If `NULL`, no function will be invoked.
+ * when the SDK reports a log message matching one of the #az_log_classification bit-flag value
+ * passed to #az_log_set_classifications(). If `NULL`, no function will be invoked.
  */
 #ifndef AZ_NO_LOGGING
 void az_log_set_callback(az_log_message_fn az_log_message_callback);

--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -36,31 +36,21 @@
  */
 typedef int32_t az_log_classification;
 
-// az_log_classification Bits:
-//   - 31 Always 0.
-//   - 16..30 Facility.
-//   - 0..15 Code.
-
-#define _az_LOG_MAKE_CLASSIFICATION(facility, code) \
-  ((az_log_classification)(((uint32_t)(facility) << 16U) | (uint32_t)(code)))
+// All zeroes and all ones are reserved.
+// Valid bit values are ones that are unused by other components, between 1 to 30, inclusive.
+#define _az_LOG_MAKE_CLASSIFICATION(bit) ((az_log_classification)(1U << (uint32_t)(bit)))
 
 /**
  * @brief Identifies the #az_log_classification produced by the SDK Core.
  */
-enum az_log_classification_core
+enum az_log_classification_bit_flags_core
 {
-  AZ_LOG_END_OF_LIST
-  = -1, ///< Terminates the classification array passed to #az_log_set_classifications().
+  AZ_LOG_HTTP_REQUEST = _az_LOG_MAKE_CLASSIFICATION(1), ///< HTTP request is about to be sent.
 
-  AZ_LOG_HTTP_REQUEST
-  = _az_LOG_MAKE_CLASSIFICATION(_az_FACILITY_HTTP, 1), ///< HTTP request is about to be sent.
+  AZ_LOG_HTTP_RESPONSE = _az_LOG_MAKE_CLASSIFICATION(2), ///< HTTP response was received.
 
-  AZ_LOG_HTTP_RESPONSE
-  = _az_LOG_MAKE_CLASSIFICATION(_az_FACILITY_HTTP, 2), ///< HTTP response was received.
-
-  AZ_LOG_HTTP_RETRY = _az_LOG_MAKE_CLASSIFICATION(
-      _az_FACILITY_HTTP,
-      3), ///< First HTTP request did not succeed and will be retried.
+  AZ_LOG_HTTP_RETRY
+  = _az_LOG_MAKE_CLASSIFICATION(3), ///< First HTTP request did not succeed and will be retried.
 };
 
 /**
@@ -83,9 +73,9 @@ typedef void (*az_log_message_fn)(az_log_classification classification, az_span 
  * #AZ_LOG_END_OF_LIST.
  */
 #ifndef AZ_NO_LOGGING
-void az_log_set_classifications(az_log_classification const classifications[]);
+void az_log_set_classifications(az_log_classification const classification);
 #else
-AZ_INLINE void az_log_set_classifications(az_log_classification const classifications[])
+AZ_INLINE void az_log_set_classifications(az_log_classification const classification)
 {
   (void)classifications;
 }

--- a/sdk/inc/azure/iot/az_iot_common.h
+++ b/sdk/inc/azure/iot/az_iot_common.h
@@ -38,23 +38,24 @@ enum az_result_iot
   AZ_ERROR_IOT_END_OF_PROPERTIES = _az_RESULT_MAKE_ERROR(_az_FACILITY_IOT, 2),
 };
 
+// Bits 0 to 10 and are reserved for core, and 11 to 30 can be used by service client components.
 /**
  * @brief Identifies the #az_log_classification produced specifically by the IoT clients within the
  * SDK.
  */
 enum az_log_classification_bit_flags_iot
 {
-  AZ_LOG_MQTT_RECEIVED_TOPIC = _az_LOG_MAKE_CLASSIFICATION(4), ///< Accepted MQTT topic received.
+  AZ_LOG_MQTT_RECEIVED_TOPIC = _az_LOG_MAKE_CLASSIFICATION(11), ///< Accepted MQTT topic received.
 
   AZ_LOG_MQTT_RECEIVED_PAYLOAD
-  = _az_LOG_MAKE_CLASSIFICATION(5), ///< Accepted MQTT payload received.
+  = _az_LOG_MAKE_CLASSIFICATION(12), ///< Accepted MQTT payload received.
 
-  AZ_LOG_IOT_RETRY = _az_LOG_MAKE_CLASSIFICATION(6), ///< IoT Client retry.
+  AZ_LOG_IOT_RETRY = _az_LOG_MAKE_CLASSIFICATION(13), ///< IoT Client retry.
 
-  AZ_LOG_IOT_SAS_TOKEN = _az_LOG_MAKE_CLASSIFICATION(7), ///< IoT Client generated new SAS token.
+  AZ_LOG_IOT_SAS_TOKEN = _az_LOG_MAKE_CLASSIFICATION(14), ///< IoT Client generated new SAS token.
 
   AZ_LOG_IOT_AZURERTOS
-  = _az_LOG_MAKE_CLASSIFICATION(8), ///< Azure IoT classification for Azure RTOS.
+  = _az_LOG_MAKE_CLASSIFICATION(15), ///< Azure IoT classification for Azure RTOS.
 };
 
 enum

--- a/sdk/inc/azure/iot/az_iot_common.h
+++ b/sdk/inc/azure/iot/az_iot_common.h
@@ -42,21 +42,19 @@ enum az_result_iot
  * @brief Identifies the #az_log_classification produced specifically by the IoT clients within the
  * SDK.
  */
-enum az_log_classification_iot
+enum az_log_classification_bit_flags_iot
 {
-  AZ_LOG_MQTT_RECEIVED_TOPIC
-  = _az_LOG_MAKE_CLASSIFICATION(_az_FACILITY_MQTT, 1), ///< Accepted MQTT topic received.
+  AZ_LOG_MQTT_RECEIVED_TOPIC = _az_LOG_MAKE_CLASSIFICATION(4), ///< Accepted MQTT topic received.
 
   AZ_LOG_MQTT_RECEIVED_PAYLOAD
-  = _az_LOG_MAKE_CLASSIFICATION(_az_FACILITY_MQTT, 2), ///< Accepted MQTT payload received.
+  = _az_LOG_MAKE_CLASSIFICATION(5), ///< Accepted MQTT payload received.
 
-  AZ_LOG_IOT_RETRY = _az_LOG_MAKE_CLASSIFICATION(_az_FACILITY_IOT, 1), ///< IoT Client retry.
+  AZ_LOG_IOT_RETRY = _az_LOG_MAKE_CLASSIFICATION(6), ///< IoT Client retry.
 
-  AZ_LOG_IOT_SAS_TOKEN
-  = _az_LOG_MAKE_CLASSIFICATION(_az_FACILITY_IOT, 2), ///< IoT Client generated new SAS token.
+  AZ_LOG_IOT_SAS_TOKEN = _az_LOG_MAKE_CLASSIFICATION(7), ///< IoT Client generated new SAS token.
 
   AZ_LOG_IOT_AZURERTOS
-  = _az_LOG_MAKE_CLASSIFICATION(_az_FACILITY_IOT, 3), ///< Azure IoT classification for Azure RTOS.
+  = _az_LOG_MAKE_CLASSIFICATION(8), ///< Azure IoT classification for Azure RTOS.
 };
 
 enum

--- a/sdk/samples/storage/blobs/src/blobs_client_example.c
+++ b/sdk/samples/storage/blobs/src/blobs_client_example.c
@@ -58,9 +58,7 @@ int main()
   */
 
   // enable logging
-  az_log_classification const classifications[]
-      = { AZ_LOG_HTTP_REQUEST, AZ_LOG_HTTP_RESPONSE, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_HTTP_REQUEST | AZ_LOG_HTTP_RESPONSE);
   az_log_set_callback(test_log_func);
 
   // 1) Init client.

--- a/sdk/tests/core/test_az_logging.c
+++ b/sdk/tests/core/test_az_logging.c
@@ -195,7 +195,7 @@ static void test_az_log(void** state)
     // callback with the classification that's in the list of customer-provided classifications, and
     // nothing is going to happen when our code attempts to log a classification that's not in that
     // list.
-    az_log_classification const classifications[] = { AZ_LOG_HTTP_REQUEST, AZ_LOG_END_OF_LIST };
+    az_log_classification const classifications = AZ_LOG_HTTP_REQUEST;
     az_log_set_classifications(classifications);
 
     assert_true(_az_LOG_SHOULD_WRITE(AZ_LOG_HTTP_REQUEST) == _az_BUILT_WITH_LOGGING(true, false));
@@ -285,7 +285,7 @@ static void test_az_log_incorrect_list_fails_gracefully(void** state)
 {
   (void)state;
   {
-    az_log_classification const classifications[] = { AZ_LOG_HTTP_RETRY, AZ_LOG_END_OF_LIST };
+    az_log_classification const classifications = AZ_LOG_HTTP_RETRY;
     az_log_set_classifications(classifications);
     az_log_set_callback(_log_listener_no_op);
 
@@ -309,19 +309,17 @@ static void test_az_log_everything_valid(void** state)
 {
   (void)state;
   {
-    az_log_classification const classifications[]
-        = { AZ_LOG_HTTP_RETRY, AZ_LOG_HTTP_RESPONSE, AZ_LOG_HTTP_REQUEST, AZ_LOG_END_OF_LIST };
+    az_log_classification const classifications
+        = AZ_LOG_HTTP_RETRY | AZ_LOG_HTTP_RESPONSE | AZ_LOG_HTTP_REQUEST;
     az_log_set_classifications(classifications);
     az_log_set_callback(_log_listener_count_logs);
 
     _number_of_log_attempts = 0;
 
     assert_true(_az_BUILT_WITH_LOGGING(true, false) == _az_LOG_SHOULD_WRITE(AZ_LOG_HTTP_REQUEST));
-    assert_false(_az_LOG_SHOULD_WRITE(AZ_LOG_END_OF_LIST));
     assert_false(_az_LOG_SHOULD_WRITE((az_log_classification)12345));
 
     _az_LOG_WRITE(AZ_LOG_HTTP_REQUEST, AZ_SPAN_EMPTY);
-    _az_LOG_WRITE(AZ_LOG_END_OF_LIST, AZ_SPAN_EMPTY);
     _az_LOG_WRITE((az_log_classification)12345, AZ_SPAN_EMPTY);
 
     assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _number_of_log_attempts);
@@ -342,12 +340,10 @@ static void test_az_log_everything_on_null(void** state)
     _number_of_log_attempts = 0;
 
     assert_true(_az_BUILT_WITH_LOGGING(true, false) == _az_LOG_SHOULD_WRITE(AZ_LOG_HTTP_REQUEST));
-    assert_false(_az_LOG_SHOULD_WRITE(AZ_LOG_END_OF_LIST));
     assert_true(
         _az_BUILT_WITH_LOGGING(true, false) == _az_LOG_SHOULD_WRITE((az_log_classification)12345));
 
     _az_LOG_WRITE(AZ_LOG_HTTP_REQUEST, AZ_SPAN_EMPTY);
-    _az_LOG_WRITE(AZ_LOG_END_OF_LIST, AZ_SPAN_EMPTY);
     _az_LOG_WRITE((az_log_classification)12345, AZ_SPAN_EMPTY);
 
     assert_int_equal(_az_BUILT_WITH_LOGGING(2, 0), _number_of_log_attempts);

--- a/sdk/tests/core/test_az_logging.c
+++ b/sdk/tests/core/test_az_logging.c
@@ -141,6 +141,7 @@ static void test_az_log(void** state)
     // null request
     _reset_log_invocation_status();
     az_log_set_callback(_log_listener_NULL);
+    az_log_set_classifications(AZ_LOG_ALL);
     _az_http_policy_logging_log_http_request(NULL);
     assert_true(_log_invoked_for_http_request == _az_BUILT_WITH_LOGGING(true, false));
     assert_true(_log_invoked_for_http_response == false);
@@ -208,7 +209,7 @@ static void test_az_log(void** state)
     assert_true(_log_invoked_for_http_response == false);
   }
 
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
   az_log_set_callback(NULL);
 }
 
@@ -259,6 +260,7 @@ static void test_az_log_corrupted_response(void** state)
 
   _reset_log_invocation_status();
   az_log_set_callback(_log_listener_stop_logging_corrupted_response);
+  az_log_set_classifications(AZ_LOG_ALL);
   assert_true(_log_invoked_for_http_request == false);
   assert_true(_log_invoked_for_http_response == false);
 
@@ -270,7 +272,7 @@ static void test_az_log_corrupted_response(void** state)
   assert_true(_log_invoked_for_http_request == _az_BUILT_WITH_LOGGING(true, false));
   assert_true(_log_invoked_for_http_response == _az_BUILT_WITH_LOGGING(true, false));
 
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
   az_log_set_callback(NULL);
 }
 
@@ -293,7 +295,7 @@ static void test_az_log_incorrect_list_fails_gracefully(void** state)
     _az_LOG_WRITE((az_log_classification)12345, AZ_SPAN_EMPTY);
 
     az_log_set_callback(NULL);
-    az_log_set_classifications(NULL);
+    az_log_set_classifications(AZ_LOG_NONE);
   }
 }
 
@@ -317,24 +319,23 @@ static void test_az_log_everything_valid(void** state)
     _number_of_log_attempts = 0;
 
     assert_true(_az_BUILT_WITH_LOGGING(true, false) == _az_LOG_SHOULD_WRITE(AZ_LOG_HTTP_REQUEST));
-    assert_false(_az_LOG_SHOULD_WRITE((az_log_classification)12345));
+    assert_false(_az_LOG_SHOULD_WRITE((az_log_classification)8));
 
     _az_LOG_WRITE(AZ_LOG_HTTP_REQUEST, AZ_SPAN_EMPTY);
-    _az_LOG_WRITE((az_log_classification)12345, AZ_SPAN_EMPTY);
+    _az_LOG_WRITE((az_log_classification)8, AZ_SPAN_EMPTY);
 
     assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _number_of_log_attempts);
 
     az_log_set_callback(NULL);
-    az_log_set_classifications(NULL);
+    az_log_set_classifications(AZ_LOG_NONE);
   }
 }
 
-static void test_az_log_everything_on_null(void** state)
+static void test_az_log_everything_on_all(void** state)
 {
   (void)state;
   {
-    az_log_classification const* classifications = NULL;
-    az_log_set_classifications(classifications);
+    az_log_set_classifications(AZ_LOG_ALL);
     az_log_set_callback(_log_listener_count_logs);
 
     _number_of_log_attempts = 0;
@@ -349,7 +350,7 @@ static void test_az_log_everything_on_null(void** state)
     assert_int_equal(_az_BUILT_WITH_LOGGING(2, 0), _number_of_log_attempts);
 
     az_log_set_callback(NULL);
-    az_log_set_classifications(NULL);
+    az_log_set_classifications(AZ_LOG_NONE);
   }
 }
 
@@ -360,7 +361,7 @@ int test_az_logging()
     cmocka_unit_test(test_az_log_corrupted_response),
     cmocka_unit_test(test_az_log_incorrect_list_fails_gracefully),
     cmocka_unit_test(test_az_log_everything_valid),
-    cmocka_unit_test(test_az_log_everything_on_null),
+    cmocka_unit_test(test_az_log_everything_on_all),
   };
   return cmocka_run_group_tests_name("az_core_logging", tests, NULL, NULL);
 }

--- a/sdk/tests/iot/common/test_az_iot_common.c
+++ b/sdk/tests/iot/common/test_az_iot_common.c
@@ -246,8 +246,7 @@ static void _log_listener(az_log_classification classification, az_span message)
 
 static void test_az_iot_calculate_retry_delay_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_IOT_RETRY, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_IOT_RETRY);
   az_log_set_callback(_log_listener);
 
   _log_retry = 0;
@@ -255,13 +254,12 @@ static void test_az_iot_calculate_retry_delay_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_retry);
 
   az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
 }
 
 static void test_az_iot_calculate_retry_delay_no_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_NONE);
   az_log_set_callback(_log_listener);
 
   _log_retry = 0;
@@ -269,7 +267,7 @@ static void test_az_iot_calculate_retry_delay_no_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_retry);
 
   az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
 }
 
 static void test_az_span_copy_url_encode_succeed()

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_c2d.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_c2d.c
@@ -213,9 +213,7 @@ static void _log_listener(az_log_classification classification, az_span message)
 
 static void test_az_iot_hub_client_c2d_logging_succeed()
 {
-  az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_MQTT_RECEIVED_TOPIC | AZ_LOG_MQTT_RECEIVED_PAYLOAD);
   az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
@@ -230,14 +228,12 @@ static void test_az_iot_hub_client_c2d_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
 
   az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
 }
 
 static void test_az_iot_hub_client_c2d_no_logging_succeed()
 {
-  az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_MQTT_RECEIVED_PAYLOAD);
   az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
@@ -252,7 +248,7 @@ static void test_az_iot_hub_client_c2d_no_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
 
   az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_methods.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_methods.c
@@ -383,9 +383,7 @@ static void _log_listener(az_log_classification classification, az_span message)
 
 static void test_az_iot_hub_client_methods_logging_succeed()
 {
-  az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_MQTT_RECEIVED_TOPIC | AZ_LOG_MQTT_RECEIVED_PAYLOAD);
   az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
@@ -401,14 +399,12 @@ static void test_az_iot_hub_client_methods_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
 
   az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
 }
 
 static void test_az_iot_hub_client_methods_no_logging_succeed()
 {
-  az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_MQTT_RECEIVED_PAYLOAD);
   az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
@@ -424,7 +420,7 @@ static void test_az_iot_hub_client_methods_no_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
 
   az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_sas.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_sas.c
@@ -440,8 +440,7 @@ static void _log_listener(az_log_classification classification, az_span message)
 
 static void test_az_iot_hub_client_sas_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_IOT_SAS_TOKEN, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_IOT_SAS_TOKEN);
   az_log_set_callback(_log_listener);
 
   _log_invoked_sas = 0;
@@ -459,13 +458,12 @@ static void test_az_iot_hub_client_sas_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_sas);
 
   az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
 }
 
 static void test_az_iot_hub_client_sas_no_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_NONE);
   az_log_set_callback(_log_listener);
 
   _log_invoked_sas = 0;
@@ -483,7 +481,7 @@ static void test_az_iot_hub_client_sas_no_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_sas);
 
   az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
@@ -357,9 +357,7 @@ static void _log_listener(az_log_classification classification, az_span message)
 
 static void test_az_iot_hub_client_twin_logging_succeed()
 {
-  az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_MQTT_RECEIVED_TOPIC | AZ_LOG_MQTT_RECEIVED_PAYLOAD);
   az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
@@ -376,14 +374,12 @@ static void test_az_iot_hub_client_twin_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
 
   az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
 }
 
 static void test_az_iot_hub_client_twin_no_logging_succeed()
 {
-  az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_MQTT_RECEIVED_PAYLOAD);
   az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
@@ -400,7 +396,7 @@ static void test_az_iot_hub_client_twin_no_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
 
   az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
@@ -505,9 +505,7 @@ static void _log_listener(az_log_classification classification, az_span message)
 
 static void test_az_iot_provisioning_client_logging_succeed()
 {
-  az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_MQTT_RECEIVED_TOPIC | AZ_LOG_MQTT_RECEIVED_PAYLOAD);
   az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
@@ -522,13 +520,12 @@ static void test_az_iot_provisioning_client_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_payload);
 
   az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
 }
 
 static void test_az_iot_provisioning_client_no_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_NONE);
   az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
@@ -543,7 +540,7 @@ static void test_az_iot_provisioning_client_no_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_payload);
 
   az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_sas.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_sas.c
@@ -284,8 +284,7 @@ static void _log_listener(az_log_classification classification, az_span message)
 
 static void test_az_iot_provisioning_client_sas_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_IOT_SAS_TOKEN, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_IOT_SAS_TOKEN);
   az_log_set_callback(_log_listener);
 
   _log_invoked_sas = 0;
@@ -306,13 +305,12 @@ static void test_az_iot_provisioning_client_sas_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_sas);
 
   az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
 }
 
 static void test_az_iot_provisioning_client_sas_no_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
+  az_log_set_classifications(AZ_LOG_NONE);
   az_log_set_callback(_log_listener);
 
   _log_invoked_sas = 0;
@@ -333,7 +331,7 @@ static void test_az_iot_provisioning_client_sas_no_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_sas);
 
   az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_classifications(AZ_LOG_NONE);
 }
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/1184 and https://github.com/Azure/azure-sdk-for-c/issues/1172

Follow up to https://github.com/Azure/azure-sdk-for-c/issues/1227 and https://github.com/Azure/azure-sdk-for-c/issues/1192

Alternative to https://github.com/Azure/azure-sdk-for-c/pull/1317 

TODO:
- Changelog update
- README update