### PR TITLE
Cgmanifest update: Remove transitive dependencies, mark paho as devdep, and simplify clang-format version.

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -38,7 +38,7 @@
           "CommitHash": "d34c51214f4172f2e12bb17532c9f44f72a57dd4"
         }
       },
-      "DevelopmentDependency": false
+      "DevelopmentDependency": true
     },
     {
       "Component": {
@@ -46,26 +46,6 @@
         "git": {
           "RepositoryUrl": "https://github.com/curl/curl",
           "CommitHash": "2cfac302fbeec68f1727cba3d1705e16f02220ad"
-        }
-      },
-      "DevelopmentDependency": false
-    },
-    {
-      "Component": {
-        "Type": "git",
-        "git": {
-          "RepositoryUrl": "https://github.com/openssl/openssl",
-          "CommitHash": "894da2fb7ed5d314ee5c2fc9fd2d9b8b74111596"
-        }
-      },
-      "DevelopmentDependency": false
-    },
-    {
-      "Component": {
-        "Type": "git",
-        "git": {
-          "RepositoryUrl": "https://github.com/madler/zlib",
-          "CommitHash": "cacf7f1d4e3d44d871b605da3b647f07d718623f"
         }
       },
       "DevelopmentDependency": false
@@ -108,7 +88,7 @@
         "Type": "other",
         "Other": {
           "Name": "clang-format",
-          "Version": "9.0.0-2~ubuntu18.04.2",
+          "Version": "9.0.0-2",
           "DownloadUrl": "https://ubuntu.pkgs.org/18.04/ubuntu-updates-universe-amd64/clang-format-9_9-2~ubuntu18.04.2_amd64.deb.html"
         }
       },


### PR DESCRIPTION
We don't directly call or reference openssl or zlib, and those are only brought in due to our curl dependency. Removing those for now.

Paho is not used within the SDK itself (src/include) and only needed for building samples, used in CI, so marking it as a `DevelopmentDependency`.

CG had trouble parsing the clang-format component version due to the `~`, so removing that detail.

> [INFO] Discovered cg manifest file at: /home/vsts/work/1/s/cgmanifest.json 
[INFO] Version string clang-format 9.0.0-2~ubuntu18.04.2 for component clang-format is invalid or unsupported and a registration will not be submitted. 
