### PR TITLE
Remove az_log_set_classifications capability for GA and let the caller filter in the callback.

### DIFF
--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -73,7 +73,7 @@ enum az_log_classification_core
 typedef void (*az_log_message_fn)(az_log_classification classification, az_span message);
 
 /**
- * @brief Sets the functions that will be invoked to check and report an SDK log message.
+ * @brief Set the function that will be invoked to report an SDK log message.
  *
  * @param[in] az_log_message_callback __[nullable]__ A pointer to the function that will be invoked
  * when the SDK reports a log message that should be logged. If `NULL`, no function will be invoked.

--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -61,47 +61,32 @@ enum az_log_classification_core
 };
 
 /**
- * @brief Defines the signature of the callback function that application developers must write in
- * order to receive Azure SDK log messages.
+ * @brief Defines the signature of the callback function that application developers must implement
+ * in order to receive Azure SDK log messages.
  *
  * @param[in] classification The log message's #az_log_classification.
  * @param[in] message The log message.
+ *
+ * @remarks The implementation of this method can filter certain log messages based on the \p
+ * classification.
  */
 typedef void (*az_log_message_fn)(az_log_classification classification, az_span message);
-
-/**
- * @brief Defines the signature of the callback function that application developers must write
- * which will be used to check whether a particular log classification should be logged.
- *
- * @param[in] classification The log message's #az_log_classification.
- *
- * @return Whether or not a log message with the provided classification should be logged.
- */
-typedef bool (*az_log_should_write_fn)(az_log_classification classification);
 
 /**
  * @brief Sets the functions that will be invoked to check and report an SDK log message.
  *
  * @param[in] az_log_message_callback __[nullable]__ A pointer to the function that will be invoked
- * when the SDK reports a log message that should be logged according to #az_log_message_callback.
- * If `NULL`, no function will be invoked.
- * @param[in] az_log_should_write_callback __[nullable]__ A pointer to the function that will be
- * invoked when the SDK checks whether a log message of a particular #az_log_classification should
- * be logged. If `NULL`, log messages for all classifications will be logged, by passing them to
- * #az_log_message_callback.
+ * when the SDK reports a log message that should be logged. If `NULL`, no function will be invoked.
+ *
+ * @remarks By default, nothing is logged unless a non-NULL callback method is provided.
  */
 #ifdef AZ_NO_LOGGING
-AZ_INLINE void az_log_set_callbacks(
-    az_log_message_fn az_log_message_callback,
-    az_log_should_write_fn az_log_should_write_callback)
+AZ_INLINE void az_log_set_callback(az_log_message_fn az_log_message_callback)
 {
   (void)az_log_message_callback;
-  (void)az_log_should_write_callback;
 }
 #else
-void az_log_set_callbacks(
-    az_log_message_fn az_log_message_callback,
-    az_log_should_write_fn az_log_should_write_callback);
+void az_log_set_callback(az_log_message_fn az_log_message_callback);
 #endif // AZ_NO_LOGGING
 
 #include <azure/core/_az_cfg_suffix.h>

--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -93,7 +93,7 @@ typedef bool (*az_log_should_write_fn)(az_log_classification classification);
 #ifdef AZ_NO_LOGGING
 AZ_INLINE void az_log_set_callbacks(
     az_log_message_fn az_log_message_callback,
-    az_log_should_write_fn az_log_message_callback)
+    az_log_should_write_fn az_log_should_write_callback)
 {
   (void)az_log_message_callback;
   (void)az_log_should_write_callback;

--- a/sdk/inc/azure/core/internal/az_log_internal.h
+++ b/sdk/inc/azure/core/internal/az_log_internal.h
@@ -13,11 +13,15 @@
 
 #ifndef AZ_NO_LOGGING
 
+bool _az_log_should_write(az_log_classification classification);
 void _az_log_write(az_log_classification classification, az_span message);
 
+#define _az_LOG_SHOULD_WRITE(classification) _az_log_should_write(classification)
 #define _az_LOG_WRITE(classification, message) _az_log_write(classification, message)
 
 #else
+
+#define _az_LOG_SHOULD_WRITE(classification) false
 #define _az_LOG_WRITE(classification, message)
 
 #endif // AZ_NO_LOGGING

--- a/sdk/inc/azure/core/internal/az_log_internal.h
+++ b/sdk/inc/azure/core/internal/az_log_internal.h
@@ -11,20 +11,13 @@
 
 #include <azure/core/_az_cfg_prefix.h>
 
-// If the user hasn't registered any classifications, then we log everything.
-
 #ifndef AZ_NO_LOGGING
 
-bool _az_log_should_write(az_log_classification classification);
 void _az_log_write(az_log_classification classification, az_span message);
 
-#define _az_LOG_SHOULD_WRITE(classification) _az_log_should_write(classification)
 #define _az_LOG_WRITE(classification, message) _az_log_write(classification, message)
 
 #else
-
-#define _az_LOG_SHOULD_WRITE(classification) false
-
 #define _az_LOG_WRITE(classification, message)
 
 #endif // AZ_NO_LOGGING

--- a/sdk/inc/azure/core/internal/az_log_internal.h
+++ b/sdk/inc/azure/core/internal/az_log_internal.h
@@ -11,18 +11,18 @@
 
 #include <azure/core/_az_cfg_prefix.h>
 
-#ifndef AZ_NO_LOGGING
+#ifdef AZ_NO_LOGGING
+
+#define _az_LOG_SHOULD_WRITE(classification) false
+#define _az_LOG_WRITE(classification, message)
+
+#else
 
 bool _az_log_should_write(az_log_classification classification);
 void _az_log_write(az_log_classification classification, az_span message);
 
 #define _az_LOG_SHOULD_WRITE(classification) _az_log_should_write(classification)
 #define _az_LOG_WRITE(classification, message) _az_log_write(classification, message)
-
-#else
-
-#define _az_LOG_SHOULD_WRITE(classification) false
-#define _az_LOG_WRITE(classification, message)
 
 #endif // AZ_NO_LOGGING
 

--- a/sdk/samples/storage/blobs/src/blobs_client_example.c
+++ b/sdk/samples/storage/blobs/src/blobs_client_example.c
@@ -37,12 +37,6 @@ static az_span content_to_upload = AZ_SPAN_LITERAL_FROM_STR("Some test content")
 #endif
 
 // Enable logging
-static void test_log_func(az_log_classification classification, az_span message)
-{
-  (void)classification;
-  printf("%.*s\n", az_span_size(message), az_span_ptr(message));
-}
-
 static bool test_log_should_write_func(az_log_classification classification)
 {
   switch (classification)
@@ -52,6 +46,14 @@ static bool test_log_should_write_func(az_log_classification classification)
       return true;
     default:
       return false;
+  }
+}
+
+static void test_log_func(az_log_classification classification, az_span message)
+{
+  if (test_log_should_write_func(classification))
+  {
+    printf("%.*s\n", az_span_size(message), az_span_ptr(message));
   }
 }
 
