### PR TITLE
Update doxygen for provisioning and hub

### DIFF
--- a/sdk/inc/azure/iot/az_iot_hub_client.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client.h
@@ -5,7 +5,7 @@
  * @file az_iot_hub_client.h
  *
  * @brief Definition for the Azure IoT Hub client.
- * @remark The IoT Hub MQTT protocol is described at
+ * @note The IoT Hub MQTT protocol is described at
  * https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support
  *
  * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
@@ -41,11 +41,20 @@ enum
  */
 typedef struct
 {
-  az_span module_id; /**< The module name (if a module identity is used). */
-  az_span user_agent; /**< The user-agent is a formatted string that will be used for Azure IoT
-                         usage statistics. */
-  az_span model_id; /**< The model id used to identify the capabilities of a device based on the
-                       Digital Twin document. */
+  /**
+   * The module name (if a module identity is used).
+   */
+  az_span module_id;
+
+  /**
+   * The user-agent is a formatted string that will be used for Azure IoT usage statistics.
+   */
+  az_span user_agent;
+
+  /**
+   * The model id used to identify the capabilities of a device based on the Digital Twin document.
+   */
+  az_span model_id;
 } az_iot_hub_client_options;
 
 /**
@@ -64,7 +73,7 @@ typedef struct
 /**
  * @brief Gets the default Azure IoT Hub Client options.
  * @details Call this to obtain an initialized #az_iot_hub_client_options structure that can be
- *          afterwards modified and passed to #az_iot_hub_client_init.
+ * afterwards modified and passed to #az_iot_hub_client_init.
  *
  * @return #az_iot_hub_client_options.
  */
@@ -101,7 +110,7 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
 /**
  * @brief The HTTP URI Path necessary when connecting to IoT Hub using WebSockets without an X509
  * client certificate.
- * @remark Most devices should use #AZ_IOT_HUB_CLIENT_WEB_SOCKET_PATH. This option is available for
+ * @note Most devices should use #AZ_IOT_HUB_CLIENT_WEB_SOCKET_PATH. This option is available for
  * devices not using X509 client certificates that fail to connect to IoT Hub.
  */
 #define AZ_IOT_HUB_CLIENT_WEB_SOCKET_PATH_NO_X509_CLIENT_CERT \
@@ -111,17 +120,22 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
  * @brief Gets the MQTT user name.
  *
  * The user name will be of the following format:
- * [Format without module id] {iothubhostname}/{device_id}/?api-version=2018-06-30&{user_agent}
- * [Format with module id]
- * {iothubhostname}/{device_id}/{module_id}/?api-version=2018-06-30&{user_agent}
+ *
+ * **Format without module id**
+ *
+ * `{iothubhostname}/{device_id}/?api-version=2018-06-30&{user_agent}`
+ *
+ * **Format with module id**
+ *
+ * `{iothubhostname}/{device_id}/{module_id}/?api-version=2018-06-30&{user_agent}`
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[out] mqtt_user_name A buffer with sufficient capacity to hold the MQTT user name.
- *                            If successful, contains a null-terminated string with the user name
- *                            that needs to be passed to the MQTT client.
+ * @param[out] mqtt_user_name A buffer with sufficient capacity to hold the MQTT user name. If
+ * successful, contains a null-terminated string with the user name that needs to be passed to the
+ * MQTT client.
  * @param[in] mqtt_user_name_size The size, in bytes of \p mqtt_user_name.
