### PR TITLE
Remove end of array sentinel for HTTP status codes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   - `AZ_LOG_IOT_AZURERTOS`
 - Removed `AZ_LOG_END_OF_LIST` log classification and `az_log_set_classifications()` from `az_log.h`.
 - Renamed `az_log_set_callback()` to `az_log_set_message_callback()`.
+- Removed `AZ_HTTP_STATUS_CODE_END_OF_LIST` HTTP status code and `status_codes` field from `az_http_policy_retry_options`.
 
 ### Bug Fixes
 

--- a/sdk/inc/azure/core/az_http.h
+++ b/sdk/inc/azure/core/az_http.h
@@ -109,9 +109,6 @@ typedef enum
   AZ_HTTP_STATUS_CODE_NOT_EXTENDED = 510, ///< HTTP 510 Not Extended.
   AZ_HTTP_STATUS_CODE_NETWORK_AUTHENTICATION_REQUIRED
   = 511, ///< HTTP 511 Network Authentication Required.
-
-  /// Used in #az_http_policy_retry_options to indicate the end of the list.
-  AZ_HTTP_STATUS_CODE_END_OF_LIST = -1,
 } az_http_status_code;
 
 /**
@@ -132,12 +129,6 @@ typedef struct
 
   /// Maximum number of retries.
   int32_t max_retries;
-
-  // Avoid using enum as the first field within structs, to allow for { 0 } initialization.
-  // This is a workaround for IAR compiler warning [Pe188]: enumerated type mixed with another type.
-
-  /// An array of HTTP status codes to retry on, terminated by #AZ_HTTP_STATUS_CODE_END_OF_LIST.
-  az_http_status_code const* status_codes;
 } az_http_policy_retry_options;
 
 typedef enum

--- a/sdk/src/azure/core/az_http_policy_retry.c
+++ b/sdk/src/azure/core/az_http_policy_retry.c
@@ -17,17 +17,14 @@
 
 #include <azure/core/_az_cfg.h>
 
-enum
-{
-  /// The number of HTTP status code used as part of the default retry policy.
-  _az_NUMBER_OF_DEFAULT_HTTP_STATUS_CODES = 6,
-};
+// Used in #az_http_policy_retry_options to indicate the end of the list.
+#define _az_HTTP_STATUS_CODE_END_OF_LIST (az_http_status_code)(-1)
 
-static az_http_status_code const _default_status_codes[_az_NUMBER_OF_DEFAULT_HTTP_STATUS_CODES] = {
-  AZ_HTTP_STATUS_CODE_REQUEST_TIMEOUT,       AZ_HTTP_STATUS_CODE_TOO_MANY_REQUESTS,
-  AZ_HTTP_STATUS_CODE_INTERNAL_SERVER_ERROR, AZ_HTTP_STATUS_CODE_BAD_GATEWAY,
-  AZ_HTTP_STATUS_CODE_SERVICE_UNAVAILABLE,   AZ_HTTP_STATUS_CODE_GATEWAY_TIMEOUT,
-};
+static az_http_status_code const _default_status_codes[]
+    = { AZ_HTTP_STATUS_CODE_REQUEST_TIMEOUT,       AZ_HTTP_STATUS_CODE_TOO_MANY_REQUESTS,
+        AZ_HTTP_STATUS_CODE_INTERNAL_SERVER_ERROR, AZ_HTTP_STATUS_CODE_BAD_GATEWAY,
+        AZ_HTTP_STATUS_CODE_SERVICE_UNAVAILABLE,   AZ_HTTP_STATUS_CODE_GATEWAY_TIMEOUT,
+        _az_HTTP_STATUS_CODE_END_OF_LIST };
 
 AZ_NODISCARD az_http_policy_retry_options _az_http_policy_retry_options_default()
 {
@@ -97,7 +94,7 @@ AZ_INLINE AZ_NODISCARD az_result _az_http_policy_retry_get_retry_after(
   _az_RETURN_IF_FAILED(az_http_response_get_status_line(ref_response, &status_line));
   az_http_status_code const response_code = status_line.status_code;
 
-  for (int32_t i = 0; i < _az_NUMBER_OF_DEFAULT_HTTP_STATUS_CODES; ++status_codes, i++)
+  for (; *status_codes != _az_HTTP_STATUS_CODE_END_OF_LIST; ++status_codes)
   {
     if (*status_codes != response_code)
     {

--- a/sdk/src/azure/core/az_http_policy_retry.c
+++ b/sdk/src/azure/core/az_http_policy_retry.c
@@ -97,7 +97,7 @@ AZ_INLINE AZ_NODISCARD az_result _az_http_policy_retry_get_retry_after(
   _az_RETURN_IF_FAILED(az_http_response_get_status_line(ref_response, &status_line));
   az_http_status_code const response_code = status_line.status_code;
 
-  for (int32_t i = 0; i <= _az_NUMBER_OF_DEFAULT_HTTP_STATUS_CODES; ++status_codes, i++)
+  for (int32_t i = 0; i < _az_NUMBER_OF_DEFAULT_HTTP_STATUS_CODES; ++status_codes, i++)
   {
     if (*status_codes != response_code)
     {

--- a/sdk/src/azure/core/az_http_policy_retry.c
+++ b/sdk/src/azure/core/az_http_policy_retry.c
@@ -17,11 +17,16 @@
 
 #include <azure/core/_az_cfg.h>
 
-static az_http_status_code const _default_status_codes[] = {
+enum
+{
+  /// The number of HTTP status code used as part of the default retry policy.
+  _az_NUMBER_OF_DEFAULT_HTTP_STATUS_CODES = 6,
+};
+
+static az_http_status_code const _default_status_codes[_az_NUMBER_OF_DEFAULT_HTTP_STATUS_CODES] = {
   AZ_HTTP_STATUS_CODE_REQUEST_TIMEOUT,       AZ_HTTP_STATUS_CODE_TOO_MANY_REQUESTS,
   AZ_HTTP_STATUS_CODE_INTERNAL_SERVER_ERROR, AZ_HTTP_STATUS_CODE_BAD_GATEWAY,
   AZ_HTTP_STATUS_CODE_SERVICE_UNAVAILABLE,   AZ_HTTP_STATUS_CODE_GATEWAY_TIMEOUT,
-  AZ_HTTP_STATUS_CODE_END_OF_LIST,
 };
 
 AZ_NODISCARD az_http_policy_retry_options _az_http_policy_retry_options_default()
@@ -31,7 +36,6 @@ AZ_NODISCARD az_http_policy_retry_options _az_http_policy_retry_options_default(
     .retry_delay_msec = 4 * _az_TIME_MILLISECONDS_PER_SECOND, // 4 seconds
     .max_retry_delay_msec
     = 2 * _az_TIME_SECONDS_PER_MINUTE * _az_TIME_MILLISECONDS_PER_SECOND, // 2 minutes
-    .status_codes = _default_status_codes,
   };
 }
 
@@ -93,7 +97,7 @@ AZ_INLINE AZ_NODISCARD az_result _az_http_policy_retry_get_retry_after(
   _az_RETURN_IF_FAILED(az_http_response_get_status_line(ref_response, &status_line));
   az_http_status_code const response_code = status_line.status_code;
 
-  for (; *status_codes != AZ_HTTP_STATUS_CODE_END_OF_LIST; ++status_codes)
+  for (int32_t i = 0; i <= _az_NUMBER_OF_DEFAULT_HTTP_STATUS_CODES; ++status_codes, i++)
   {
     if (*status_codes != response_code)
     {
@@ -160,7 +164,7 @@ AZ_NODISCARD az_result az_http_pipeline_policy_retry(
   int32_t const max_retries = retry_options->max_retries;
   int32_t const retry_delay_msec = retry_options->retry_delay_msec;
   int32_t const max_retry_delay_msec = retry_options->max_retry_delay_msec;
-  az_http_status_code const* const status_codes = retry_options->status_codes;
+  az_http_status_code const* const status_codes = _default_status_codes;
 
   _az_RETURN_IF_FAILED(_az_http_request_mark_retry_headers_start(ref_request));
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/1184

Minimal change following https://github.com/Azure/azure-sdk-for-c/pull/1333 to avoid having to make a breaking change post-GA. With the storage client pushed out to 1.1.0, there are no callers within the SDK impacted by this.