@@ -70,7 +72,7 @@ int main()
   */
 
   // enable logging
-  az_log_set_callbacks(test_log_func, test_log_should_write_func);
+  az_log_set_callback(test_log_func);
 
   // 1) Init client.
   // Example expects AZURE_STORAGE_URL in env to be a URL w/ SAS token

--- a/sdk/samples/storage/blobs/src/blobs_client_example.c
+++ b/sdk/samples/storage/blobs/src/blobs_client_example.c
@@ -43,6 +43,18 @@ static void test_log_func(az_log_classification classification, az_span message)
   printf("%.*s\n", az_span_size(message), az_span_ptr(message));
 }
 
+static bool test_log_should_write_func(az_log_classification classification)
+{
+  switch (classification)
+  {
+    case AZ_LOG_HTTP_REQUEST:
+    case AZ_LOG_HTTP_RESPONSE:
+      return true;
+    default:
+      return false;
+  }
+}
+
 int main()
 {
   // Uncomment below lines when working with libcurl
@@ -58,10 +70,7 @@ int main()
   */
 
   // enable logging
-  az_log_classification const classifications[]
-      = { AZ_LOG_HTTP_REQUEST, AZ_LOG_HTTP_RESPONSE, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(test_log_func);
+  az_log_set_callbacks(test_log_func, test_log_should_write_func);
 
   // 1) Init client.
   // Example expects AZURE_STORAGE_URL in env to be a URL w/ SAS token

--- a/sdk/src/azure/core/az_log.c
+++ b/sdk/src/azure/core/az_log.c
@@ -25,6 +25,18 @@ void az_log_set_callback(az_log_message_fn az_log_message_callback)
   _az_log_message_callback = az_log_message_callback;
 }
 
+// This function returns whether or not the passed-in message should be logged.
+bool _az_log_should_write(az_log_classification classification)
+{
+  _az_PRECONDITION(classification > 0);
+
+  // Copy the volatile fields to local variables so that they don't change within this function.
+  az_log_message_fn const message_callback = _az_log_message_callback;
+
+  // If the user has registered a message_callback, then we log everything.
+  return message_callback != NULL;
+}
+
 // This function attempts to log the passed-in message.
 void _az_log_write(az_log_classification classification, az_span message)
 {
@@ -34,7 +46,8 @@ void _az_log_write(az_log_classification classification, az_span message)
   // Copy the volatile fields to local variables so that they don't change within this function.
   az_log_message_fn const message_callback = _az_log_message_callback;
 
-  if (message_callback != NULL)
+  // If the user has registered a message_callback, then we log everything.
+  if (_az_log_should_write(classification))
   {
     message_callback(classification, message);
   }

--- a/sdk/src/azure/core/az_log.c
+++ b/sdk/src/azure/core/az_log.c
@@ -30,6 +30,8 @@ bool _az_log_should_write(az_log_classification classification)
 {
   _az_PRECONDITION(classification > 0);
 
+  (void)classification;
+
   // Copy the volatile fields to local variables so that they don't change within this function.
   az_log_message_fn const message_callback = _az_log_message_callback;
 

--- a/sdk/src/azure/core/az_log.c
+++ b/sdk/src/azure/core/az_log.c
@@ -16,75 +16,47 @@
 
 #ifndef AZ_NO_LOGGING
 
-static az_log_classification const* volatile _az_log_classifications = NULL;
 static az_log_message_fn volatile _az_log_message_callback = NULL;
+static az_log_should_write_fn volatile _az_log_should_write_callback = NULL;
 
-void az_log_set_classifications(az_log_classification const classifications[])
-{
-  _az_log_classifications = classifications;
-}
-
-void az_log_set_callback(az_log_message_fn az_log_message_callback)
+void az_log_set_callbacks(
+    az_log_message_fn az_log_message_callback,
+    az_log_should_write_fn az_log_should_write_callback)
 {
   _az_log_message_callback = az_log_message_callback;
-}
-
-// _az_LOG_WRITE_engine is a function private to this .c file; it contains the code to handle
-// _az_LOG_SHOULD_WRITE & _az_LOG_WRITE.
-//
-// If log_it is false, then the function returns true or false indicating whether the message
-// should be logged (without actually logging it).
-//
-// If log_it is true, then the function logs the message (if it should) and returns true or
-// false indicating whether it was logged.
-static bool _az_log_write_engine(bool log_it, az_log_classification classification, az_span message)
-{
-  // Copy the volatile fields to local variables so that they don't change within this function
-  az_log_message_fn const callback = _az_log_message_callback;
-  az_log_classification const* classifications = _az_log_classifications;
-
-  if (callback == NULL)
-  {
-    // If no one is listening, don't attempt to log.
-    return false;
-  }
-
-  if (classifications == NULL)
-  {
-    // If the user hasn't registered any classifications, then we log everything.
-    classifications
-        = &classification; // We don't need AZ_LOG_END_OF_LIST to be there, as very first comparison
-                           // is going to succeed and return from the function.
-  }
-
-  for (az_log_classification const* cls = classifications; *cls != AZ_LOG_END_OF_LIST; ++cls)
-  {
-    // If this message's classification is in the customer-provided list, we should log it.
-    if (*cls == classification)
-    {
-      if (log_it)
-      {
-        callback(classification, message);
-      }
-
-      return true;
-    }
-  }
-
-  // This message's classification is not in the customer-provided list; we should not log it.
-  return false;
+  _az_log_should_write_callback = az_log_should_write_callback;
 }
 
 // This function returns whether or not the passed-in message should be logged.
 bool _az_log_should_write(az_log_classification classification)
 {
-  return _az_log_write_engine(false, classification, AZ_SPAN_EMPTY);
+  _az_PRECONDITION(classification > 0);
+
+  // Copy the volatile fields to local variables so that they don't change within this function
+  az_log_message_fn const message_callback = _az_log_message_callback;
+  az_log_should_write_fn const should_write_callback = _az_log_should_write_callback;
+
+  // If the user hasn't registered a should_write_callback, then we log everything, as long as a
+  // message_callback metho was provided.
+  return (should_write_callback == NULL || should_write_callback(classification))
+      && message_callback != NULL;
 }
 
 // This function attempts to log the passed-in message.
 void _az_log_write(az_log_classification classification, az_span message)
 {
-  (void)_az_log_write_engine(true, classification, message);
+  _az_PRECONDITION(classification > 0);
+  _az_PRECONDITION_VALID_SPAN(message, 0, true);
+
+  // Copy the volatile fields to local variables so that they don't change within this function
+  az_log_message_fn const message_callback = _az_log_message_callback;
+
+  // If the user hasn't registered a should_write_callback, then we log everything, as long as a
+  // message_callback metho was provided.
+  if (_az_log_should_write(classification))
+  {
+    message_callback(classification, message);
+  }
 }
 
 #endif // AZ_NO_LOGGING

--- a/sdk/src/azure/core/az_log.c
+++ b/sdk/src/azure/core/az_log.c
@@ -16,30 +16,13 @@
 
 #ifndef AZ_NO_LOGGING
 
+// Only using volatile here, not for thread safety, but so that the compiler does not optimize what
+// it thinks falsely thinks are stale reads.
 static az_log_message_fn volatile _az_log_message_callback = NULL;
-static az_log_should_write_fn volatile _az_log_should_write_callback = NULL;
 
-void az_log_set_callbacks(
-    az_log_message_fn az_log_message_callback,
-    az_log_should_write_fn az_log_should_write_callback)
+void az_log_set_callback(az_log_message_fn az_log_message_callback)
 {
   _az_log_message_callback = az_log_message_callback;
-  _az_log_should_write_callback = az_log_should_write_callback;
-}
-
-// This function returns whether or not the passed-in message should be logged.
-bool _az_log_should_write(az_log_classification classification)
-{
-  _az_PRECONDITION(classification > 0);
-
-  // Copy the volatile fields to local variables so that they don't change within this function
-  az_log_message_fn const message_callback = _az_log_message_callback;
-  az_log_should_write_fn const should_write_callback = _az_log_should_write_callback;
-
-  // If the user hasn't registered a should_write_callback, then we log everything, as long as a
-  // message_callback metho was provided.
-  return (should_write_callback == NULL || should_write_callback(classification))
-      && message_callback != NULL;
 }
 
 // This function attempts to log the passed-in message.
@@ -48,12 +31,10 @@ void _az_log_write(az_log_classification classification, az_span message)
   _az_PRECONDITION(classification > 0);
   _az_PRECONDITION_VALID_SPAN(message, 0, true);
 
-  // Copy the volatile fields to local variables so that they don't change within this function
+  // Copy the volatile fields to local variables so that they don't change within this function.
   az_log_message_fn const message_callback = _az_log_message_callback;
 
-  // If the user hasn't registered a should_write_callback, then we log everything, as long as a
-  // message_callback metho was provided.
-  if (_az_log_should_write(classification))
+  if (message_callback != NULL)
   {
     message_callback(classification, message);
   }

--- a/sdk/tests/core/inc/az_test_log.h
+++ b/sdk/tests/core/inc/az_test_log.h
@@ -6,10 +6,10 @@
 
 // This macro helps with the expected values for tests when verifying logging.
 
-#ifndef AZ_NO_LOGGING
-#define _az_BUILT_WITH_LOGGING(value_if_yes, value_if_no) (value_if_yes)
-#else
+#ifdef AZ_NO_LOGGING
 #define _az_BUILT_WITH_LOGGING(value_if_yes, value_if_no) (value_if_no)
+#else
+#define _az_BUILT_WITH_LOGGING(value_if_yes, value_if_no) (value_if_yes)
 #endif // AZ_NO_LOGGING
 
 #endif // _az_TEST_LOG_H

--- a/sdk/tests/core/test_az_logging.c
+++ b/sdk/tests/core/test_az_logging.c
@@ -83,38 +83,7 @@ static void _log_listener_with_filter(az_log_classification classification, az_s
   {
     return;
   }
-  switch (classification)
-  {
-    case AZ_LOG_HTTP_REQUEST:
-      _log_invoked_for_http_request = true;
-      assert_true(az_span_is_content_equal(
-          message,
-          AZ_SPAN_FROM_STR("HTTP Request : GET https://www.example.com\n"
-                           "\tHeader1 : Value1\n"
-                           "\tHeader2 : ZZZZYYYYXXXXWWWWVVVVUU ... SSSRRRRQQQQPPPPOOOONNNN\n"
-                           "\tHeader3 : 1111112222223333334444 ... 55666666777777888888abc\n"
-                           "\tauthorization")));
-      break;
-    case AZ_LOG_HTTP_RESPONSE:
-      _log_invoked_for_http_response = true;
-      assert_true(az_span_is_content_equal(
-          message,
-          AZ_SPAN_FROM_STR("HTTP Response (3456ms) : 404 Not Found\n"
-                           "\tHeader11 : Value11\n"
-                           "\tHeader22 : NNNNOOOOPPPPQQQQRRRRSS ... UUUVVVVWWWWXXXXYYYYZZZZ\n"
-                           "\tHeader33\n"
-                           "\tHeader44 : cba8888887777776666665 ... 44444333333222222111111\n"
-                           "\n"
-                           " -> HTTP Request : GET https://www.example.com\n"
-                           "\tHeader1 : Value1\n"
-                           "\tHeader2 : ZZZZYYYYXXXXWWWWVVVVUU ... SSSRRRRQQQQPPPPOOOONNNN\n"
-                           "\tHeader3 : 1111112222223333334444 ... 55666666777777888888abc\n"
-                           "\tauthorization")));
-      break;
-    default:
-      assert_true(false);
-      break;
-  }
+  _log_listener(classification, message);
 }
 
 static void _log_listener_NULL(az_log_classification classification, az_span message)

--- a/sdk/tests/core/test_az_logging.c
+++ b/sdk/tests/core/test_az_logging.c
@@ -170,7 +170,7 @@ static void test_az_log(void** state)
   {
     // null request
     _reset_log_invocation_status();
-    az_log_set_callbacks(_log_listener_NULL, _log_listener_should_write_everything_valid);
+    az_log_set_callback(_log_listener_NULL);
     _az_http_policy_logging_log_http_request(NULL);
     assert_true(_log_invoked_for_http_request == _az_BUILT_WITH_LOGGING(true, false));
     assert_true(_log_invoked_for_http_response == false);
@@ -180,7 +180,7 @@ static void test_az_log(void** state)
     // Verify that log callback gets invoked, and with the correct classification type.
     // Also, our callback function does the verification for the message content.
     _reset_log_invocation_status();
-    az_log_set_callbacks(_log_listener, _log_listener_should_write_everything_valid);
+    az_log_set_callback(_log_listener);
     assert_true(_log_invoked_for_http_request == false);
     assert_true(_log_invoked_for_http_response == false);
 
@@ -194,7 +194,7 @@ static void test_az_log(void** state)
   }
   {
     _reset_log_invocation_status();
-    az_log_set_callbacks(NULL, NULL);
+    az_log_set_callback(NULL);
 
     // Verify that user can unset log callback, and we are not going to call the previously set one.
     assert_true(_log_invoked_for_http_request == false);
@@ -213,7 +213,7 @@ static void test_az_log(void** state)
 
       // If a callback is set, and no should_write callback is specified, we are going to log all of
       // them (and customer is going to get all of them).
-      az_log_set_callbacks(_log_listener, NULL);
+      az_log_set_callback(_log_listener);
 
       assert_true(_az_LOG_SHOULD_WRITE(AZ_LOG_HTTP_REQUEST) == _az_BUILT_WITH_LOGGING(true, false));
 
@@ -224,7 +224,7 @@ static void test_az_log(void** state)
     // Verify that if customer overrides the should_write callback, we'll only invoking the logging
     // callback with the classification that it allows, and nothing is going to happen when our code
     // attempts to log a classification that it doesn't.
-    az_log_set_callbacks(_log_listener, _log_listener_should_write_request);
+    az_log_set_callback(_log_listener);
 
     assert_true(_az_LOG_SHOULD_WRITE(AZ_LOG_HTTP_REQUEST) == _az_BUILT_WITH_LOGGING(true, false));
     assert_true(_az_LOG_SHOULD_WRITE(AZ_LOG_HTTP_RESPONSE) == false);
@@ -236,7 +236,7 @@ static void test_az_log(void** state)
     assert_true(_log_invoked_for_http_response == false);
   }
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 static void _log_listener_stop_logging_corrupted_response(
@@ -285,7 +285,7 @@ static void test_az_log_corrupted_response(void** state)
   TEST_EXPECT_SUCCESS(az_http_response_init(&response, response_span));
 
   _reset_log_invocation_status();
-  az_log_set_callbacks(_log_listener_stop_logging_corrupted_response, NULL);
+  az_log_set_callback(_log_listener_stop_logging_corrupted_response);
   assert_true(_log_invoked_for_http_request == false);
   assert_true(_log_invoked_for_http_response == false);
 
@@ -297,7 +297,7 @@ static void test_az_log_corrupted_response(void** state)
   assert_true(_log_invoked_for_http_request == _az_BUILT_WITH_LOGGING(true, false));
   assert_true(_log_invoked_for_http_response == _az_BUILT_WITH_LOGGING(true, false));
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 static void _log_listener_no_op(az_log_classification classification, az_span message)
@@ -322,12 +322,12 @@ static void test_az_log_incorrect_list_fails_gracefully(void** state)
 {
   (void)state;
   {
-    az_log_set_callbacks(_log_listener_no_op, _log_listener_should_write_http_retry);
+    az_log_set_callback(_log_listener_no_op);
 
     assert_false(_az_LOG_SHOULD_WRITE((az_log_classification)12345));
     _az_LOG_WRITE((az_log_classification)12345, AZ_SPAN_EMPTY);
 
-    az_log_set_callbacks(NULL, NULL);
+    az_log_set_callback(NULL);
   }
 }
 
@@ -343,7 +343,7 @@ static void test_az_log_everything_valid(void** state)
 {
   (void)state;
   {
-    az_log_set_callbacks(_log_listener_count_logs, _log_listener_should_write_everything_valid);
+    az_log_set_callback(_log_listener_count_logs);
 
     _number_of_log_attempts = 0;
 
@@ -355,7 +355,7 @@ static void test_az_log_everything_valid(void** state)
 
     assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _number_of_log_attempts);
 
-    az_log_set_callbacks(NULL, NULL);
+    az_log_set_callback(NULL);
   }
 }
 
@@ -363,7 +363,7 @@ static void test_az_log_everything_on_null(void** state)
 {
   (void)state;
   {
-    az_log_set_callbacks(_log_listener_count_logs, NULL);
+    az_log_set_callback(_log_listener_count_logs);
 
     _number_of_log_attempts = 0;
 
@@ -376,7 +376,7 @@ static void test_az_log_everything_on_null(void** state)
 
     assert_int_equal(_az_BUILT_WITH_LOGGING(2, 0), _number_of_log_attempts);
 
-    az_log_set_callbacks(NULL, NULL);
+    az_log_set_callback(NULL);
   }
 }
 

--- a/sdk/tests/core/test_az_logging.c
+++ b/sdk/tests/core/test_az_logging.c
@@ -117,19 +117,6 @@ static void _log_listener_with_filter(az_log_classification classification, az_s
   }
 }
 
-static bool _log_listener_should_write_everything_valid(az_log_classification classification)
-{
-  switch (classification)
-  {
-    case AZ_LOG_HTTP_RETRY:
-    case AZ_LOG_HTTP_RESPONSE:
-    case AZ_LOG_HTTP_REQUEST:
-      return true;
-    default:
-      return false;
-  }
-}
-
 static void _log_listener_NULL(az_log_classification classification, az_span message)
 {
   switch (classification)
@@ -146,12 +133,6 @@ static void _log_listener_NULL(az_log_classification classification, az_span mes
       assert_true(false);
       break;
   }
-}
-
-static bool _log_listener_should_write_nothing(az_log_classification classification)
-{
-  (void)classification;
-  return false;
 }
 
 static void test_az_log(void** state)

--- a/sdk/tests/core/test_az_logging.c
+++ b/sdk/tests/core/test_az_logging.c
@@ -292,17 +292,6 @@ static void _log_listener_no_op(az_log_classification classification, az_span me
   (void)message;
 }
 
-static bool _log_listener_should_write_http_retry(az_log_classification classification)
-{
-  switch (classification)
-  {
-    case AZ_LOG_HTTP_RETRY:
-      return true;
-    default:
-      return false;
-  }
-}
-
 static void test_az_log_incorrect_list_fails_gracefully(void** state)
 {
   (void)state;

--- a/sdk/tests/iot/common/test_az_iot_common.c
+++ b/sdk/tests/iot/common/test_az_iot_common.c
@@ -263,24 +263,24 @@ static bool _log_listener_should_write_nothing(az_log_classification classificat
 
 static void test_az_iot_calculate_retry_delay_logging_succeed()
 {
-  az_log_set_callbacks(_log_listener, _log_listener_should_write_log_retry);
+  az_log_set_callback(_log_listener);
 
   _log_retry = 0;
   assert_int_equal(2229, az_iot_calculate_retry_delay(5, 1, 500, 100000, 1234));
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_retry);
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 static void test_az_iot_calculate_retry_delay_no_logging_succeed()
 {
-  az_log_set_callbacks(_log_listener, _log_listener_should_write_nothing);
+  az_log_set_callback(_log_listener);
 
   _log_retry = 0;
   assert_int_equal(2229, az_iot_calculate_retry_delay(5, 1, 500, 100000, 1234));
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_retry);
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 static void test_az_span_copy_url_encode_succeed()

--- a/sdk/tests/iot/common/test_az_iot_common.c
+++ b/sdk/tests/iot/common/test_az_iot_common.c
@@ -244,32 +244,43 @@ static void _log_listener(az_log_classification classification, az_span message)
   }
 }
 
+static bool _log_listener_should_write_log_retry(az_log_classification classification)
+{
+  switch (classification)
+  {
+    case AZ_LOG_IOT_RETRY:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool _log_listener_should_write_nothing(az_log_classification classification)
+{
+  (void)classification;
+  return false;
+}
+
 static void test_az_iot_calculate_retry_delay_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_IOT_RETRY, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_set_callbacks(_log_listener, _log_listener_should_write_log_retry);
 
   _log_retry = 0;
   assert_int_equal(2229, az_iot_calculate_retry_delay(5, 1, 500, 100000, 1234));
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_retry);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_callbacks(NULL, NULL);
 }
 
 static void test_az_iot_calculate_retry_delay_no_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_set_callbacks(_log_listener, _log_listener_should_write_nothing);
 
   _log_retry = 0;
   assert_int_equal(2229, az_iot_calculate_retry_delay(5, 1, 500, 100000, 1234));
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_retry);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_callbacks(NULL, NULL);
 }
 
 static void test_az_span_copy_url_encode_succeed()

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_c2d.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_c2d.c
@@ -211,12 +211,33 @@ static void _log_listener(az_log_classification classification, az_span message)
   }
 }
 
