### PR TITLE
update property with status API

### DIFF
--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -472,6 +472,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_document_get_publish_topic(
     char* mqtt_topic,
     size_t mqtt_topic_size,
     size_t* out_mqtt_topic_length);
+
 /**
  * @brief Gets the MQTT topic that is used to submit a Plug and Play Property PATCH request.
  * @note The payload of the MQTT publish message should contain a JSON document formatted according
@@ -565,33 +566,43 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_property_builder_end_component(
  *
  * https://docs.microsoft.com/en-us/azure/iot-pnp/concepts-convention#writable-properties
  *
- * The payload will be of the form
+ * The payload will be of the form:
  *
  * **Without Component**
  * @code
- * {
- *   "<property_name>":{
- *     "ac": <ack_code>,
- *     "av": <ack_version>,
- *     "ad": "<ack_description>",
- *     "value": 23
- *   }
- * }
+ * //{
+ * //  "<property_name>":{
+ * //    "ac": <ack_code>,
+ * //    "av": <ack_version>,
+ * //    "ad": "<ack_description>",
+ * //    "value": 23
+ * //  }
+ * //}
  * @endcode
+ *
+ * To send a status for a property belonging to a component, first call the
+ * az_iot_pnp_client_twin_property_builder_begin_component() API to prefix the payload with the
+ * necessary identification. The API call flow would look like the following with the listed JSON payload being generated.
  *
  * **With Component**
  * @code
- * {
- *   "<component_name>": {
- *     "__t": "c",
- *     "<property_name>": {
- *       "ac": <ack_code>,
- *       "av": <ack_version>,
- *       "ad": "<ack_description>",
- *       "value": 23
- *     }
- *   }
- * }
+ * 
+ * az_iot_pnp_client_twin_property_builder_begin_component()
+ * az_iot_pnp_client_twin_begin_property_with_status()
+ * az_iot_pnp_client_twin_end_property_with_status()
+ * az_iot_pnp_client_twin_property_builder_end_component()
+ * 
+ * //{
+ * //  "<component_name>": {
+ * //    "__t": "c",
+ * //    "<property_name>": {
+ * //      "ac": <ack_code>,
+ * //      "av": <ack_version>,
+ * //      "ad": "<ack_description>",
+ * //      "value": 23
+ * //    }
+ * //  }
+ * //}
  * @endcode
  *
  * @note This API should be used in conjunction with
@@ -599,8 +610,6 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_property_builder_end_component(
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
  * @param[in,out] ref_json_writer The initialized #az_json_writer to append data to.
- * @param[in] component_name The name of the component to use with this property payload. If this is
- * for a root or non-component, this can be #AZ_SPAN_EMPTY.
  * @param[in] property_name The name of the property to build a response payload for.
  * @param[in] ack_code The HTTP-like status code to respond with. See #az_iot_status for
  * possible supported values.
@@ -618,7 +627,6 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_property_builder_end_component(
 AZ_NODISCARD az_result az_iot_pnp_client_twin_begin_property_with_status(
     az_iot_pnp_client const* client,
     az_json_writer* ref_json_writer,
-    az_span component_name,
     az_span property_name,
     int32_t ack_code,
     int32_t ack_version,
@@ -632,8 +640,6 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_begin_property_with_status(
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
  * @param[in,out] ref_json_writer The initialized #az_json_writer to append data to.
- * @param[in] component_name The name of the component to use with this property payload. If this is
- * for a root or non-component, this can be #AZ_SPAN_EMPTY.
  *
  * @pre \p client must not be `NULL`.
  * @pre \p ref_json_writer must not be `NULL`.
@@ -643,8 +649,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_begin_property_with_status(
  */
 AZ_NODISCARD az_result az_iot_pnp_client_twin_end_property_with_status(
     az_iot_pnp_client const* client,
-    az_json_writer* ref_json_writer,
-    az_span component_name);
+    az_json_writer* ref_json_writer);
 
 /**
  * @brief Read the IoT Plug and Play twin properties version.

--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -257,7 +257,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_sas_get_password(
  * @note This topic can also be used to set the MQTT Will message in the Connect message.
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
- * @param[in] component_name An #az_span specifying the component name to publish telemetry on.
+ * @param[in] component_name An #az_span specifying the component name to publish telemetry on. If
  * @param[in] properties Properties to attach to append to the topic.
  * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If successful,
  * contains a null-terminated string with the topic that needs to be passed to the MQTT client.
@@ -504,7 +504,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_patch_get_publish_topic(
 
 /**
  * @brief Append the necessary characters to a reported property JSON payload belonging to a
- * subcomponent.
+ * component.
  *
  * The payload will be of the form:
  *
@@ -539,7 +539,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_property_builder_begin_component(
 
 /**
  * @brief Append the necessary characters to end a reported property JSON payload belonging to a
- * subcomponent.
+ * component.
  *
  * @note This API should be used in conjunction with
  * az_iot_pnp_client_twin_property_builder_begin_component().

--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -257,7 +257,8 @@ AZ_NODISCARD az_result az_iot_pnp_client_sas_get_password(
  * @note This topic can also be used to set the MQTT Will message in the Connect message.
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
- * @param[in] component_name An #az_span specifying the component name to publish telemetry on. If
+ * @param[in] component_name An #az_span specifying the component name to publish telemetry on. Can
+ * be #AZ_SPAN_EMPTY if the telemetry is not for a component.
  * @param[in] properties Properties to attach to append to the topic.
  * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic. If successful,
  * contains a null-terminated string with the topic that needs to be passed to the MQTT client.
@@ -575,23 +576,25 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_property_builder_end_component(
  * //    "ac": <ack_code>,
  * //    "av": <ack_version>,
  * //    "ad": "<ack_description>",
- * //    "value": 23
+ * //    "value": <user_value>
  * //  }
  * //}
  * @endcode
  *
  * To send a status for a property belonging to a component, first call the
  * az_iot_pnp_client_twin_property_builder_begin_component() API to prefix the payload with the
- * necessary identification. The API call flow would look like the following with the listed JSON payload being generated.
+ * necessary identification. The API call flow would look like the following with the listed JSON
+ * payload being generated.
  *
  * **With Component**
  * @code
- * 
+ *
  * az_iot_pnp_client_twin_property_builder_begin_component()
  * az_iot_pnp_client_twin_begin_property_with_status()
+ * // Append user value here (<user_value>)
  * az_iot_pnp_client_twin_end_property_with_status()
  * az_iot_pnp_client_twin_property_builder_end_component()
- * 
+ *
  * //{
  * //  "<component_name>": {
  * //    "__t": "c",
@@ -599,7 +602,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_property_builder_end_component(
  * //      "ac": <ack_code>,
  * //      "av": <ack_version>,
  * //      "ad": "<ack_description>",
- * //      "value": 23
+ * //      "value": <user_value>
  * //    }
  * //  }
  * //}

--- a/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
@@ -868,7 +868,7 @@ static void process_twin_message(
             &pnp_client, &jw, component_name);
         if (az_result_failed(rc))
         {
-          IOT_SAMPLE_LOG_ERROR("Could not begin the component: az_result return code 0x%08x.", rc);
+          IOT_SAMPLE_LOG_ERROR("Could not begin the property component: az_result return code 0x%08x.", rc);
           exit(rc);
         }
 
@@ -912,7 +912,7 @@ static void process_twin_message(
         rc = az_iot_pnp_client_twin_property_builder_end_component(&pnp_client, &jw);
         if (az_result_failed(rc))
         {
-          IOT_SAMPLE_LOG_ERROR("Could not end the component: az_result return code 0x%08x.", rc);
+          IOT_SAMPLE_LOG_ERROR("Could not end the property component: az_result return code 0x%08x.", rc);
           exit(rc);
         }
 

--- a/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
@@ -868,7 +868,8 @@ static void process_twin_message(
             &pnp_client, &jw, component_name);
         if (az_result_failed(rc))
         {
-          IOT_SAMPLE_LOG_ERROR("Could not begin the property component: az_result return code 0x%08x.", rc);
+          IOT_SAMPLE_LOG_ERROR(
+              "Could not begin the property component: az_result return code 0x%08x.", rc);
           exit(rc);
         }
 
@@ -912,7 +913,8 @@ static void process_twin_message(
         rc = az_iot_pnp_client_twin_property_builder_end_component(&pnp_client, &jw);
         if (az_result_failed(rc))
         {
-          IOT_SAMPLE_LOG_ERROR("Could not end the property component: az_result return code 0x%08x.", rc);
+          IOT_SAMPLE_LOG_ERROR(
+              "Could not end the property component: az_result return code 0x%08x.", rc);
           exit(rc);
         }
 

--- a/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
@@ -871,7 +871,8 @@ static void process_twin_message(
             "Could not advance to property value");
 
         IOT_SAMPLE_EXIT_IF_AZ_FAILED(
-            append_simple_json_token(&jw, &property_name_and_value.token), "Could not append the property");
+            append_simple_json_token(&jw, &property_name_and_value.token),
+            "Could not append the property");
 
         IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             az_iot_pnp_client_twin_end_property_with_status(&pnp_client, &jw),

--- a/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
@@ -833,7 +833,7 @@ static void process_twin_message(
             az_span_ptr(property_name_and_value.token.slice));
 
         // Get the Twin Patch topic to send a reported property update.
-        IOT_SAMPLE_EXIT_IF_FAILED(
+        IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             az_iot_pnp_client_twin_patch_get_publish_topic(
                 &pnp_client,
                 pnp_mqtt_get_request_id(),
@@ -844,19 +844,19 @@ static void process_twin_message(
 
         // Build the root component error reported property message.
         az_json_writer jw;
-        IOT_SAMPLE_EXIT_IF_FAILED(
+        IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             az_json_writer_init(&jw, publish_message.payload, NULL),
             "Could not initialize the json writer");
 
-        IOT_SAMPLE_EXIT_IF_FAILED(
+        IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             az_json_writer_append_begin_object(&jw), "Could not append the begin object");
 
-        IOT_SAMPLE_EXIT_IF_FAILED(
+        IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             az_iot_pnp_client_twin_property_builder_begin_component(
                 &pnp_client, &jw, component_name),
             "Could not begin the property component");
 
-        IOT_SAMPLE_EXIT_IF_FAILED(
+        IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             az_iot_pnp_client_twin_begin_property_with_status(
                 &pnp_client,
                 &jw,
@@ -866,22 +866,22 @@ static void process_twin_message(
                 twin_response_failed),
             "Could not begin the property with status");
 
-        IOT_SAMPLE_EXIT_IF_FAILED(
+        IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             az_json_reader_next_token(&property_name_and_value),
             "Could not advance to property value");
 
-        IOT_SAMPLE_EXIT_IF_FAILED(
+        IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             append_simple_json_token(&jw, &property_name_and_value.token), "Could not append the property");
 
-        IOT_SAMPLE_EXIT_IF_FAILED(
+        IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             az_iot_pnp_client_twin_end_property_with_status(&pnp_client, &jw),
             "Could not end the property with status");
 
-        IOT_SAMPLE_EXIT_IF_FAILED(
+        IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             az_iot_pnp_client_twin_property_builder_end_component(&pnp_client, &jw),
             "Could not end the property component");
 
-        IOT_SAMPLE_EXIT_IF_FAILED(
+        IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             az_json_writer_append_end_object(&jw), "Could not append end the object");
 
         // Send error response to the updated property.

--- a/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
@@ -833,98 +833,56 @@ static void process_twin_message(
             az_span_ptr(property_name_and_value.token.slice));
 
         // Get the Twin Patch topic to send a reported property update.
-        rc = az_iot_pnp_client_twin_patch_get_publish_topic(
-            &pnp_client,
-            pnp_mqtt_get_request_id(),
-            publish_message.topic,
-            publish_message.topic_length,
-            NULL);
-        if (az_result_failed(rc))
-        {
-          IOT_SAMPLE_LOG_ERROR(
-              "Failed to get Twin Patch publish topic: az_result return code 0x%08x.", rc);
-          exit(rc);
-        }
+        IOT_SAMPLE_EXIT_IF_FAILED(
+            az_iot_pnp_client_twin_patch_get_publish_topic(
+                &pnp_client,
+                pnp_mqtt_get_request_id(),
+                publish_message.topic,
+                publish_message.topic_length,
+                NULL),
+            "Failed to get Twin Patch publish topic");
 
         // Build the root component error reported property message.
         az_json_writer jw;
-        rc = az_json_writer_init(&jw, publish_message.payload, NULL);
-        if (az_result_failed(rc))
-        {
-          IOT_SAMPLE_LOG_ERROR(
-              "Could not initialize the json writer: az_result return code 0x%08x.", rc);
-          exit(rc);
-        }
+        IOT_SAMPLE_EXIT_IF_FAILED(
+            az_json_writer_init(&jw, publish_message.payload, NULL),
+            "Could not initialize the json writer");
 
-        rc = az_json_writer_append_begin_object(&jw);
-        if (az_result_failed(rc))
-        {
-          IOT_SAMPLE_LOG_ERROR(
-              "Could not append the begin object: az_result return code 0x%08x.", rc);
-          exit(rc);
-        }
+        IOT_SAMPLE_EXIT_IF_FAILED(
+            az_json_writer_append_begin_object(&jw), "Could not append the begin object");
 
-        rc = az_iot_pnp_client_twin_property_builder_begin_component(
-            &pnp_client, &jw, component_name);
-        if (az_result_failed(rc))
-        {
-          IOT_SAMPLE_LOG_ERROR(
-              "Could not begin the property component: az_result return code 0x%08x.", rc);
-          exit(rc);
-        }
+        IOT_SAMPLE_EXIT_IF_FAILED(
+            az_iot_pnp_client_twin_property_builder_begin_component(
+                &pnp_client, &jw, component_name),
+            "Could not begin the property component");
 
-        rc = az_iot_pnp_client_twin_begin_property_with_status(
-            &pnp_client,
-            &jw,
-            property_name_and_value.token.slice,
-            AZ_IOT_STATUS_NOT_FOUND,
-            version,
-            twin_response_failed);
-        if (az_result_failed(rc))
-        {
-          IOT_SAMPLE_LOG_ERROR(
-              "Could not begin the property with status: az_result return code 0x%08x.", rc);
-          exit(rc);
-        }
+        IOT_SAMPLE_EXIT_IF_FAILED(
+            az_iot_pnp_client_twin_begin_property_with_status(
+                &pnp_client,
+                &jw,
+                property_name_and_value.token.slice,
+                AZ_IOT_STATUS_NOT_FOUND,
+                version,
+                twin_response_failed),
+            "Could not begin the property with status");
 
-        rc = az_json_reader_next_token(&property_name_and_value);
-        if (az_result_failed(rc))
-        {
-          IOT_SAMPLE_LOG_ERROR(
-              "Could not advance to the property value: az_result return code 0x%08x.", rc);
-          exit(rc);
-        }
+        IOT_SAMPLE_EXIT_IF_FAILED(
+            az_json_reader_next_token(&property_name_and_value),
+            "Could not advance to property value");
 
-        rc = append_simple_json_token(&jw, &property_name_and_value.token);
-        if (az_result_failed(rc))
-        {
-          IOT_SAMPLE_LOG_ERROR("Could not append the property: az_result return code 0x%08x.", rc);
-          exit(rc);
-        }
+        IOT_SAMPLE_EXIT_IF_FAILED(
+            append_simple_json_token(&jw, &property_name_and_value.token), "Could not append the property");
 
-        rc = az_iot_pnp_client_twin_end_property_with_status(&pnp_client, &jw);
-        if (az_result_failed(rc))
-        {
-          IOT_SAMPLE_LOG_ERROR(
-              "Could not end the property with status: az_result return code 0x%08x.", rc);
-          exit(rc);
-        }
+        IOT_SAMPLE_EXIT_IF_FAILED(
+            az_iot_pnp_client_twin_end_property_with_status(&pnp_client, &jw),
+            "Could not end the property with status");
 
-        rc = az_iot_pnp_client_twin_property_builder_end_component(&pnp_client, &jw);
-        if (az_result_failed(rc))
-        {
-          IOT_SAMPLE_LOG_ERROR(
-              "Could not end the property component: az_result return code 0x%08x.", rc);
-          exit(rc);
-        }
+        IOT_SAMPLE_EXIT_IF_FAILED(
+            az_iot_pnp_client_twin_property_builder_end_component(&pnp_client, &jw),
+            "Could not end the property component");
 
-        rc = az_json_writer_append_end_object(&jw);
-        if (az_result_failed(rc))
-        {
-          IOT_SAMPLE_LOG_ERROR(
-              "Could not append end the object: az_result return code 0x%08x.", rc);
-          exit(rc);
-        }
+        IOT_SAMPLE_EXIT_IF_FAILED(
+            az_json_writer_append_end_object(&jw), "Could not append end the object");
 
         // Send error response to the updated property.
         publish_mqtt_message(

--- a/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
@@ -864,10 +864,17 @@ static void process_twin_message(
           exit(rc);
         }
 
+        rc = az_iot_pnp_client_twin_property_builder_begin_component(
+            &pnp_client, &jw, component_name);
+        if (az_result_failed(rc))
+        {
+          IOT_SAMPLE_LOG_ERROR("Could not begin the component: az_result return code 0x%08x.", rc);
+          exit(rc);
+        }
+
         rc = az_iot_pnp_client_twin_begin_property_with_status(
             &pnp_client,
             &jw,
-            component_name,
             property_name_and_value.token.slice,
             AZ_IOT_STATUS_NOT_FOUND,
             version,
@@ -894,11 +901,18 @@ static void process_twin_message(
           exit(rc);
         }
 
-        rc = az_iot_pnp_client_twin_end_property_with_status(&pnp_client, &jw, component_name);
+        rc = az_iot_pnp_client_twin_end_property_with_status(&pnp_client, &jw);
         if (az_result_failed(rc))
         {
           IOT_SAMPLE_LOG_ERROR(
               "Could not end the property with status: az_result return code 0x%08x.", rc);
+          exit(rc);
+        }
+
+        rc = az_iot_pnp_client_twin_property_builder_end_component(&pnp_client, &jw);
+        if (az_result_failed(rc))
+        {
+          IOT_SAMPLE_LOG_ERROR("Could not end the component: az_result return code 0x%08x.", rc);
           exit(rc);
         }
 

--- a/sdk/samples/iot/pnp/pnp_thermostat_component.c
+++ b/sdk/samples/iot/pnp/pnp_thermostat_component.c
@@ -282,10 +282,13 @@ az_result pnp_thermostat_process_property_update(
 
     IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc = az_json_writer_append_begin_object(&jw), property_log);
     IOT_SAMPLE_EXIT_IF_AZ_FAILED(
+        rc = az_iot_pnp_client_twin_property_builder_begin_component(
+            pnp_client, &jw, ref_thermostat_component->component_name),
+        property_log);
+    IOT_SAMPLE_EXIT_IF_AZ_FAILED(
         rc = az_iot_pnp_client_twin_begin_property_with_status(
             pnp_client,
             &jw,
-            ref_thermostat_component->component_name,
             property_name_span,
             (int32_t)AZ_IOT_STATUS_OK,
             version,
@@ -295,9 +298,10 @@ az_result pnp_thermostat_process_property_update(
         rc = az_json_writer_append_double(&jw, parsed_property_value, DOUBLE_DECIMAL_PLACE_DIGITS),
         property_log);
     IOT_SAMPLE_EXIT_IF_AZ_FAILED(
-        rc = az_iot_pnp_client_twin_end_property_with_status(
-            pnp_client, &jw, ref_thermostat_component->component_name),
-        property_log);
+        rc = az_iot_pnp_client_twin_end_property_with_status(pnp_client, &jw), property_log);
+    IOT_SAMPLE_EXIT_IF_AZ_FAILED(
+        rc = az_iot_pnp_client_twin_property_builder_end_component(pnp_client, &jw), property_log);
+
     IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc = az_json_writer_append_end_object(&jw), property_log);
 
     *out_payload = az_json_writer_get_bytes_used_in_destination(&jw);

--- a/sdk/samples/iot/pnp/pnp_thermostat_component.c
+++ b/sdk/samples/iot/pnp/pnp_thermostat_component.c
@@ -276,17 +276,18 @@ az_result pnp_thermostat_process_property_update(
     IOT_SAMPLE_LOG("Average Temperature: %2f", ref_thermostat_component->average_temperature);
 
     az_json_writer jw;
-    az_result rc = az_json_writer_init(&jw, payload, NULL);
+    IOT_SAMPLE_EXIT_IF_AZ_FAILED(
+        az_json_writer_init(&jw, payload, NULL), "Failed to initialize the json writer");
 
     const char* const property_log = "Failed to create property with status payload";
 
-    IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc = az_json_writer_append_begin_object(&jw), property_log);
+    IOT_SAMPLE_EXIT_IF_AZ_FAILED(az_json_writer_append_begin_object(&jw), property_log);
     IOT_SAMPLE_EXIT_IF_AZ_FAILED(
-        rc = az_iot_pnp_client_twin_property_builder_begin_component(
+        az_iot_pnp_client_twin_property_builder_begin_component(
             pnp_client, &jw, ref_thermostat_component->component_name),
         property_log);
     IOT_SAMPLE_EXIT_IF_AZ_FAILED(
-        rc = az_iot_pnp_client_twin_begin_property_with_status(
+        az_iot_pnp_client_twin_begin_property_with_status(
             pnp_client,
             &jw,
             property_name_span,
@@ -295,14 +296,14 @@ az_result pnp_thermostat_process_property_update(
             twin_response_success),
         property_log);
     IOT_SAMPLE_EXIT_IF_AZ_FAILED(
-        rc = az_json_writer_append_double(&jw, parsed_property_value, DOUBLE_DECIMAL_PLACE_DIGITS),
+        az_json_writer_append_double(&jw, parsed_property_value, DOUBLE_DECIMAL_PLACE_DIGITS),
         property_log);
     IOT_SAMPLE_EXIT_IF_AZ_FAILED(
-        rc = az_iot_pnp_client_twin_end_property_with_status(pnp_client, &jw), property_log);
+        az_iot_pnp_client_twin_end_property_with_status(pnp_client, &jw), property_log);
     IOT_SAMPLE_EXIT_IF_AZ_FAILED(
-        rc = az_iot_pnp_client_twin_property_builder_end_component(pnp_client, &jw), property_log);
+        az_iot_pnp_client_twin_property_builder_end_component(pnp_client, &jw), property_log);
 
-    IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc = az_json_writer_append_end_object(&jw), property_log);
+    IOT_SAMPLE_EXIT_IF_AZ_FAILED(az_json_writer_append_end_object(&jw), property_log);
 
     *out_payload = az_json_writer_get_bytes_used_in_destination(&jw);
   }

--- a/sdk/src/azure/iot/az_iot_pnp_client_twin.c
+++ b/sdk/src/azure/iot/az_iot_pnp_client_twin.c
@@ -103,7 +103,6 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_property_builder_end_component(
 AZ_NODISCARD az_result az_iot_pnp_client_twin_begin_property_with_status(
     az_iot_pnp_client const* client,
     az_json_writer* ref_json_writer,
-    az_span component_name,
     az_span property_name,
     int32_t ack_code,
     int32_t ack_version,
@@ -114,16 +113,6 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_begin_property_with_status(
   _az_PRECONDITION_VALID_SPAN(property_name, 1, false);
 
   (void)client;
-
-  if (az_span_size(component_name) != 0)
-  {
-    _az_RETURN_IF_FAILED(az_json_writer_append_property_name(ref_json_writer, component_name));
-    _az_RETURN_IF_FAILED(az_json_writer_append_begin_object(ref_json_writer));
-    _az_RETURN_IF_FAILED(
-        az_json_writer_append_property_name(ref_json_writer, component_property_label_name));
-    _az_RETURN_IF_FAILED(
-        az_json_writer_append_string(ref_json_writer, component_property_label_value));
-  }
 
   _az_RETURN_IF_FAILED(az_json_writer_append_property_name(ref_json_writer, property_name));
   _az_RETURN_IF_FAILED(az_json_writer_append_begin_object(ref_json_writer));
@@ -149,8 +138,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_begin_property_with_status(
 
 AZ_NODISCARD az_result az_iot_pnp_client_twin_end_property_with_status(
     az_iot_pnp_client const* client,
-    az_json_writer* ref_json_writer,
-    az_span component_name)
+    az_json_writer* ref_json_writer)
 {
   _az_PRECONDITION_NOT_NULL(client);
   _az_PRECONDITION_NOT_NULL(ref_json_writer);
@@ -158,11 +146,6 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_end_property_with_status(
   (void)client;
 
   _az_RETURN_IF_FAILED(az_json_writer_append_end_object(ref_json_writer));
-
-  if (az_span_size(component_name) != 0)
-  {
-    _az_RETURN_IF_FAILED(az_json_writer_append_end_object(ref_json_writer));
-  }
 
   return AZ_OK;
 }


### PR DESCRIPTION
This removes the responsibility of appending the component JSON "container" from the `az_iot_pnp_client_twin_begin_property_with_status()` API. Instead, the user will call the `az_iot_pnp_client_twin_property_builder_begin_component()` API if they want to prepend with component name. This allows for multiple properties from the same subcomponent to be acknowledged in the same payload.