### PR TITLE
Revert "Turn DevelopmentDependency to false to test out behavior.

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -8,7 +8,7 @@
           "CommitHash": "66fa2579d36f30cdab93d1dbd4c3d682a25ae5f3"
         }
       },
-      "DevelopmentDependency": false
+      "DevelopmentDependency": true
     },
     {
       "Component": {
@@ -18,7 +18,7 @@
           "CommitHash": "3cb0a1bf023cce7209290f998b8dc3029ed3df77"
         }
       },
-      "DevelopmentDependency": false
+      "DevelopmentDependency": true
     }
   ]
 }


### PR DESCRIPTION
Reverts #1331 

This reverts commit 9d72729935f3aeb77e096a728011a8c6c52cba04.

These dependencies are not part of the "product" and only used as CI tools for code coverage

It was needed to be checked-in as a way to test out auto-notice generation.