+static bool _log_listener_should_write_MQTT(az_log_classification classification)
+{
+  switch (classification)
+  {
+    case AZ_LOG_MQTT_RECEIVED_TOPIC:
+    case AZ_LOG_MQTT_RECEIVED_PAYLOAD:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool _log_listener_should_write_MQTT_received_payload_only(
+    az_log_classification classification)
+{
+  switch (classification)
+  {
+    case AZ_LOG_MQTT_RECEIVED_PAYLOAD:
+      return true;
+    default:
+      return false;
+  }
+}
+
 static void test_az_iot_hub_client_c2d_logging_succeed()
 {
-  az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_set_callbacks(_log_listener, _log_listener_should_write_MQTT);
 
   _log_invoked_topic = 0;
 
@@ -229,16 +250,12 @@ static void test_az_iot_hub_client_c2d_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_callbacks(NULL, NULL);
 }
 
 static void test_az_iot_hub_client_c2d_no_logging_succeed()
 {
-  az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_set_callbacks(_log_listener, _log_listener_should_write_MQTT_received_payload_only);
 
   _log_invoked_topic = 0;
 
@@ -251,8 +268,7 @@ static void test_az_iot_hub_client_c2d_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_callbacks(NULL, NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_c2d.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_c2d.c
@@ -237,7 +237,7 @@ static bool _log_listener_should_write_MQTT_received_payload_only(
 
 static void test_az_iot_hub_client_c2d_logging_succeed()
 {
-  az_log_set_callbacks(_log_listener, _log_listener_should_write_MQTT);
+  az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
 
@@ -250,12 +250,12 @@ static void test_az_iot_hub_client_c2d_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 static void test_az_iot_hub_client_c2d_no_logging_succeed()
 {
-  az_log_set_callbacks(_log_listener, _log_listener_should_write_MQTT_received_payload_only);
+  az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
 
@@ -268,7 +268,7 @@ static void test_az_iot_hub_client_c2d_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_methods.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_methods.c
@@ -407,7 +407,7 @@ static bool _log_listener_should_write_MQTT_received_payload_only(
 
 static void test_az_iot_hub_client_methods_logging_succeed()
 {
-  az_log_set_callbacks(_log_listener, _log_listener_should_write_MQTT);
+  az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
 
@@ -421,12 +421,12 @@ static void test_az_iot_hub_client_methods_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 static void test_az_iot_hub_client_methods_no_logging_succeed()
 {
-  az_log_set_callbacks(_log_listener, _log_listener_should_write_MQTT_received_payload_only);
+  az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
 
@@ -440,7 +440,7 @@ static void test_az_iot_hub_client_methods_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_methods.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_methods.c
@@ -364,23 +364,6 @@ static void test_az_iot_hub_client_methods_parse_received_topic_response_topic_f
       == AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
-const az_span _log_expected_topic
-    = AZ_SPAN_LITERAL_FROM_STR("$iothub/methods/POST/TestMethod/?$rid=1");
-static int _log_invoked_topic = 0;
-static void _log_listener(az_log_classification classification, az_span message)
-{
-  switch (classification)
-  {
-    case AZ_LOG_MQTT_RECEIVED_TOPIC:
-      assert_memory_equal(
-          az_span_ptr(_log_expected_topic), az_span_ptr(message), (size_t)az_span_size(message));
-      _log_invoked_topic++;
-      break;
-    default:
-      assert_true(false);
-  }
-}
-
 static bool _log_listener_should_write_MQTT(az_log_classification classification)
 {
   switch (classification)
@@ -390,6 +373,27 @@ static bool _log_listener_should_write_MQTT(az_log_classification classification
       return true;
     default:
       return false;
+  }
+}
+
+const az_span _log_expected_topic
+    = AZ_SPAN_LITERAL_FROM_STR("$iothub/methods/POST/TestMethod/?$rid=1");
+static int _log_invoked_topic = 0;
+static void _log_listener(az_log_classification classification, az_span message)
+{
+  if (!_log_listener_should_write_MQTT(classification))
+  {
+    return;
+  }
+  switch (classification)
+  {
+    case AZ_LOG_MQTT_RECEIVED_TOPIC:
+      assert_memory_equal(
+          az_span_ptr(_log_expected_topic), az_span_ptr(message), (size_t)az_span_size(message));
+      _log_invoked_topic++;
+      break;
+    default:
+      assert_true(false);
   }
 }
 
@@ -403,6 +407,15 @@ static bool _log_listener_should_write_MQTT_received_payload_only(
     default:
       return false;
   }
+}
+
+static void _log_listener_filtered(az_log_classification classification, az_span message)
+{
+  if (!_log_listener_should_write_MQTT_received_payload_only(classification))
+  {
+    return;
+  }
+  _log_listener(classification, message);
 }
 
 static void test_az_iot_hub_client_methods_logging_succeed()
@@ -426,7 +439,7 @@ static void test_az_iot_hub_client_methods_logging_succeed()
 
 static void test_az_iot_hub_client_methods_no_logging_succeed()
 {
-  az_log_set_callback(_log_listener);
+  az_log_set_callback(_log_listener_filtered);
 
   _log_invoked_topic = 0;
 

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_methods.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_methods.c
@@ -381,12 +381,33 @@ static void _log_listener(az_log_classification classification, az_span message)
   }
 }
 
+static bool _log_listener_should_write_MQTT(az_log_classification classification)
+{
+  switch (classification)
+  {
+    case AZ_LOG_MQTT_RECEIVED_TOPIC:
+    case AZ_LOG_MQTT_RECEIVED_PAYLOAD:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool _log_listener_should_write_MQTT_received_payload_only(
+    az_log_classification classification)
+{
+  switch (classification)
+  {
+    case AZ_LOG_MQTT_RECEIVED_PAYLOAD:
+      return true;
+    default:
+      return false;
+  }
+}
+
 static void test_az_iot_hub_client_methods_logging_succeed()
 {
-  az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_set_callbacks(_log_listener, _log_listener_should_write_MQTT);
 
   _log_invoked_topic = 0;
 
@@ -400,16 +421,12 @@ static void test_az_iot_hub_client_methods_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_callbacks(NULL, NULL);
 }
 
 static void test_az_iot_hub_client_methods_no_logging_succeed()
 {
-  az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_set_callbacks(_log_listener, _log_listener_should_write_MQTT_received_payload_only);
 
   _log_invoked_topic = 0;
 
@@ -423,8 +440,7 @@ static void test_az_iot_hub_client_methods_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_callbacks(NULL, NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_sas.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_sas.c
@@ -457,7 +457,7 @@ static bool _log_listener_should_write_nothing(az_log_classification classificat
 
 static void test_az_iot_hub_client_sas_logging_succeed()
 {
-  az_log_set_callbacks(_log_listener, _log_listener_should_write_sas);
+  az_log_set_callback(_log_listener);
 
   _log_invoked_sas = 0;
 
@@ -473,12 +473,12 @@ static void test_az_iot_hub_client_sas_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_sas);
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 static void test_az_iot_hub_client_sas_no_logging_succeed()
 {
-  az_log_set_callbacks(_log_listener, _log_listener_should_write_nothing);
+  az_log_set_callback(_log_listener);
 
   _log_invoked_sas = 0;
 
@@ -494,7 +494,7 @@ static void test_az_iot_hub_client_sas_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_sas);
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_sas.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_sas.c
@@ -421,9 +421,25 @@ static void az_iot_hub_client_sas_get_signature_module_signature_overflow_fails(
       AZ_ERROR_NOT_ENOUGH_SPACE);
 }
 
+static bool _log_listener_should_write_sas(az_log_classification classification)
+{
+  switch (classification)
+  {
+    case AZ_LOG_IOT_SAS_TOKEN:
+      return true;
+    default:
+      return false;
+  }
+}
+
 static int _log_invoked_sas = 0;
 static void _log_listener(az_log_classification classification, az_span message)
 {
+  if (!_log_listener_should_write_sas(classification))
+  {
+    return;
+  }
+
   const char expected[]
       = TEST_DEVICE_HOSTNAME_STR "%2Fdevices%2F" TEST_DEVICE_ID_STR "\n" TEST_EXPIRATION_STR;
 
@@ -438,21 +454,19 @@ static void _log_listener(az_log_classification classification, az_span message)
   }
 }
 
-static bool _log_listener_should_write_sas(az_log_classification classification)
-{
-  switch (classification)
-  {
-    case AZ_LOG_IOT_SAS_TOKEN:
-      return true;
-    default:
-      return false;
-  }
-}
-
 static bool _log_listener_should_write_nothing(az_log_classification classification)
 {
   (void)classification;
   return false;
+}
+
+static void _log_listener_filtered(az_log_classification classification, az_span message)
+{
+  if (!_log_listener_should_write_nothing(classification))
+  {
+    return;
+  }
+  _log_listener(classification, message);
 }
 
 static void test_az_iot_hub_client_sas_logging_succeed()
@@ -478,7 +492,7 @@ static void test_az_iot_hub_client_sas_logging_succeed()
 
 static void test_az_iot_hub_client_sas_no_logging_succeed()
 {
-  az_log_set_callback(_log_listener);
+  az_log_set_callback(_log_listener_filtered);
 
   _log_invoked_sas = 0;
 

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_sas.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_sas.c
@@ -438,11 +438,26 @@ static void _log_listener(az_log_classification classification, az_span message)
   }
 }
 
+static bool _log_listener_should_write_sas(az_log_classification classification)
+{
+  switch (classification)
+  {
+    case AZ_LOG_IOT_SAS_TOKEN:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool _log_listener_should_write_nothing(az_log_classification classification)
+{
+  (void)classification;
+  return false;
+}
+
 static void test_az_iot_hub_client_sas_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_IOT_SAS_TOKEN, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_set_callbacks(_log_listener, _log_listener_should_write_sas);
 
   _log_invoked_sas = 0;
 
@@ -458,15 +473,12 @@ static void test_az_iot_hub_client_sas_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_sas);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_callbacks(NULL, NULL);
 }
 
 static void test_az_iot_hub_client_sas_no_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_set_callbacks(_log_listener, _log_listener_should_write_nothing);
 
   _log_invoked_sas = 0;
 
@@ -482,8 +494,7 @@ static void test_az_iot_hub_client_sas_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_sas);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_callbacks(NULL, NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
@@ -355,12 +355,33 @@ static void _log_listener(az_log_classification classification, az_span message)
   }
 }
 
+static bool _log_listener_should_write_MQTT(az_log_classification classification)
+{
+  switch (classification)
+  {
+    case AZ_LOG_MQTT_RECEIVED_TOPIC:
+    case AZ_LOG_MQTT_RECEIVED_PAYLOAD:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool _log_listener_should_write_MQTT_received_payload_only(
+    az_log_classification classification)
+{
+  switch (classification)
+  {
+    case AZ_LOG_MQTT_RECEIVED_PAYLOAD:
+      return true;
+    default:
+      return false;
+  }
+}
+
 static void test_az_iot_hub_client_twin_logging_succeed()
 {
-  az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_set_callbacks(_log_listener, _log_listener_should_write_MQTT);
 
   _log_invoked_topic = 0;
 
@@ -375,16 +396,12 @@ static void test_az_iot_hub_client_twin_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_callbacks(NULL, NULL);
 }
 
 static void test_az_iot_hub_client_twin_no_logging_succeed()
 {
-  az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_set_callbacks(_log_listener, _log_listener_should_write_MQTT_received_payload_only);
 
   _log_invoked_topic = 0;
 
@@ -399,8 +416,7 @@ static void test_az_iot_hub_client_twin_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_callbacks(NULL, NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
@@ -381,7 +381,7 @@ static bool _log_listener_should_write_MQTT_received_payload_only(
 
 static void test_az_iot_hub_client_twin_logging_succeed()
 {
-  az_log_set_callbacks(_log_listener, _log_listener_should_write_MQTT);
+  az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
 
@@ -396,12 +396,12 @@ static void test_az_iot_hub_client_twin_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 static void test_az_iot_hub_client_twin_no_logging_succeed()
 {
-  az_log_set_callbacks(_log_listener, _log_listener_should_write_MQTT_received_payload_only);
+  az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
 
@@ -416,7 +416,7 @@ static void test_az_iot_hub_client_twin_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
@@ -523,7 +523,7 @@ static bool _log_listener_should_write_nothing(az_log_classification classificat
 
 static void test_az_iot_provisioning_client_logging_succeed()
 {
-  az_log_set_callbacks(_log_listener, _log_listener_should_write_MQTT);
+  az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
   _log_invoked_payload = 0;
@@ -536,12 +536,12 @@ static void test_az_iot_provisioning_client_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_payload);
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 static void test_az_iot_provisioning_client_no_logging_succeed()
 {
-  az_log_set_callbacks(_log_listener, _log_listener_should_write_nothing);
+  az_log_set_callback(_log_listener);
 
   _log_invoked_topic = 0;
   _log_invoked_payload = 0;
@@ -554,7 +554,7 @@ static void test_az_iot_provisioning_client_no_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_payload);
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
@@ -503,12 +503,27 @@ static void _log_listener(az_log_classification classification, az_span message)
   }
 }
 
+static bool _log_listener_should_write_MQTT(az_log_classification classification)
+{
+  switch (classification)
+  {
+    case AZ_LOG_MQTT_RECEIVED_TOPIC:
+    case AZ_LOG_MQTT_RECEIVED_PAYLOAD:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool _log_listener_should_write_nothing(az_log_classification classification)
+{
+  (void)classification;
+  return false;
+}
+
 static void test_az_iot_provisioning_client_logging_succeed()
 {
-  az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_set_callbacks(_log_listener, _log_listener_should_write_MQTT);
 
   _log_invoked_topic = 0;
   _log_invoked_payload = 0;
@@ -521,15 +536,12 @@ static void test_az_iot_provisioning_client_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_payload);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_callbacks(NULL, NULL);
 }
 
 static void test_az_iot_provisioning_client_no_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_set_callbacks(_log_listener, _log_listener_should_write_nothing);
 
   _log_invoked_topic = 0;
   _log_invoked_payload = 0;
@@ -542,8 +554,7 @@ static void test_az_iot_provisioning_client_no_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_payload);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_callbacks(NULL, NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_sas.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_sas.c
@@ -282,11 +282,26 @@ static void _log_listener(az_log_classification classification, az_span message)
   }
 }
 
+static bool _log_listener_should_write_sas(az_log_classification classification)
+{
+  switch (classification)
+  {
+    case AZ_LOG_IOT_SAS_TOKEN:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool _log_listener_should_write_nothing(az_log_classification classification)
+{
+  (void)classification;
+  return false;
+}
+
 static void test_az_iot_provisioning_client_sas_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_IOT_SAS_TOKEN, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_set_callbacks(_log_listener, _log_listener_should_write_sas);
 
   _log_invoked_sas = 0;
 
@@ -305,15 +320,12 @@ static void test_az_iot_provisioning_client_sas_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_sas);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_callbacks(NULL, NULL);
 }
 
 static void test_az_iot_provisioning_client_sas_no_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_set_callbacks(_log_listener, _log_listener_should_write_nothing);
 
   _log_invoked_sas = 0;
 
@@ -332,8 +344,7 @@ static void test_az_iot_provisioning_client_sas_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_sas);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_callbacks(NULL, NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_sas.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_sas.c
@@ -301,7 +301,7 @@ static bool _log_listener_should_write_nothing(az_log_classification classificat
 
 static void test_az_iot_provisioning_client_sas_logging_succeed()
 {
-  az_log_set_callbacks(_log_listener, _log_listener_should_write_sas);
+  az_log_set_callback(_log_listener);
 
   _log_invoked_sas = 0;
 
@@ -320,12 +320,12 @@ static void test_az_iot_provisioning_client_sas_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_sas);
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 static void test_az_iot_provisioning_client_sas_no_logging_succeed()
 {
-  az_log_set_callbacks(_log_listener, _log_listener_should_write_nothing);
+  az_log_set_callback(_log_listener);
 
   _log_invoked_sas = 0;
 
@@ -344,7 +344,7 @@ static void test_az_iot_provisioning_client_sas_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_sas);
 
-  az_log_set_callbacks(NULL, NULL);
+  az_log_set_callback(NULL);
 }
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/1184 and https://github.com/Azure/azure-sdk-for-c/issues/1172

Follow up to https://github.com/Azure/azure-sdk-for-c/issues/1227 and https://github.com/Azure/azure-sdk-for-c/issues/1192

Based on @antkmsft's suggestion, exploring a potentially less disruptive alternative to https://github.com/Azure/azure-sdk-for-c/pull/1317 by limiting changes for GA.

TODO:
- Changelog update
- README update