- * @param[out] out_mqtt_user_name_length __[nullable]__ Contains the string length, in bytes, of
- *                                                      \p mqtt_user_name. Can be `NULL`.
+ * @param[out] out_mqtt_user_name_length __[nullable]__ Contains the string length, in bytes, of \p
+ * mqtt_user_name. Can be `NULL`.
  * @return An #az_result value indicating the result of the operation.
  */
 AZ_NODISCARD az_result az_iot_hub_client_get_user_name(
@@ -134,16 +148,22 @@ AZ_NODISCARD az_result az_iot_hub_client_get_user_name(
  * @brief Gets the MQTT client id.
  *
  * The client id will be of the following format:
- * [Format without module id] {device_id}
- * [Format with module id] {device_id}/{module_id}
+ *
+ * **Format without module id**
+ *
+ * `{device_id}`
+ *
+ * **Format with module id**
+ *
+ * `{device_id}/{module_id}`
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[out] mqtt_client_id A buffer with sufficient capacity to hold the MQTT client id.
- *                            If successful, contains a null-terminated string with the client id
- *                            that needs to be passed to the MQTT client.
+ * @param[out] mqtt_client_id A buffer with sufficient capacity to hold the MQTT client id. If
+ * successful, contains a null-terminated string with the client id that needs to be passed to the
+ * MQTT client.
  * @param[in] mqtt_client_id_size The size, in bytes of \p mqtt_client_id.
  * @param[out] out_mqtt_client_id_length __[nullable]__ Contains the string length, in bytes, of
- *                                                      of \p mqtt_client_id. Can be `NULL`.
+ * \p mqtt_client_id. Can be `NULL`.
  * @return An #az_result value indicating the result of the operation.
  */
 AZ_NODISCARD az_result az_iot_hub_client_get_client_id(
@@ -164,10 +184,40 @@ AZ_NODISCARD az_result az_iot_hub_client_get_client_id(
 /**
  * @brief Gets the Shared Access clear-text signature.
  * @details The application must obtain a valid clear-text signature using this API, sign it using
- *          HMAC-SHA256 using the Shared Access Key as password then Base64 encode the result.
+ * HMAC-SHA256 using the Shared Access Key as password then Base64 encode the result.
  *
- * @remark More information available at
+ * Use the following APIs when the Shared Access Key is available to the application or stored
+ * within a Hardware Security Module. The APIs are not necessary if X509 Client Certificate
+ * Authentication is used.
+ *
+ * @note This API should be used in conjunction with az_iot_hub_client_sas_get_password().
+ *
+ * @note More information available at
  * https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#security-tokens
+ *
+ * A typical flow for using these two API's might look something like the following (note the size
+ * of buffers and non-SDK APIs are for demo purposes only):
+ *
+ * @code
+ * const char* const signature_str = "TST+J9i1F8tE6dLYCtuQcu10u7umGO+aWGqPQhd9AAo=";
+ * az_span signature = AZ_SPAN_FROM_STR(signature_str);
+ * az_iot_hub_client_sas_get_signature(&client, expiration_time_in_seconds, signature, &signature);
+ *
+ * char decoded_sas_key[128];
+ * base64_decode(base64_encoded_sas_key, decoded_sas_key);
+ *
+ * char signed_bytes[256];
+ * hmac_256(az_span_ptr(signature), az_span_size(signature), decoded_sas_key, signed_bytes);
+ *
+ * char signed_bytes_base64_encoded[256];
+ * base64_encode(signed_bytes, signed_bytes_base64_encoded);
+ *
+ * char final_password[512];
+ * az_iot_hub_client_sas_get_password(client, expiration_time_in_seconds,
+ *   AZ_SPAN_FROM_STR(signed_bytes_base64_encoded), final_password, sizeof(final_password), NULL);
+ *
+ * mqtt_set_password(&mqtt_client, final_password);
+ * @endcode
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] token_expiration_epoch_time The time, in seconds, from 1/1/1970.
@@ -183,23 +233,22 @@ AZ_NODISCARD az_result az_iot_hub_client_sas_get_signature(
 
 /**
  * @brief Gets the MQTT password.
- * @remark The MQTT password must be an empty string if X509 Client certificates are used. Use this
- *       API only when authenticating with SAS tokens.
+ * @note The MQTT password must be an empty string if X509 Client certificates are used. Use this
+ * API only when authenticating with SAS tokens.
+ *
+ * @note This API should be used in conjunction with az_iot_hub_client_sas_get_signature().
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] base64_hmac_sha256_signature The Base64 encoded value of the HMAC-SHA256(signature,
- *                                         SharedAccessKey). The signature is obtained by using
- *                                         az_iot_hub_client_sas_get_signature().
- * @param[in] token_expiration_epoch_time The time, in seconds, from 1/1/1970.
- *                                        It MUST be the same value passed to
- *                                        az_iot_hub_client_sas_get_signature().
+ * SharedAccessKey). The signature is obtained by using az_iot_hub_client_sas_get_signature().
+ * @param[in] token_expiration_epoch_time The time, in seconds, from 1/1/1970. It MUST be the same
+ * value passed to az_iot_hub_client_sas_get_signature().
  * @param[in] key_name The Shared Access Key Name (Policy Name). This is optional. For security
- *                     reasons we recommend using one key per device instead of using a global
- *                     policy key.
+ * reasons we recommend using one key per device instead of using a global policy key.
  * @param[out] mqtt_password A char buffer with sufficient capacity to hold the MQTT password.
  * @param[in] mqtt_password_size The size, in bytes of \p mqtt_password.
- * @param[out] out_mqtt_password_length __[nullable]__ Contains the string length, in bytes, of
- *                                                     \p mqtt_password. Can be `NULL`.
+ * @param[out] out_mqtt_password_length __[nullable]__ Contains the string length, in bytes, of \p
+ * mqtt_password. Can be `NULL`.
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The operation was successful. In this case, \p mqtt_password will contain a
  * null-terminated string with the password that needs to be passed to the MQTT client.
@@ -222,17 +271,15 @@ AZ_NODISCARD az_result az_iot_hub_client_sas_get_password(
 
 /**
  * @brief Gets the MQTT topic that must be used for device to cloud telemetry messages.
- * @remark Telemetry MQTT Publish messages must have QoS At least once (1).
- * @remark This topic can also be used to set the MQTT Will message in the Connect message.
+ * @note This topic can also be used to set the MQTT Will message in the Connect message.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] properties An optional #az_iot_message_properties object (can be NULL).
- * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If
- *                        successful, contains a null-terminated string with the topic that
- *                        needs to be passed to the MQTT client.
+ * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If successful,
+ * contains a null-terminated string with the topic that needs to be passed to the MQTT client.
  * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
- * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of
- *                                                  \p mqtt_topic. Can be `NULL`.
+ * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of \p
+ * mqtt_topic. Can be `NULL`.
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic was retrieved successfully.
  */
@@ -251,7 +298,7 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
 
 /**
  * @brief The MQTT topic filter to subscribe to Cloud-to-Device requests.
- * @remark C2D MQTT Publish messages will have QoS At least once (1).
+ * @note C2D MQTT Publish messages will have QoS At least once (1).
  */
 #define AZ_IOT_HUB_CLIENT_C2D_SUBSCRIBE_TOPIC "devices/+/messages/devicebound/#"
 
@@ -261,7 +308,10 @@ AZ_NODISCARD az_result az_iot_hub_client_telemetry_get_publish_topic(
  */
 typedef struct
 {
-  az_iot_message_properties properties; /**< The properties associated with this C2D request. */
+  /**
+   * The properties associated with this C2D request.
+   */
+  az_iot_message_properties properties;
 } az_iot_hub_client_c2d_request;
 
 /**
@@ -270,7 +320,7 @@ typedef struct
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] received_topic An #az_span containing the received topic.
  * @param[out] out_request If the message is a C2D request, this will contain the
- *                         #az_iot_hub_client_c2d_request
+ * #az_iot_hub_client_c2d_request
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic is meant for this feature and the \p out_request was populated
  * with relevant information.
@@ -291,7 +341,7 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
 
 /**
  * @brief The MQTT topic filter to subscribe to method requests.
- * @remark Methods MQTT Publish messages will have QoS At most once (0).
+ * @note Methods MQTT Publish messages will have QoS At most once (0).
  */
 #define AZ_IOT_HUB_CLIENT_METHODS_SUBSCRIBE_TOPIC "$iothub/methods/POST/#"
 
@@ -301,9 +351,16 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
  */
 typedef struct
 {
-  az_span request_id; /**< The request id.
-                       * @note The application must match the method request and method response. */
-  az_span name; /**< The method name. */
+  /**
+   * The request id.
+   * @note The application must match the method request and method response.
+   */
+  az_span request_id;
+
+  /**
+   * The method name.
+   */
+  az_span name;
 } az_iot_hub_client_method_request;
 
 /**
@@ -312,7 +369,7 @@ typedef struct
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] received_topic An #az_span containing the received topic.
  * @param[out] out_request If the message is a method request, this will contain the
- *                         #az_iot_hub_client_method_request.
+ * #az_iot_hub_client_method_request.
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic is meant for this feature and the \p out_request was populated
  * with relevant information.
@@ -330,14 +387,13 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_parse_received_topic(
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] request_id The request id. Must match a received #az_iot_hub_client_method_request
- *                       request_id.
+ * request_id.
  * @param[in] status A code that indicates the result of the method, as defined by the user.
- * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If
- *                        successful, contains a null-terminated string with the topic that
- *                        needs to be passed to the MQTT client.
+ * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If successful,
+ * contains a null-terminated string with the topic that needs to be passed to the MQTT client.
  * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
- * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of
- *                                                  \p mqtt_topic. Can be `NULL`.
+ * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of \p
+ * mqtt_topic. Can be `NULL`.
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic was retrieved successfully.
  */
@@ -357,13 +413,13 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_response_get_publish_topic(
 
 /**
  * @brief The MQTT topic filter to subscribe to twin operation responses.
- * @remark Twin MQTT Publish messages will have QoS At most once (0).
+ * @note Twin MQTT Publish messages will have QoS At most once (0).
  */
 #define AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_SUBSCRIBE_TOPIC "$iothub/twin/res/#"
 
 /**
  * @brief Gets the MQTT topic filter to subscribe to twin desired property changes.
- * @remark Twin MQTT Publish messages will have QoS At most once (0).
+ * @note Twin MQTT Publish messages will have QoS At most once (0).
  */
 #define AZ_IOT_HUB_CLIENT_TWIN_PATCH_SUBSCRIBE_TOPIC "$iothub/twin/PATCH/properties/desired/#"
 
@@ -384,19 +440,32 @@ typedef enum
  */
 typedef struct
 {
-  az_span
-      request_id; /**< Request ID matches the ID specified when issuing a Get or Patch command. */
+  /**
+   * Request ID matches the ID specified when issuing a Get or Patch command.
+   */
+  az_span request_id;
 
   // Avoid using enum as the first field within structs, to allow for { 0 } initialization.
   // This is a workaround for IAR compiler warning [Pe188]: enumerated type mixed with another type.
 
-  az_iot_hub_client_twin_response_type response_type; /**< Twin response type. */
-  az_iot_status status; /**< The operation status. */
-  az_span version; /**< The Twin object version.
-                    * @remark This is only returned when
-                    * `response_type==AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES`
-                    * or
-                    * `response_type==AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES`. */
+  /**
+   * Twin response type.
+   */
+  az_iot_hub_client_twin_response_type response_type;
+
+  /**
+   * The operation status.
+   */
+  az_iot_status status;
+
+  /**
+   * The Twin object version.
+   * @note This is only returned when
+   * `response_type==AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES`
+   * or
+   * `response_type==AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES`.
+   */
+  az_span version;
 } az_iot_hub_client_twin_response;
 
 /**
@@ -405,7 +474,7 @@ typedef struct
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] received_topic An #az_span containing the received topic.
  * @param[out] out_response If the message is twin-operation related, this will contain the
- *                         #az_iot_hub_client_twin_response.
+ * #az_iot_hub_client_twin_response.
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic is meant for this feature and the \p out_response was populated
  * with relevant information.
@@ -420,16 +489,15 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
 
 /**
  * @brief Gets the MQTT topic that must be used to submit a Twin GET request.
- * @remark The payload of the MQTT publish message should be empty.
+ * @note The payload of the MQTT publish message should be empty.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] request_id The request id.
- * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If
- *                        successful, contains a null-terminated string with the topic that
- *                        needs to be passed to the MQTT client.
+ * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If successful,
+ * contains a null-terminated string with the topic that needs to be passed to the MQTT client.
  * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
- * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of
- *                                                  \p mqtt_topic. Can be `NULL`.
+ * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of \p
+ * mqtt_topic. Can be `NULL`.
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic was retrieved successfully.
  */
@@ -442,17 +510,16 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_document_get_publish_topic(
 
 /**
  * @brief Gets the MQTT topic that must be used to submit a Twin PATCH request.
- * @remark The payload of the MQTT publish message should contain a JSON document
- *         formatted according to the Twin specification.
+ * @note The payload of the MQTT publish message should contain a JSON document formatted according
+ * to the Twin specification.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in] request_id The request id.
- * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If
- *                        successful, contains a null-terminated string with the topic that
- *                        needs to be passed to the MQTT client.
+ * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If successful,
+ * contains a null-terminated string with the topic that needs to be passed to the MQTT client.
  * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
- * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of
- *                                                  \p mqtt_topic. Can be `NULL`.
+ * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of \p
+ * mqtt_topic. Can be `NULL`.
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic was retrieved successfully.
  */

--- a/sdk/inc/azure/iot/az_iot_hub_client.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client.h
@@ -52,7 +52,7 @@ typedef struct
   az_span user_agent;
 
   /**
-   * The model id used to identify the capabilities of a device based on the Digital Twin document.
+   * The model ID used to identify the capabilities of a device based on the Digital Twin document.
    */
   az_span model_id;
 } az_iot_hub_client_options;
@@ -121,11 +121,11 @@ AZ_NODISCARD az_result az_iot_hub_client_init(
  *
  * The user name will be of the following format:
  *
- * **Format without module id**
+ * **Format without module ID**
  *
  * `{iothubhostname}/{device_id}/?api-version=2018-06-30&{user_agent}`
  *
- * **Format with module id**
+ * **Format with module ID**
  *
  * `{iothubhostname}/{device_id}/{module_id}/?api-version=2018-06-30&{user_agent}`
  *
@@ -145,21 +145,21 @@ AZ_NODISCARD az_result az_iot_hub_client_get_user_name(
     size_t* out_mqtt_user_name_length);
 
 /**
- * @brief Gets the MQTT client id.
+ * @brief Gets the MQTT client ID.
  *
- * The client id will be of the following format:
+ * The client ID will be of the following format:
  *
- * **Format without module id**
+ * **Format without module ID**
  *
  * `{device_id}`
  *
- * **Format with module id**
+ * **Format with module ID**
  *
  * `{device_id}/{module_id}`
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[out] mqtt_client_id A buffer with sufficient capacity to hold the MQTT client id. If
- * successful, contains a null-terminated string with the client id that needs to be passed to the
+ * @param[out] mqtt_client_id A buffer with sufficient capacity to hold the MQTT client ID. If
+ * successful, contains a null-terminated string with the client ID that needs to be passed to the
  * MQTT client.
  * @param[in] mqtt_client_id_size The size, in bytes of \p mqtt_client_id.
  * @param[out] out_mqtt_client_id_length __[nullable]__ Contains the string length, in bytes, of
@@ -195,7 +195,7 @@ AZ_NODISCARD az_result az_iot_hub_client_get_client_id(
  * @note More information available at
  * https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#security-tokens
  *
- * A typical flow for using these two API's might look something like the following (note the size
+ * A typical flow for using these two APIs might look something like the following (note the size
  * of buffers and non-SDK APIs are for demo purposes only):
  *
  * @code
@@ -203,16 +203,16 @@ AZ_NODISCARD az_result az_iot_hub_client_get_client_id(
  * az_span signature = AZ_SPAN_FROM_STR(signature_str);
  * az_iot_hub_client_sas_get_signature(&client, expiration_time_in_seconds, signature, &signature);
  *
- * char decoded_sas_key[128];
+ * char decoded_sas_key[128] = { 0 };
  * base64_decode(base64_encoded_sas_key, decoded_sas_key);
  *
- * char signed_bytes[256];
+ * char signed_bytes[256] = { 0 };
  * hmac_256(az_span_ptr(signature), az_span_size(signature), decoded_sas_key, signed_bytes);
  *
- * char signed_bytes_base64_encoded[256];
+ * char signed_bytes_base64_encoded[256] = { 0 };
  * base64_encode(signed_bytes, signed_bytes_base64_encoded);
  *
- * char final_password[512];
+ * char final_password[512] = { 0 };
  * az_iot_hub_client_sas_get_password(client, expiration_time_in_seconds,
  *   AZ_SPAN_FROM_STR(signed_bytes_base64_encoded), final_password, sizeof(final_password), NULL);
  *
@@ -352,7 +352,7 @@ AZ_NODISCARD az_result az_iot_hub_client_c2d_parse_received_topic(
 typedef struct
 {
   /**
-   * The request id.
+   * The request ID.
    * @note The application must match the method request and method response.
    */
   az_span request_id;
@@ -386,7 +386,7 @@ AZ_NODISCARD az_result az_iot_hub_client_methods_parse_received_topic(
  * @brief Gets the MQTT topic that must be used to respond to method requests.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[in] request_id The request id. Must match a received #az_iot_hub_client_method_request
+ * @param[in] request_id The request ID. Must match a received #az_iot_hub_client_method_request
  * request_id.
  * @param[in] status A code that indicates the result of the method, as defined by the user.
  * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If successful,
@@ -461,9 +461,9 @@ typedef struct
   /**
    * The Twin object version.
    * @note This is only returned when
-   * `response_type==AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES`
+   * `response_type == AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES`
    * or
-   * `response_type==AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES`.
+   * `response_type == AZ_IOT_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES`.
    */
   az_span version;
 } az_iot_hub_client_twin_response;
@@ -492,7 +492,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
  * @note The payload of the MQTT publish message should be empty.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[in] request_id The request id.
+ * @param[in] request_id The request ID.
  * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If successful,
  * contains a null-terminated string with the topic that needs to be passed to the MQTT client.
  * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
@@ -514,7 +514,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_document_get_publish_topic(
  * to the Twin specification.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
- * @param[in] request_id The request id.
+ * @param[in] request_id The request ID.
  * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If successful,
  * contains a null-terminated string with the topic that needs to be passed to the MQTT client.
  * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -37,8 +37,10 @@
  */
 typedef struct
 {
-  az_span user_agent; /**< The user-agent is a formatted string that will be used for Azure IoT
-                         usage statistics. */
+  /**
+   * The user-agent is a formatted string that will be used for Azure IoT usage statistics.
+   */
+  az_span user_agent;
 } az_iot_provisioning_client_options;
 
 /**
@@ -58,8 +60,9 @@ typedef struct
 
 /**
  * @brief Gets the default Azure IoT Provisioning Client options.
- * @details Call this to obtain an initialized #az_iot_provisioning_client_options structure that
- *          can be afterwards modified and passed to az_iot_provisioning_client_init().
+ *
+ * Call this to obtain an initialized #az_iot_provisioning_client_options structure that
+ * can be afterwards modified and passed to az_iot_provisioning_client_init().
  *
  * @return #az_iot_provisioning_client_options.
  */
@@ -72,10 +75,9 @@ AZ_NODISCARD az_iot_provisioning_client_options az_iot_provisioning_client_optio
  * @param[in] global_device_hostname The device provisioning services global host name.
  * @param[in] id_scope The ID Scope.
  * @param[in] registration_id The Registration ID. This must match the client certificate name (CN
- *                            part of the certificate subject).
- * @param[in] options __[nullable]__ A reference to an
- *                                   #az_iot_provisioning_client_options structure. Can be `NULL`
- *                                   for default options.
+ * part of the certificate subject).
+ * @param[in] options __[nullable]__ A reference to an #az_iot_provisioning_client_options
+ * structure. Can be `NULL` for default options.
  * @return An #az_result value indicating the result of the operation.
  */
 AZ_NODISCARD az_result az_iot_provisioning_client_init(
@@ -89,12 +91,12 @@ AZ_NODISCARD az_result az_iot_provisioning_client_init(
  * @brief Gets the MQTT user name.
  *
  * @param[in] client The #az_iot_provisioning_client to use for this call.
- * @param[out] mqtt_user_name A buffer with sufficient capacity to hold the MQTT user name.
- *                            If successful, contains a null-terminated string with the user name
- *                            that needs to be passed to the MQTT client.
+ * @param[out] mqtt_user_name A buffer with sufficient capacity to hold the MQTT user name. If
+ * successful, contains a null-terminated string with the user name that needs to be passed to the
+ * MQTT client.
  * @param[in] mqtt_user_name_size The size, in bytes of \p mqtt_user_name.
- * @param[out] out_mqtt_user_name_length __[nullable]__ Contains the string length, in bytes, of
- *                                                      \p mqtt_user_name. Can be `NULL`.
+ * @param[out] out_mqtt_user_name_length __[nullable]__ Contains the string length, in bytes, of \p
+ * mqtt_user_name. Can be `NULL`.
  * @return An #az_result value indicating the result of the operation.
  */
 AZ_NODISCARD az_result az_iot_provisioning_client_get_user_name(
@@ -107,12 +109,12 @@ AZ_NODISCARD az_result az_iot_provisioning_client_get_user_name(
  * @brief Gets the MQTT client id.
  *
  * @param[in] client The #az_iot_provisioning_client to use for this call.
- * @param[out] mqtt_client_id A buffer with sufficient capacity to hold the MQTT client id.
- *                            If successful, contains a null-terminated string with the client id
- *                            that needs to be passed to the MQTT client.
+ * @param[out] mqtt_client_id A buffer with sufficient capacity to hold the MQTT client id. If
+ * successful, contains a null-terminated string with the client id that needs to be passed to the
+ * MQTT client.
  * @param[in] mqtt_client_id_size The size, in bytes of \p mqtt_client_id.
- * @param[out] out_mqtt_client_id_length __[nullable]__ Contains the string length, in bytes, of
- *                                                      of \p mqtt_client_id. Can be `NULL`.
+ * @param[out] out_mqtt_client_id_length __[nullable]__ Contains the string length, in bytes, of of
+ * \p mqtt_client_id. Can be `NULL`.
  * @return An #az_result value indicating the result of the operation.
  */
 AZ_NODISCARD az_result az_iot_provisioning_client_get_client_id(
@@ -135,9 +137,9 @@ AZ_NODISCARD az_result az_iot_provisioning_client_get_client_id(
 
 /**
  * @brief Gets the Shared Access clear-text signature.
- * @details The application must obtain a valid clear-text signature using
- *          this API, sign it using HMAC-SHA256 using the Shared Access Key as password then Base64
- *          encode the result.
+ *
+ * The application must obtain a valid clear-text signature using this API, sign it using
+ * HMAC-SHA256 using the Shared Access Key as password then Base64 encode the result.
  *
  * @remark More information available at
  * https://docs.microsoft.com/en-us/azure/iot-dps/concepts-symmetric-key-attestation#detailed-attestation-process
@@ -157,22 +159,21 @@ AZ_NODISCARD az_result az_iot_provisioning_client_sas_get_signature(
 /**
  * @brief Gets the MQTT password.
  * @remark The MQTT password must be an empty string if X509 Client certificates are used. Use this
- *       API only when authenticating with SAS tokens.
+ * API only when authenticating with SAS tokens.
  *
  * @param[in] client The #az_iot_provisioning_client to use for this call.
  * @param[in] base64_hmac_sha256_signature The Base64 encoded value of the HMAC-SHA256(signature,
- *                                         SharedAccessKey). The signature is obtained by using
- *                                         #az_iot_provisioning_client_sas_get_signature.
+ * SharedAccessKey). The signature is obtained by using
+ * #az_iot_provisioning_client_sas_get_signature.
  * @param[in] token_expiration_epoch_time The time, in seconds, from 1/1/1970.
  * @param[in] key_name The Shared Access Key Name (Policy Name). This is optional. For security
- *                     reasons we recommend using one key per device instead of using a global
- *                     policy key.
- * @param[out] mqtt_password A buffer with sufficient capacity to hold the MQTT password.
- *                           If successful, contains a null-terminated string with the password that
- *                           needs to be passed to the MQTT client.
+ * reasons we recommend using one key per device instead of using a global policy key.
+ * @param[out] mqtt_password A buffer with sufficient capacity to hold the MQTT password. If
+ * successful, contains a null-terminated string with the password that needs to be passed to the
+ * MQTT client.
  * @param[in] mqtt_password_size The size, in bytes of \p mqtt_password.
- * @param[out] out_mqtt_password_length __[nullable]__ Contains the string length, in bytes, of
- *                                                     \p mqtt_password. Can be `NULL`.
+ * @param[out] out_mqtt_password_length __[nullable]__ Contains the string length, in bytes, of \p
+ * mqtt_password. Can be `NULL`.
  * @return An #az_result value indicating the result of the operation..
  */
 AZ_NODISCARD az_result az_iot_provisioning_client_sas_get_password(
@@ -206,15 +207,41 @@ AZ_NODISCARD az_result az_iot_provisioning_client_sas_get_password(
  */
 typedef struct
 {
-  az_span assigned_hub_hostname; /**< Assigned Azure IoT Hub hostname. @remark This is only
-                                    available if error_code is success. */
-  az_span device_id; /**< Assigned device ID. */
-  az_iot_status error_code; /**< The error code. */
-  uint32_t extended_error_code; /**< The extended, 6 digit error code. */
-  az_span error_message; /**< Error description. */
-  az_span error_tracking_id; /**< Submit this ID when asking for Azure IoT service-desk help. */
-  az_span
-      error_timestamp; /**< Submit this timestamp when asking for Azure IoT service-desk help. */
+  /**
+   * Assigned Azure IoT Hub hostname.
+   * @remark This is only available if error_code is success.
+   */
+  az_span assigned_hub_hostname;
+
+  /**
+   * Assigned device ID.
+   */
+  az_span device_id;
+
+  /**
+   * The error code.
+   */
+  az_iot_status error_code;
+
+  /**
+   * The extended, 6 digit error code.
+   */
+  uint32_t extended_error_code;
+
+  /**
+   * Error description.
+   */
+  az_span error_message;
+
+  /**
+   * Submit this ID when asking for Azure IoT service-desk help.
+   */
+  az_span error_tracking_id;
+
+  /**
+   * Submit this timestamp when asking for Azure IoT service-desk help.
+   */
+  az_span error_timestamp;
 } az_iot_provisioning_client_registration_state;
 
 /**
@@ -223,13 +250,29 @@ typedef struct
  */
 typedef enum
 {
-  // Device assignment in progress.
+  /**
+   * Starting state (not assigned).
+   */
   AZ_IOT_PROVISIONING_STATUS_UNASSIGNED,
+  /**
+   * Assigning in progress.
+   */
   AZ_IOT_PROVISIONING_STATUS_ASSIGNING,
 
   // Device assignment operation complete.
+  /**
+   * Device was assigned successfully.
+   */
   AZ_IOT_PROVISIONING_STATUS_ASSIGNED,
+
+  /**
+   * The provisioning for the device failed.
+   */
   AZ_IOT_PROVISIONING_STATUS_FAILED,
+
+  /**
+   * The provisioning for this device was disabled.
+   */
   AZ_IOT_PROVISIONING_STATUS_DISABLED,
 } az_iot_provisioning_client_operation_status;
 
@@ -239,22 +282,36 @@ typedef enum
  */
 typedef struct
 {
-  az_span operation_id; /**< The id of the register operation. */
+  /**
+   * The id of the register operation.
+   */
+  az_span operation_id;
 
   // Avoid using enum as the first field within structs, to allow for { 0 } initialization.
   // This is a workaround for IAR compiler warning [Pe188]: enumerated type mixed with another type.
 
-  az_iot_status status; /**< The current request status.
-                         * @remark The authoritative response for the device registration operation
-                         * (which may require several requests) is available only through
-                         * #operation_status.  */
-  az_iot_provisioning_client_operation_status
-      operation_status; /**< The status of the register operation. */
-  uint32_t retry_after_seconds; /**< Recommended timeout before sending the next MQTT publish. */
-  az_iot_provisioning_client_registration_state
-      registration_state; /**< If the operation is complete (success or error), the
-                                   registration state will contain the hub and device id in case of
-                                   success. */
+  /**
+   * The current request status.
+   * @remark The authoritative response for the device registration operation (which may require
+   * several requests) is available only through #operation_status.
+   */
+  az_iot_status status;
+
+  /**
+   * The status of the register operation.
+   */
+  az_iot_provisioning_client_operation_status operation_status;
+
+  /**
+   * Recommended timeout before sending the next MQTT publish.
+   */
+  uint32_t retry_after_seconds;
+
+  /**
+   * If the operation is complete (success or error), the registration state will contain the hub
+   * and device id in case of success.
+   */
+  az_iot_provisioning_client_registration_state registration_state;
 } az_iot_provisioning_client_register_response;
 
 /**
@@ -264,7 +321,7 @@ typedef struct
  * @param[in] received_topic An #az_span containing the received MQTT topic.
  * @param[in] received_payload An #az_span containing the received MQTT payload.
  * @param[out] out_response If the message is register-operation related, this will contain the
- *                          #az_iot_provisioning_client_register_response.
+ * #az_iot_provisioning_client_register_response.
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_ERROR_IOT_TOPIC_NO_MATCH If the topic is not matching the expected format.
  */
@@ -277,8 +334,11 @@ AZ_NODISCARD az_result az_iot_provisioning_client_parse_received_topic_and_paylo
 /**
  * @brief Checks if the status indicates that the service has an authoritative result of the
  * register operation. The operation may have completed in either success or error. Completed
- * states are AZ_IOT_PROVISIONING_STATUS_ASSIGNED, AZ_IOT_PROVISIONING_STATUS_FAILED, or
- * AZ_IOT_PROVISIONING_STATUS_DISABLED.
+ * states are:
+ *
+ * - #AZ_IOT_PROVISIONING_STATUS_ASSIGNED
+ * - #AZ_IOT_PROVISIONING_STATUS_FAILED
+ * - #AZ_IOT_PROVISIONING_STATUS_DISABLED
  *
  * @param[in] operation_status The status used to check if the operation completed.
  * @return `true` if the operation completed. `false` otherwise.
@@ -298,11 +358,11 @@ AZ_INLINE bool az_iot_provisioning_client_operation_complete(
  *
  * @param[in] client The #az_iot_provisioning_client to use for this call.
  * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic filter. If
- *                        successful, contains a null-terminated string with the topic filter that
- *                        needs to be passed to the MQTT client.
+ * successful, contains a null-terminated string with the topic filter that needs to be passed to
+ * the MQTT client.
  * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
- * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of
- *                                                  \p mqtt_topic. Can be `NULL`.
+ * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of \p
+ * mqtt_topic. Can be `NULL`.
  * @return An #az_result value indicating the result of the operation.
  */
 AZ_NODISCARD az_result az_iot_provisioning_client_register_get_publish_topic(
@@ -319,11 +379,11 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_get_publish_topic(
  * @param[in] operation_id The received operation_id from the
  * #az_iot_provisioning_client_register_response response.
  * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic filter. If
- *                        successful, contains a null-terminated string with the topic filter that
- *                        needs to be passed to the MQTT client.
+ * successful, contains a null-terminated string with the topic filter that needs to be passed to
+ * the MQTT client.
  * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
- * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of
- *                                                  \p mqtt_topic. Can be `NULL`.
+ * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of \p
+ * mqtt_topic. Can be `NULL`.
  * @return An #az_result value indicating the result of the operation.
  */
 AZ_NODISCARD az_result az_iot_provisioning_client_query_status_get_publish_topic(

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -209,7 +209,7 @@ typedef struct
 {
   /**
    * Assigned Azure IoT Hub hostname.
-   * @remark This is only available if error_code is success.
+   * @remark This is only available if `error_code` is success.
    */
   az_span assigned_hub_hostname;
 


### PR DESCRIPTION
- Update the doxygen for consistency (spacing).
- Use `@note` over `@remark` to make important info pop a bit more.
- Added a pseudo-code code snippet for sas keys.