### PR TITLE
update az_iot_pnp_client_twin_get_next_component_property() API

### DIFF
--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -695,7 +695,8 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_get_property_version(
  * instance.
  *
  * @return An #az_result value indicating the result of the operation.
- * @retval #AZ_OK If the function returned a valid #az_json_reader pointing to the property name.
+ * @retval #AZ_OK If the function returned a valid #az_json_reader pointing to the property name and
+ * the #az_span with a component name.
  * @retval #AZ_ERROR_IOT_END_OF_PROPERTIES If there are no more properties left for the component.
  */
 AZ_NODISCARD az_result az_iot_pnp_client_twin_get_next_component_property(

--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -676,22 +676,26 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_get_property_version(
  * only checked and compared. Internally, the #az_span is only changed if the component name changes
  * in the JSON document and is not necessarily set every invocation of the function.
  *
+ * The `out_property_name_and_value` is passed back as an #az_json_reader. On success, the reader
+ * will be pointing to the property name. After checking the property name, the reader can be
+ * advanced to the property value by calling az_json_reader_next_token().
+ *
  * @param[in] client The #az_iot_pnp_client to use for this call.
  * @param[in,out] ref_json_reader The #az_json_reader to parse through.
  * @param[in] response_type The #az_iot_pnp_client_twin_response_type representing the message type
  * associated with the payload.
  * @param[out] out_component_name The #az_span* representing the value of the component.
- * @param[out] out_property_name The #az_json_token* representing the name of the property.
- * @param[out] out_property_value The #az_json_reader* representing the value of the property.
+ * @param[out] out_property_name_and_value The #az_json_reader* which, on success, will point to the
+ * property name.
  *
  * @pre \p client must not be `NULL`.
  * @pre \p ref_json_reader must not be `NULL`.
  * @pre \p out_component_name must not be `NULL`. It must point to an #az_span instance.
- * @pre \p out_property_name must not be `NULL`. It must point to an #az_json_token instance.
- * @pre \p out_property_value must not be `NULL`. It must point to an #az_json_reader instance.
+ * @pre \p out_property_name_and_value must not be `NULL`. It must point to an #az_json_reader
+ * instance.
  *
  * @return An #az_result value indicating the result of the operation.
- * @retval #AZ_OK If the function returned a valid property name and value.
+ * @retval #AZ_OK If the function returned a valid #az_json_reader pointing to the property name.
  * @retval #AZ_ERROR_IOT_END_OF_PROPERTIES If there are no more properties left for the component.
  */
 AZ_NODISCARD az_result az_iot_pnp_client_twin_get_next_component_property(
@@ -699,8 +703,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_get_next_component_property(
     az_json_reader* ref_json_reader,
     az_iot_pnp_client_twin_response_type response_type,
     az_span* out_component_name,
-    az_json_token* out_property_name,
-    az_json_reader* out_property_value);
+    az_json_reader* out_property_name_and_value);
 
 #include <azure/core/_az_cfg_suffix.h>
 

--- a/sdk/samples/iot/pnp/pnp_thermostat_component.h
+++ b/sdk/samples/iot/pnp/pnp_thermostat_component.h
@@ -58,6 +58,7 @@ void pnp_thermostat_build_telemetry_message(
 /**
  * @brief Build the thermostat's maximum temperature reported property message.
  *
+ * @param[in] pnp_client The #az_iot_pnp_client to use for this call.
  * @param[in] thermostat_component A pointer to the themostat component to get data.
  * @param[in] payload An #az_span with sufficient capacity to hold the json payload.
  * @param[out] out_payload A pointer to the #az_span containing the output json payload.
@@ -73,6 +74,7 @@ void pnp_thermostat_build_maximum_temperature_reported_property(
 /**
  * @brief Build the thermostat's error message with status.
  *
+ * @param[in] pnp_client The #az_iot_pnp_client to use for this call.
  * @param[in] component_name The name of the component for the reported property.
  * @param[in] property_name The name of the property for which to send an update.
  * @param[in] property_value The property value to be appended.
@@ -94,9 +96,9 @@ void pnp_thermostat_build_error_reported_property_with_status(
 /**
  * @brief Update the thermostat's member variables and prepare reported property message.
  *
+ * @param[in] pnp_client The #az_iot_pnp_client to use for this call.
  * @param[in,out] ref_thermostat_component A pointer to the themostat component to update data.
- * @param[in] property_name The name of the property to be updated.
- * @param[in] property_value The value used for the property update.
+ * @param[in] property_name_and_value The #az_json_reader pointing to the property name.
  * @param[in] version The version parsed from the received message, and used to prepare the returned
  * reported property message.
  * @param[in] payload An #az_span with sufficient capacity to hold the prepared reported property
@@ -110,8 +112,7 @@ void pnp_thermostat_build_error_reported_property_with_status(
 az_result pnp_thermostat_process_property_update(
     az_iot_pnp_client const* pnp_client,
     pnp_thermostat_component* ref_thermostat_component,
-    az_json_token const* property_name,
-    az_json_reader const* property_value,
+    az_json_reader* property_name_and_value,
     int32_t version,
     az_span payload,
     az_span* out_payload);

--- a/sdk/src/azure/iot/az_iot_pnp_client_twin.c
+++ b/sdk/src/azure/iot/az_iot_pnp_client_twin.c
@@ -370,14 +370,12 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_get_next_component_property(
     az_json_reader* ref_json_reader,
     az_iot_pnp_client_twin_response_type response_type,
     az_span* out_component_name,
-    az_json_token* out_property_name,
-    az_json_reader* out_property_value)
+    az_json_reader* out_property_name_and_value)
 {
   _az_PRECONDITION_NOT_NULL(client);
   _az_PRECONDITION_NOT_NULL(ref_json_reader);
   _az_PRECONDITION_NOT_NULL(out_component_name);
-  _az_PRECONDITION_NOT_NULL(out_property_name);
-  _az_PRECONDITION_NOT_NULL(out_property_value);
+  _az_PRECONDITION_NOT_NULL(out_property_name_and_value);
 
   (void)client;
 
@@ -428,11 +426,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_twin_get_next_component_property(
     }
   }
 
-  *out_property_name = ref_json_reader->token;
-
-  _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
-
-  *out_property_value = *ref_json_reader;
+  *out_property_name_and_value = *ref_json_reader;
 
   // Skip the property value array (if applicable) and move to next token
   _az_RETURN_IF_FAILED(az_json_reader_skip_children(ref_json_reader));

--- a/sdk/tests/iot/pnp/test_az_iot_pnp_client_twin.c
+++ b/sdk/tests/iot/pnp/test_az_iot_pnp_client_twin.c
@@ -776,60 +776,71 @@ static void test_az_iot_pnp_client_twin_get_next_component_property_succeed()
   az_iot_pnp_client_twin_response_type response_type
       = AZ_IOT_PNP_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES;
   az_span component_name;
-  az_json_token property_name;
-  az_json_reader property_value;
+  az_json_reader property_name_and_value;
   int32_t value;
 
   // First component
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_component_one));
-  assert_true(az_json_token_is_text_equal(&property_name, AZ_SPAN_FROM_STR("prop_one")));
-  assert_int_equal(az_json_token_get_int32(&property_value.token, &value), AZ_OK);
+  assert_true(
+      az_json_token_is_text_equal(&property_name_and_value.token, AZ_SPAN_FROM_STR("prop_one")));
+  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
   assert_int_equal(value, 1);
 
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_component_one));
-  assert_true(az_json_token_is_text_equal(&property_name, AZ_SPAN_FROM_STR("prop_two")));
-  assert_true(az_json_token_is_text_equal(&property_value.token, AZ_SPAN_FROM_STR("string")));
+  assert_true(
+      az_json_token_is_text_equal(&property_name_and_value.token, AZ_SPAN_FROM_STR("prop_two")));
+  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+  assert_true(
+      az_json_token_is_text_equal(&property_name_and_value.token, AZ_SPAN_FROM_STR("string")));
 
   // Second component
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_component_two));
-  assert_true(az_json_token_is_text_equal(&property_name, AZ_SPAN_FROM_STR("prop_three")));
-  assert_int_equal(az_json_token_get_int32(&property_value.token, &value), AZ_OK);
+  assert_true(
+      az_json_token_is_text_equal(&property_name_and_value.token, AZ_SPAN_FROM_STR("prop_three")));
+  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
   assert_int_equal(value, 45);
   // assert_int_equal(version, 5);
 
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_OK);
-  assert_true(az_json_token_is_text_equal(&property_name, AZ_SPAN_FROM_STR("prop_four")));
-  assert_true(az_json_token_is_text_equal(&property_value.token, AZ_SPAN_FROM_STR("string")));
+  assert_true(
+      az_json_token_is_text_equal(&property_name_and_value.token, AZ_SPAN_FROM_STR("prop_four")));
+  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+  assert_true(
+      az_json_token_is_text_equal(&property_name_and_value.token, AZ_SPAN_FROM_STR("string")));
 
   // Not a component
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, AZ_SPAN_EMPTY));
-  assert_true(az_json_token_is_text_equal(&property_name, AZ_SPAN_FROM_STR("not_component")));
-  assert_int_equal(az_json_token_get_int32(&property_value.token, &value), AZ_OK);
+  assert_true(az_json_token_is_text_equal(
+      &property_name_and_value.token, AZ_SPAN_FROM_STR("not_component")));
+  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
   assert_int_equal(value, 42);
 
   // End of components (skipping version)
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_ERROR_IOT_END_OF_PROPERTIES);
 }
 
@@ -849,24 +860,24 @@ static void test_az_iot_pnp_client_twin_get_next_component_property_two_succeed(
 
   az_iot_pnp_client_twin_response_type response_type = AZ_IOT_PNP_CLIENT_TWIN_RESPONSE_TYPE_GET;
   az_span component_name;
-  az_json_token property_name;
-  az_json_reader property_value;
-  // int32_t version;
+  az_json_reader property_name_and_value;
   int32_t value;
   // First component
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_one));
-  assert_true(az_json_token_is_text_equal(&property_name, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_token_get_int32(&property_value.token, &value), AZ_OK);
+  assert_true(az_json_token_is_text_equal(
+      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
   assert_int_equal(value, 47);
 
   // End of components (skipping version and reported properties section)
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_ERROR_IOT_END_OF_PROPERTIES);
 }
 
@@ -886,24 +897,24 @@ static void test_az_iot_pnp_client_twin_get_next_component_property_out_of_order
 
   az_iot_pnp_client_twin_response_type response_type = AZ_IOT_PNP_CLIENT_TWIN_RESPONSE_TYPE_GET;
   az_span component_name;
-  az_json_token property_name;
-  az_json_reader property_value;
-  // int32_t version;
+  az_json_reader property_name_and_value;
   int32_t value;
   // First component
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_one));
-  assert_true(az_json_token_is_text_equal(&property_name, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_token_get_int32(&property_value.token, &value), AZ_OK);
+  assert_true(az_json_token_is_text_equal(
+      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
   assert_int_equal(value, 47);
 
   // End of components (skipping version and reported properties section)
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_ERROR_IOT_END_OF_PROPERTIES);
 }
 
@@ -923,44 +934,48 @@ static void test_az_iot_pnp_client_twin_get_next_component_property_long_succeed
 
   az_iot_pnp_client_twin_response_type response_type = AZ_IOT_PNP_CLIENT_TWIN_RESPONSE_TYPE_GET;
   az_span component_name;
-  az_json_token property_name;
-  az_json_reader property_value;
-  // int32_t version;
+  az_json_reader property_name_and_value;
   int32_t value;
   // First component
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_two));
-  assert_true(az_json_token_is_text_equal(&property_name, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_token_get_int32(&property_value.token, &value), AZ_OK);
+  assert_true(az_json_token_is_text_equal(
+      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
   assert_int_equal(value, 50);
 
   // Second component
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_one));
-  assert_true(az_json_token_is_text_equal(&property_name, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_token_get_int32(&property_value.token, &value), AZ_OK);
+  assert_true(az_json_token_is_text_equal(
+      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
   assert_int_equal(value, 90);
 
   // Not a component
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, AZ_SPAN_EMPTY));
-  assert_true(az_json_token_is_text_equal(&property_name, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_token_get_int32(&property_value.token, &value), AZ_OK);
+  assert_true(az_json_token_is_text_equal(
+      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
   assert_int_equal(value, 54);
 
   // End of components (skipping version and reported properties section)
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_ERROR_IOT_END_OF_PROPERTIES);
 }
 
@@ -985,43 +1000,48 @@ static void test_az_iot_pnp_client_twin_get_next_component_property_long_with_ve
   assert_int_equal(version, 30);
 
   az_span component_name;
-  az_json_token property_name;
-  az_json_reader property_value;
+  az_json_reader property_name_and_value;
   int32_t value;
   // First component
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_two));
-  assert_true(az_json_token_is_text_equal(&property_name, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_token_get_int32(&property_value.token, &value), AZ_OK);
+  assert_true(az_json_token_is_text_equal(
+      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
   assert_int_equal(value, 50);
 
   // Second component
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_one));
-  assert_true(az_json_token_is_text_equal(&property_name, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_token_get_int32(&property_value.token, &value), AZ_OK);
+  assert_true(az_json_token_is_text_equal(
+      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
   assert_int_equal(value, 90);
 
   // Not a component
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, AZ_SPAN_EMPTY));
-  assert_true(az_json_token_is_text_equal(&property_name, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_token_get_int32(&property_value.token, &value), AZ_OK);
+  assert_true(az_json_token_is_text_equal(
+      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
   assert_int_equal(value, 54);
 
   // End of components (skipping version and reported properties section)
   assert_int_equal(
       az_iot_pnp_client_twin_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name, &property_value),
+          &client, &jr, response_type, &component_name, &property_name_and_value),
       AZ_ERROR_IOT_END_OF_PROPERTIES);
 }
 


### PR DESCRIPTION
Updated the `az_iot_pnp_client_twin_get_next_component_property()` API to pass back only the `az_json_reader` pointing to the property name. It saves us 60 bytes on the stack by not having another `az_json_token` and the only overhead for the user is that they have to call `az_json_reader_next_token()` to get to the value.