### PR TITLE
Use return instead of retval for boolean values in az_result docs.

### DIFF
--- a/sdk/inc/azure/core/az_result.h
+++ b/sdk/inc/azure/core/az_result.h
@@ -143,8 +143,7 @@ enum az_result_core
  *
  * @param[in] result Result value to check for failure.
  *
- * @retval true The operation that returned this \p result failed.
- * @retval false The operation that returned this \p result was successful.
+ * @return `true` if the operation that returned this \p result failed, otherwise return `false`.
  */
 AZ_NODISCARD AZ_INLINE bool az_result_failed(az_result result)
 {
@@ -156,8 +155,8 @@ AZ_NODISCARD AZ_INLINE bool az_result_failed(az_result result)
  *
  * @param[in] result Result value to check for success.
  *
- * @retval `true` The operation that returned this \p result was successful.
- * @retval `false` The operation that returned this \p result failed.
+ * @return `true` if the operation that returned this \p result was successful, otherwise return
+ * `false`.
  */
 AZ_NODISCARD AZ_INLINE bool az_result_succeeded(az_result result)
 {


### PR DESCRIPTION
Fixes the doc rendering issue with `retval` which doesn't handle back-ticks well:
https://github.com/Azure/azure-sdk-for-c/issues/1104#issuecomment-678612494

**Before:**
![image](https://user-images.githubusercontent.com/6527137/93857874-207fbb00-fc70-11ea-8f6b-a12c7ef0c66e.png)

**After:**
![image](https://user-images.githubusercontent.com/6527137/93857912-30979a80-fc70-11ea-85af-aa6deb6cd687.png)
