### PR TITLE
Make az_log_set_classifications internal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   - `AZ_LOG_IOT_RETRY`
   - `AZ_LOG_IOT_SAS_TOKEN`
   - `AZ_LOG_IOT_AZURERTOS`
+- Removed `AZ_LOG_END_OF_LIST` log classification and `az_log_set_classifications()` from `az_log.h`.
+- Renamed `az_log_set_callback()` to `az_log_set_message_callback()`.
 
 ### Bug Fixes
 

--- a/sdk/docs/core/README.md
+++ b/sdk/docs/core/README.md
@@ -85,14 +85,16 @@ As our SDK performs operations, it can send log messages to a customer-defined c
 To enable logging, you must first write a callback function that our logging mechanism will invoke periodically with messages. The function signature must match this type definition (defined in the [az_log.h](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/inc/azure/core/az_log.h) file):
 
    ```C
-   typedef void (*az_log_fn)(az_log_classification classification, az_span message);
+   typedef void (*az_log_message_fn)(az_log_classification classification, az_span message);
    ```
 
 And then, during your application's initialization, you must register your function with our SDK by calling this function:
 
    ```C
-   void az_log_set_listener(az_log_fn listener);
+   void az_log_set_message_callback(az_log_message_fn log_message_callback);
    ```
+
+This will log messages for all classifications. If you are only interested in certain kinds of messages, you can add filters based on the classifications in the callback function.
 
 Now, whenever our SDK wants to send a log message, it will invoke your callback function passing it the log classification and an `az_span` containing the message string (not 0-terminated). Your callback method can now do whatever it wants to with this message such as append it to a file or write it to the console.
 
@@ -101,24 +103,28 @@ Now, whenever our SDK wants to send a log message, it will invoke your callback 
 Log classifications allow your application to select which specific log messages it wants to receive. Here is a complete example that logs HTTP request and response messages to standard output:
 
    ```C
-   static void test_log_func(az_log_classification classification, az_span message)
+   static void write_log_message(az_log_classification classification, az_span message)
    {
-      printf("%.*s\n", az_span_size(message), az_span_ptr(message));
+   switch (classification)
+   {
+      case AZ_LOG_HTTP_REQUEST:
+      case AZ_LOG_HTTP_RESPONSE:
+         printf("%.*s\n", az_span_size(message), az_span_ptr(message));
+      default:
+         return;
    }
-
-   static az_log_classification const log_classifications[] = { AZ_LOG_HTTP_REQUEST, AZ_LOG_HTTP_RESPONSE, AZ_LOG_END_OF_LIST };
+   }
 
    int main()
    {
-      az_log_set_classifications(log_classifications);
-      az_log_set_callback(test_log_func);
+      az_log_set_message_callback(write_log_message);
 
       // More code goes here...
    }
    ```
 
-If the SDK is built with `AZ_NO_LOGGING` macro defined (or adding option -DLOGGING=OFF with cmake), it should reduce the binary size and slightly improve performance.
-Logging has a negligible performance impact if no listener is registered or if you specify few classifications. However, if you'd like to exclude all of the logging code to make your final executable smaller, define the `AZ_NO_LOGGING` symbol when building the SDK.
+If the SDK is built with `AZ_NO_LOGGING` macro defined (or adding option -DLOGGING=OFF with CMake), it should reduce the binary size and slightly improve performance.
+Logging has a negligible performance impact if no listener is registered or if your filter allows few classifications. However, if you'd like to exclude all of the logging code to make your final executable smaller, define the `AZ_NO_LOGGING` symbol when building the SDK.
 
 ### SDK Function Argument Validation
 

--- a/sdk/docs/core/README.md
+++ b/sdk/docs/core/README.md
@@ -105,14 +105,14 @@ Log classifications allow your application to select which specific log messages
    ```C
    static void write_log_message(az_log_classification classification, az_span message)
    {
-   switch (classification)
-   {
-      case AZ_LOG_HTTP_REQUEST:
-      case AZ_LOG_HTTP_RESPONSE:
-         printf("%.*s\n", az_span_size(message), az_span_ptr(message));
-      default:
-         return;
-   }
+      switch (classification)
+      {
+         case AZ_LOG_HTTP_REQUEST:
+         case AZ_LOG_HTTP_RESPONSE:
+            printf("%.*s\n", az_span_size(message), az_span_ptr(message));
+         default:
+            return;
+      }
    }
 
    int main()

--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -73,34 +73,6 @@ enum az_log_classification_core
 typedef void (*az_log_message_fn)(az_log_classification classification, az_span message);
 
 /**
- * @brief Allows the application to specify which #az_log_classification types it is interested in
- * receiving.
- *
- * @param[in] classifications __[nullable]__ An array of #az_log_classification values, terminated
- * by #AZ_LOG_END_OF_LIST.
- *
- * @details If no classifications are set (\p classifications is `NULL`), the application will
- * receive log messages for all #az_log_classification values.
- * @details If \p classifications is not `NULL`, it must point to an array of
- * #az_log_classification, terminated by #AZ_LOG_END_OF_LIST.
- * @details In contrast to \p classifications being `NULL`, \p classifications pointing to an empty
- * array (which still should be terminated by #AZ_LOG_END_OF_LIST), states that an application is
- * not interested in receiving any log messages.
- *
- * @warning Users must not change the \p classifications array elements, once it is passed to this
- * function. If \p classifications array is allocated on a stack, program behavior in multi-threaded
- * environment is undefined.
- */
-#ifndef AZ_NO_LOGGING
-void az_log_set_classifications(az_log_classification const classifications[]);
-#else
-AZ_INLINE void az_log_set_classifications(az_log_classification const classifications[])
-{
-  (void)classifications;
-}
-#endif // AZ_NO_LOGGING
-
-/**
  * @brief Sets the function that will be invoked to report an SDK log message.
  *
  * @param[in] az_log_message_callback __[nullable]__ A pointer to the function that will be invoked

--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -72,7 +72,7 @@ typedef void (*az_log_message_fn)(az_log_classification classification, az_span 
 /**
  * @brief Sets the function that will be invoked to report an SDK log message.
  *
- * @param[in] az_log_message_callback __[nullable]__ A pointer to the function that will be invoked
+ * @param[in] log_message_callback __[nullable]__ A pointer to the function that will be invoked
  * when the SDK reports a log message. If `NULL`, no function will be invoked.
  */
 #ifndef AZ_NO_LOGGING

--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -49,9 +49,6 @@ typedef int32_t az_log_classification;
  */
 enum az_log_classification_core
 {
-  AZ_LOG_END_OF_LIST
-  = -1, ///< Terminates the classification array passed to #az_log_set_classifications().
-
   AZ_LOG_HTTP_REQUEST
   = _az_LOG_MAKE_CLASSIFICATION(_az_FACILITY_HTTP, 1), ///< HTTP request is about to be sent.
 
@@ -76,15 +73,14 @@ typedef void (*az_log_message_fn)(az_log_classification classification, az_span 
  * @brief Sets the function that will be invoked to report an SDK log message.
  *
  * @param[in] az_log_message_callback __[nullable]__ A pointer to the function that will be invoked
- * when the SDK reports a log message matching one of the #az_log_classification passed to
- * #az_log_set_classifications(). If `NULL`, no function will be invoked.
+ * when the SDK reports a log message. If `NULL`, no function will be invoked.
  */
 #ifndef AZ_NO_LOGGING
-void az_log_set_callback(az_log_message_fn az_log_message_callback);
+void az_log_set_message_callback(az_log_message_fn log_message_callback);
 #else
-AZ_INLINE void az_log_set_callback(az_log_message_fn az_log_message_callback)
+AZ_INLINE void az_log_set_message_callback(az_log_message_fn log_message_callback)
 {
-  (void)az_log_message_callback;
+  (void)log_message_callback;
 }
 #endif // AZ_NO_LOGGING
 

--- a/sdk/inc/azure/core/internal/az_log_internal.h
+++ b/sdk/inc/azure/core/internal/az_log_internal.h
@@ -13,19 +13,22 @@
 
 // If the user hasn't registered any classifications, then we log everything.
 
+// Terminates the classification array passed to #_az_log_set_classifications().
+#define _az_LOG_END_OF_LIST -1
+
 /**
  * @brief Allows the application to specify which #az_log_classification types it is interested in
  * receiving.
  *
  * @param[in] classifications __[nullable]__ An array of #az_log_classification values, terminated
- * by #AZ_LOG_END_OF_LIST.
+ * by #_az_LOG_END_OF_LIST.
  *
  * @details If no classifications are set (\p classifications is `NULL`), the application will
  * receive log messages for all #az_log_classification values.
  * @details If \p classifications is not `NULL`, it must point to an array of
- * #az_log_classification, terminated by #AZ_LOG_END_OF_LIST.
+ * #az_log_classification, terminated by #_az_LOG_END_OF_LIST.
  * @details In contrast to \p classifications being `NULL`, \p classifications pointing to an empty
- * array (which still should be terminated by #AZ_LOG_END_OF_LIST), states that an application is
+ * array (which still should be terminated by #_az_LOG_END_OF_LIST), states that an application is
  * not interested in receiving any log messages.
  *
  * @warning Users must not change the \p classifications array elements, once it is passed to this
@@ -33,9 +36,9 @@
  * environment is undefined.
  */
 #ifndef AZ_NO_LOGGING
-void az_log_set_classifications(az_log_classification const classifications[]);
+void _az_log_set_classifications(az_log_classification const classifications[]);
 #else
-AZ_INLINE void az_log_set_classifications(az_log_classification const classifications[])
+AZ_INLINE void _az_log_set_classifications(az_log_classification const classifications[])
 {
   (void)classifications;
 }

--- a/sdk/inc/azure/core/internal/az_log_internal.h
+++ b/sdk/inc/azure/core/internal/az_log_internal.h
@@ -13,6 +13,34 @@
 
 // If the user hasn't registered any classifications, then we log everything.
 
+/**
+ * @brief Allows the application to specify which #az_log_classification types it is interested in
+ * receiving.
+ *
+ * @param[in] classifications __[nullable]__ An array of #az_log_classification values, terminated
+ * by #AZ_LOG_END_OF_LIST.
+ *
+ * @details If no classifications are set (\p classifications is `NULL`), the application will
+ * receive log messages for all #az_log_classification values.
+ * @details If \p classifications is not `NULL`, it must point to an array of
+ * #az_log_classification, terminated by #AZ_LOG_END_OF_LIST.
+ * @details In contrast to \p classifications being `NULL`, \p classifications pointing to an empty
+ * array (which still should be terminated by #AZ_LOG_END_OF_LIST), states that an application is
+ * not interested in receiving any log messages.
+ *
+ * @warning Users must not change the \p classifications array elements, once it is passed to this
+ * function. If \p classifications array is allocated on a stack, program behavior in multi-threaded
+ * environment is undefined.
+ */
+#ifndef AZ_NO_LOGGING
+void az_log_set_classifications(az_log_classification const classifications[]);
+#else
+AZ_INLINE void az_log_set_classifications(az_log_classification const classifications[])
+{
+  (void)classifications;
+}
+#endif // AZ_NO_LOGGING
+
 #ifndef AZ_NO_LOGGING
 
 bool _az_log_should_write(az_log_classification classification);

--- a/sdk/samples/storage/blobs/src/blobs_client_example.c
+++ b/sdk/samples/storage/blobs/src/blobs_client_example.c
@@ -43,9 +43,6 @@ static void test_log_func(az_log_classification classification, az_span message)
   printf("%.*s\n", az_span_size(message), az_span_ptr(message));
 }
 
-static az_log_classification const log_classifications[]
-    = { AZ_LOG_HTTP_REQUEST, AZ_LOG_HTTP_RESPONSE, AZ_LOG_END_OF_LIST };
-
 int main()
 {
   // Uncomment below lines when working with libcurl
@@ -61,7 +58,6 @@ int main()
   */
 
   // enable logging
-  az_log_set_classifications(log_classifications);
   az_log_set_callback(test_log_func);
 
   // 1) Init client.

--- a/sdk/samples/storage/blobs/src/blobs_client_example.c
+++ b/sdk/samples/storage/blobs/src/blobs_client_example.c
@@ -37,10 +37,16 @@ static az_span content_to_upload = AZ_SPAN_LITERAL_FROM_STR("Some test content")
 #endif
 
 // Enable logging
-static void test_log_func(az_log_classification classification, az_span message)
+static void write_log_message(az_log_classification classification, az_span message)
 {
-  (void)classification;
-  printf("%.*s\n", az_span_size(message), az_span_ptr(message));
+  switch (classification)
+  {
+    case AZ_LOG_HTTP_REQUEST:
+    case AZ_LOG_HTTP_RESPONSE:
+      printf("%.*s\n", az_span_size(message), az_span_ptr(message));
+    default:
+      return;
+  }
 }
 
 int main()
@@ -58,7 +64,7 @@ int main()
   */
 
   // enable logging
-  az_log_set_callback(test_log_func);
+  az_log_set_message_callback(write_log_message);
 
   // 1) Init client.
   // Example expects AZURE_STORAGE_URL in env to be a URL w/ SAS token

--- a/sdk/src/azure/core/az_log.c
+++ b/sdk/src/azure/core/az_log.c
@@ -19,14 +19,14 @@
 static az_log_classification const* volatile _az_log_classifications = NULL;
 static az_log_message_fn volatile _az_log_message_callback = NULL;
 
-void az_log_set_classifications(az_log_classification const classifications[])
+void _az_log_set_classifications(az_log_classification const classifications[])
 {
   _az_log_classifications = classifications;
 }
 
-void az_log_set_callback(az_log_message_fn az_log_message_callback)
+void az_log_set_message_callback(az_log_message_fn log_message_callback)
 {
-  _az_log_message_callback = az_log_message_callback;
+  _az_log_message_callback = log_message_callback;
 }
 
 // _az_LOG_WRITE_engine is a function private to this .c file; it contains the code to handle
@@ -53,11 +53,11 @@ static bool _az_log_write_engine(bool log_it, az_log_classification classificati
   {
     // If the user hasn't registered any classifications, then we log everything.
     classifications
-        = &classification; // We don't need AZ_LOG_END_OF_LIST to be there, as very first comparison
-                           // is going to succeed and return from the function.
+        = &classification; // We don't need _az_LOG_END_OF_LIST to be there, as very first
+                           // comparison is going to succeed and return from the function.
   }
 
-  for (az_log_classification const* cls = classifications; *cls != AZ_LOG_END_OF_LIST; ++cls)
+  for (az_log_classification const* cls = classifications; *cls != _az_LOG_END_OF_LIST; ++cls)
   {
     // If this message's classification is in the customer-provided list, we should log it.
     if (*cls == classification)

--- a/sdk/tests/core/test_az_logging.c
+++ b/sdk/tests/core/test_az_logging.c
@@ -140,7 +140,7 @@ static void test_az_log(void** state)
   {
     // null request
     _reset_log_invocation_status();
-    az_log_set_callback(_log_listener_NULL);
+    az_log_set_message_callback(_log_listener_NULL);
     _az_http_policy_logging_log_http_request(NULL);
     assert_true(_log_invoked_for_http_request == _az_BUILT_WITH_LOGGING(true, false));
     assert_true(_log_invoked_for_http_response == false);
@@ -150,7 +150,7 @@ static void test_az_log(void** state)
     // Verify that log callback gets invoked, and with the correct classification type.
     // Also, our callback function does the verification for the message content.
     _reset_log_invocation_status();
-    az_log_set_callback(_log_listener);
+    az_log_set_message_callback(_log_listener);
     assert_true(_log_invoked_for_http_request == false);
     assert_true(_log_invoked_for_http_response == false);
 
@@ -164,7 +164,7 @@ static void test_az_log(void** state)
   }
   {
     _reset_log_invocation_status();
-    az_log_set_callback(NULL);
+    az_log_set_message_callback(NULL);
 
     // Verify that user can unset log callback, and we are not going to call the previously set one.
     assert_true(_log_invoked_for_http_request == false);
@@ -183,7 +183,7 @@ static void test_az_log(void** state)
 
       // If a callback is set, and no classifications are specified, we are going to log all of them
       // (and customer is going to get all of them).
-      az_log_set_callback(_log_listener);
+      az_log_set_message_callback(_log_listener);
 
       assert_true(_az_LOG_SHOULD_WRITE(AZ_LOG_HTTP_REQUEST) == _az_BUILT_WITH_LOGGING(true, false));
 
@@ -195,8 +195,8 @@ static void test_az_log(void** state)
     // callback with the classification that's in the list of customer-provided classifications, and
     // nothing is going to happen when our code attempts to log a classification that's not in that
     // list.
-    az_log_classification const classifications[] = { AZ_LOG_HTTP_REQUEST, AZ_LOG_END_OF_LIST };
-    az_log_set_classifications(classifications);
+    az_log_classification const classifications[] = { AZ_LOG_HTTP_REQUEST, _az_LOG_END_OF_LIST };
+    _az_log_set_classifications(classifications);
 
     assert_true(_az_LOG_SHOULD_WRITE(AZ_LOG_HTTP_REQUEST) == _az_BUILT_WITH_LOGGING(true, false));
     assert_true(_az_LOG_SHOULD_WRITE(AZ_LOG_HTTP_RESPONSE) == false);
@@ -208,8 +208,8 @@ static void test_az_log(void** state)
     assert_true(_log_invoked_for_http_response == false);
   }
 
-  az_log_set_classifications(NULL);
-  az_log_set_callback(NULL);
+  _az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
 }
 
 static void _log_listener_stop_logging_corrupted_response(
@@ -258,7 +258,7 @@ static void test_az_log_corrupted_response(void** state)
   TEST_EXPECT_SUCCESS(az_http_response_init(&response, response_span));
 
   _reset_log_invocation_status();
-  az_log_set_callback(_log_listener_stop_logging_corrupted_response);
+  az_log_set_message_callback(_log_listener_stop_logging_corrupted_response);
   assert_true(_log_invoked_for_http_request == false);
   assert_true(_log_invoked_for_http_response == false);
 
@@ -270,8 +270,8 @@ static void test_az_log_corrupted_response(void** state)
   assert_true(_log_invoked_for_http_request == _az_BUILT_WITH_LOGGING(true, false));
   assert_true(_log_invoked_for_http_response == _az_BUILT_WITH_LOGGING(true, false));
 
-  az_log_set_classifications(NULL);
-  az_log_set_callback(NULL);
+  _az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
 }
 
 static void _log_listener_no_op(az_log_classification classification, az_span message)
@@ -285,15 +285,15 @@ static void test_az_log_incorrect_list_fails_gracefully(void** state)
 {
   (void)state;
   {
-    az_log_classification const classifications[] = { AZ_LOG_HTTP_RETRY, AZ_LOG_END_OF_LIST };
-    az_log_set_classifications(classifications);
-    az_log_set_callback(_log_listener_no_op);
+    az_log_classification const classifications[] = { AZ_LOG_HTTP_RETRY, _az_LOG_END_OF_LIST };
+    _az_log_set_classifications(classifications);
+    az_log_set_message_callback(_log_listener_no_op);
 
     assert_false(_az_LOG_SHOULD_WRITE((az_log_classification)12345));
     _az_LOG_WRITE((az_log_classification)12345, AZ_SPAN_EMPTY);
 
-    az_log_set_callback(NULL);
-    az_log_set_classifications(NULL);
+    az_log_set_message_callback(NULL);
+    _az_log_set_classifications(NULL);
   }
 }
 
@@ -310,24 +310,24 @@ static void test_az_log_everything_valid(void** state)
   (void)state;
   {
     az_log_classification const classifications[]
-        = { AZ_LOG_HTTP_RETRY, AZ_LOG_HTTP_RESPONSE, AZ_LOG_HTTP_REQUEST, AZ_LOG_END_OF_LIST };
-    az_log_set_classifications(classifications);
-    az_log_set_callback(_log_listener_count_logs);
+        = { AZ_LOG_HTTP_RETRY, AZ_LOG_HTTP_RESPONSE, AZ_LOG_HTTP_REQUEST, _az_LOG_END_OF_LIST };
+    _az_log_set_classifications(classifications);
+    az_log_set_message_callback(_log_listener_count_logs);
 
     _number_of_log_attempts = 0;
 
     assert_true(_az_BUILT_WITH_LOGGING(true, false) == _az_LOG_SHOULD_WRITE(AZ_LOG_HTTP_REQUEST));
-    assert_false(_az_LOG_SHOULD_WRITE(AZ_LOG_END_OF_LIST));
+    assert_false(_az_LOG_SHOULD_WRITE(_az_LOG_END_OF_LIST));
     assert_false(_az_LOG_SHOULD_WRITE((az_log_classification)12345));
 
     _az_LOG_WRITE(AZ_LOG_HTTP_REQUEST, AZ_SPAN_EMPTY);
-    _az_LOG_WRITE(AZ_LOG_END_OF_LIST, AZ_SPAN_EMPTY);
+    _az_LOG_WRITE(_az_LOG_END_OF_LIST, AZ_SPAN_EMPTY);
     _az_LOG_WRITE((az_log_classification)12345, AZ_SPAN_EMPTY);
 
     assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _number_of_log_attempts);
 
-    az_log_set_callback(NULL);
-    az_log_set_classifications(NULL);
+    az_log_set_message_callback(NULL);
+    _az_log_set_classifications(NULL);
   }
 }
 
@@ -336,24 +336,24 @@ static void test_az_log_everything_on_null(void** state)
   (void)state;
   {
     az_log_classification const* classifications = NULL;
-    az_log_set_classifications(classifications);
-    az_log_set_callback(_log_listener_count_logs);
+    _az_log_set_classifications(classifications);
+    az_log_set_message_callback(_log_listener_count_logs);
 
     _number_of_log_attempts = 0;
 
     assert_true(_az_BUILT_WITH_LOGGING(true, false) == _az_LOG_SHOULD_WRITE(AZ_LOG_HTTP_REQUEST));
-    assert_false(_az_LOG_SHOULD_WRITE(AZ_LOG_END_OF_LIST));
+    assert_false(_az_LOG_SHOULD_WRITE(_az_LOG_END_OF_LIST));
     assert_true(
         _az_BUILT_WITH_LOGGING(true, false) == _az_LOG_SHOULD_WRITE((az_log_classification)12345));
 
     _az_LOG_WRITE(AZ_LOG_HTTP_REQUEST, AZ_SPAN_EMPTY);
-    _az_LOG_WRITE(AZ_LOG_END_OF_LIST, AZ_SPAN_EMPTY);
+    _az_LOG_WRITE(_az_LOG_END_OF_LIST, AZ_SPAN_EMPTY);
     _az_LOG_WRITE((az_log_classification)12345, AZ_SPAN_EMPTY);
 
     assert_int_equal(_az_BUILT_WITH_LOGGING(2, 0), _number_of_log_attempts);
 
-    az_log_set_callback(NULL);
-    az_log_set_classifications(NULL);
+    az_log_set_message_callback(NULL);
+    _az_log_set_classifications(NULL);
   }
 }
 

--- a/sdk/tests/iot/common/test_az_iot_common.c
+++ b/sdk/tests/iot/common/test_az_iot_common.c
@@ -8,6 +8,7 @@
 #include <azure/core/az_log.h>
 #include <azure/core/az_precondition.h>
 #include <azure/core/az_span.h>
+#include <azure/core/internal/az_log_internal.h>
 #include <azure/core/internal/az_precondition_internal.h>
 #include <azure/iot/az_iot_common.h>
 #include <azure/iot/internal/az_iot_common_internal.h>

--- a/sdk/tests/iot/common/test_az_iot_common.c
+++ b/sdk/tests/iot/common/test_az_iot_common.c
@@ -247,30 +247,30 @@ static void _log_listener(az_log_classification classification, az_span message)
 
 static void test_az_iot_calculate_retry_delay_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_IOT_RETRY, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_classification const classifications[] = { AZ_LOG_IOT_RETRY, _az_LOG_END_OF_LIST };
+  _az_log_set_classifications(classifications);
+  az_log_set_message_callback(_log_listener);
 
   _log_retry = 0;
   assert_int_equal(2229, az_iot_calculate_retry_delay(5, 1, 500, 100000, 1234));
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_retry);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
+  _az_log_set_classifications(NULL);
 }
 
 static void test_az_iot_calculate_retry_delay_no_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_classification const classifications[] = { _az_LOG_END_OF_LIST };
+  _az_log_set_classifications(classifications);
+  az_log_set_message_callback(_log_listener);
 
   _log_retry = 0;
   assert_int_equal(2229, az_iot_calculate_retry_delay(5, 1, 500, 100000, 1234));
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_retry);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
+  _az_log_set_classifications(NULL);
 }
 
 static void test_az_span_copy_url_encode_succeed()

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_c2d.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_c2d.c
@@ -8,6 +8,7 @@
 #include <azure/core/az_log.h>
 #include <azure/core/az_precondition.h>
 #include <azure/core/az_span.h>
+#include <azure/core/internal/az_log_internal.h>
 #include <azure/core/internal/az_precondition_internal.h>
 #include <azure/iot/az_iot_hub_client.h>
 

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_c2d.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_c2d.c
@@ -215,9 +215,9 @@ static void _log_listener(az_log_classification classification, az_span message)
 static void test_az_iot_hub_client_c2d_logging_succeed()
 {
   az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, _az_LOG_END_OF_LIST };
+  _az_log_set_classifications(classifications);
+  az_log_set_message_callback(_log_listener);
 
   _log_invoked_topic = 0;
 
@@ -230,16 +230,16 @@ static void test_az_iot_hub_client_c2d_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
+  _az_log_set_classifications(NULL);
 }
 
 static void test_az_iot_hub_client_c2d_no_logging_succeed()
 {
   az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+      = { AZ_LOG_MQTT_RECEIVED_PAYLOAD, _az_LOG_END_OF_LIST };
+  _az_log_set_classifications(classifications);
+  az_log_set_message_callback(_log_listener);
 
   _log_invoked_topic = 0;
 
@@ -252,8 +252,8 @@ static void test_az_iot_hub_client_c2d_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
+  _az_log_set_classifications(NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_methods.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_methods.c
@@ -385,9 +385,9 @@ static void _log_listener(az_log_classification classification, az_span message)
 static void test_az_iot_hub_client_methods_logging_succeed()
 {
   az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, _az_LOG_END_OF_LIST };
+  _az_log_set_classifications(classifications);
+  az_log_set_message_callback(_log_listener);
 
   _log_invoked_topic = 0;
 
@@ -401,16 +401,16 @@ static void test_az_iot_hub_client_methods_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
+  _az_log_set_classifications(NULL);
 }
 
 static void test_az_iot_hub_client_methods_no_logging_succeed()
 {
   az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+      = { AZ_LOG_MQTT_RECEIVED_PAYLOAD, _az_LOG_END_OF_LIST };
+  _az_log_set_classifications(classifications);
+  az_log_set_message_callback(_log_listener);
 
   _log_invoked_topic = 0;
 
@@ -424,8 +424,8 @@ static void test_az_iot_hub_client_methods_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
+  _az_log_set_classifications(NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_methods.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_methods.c
@@ -9,6 +9,7 @@
 #include <azure/core/az_precondition.h>
 #include <azure/core/az_result.h>
 #include <azure/core/az_span.h>
+#include <azure/core/internal/az_log_internal.h>
 #include <azure/core/internal/az_precondition_internal.h>
 #include <azure/iot/az_iot_hub_client.h>
 

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_sas.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_sas.c
@@ -8,6 +8,7 @@
 #include <azure/core/az_log.h>
 #include <azure/core/az_precondition.h>
 #include <azure/core/az_span.h>
+#include <azure/core/internal/az_log_internal.h>
 #include <azure/core/internal/az_precondition_internal.h>
 #include <azure/iot/az_iot_hub_client.h>
 

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_sas.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_sas.c
@@ -441,9 +441,9 @@ static void _log_listener(az_log_classification classification, az_span message)
 
 static void test_az_iot_hub_client_sas_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_IOT_SAS_TOKEN, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_classification const classifications[] = { AZ_LOG_IOT_SAS_TOKEN, _az_LOG_END_OF_LIST };
+  _az_log_set_classifications(classifications);
+  az_log_set_message_callback(_log_listener);
 
   _log_invoked_sas = 0;
 
@@ -459,15 +459,15 @@ static void test_az_iot_hub_client_sas_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_sas);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
+  _az_log_set_classifications(NULL);
 }
 
 static void test_az_iot_hub_client_sas_no_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_classification const classifications[] = { _az_LOG_END_OF_LIST };
+  _az_log_set_classifications(classifications);
+  az_log_set_message_callback(_log_listener);
 
   _log_invoked_sas = 0;
 
@@ -483,8 +483,8 @@ static void test_az_iot_hub_client_sas_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_sas);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
+  _az_log_set_classifications(NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
@@ -8,6 +8,7 @@
 #include <azure/core/az_log.h>
 #include <azure/core/az_precondition.h>
 #include <azure/core/az_span.h>
+#include <azure/core/internal/az_log_internal.h>
 #include <azure/core/internal/az_precondition_internal.h>
 #include <azure/iot/az_iot_hub_client.h>
 

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
@@ -359,9 +359,9 @@ static void _log_listener(az_log_classification classification, az_span message)
 static void test_az_iot_hub_client_twin_logging_succeed()
 {
   az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, _az_LOG_END_OF_LIST };
+  _az_log_set_classifications(classifications);
+  az_log_set_message_callback(_log_listener);
 
   _log_invoked_topic = 0;
 
@@ -376,16 +376,16 @@ static void test_az_iot_hub_client_twin_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
+  _az_log_set_classifications(NULL);
 }
 
 static void test_az_iot_hub_client_twin_no_logging_succeed()
 {
   az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+      = { AZ_LOG_MQTT_RECEIVED_PAYLOAD, _az_LOG_END_OF_LIST };
+  _az_log_set_classifications(classifications);
+  az_log_set_message_callback(_log_listener);
 
   _log_invoked_topic = 0;
 
@@ -400,8 +400,8 @@ static void test_az_iot_hub_client_twin_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
+  _az_log_set_classifications(NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
@@ -507,9 +507,9 @@ static void _log_listener(az_log_classification classification, az_span message)
 static void test_az_iot_provisioning_client_logging_succeed()
 {
   az_log_classification const classifications[]
-      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+      = { AZ_LOG_MQTT_RECEIVED_TOPIC, AZ_LOG_MQTT_RECEIVED_PAYLOAD, _az_LOG_END_OF_LIST };
+  _az_log_set_classifications(classifications);
+  az_log_set_message_callback(_log_listener);
 
   _log_invoked_topic = 0;
   _log_invoked_payload = 0;
@@ -522,15 +522,15 @@ static void test_az_iot_provisioning_client_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_topic);
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_payload);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
+  _az_log_set_classifications(NULL);
 }
 
 static void test_az_iot_provisioning_client_no_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_classification const classifications[] = { _az_LOG_END_OF_LIST };
+  _az_log_set_classifications(classifications);
+  az_log_set_message_callback(_log_listener);
 
   _log_invoked_topic = 0;
   _log_invoked_payload = 0;
@@ -543,8 +543,8 @@ static void test_az_iot_provisioning_client_no_logging_succeed()
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_topic);
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_payload);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
+  _az_log_set_classifications(NULL);
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
@@ -6,6 +6,7 @@
 #include <az_test_span.h>
 #include <azure/core/az_log.h>
 #include <azure/core/az_span.h>
+#include <azure/core/internal/az_log_internal.h>
 #include <azure/iot/az_iot_provisioning_client.h>
 
 #include <setjmp.h>

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_sas.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_sas.c
@@ -8,6 +8,7 @@
 #include <azure/core/az_log.h>
 #include <azure/core/az_precondition.h>
 #include <azure/core/az_span.h>
+#include <azure/core/internal/az_log_internal.h>
 #include <azure/core/internal/az_precondition_internal.h>
 #include <azure/iot/az_iot_provisioning_client.h>
 

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_sas.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_sas.c
@@ -285,9 +285,9 @@ static void _log_listener(az_log_classification classification, az_span message)
 
 static void test_az_iot_provisioning_client_sas_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_IOT_SAS_TOKEN, AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_classification const classifications[] = { AZ_LOG_IOT_SAS_TOKEN, _az_LOG_END_OF_LIST };
+  _az_log_set_classifications(classifications);
+  az_log_set_message_callback(_log_listener);
 
   _log_invoked_sas = 0;
 
@@ -306,15 +306,15 @@ static void test_az_iot_provisioning_client_sas_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_invoked_sas);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
+  _az_log_set_classifications(NULL);
 }
 
 static void test_az_iot_provisioning_client_sas_no_logging_succeed()
 {
-  az_log_classification const classifications[] = { AZ_LOG_END_OF_LIST };
-  az_log_set_classifications(classifications);
-  az_log_set_callback(_log_listener);
+  az_log_classification const classifications[] = { _az_LOG_END_OF_LIST };
+  _az_log_set_classifications(classifications);
+  az_log_set_message_callback(_log_listener);
 
   _log_invoked_sas = 0;
 
@@ -333,8 +333,8 @@ static void test_az_iot_provisioning_client_sas_no_logging_succeed()
 
   assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_invoked_sas);
 
-  az_log_set_callback(NULL);
-  az_log_set_classifications(NULL);
+  az_log_set_message_callback(NULL);
+  _az_log_set_classifications(NULL);
 }
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Intentionally kept the changes here to a minimum.

Fixes https://github.com/Azure/azure-sdk-for-c/issues/1172 and also addresses a big part of https://github.com/Azure/azure-sdk-for-c/issues/1184.

Follow up to https://github.com/Azure/azure-sdk-for-c/issues/1227 and https://github.com/Azure/azure-sdk-for-c/issues/1192

- Removed `AZ_LOG_END_OF_LIST` log classification and `az_log_set_classifications()` from `az_log.h`.
- Renamed `az_log_set_callback()` to `az_log_set_message_callback()`.

The subsequent PR - https://github.com/Azure/azure-sdk-for-c/pull/1317, will add a `az_log_set_classification_filter_callback` mechanism to let the users filter messages.