### PR TITLE
Consume CMocka CMake module directly from CMocka repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,22 @@ endif()
 # default for Unit testing with cmocka is OFF, however, this will be ON on CI and tests must
 # pass before committing changes
 if (UNIT_TESTING)
+  # make generate step fail if cmocka dependency is not found
+  find_package(cmocka CONFIG REQUIRED)
+
+  # When using VCPKG, cmocka lib name is set different than when it is globally installed
+  if(DEFINED ENV{VCPKG_ROOT} OR DEFINED ENV{VCPKG_INSTALLATION_ROOT})
+    set(CMOCKA_LIB ${CMOCKA_LIBRARIES})
+  else()
+    set(CMOCKA_LIB cmocka::cmocka)
+  endif()
+
+  # for gcc, we need to add no-clobbered compile opt to avoid warning about set-jump function
+  set(NO_CLOBBERED_WARNING "")
+  if (CMAKE_C_COMPILER_ID MATCHES "GNU")
+    set(NO_CLOBBERED_WARNING "-Wno-clobbered")
+  endif()
+  
   # Core
   add_subdirectory(sdk/tests/core)
 

--- a/cmake-modules/AddCMockaTest.cmake
+++ b/cmake-modules/AddCMockaTest.cmake
@@ -4,15 +4,17 @@
 # Copyright (c) 2018      Anderson Toshiyuki Sasaki <ansasaki@redhat.com>
 #
 # Redistribution and use is allowed according to the terms of the BSD license.
-#
-# Modifed version from https://github.com/xbmc/libssh/blob/667fb5f9a9c96f210583dbfb11755c43250c5e55/cmake/Modules/AddCMockaTest.cmake
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
 #.rst:
-# AddTestCMocka
+# AddCMockaTest
 # -------------
 #
 # This file provides a function to add a test
 #
 # Functions provided
+# Modified version from https://gitlab.com/cmocka/cmocka/-/blob/master/cmake/Modules/AddCMockaTest.cmake
+# (Adding `target_include_directories` support to the tests to add headers source)
 # ------------------
 #
 # ::
@@ -20,9 +22,9 @@
 #   add_cmocka_test(target_name
 #                   SOURCES src1 src2 ... srcN
 #                   [COMPILE_OPTIONS opt1 opt2 ... optN]
+#                   [LINK_LIBRARIES lib1 lib2 ... libN]
 #                   [LINK_OPTIONS lopt1 lop2 .. loptN]
-#                   [PRIVATE_ACCESS ON/OFF]
-#                   [LINK_TARGETS target1 target2 .. targetN]
+#                   [INCLUDE_DIRECTORIES dir1 dir2 .. dirN]
 #                  )
 #
 # ``target_name``:
@@ -34,15 +36,15 @@
 # ``COMPILE_OPTIONS``:
 #   Optional, expects one or more options to be passed to the compiler
 #
+# ``LINK_LIBRARIES``:
+#   Optional, expects one or more libraries to be linked with the test
+#   executable.
+#
 # ``LINK_OPTIONS``:
 #   Optional, expects one or more options to be passed to the linker
 #
-# ``PRIVATE_ACCESS``:
-#   Optional, when ON, tests are granted access to az_core private layer
-#
-# ``LINK_TARGETS``:
-#   Optional, expects one or more targets from the same project to be passed to cmake target linker
-#
+# ``INCLUDE_DIRECTORIES``:
+#   Optional, expects one or more directories to be included as include directories for tests
 #
 # Example:
 #
@@ -51,26 +53,27 @@
 #   add_cmocka_test(my_test
 #                   SOURCES my_test.c other_source.c
 #                   COMPILE_OPTIONS -g -Wall
+#                   LINK_LIBRARIES mylib
 #                   LINK_OPTIONS -Wl,--enable-syscall-fixup
-#                   PRIVATE_ACCESS ON
-#                   LINK_TARGETS target1, target2
+#                   INCLUDE_DIRECTORIES some/path/with/headers_files
 #                  )
 #
 # Where ``my_test`` is the name of the test, ``my_test.c`` and
 # ``other_source.c`` are sources for the binary, ``-g -Wall`` are compiler
-# options to be used, ``-Wl,--enable-syscall-fixup`` is an option passed to the linker,
-# ``PRIVATE_ACCESS`` is ON to let tests access private layer from az_core and ``LINK_TAGETS```
-# list all the cmake tagets to link to
+# options to be used, ``mylib`` is a target of a library to be linked,
+# ``-Wl,--enable-syscall-fixup`` is an option passed to the linker, and
+# ``some/path/with/headers_files`` is a file path with header files.
 #
-
-find_package(cmocka CONFIG REQUIRED)
 
 enable_testing()
 include(CTest)
 
-set(MATH_LIB_UNIX "")
-if (UNIX)
-    set(MATH_LIB_UNIX "m")
+if (CMAKE_CROSSCOMPILING)
+    if (WIN32)
+        find_program(WINE_EXECUTABLE
+                     NAMES wine)
+        set(TARGET_SYSTEM_EMULATOR ${WINE_EXECUTABLE} CACHE INTERNAL "")
+    endif()
 endif()
 
 function(ADD_CMOCKA_TEST _TARGET_NAME)
@@ -81,9 +84,9 @@ function(ADD_CMOCKA_TEST _TARGET_NAME)
     set(multi_value_arguments
         SOURCES
         COMPILE_OPTIONS
+        LINK_LIBRARIES
         LINK_OPTIONS
-        PRIVATE_ACCESS
-        LINK_TARGETS
+        INCLUDE_DIRECTORIES
     )
 
     cmake_parse_arguments(_add_cmocka_test
@@ -99,32 +102,15 @@ function(ADD_CMOCKA_TEST _TARGET_NAME)
 
     add_executable(${_TARGET_NAME} ${_add_cmocka_test_SOURCES})
 
-    # Suppress clobber warning for longjmp
-    if(CMAKE_C_COMPILER_ID MATCHES "GNU")
-      target_compile_options(${_TARGET_NAME} PRIVATE -Wno-clobbered)
-    endif()
-
     if (DEFINED _add_cmocka_test_COMPILE_OPTIONS)
         target_compile_options(${_TARGET_NAME}
             PRIVATE ${_add_cmocka_test_COMPILE_OPTIONS}
         )
     endif()
 
-    if(DEFINED ENV{VCPKG_ROOT} OR DEFINED ENV{VCPKG_INSTALLATION_ROOT})
-        set(CMOCKA_LIB ${CMOCKA_LIBRARIES})
-    else()
-        set(CMOCKA_LIB cmocka)
-    endif()
-
-    if (DEFINED _add_cmocka_test_LINK_TARGETS)
-        # link to user defined
+    if (DEFINED _add_cmocka_test_LINK_LIBRARIES)
         target_link_libraries(${_TARGET_NAME}
-            PRIVATE ${CMOCKA_LIB} ${_add_cmocka_test_LINK_TARGETS} ${MATH_LIB_UNIX}
-        )
-    else()
-        # link against az_core by default
-        target_link_libraries(${_TARGET_NAME}
-            PRIVATE ${CMOCKA_LIB} az_core ${MATH_LIB_UNIX}
+            PRIVATE ${_add_cmocka_test_LINK_LIBRARIES}
         )
     endif()
 
@@ -135,14 +121,38 @@ function(ADD_CMOCKA_TEST _TARGET_NAME)
         )
     endif()
 
-    target_include_directories(${_TARGET_NAME} PRIVATE ${CMOCKA_INCLUDE_DIR})
-
-    if (DEFINED _add_cmocka_test_PRIVATE_ACCESS)
-        target_include_directories(${_TARGET_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/sdk/src/azure/core/)
+    # include header files from cmocka and any path from the function parameters
+    if (DEFINED _add_cmocka_test_INCLUDE_DIRECTORIES)
+        target_include_directories(${_TARGET_NAME}
+            PRIVATE ${_add_cmocka_test_INCLUDE_DIRECTORIES})
     endif()
+    
 
     add_test(${_TARGET_NAME}
         ${TARGET_SYSTEM_EMULATOR} ${_TARGET_NAME}
     )
 
 endfunction (ADD_CMOCKA_TEST)
+
+function(ADD_CMOCKA_TEST_ENVIRONMENT _TARGET_NAME)
+    if (WIN32 OR CYGWIN OR MINGW OR MSVC)
+        file(TO_NATIVE_PATH "${cmocka-library_BINARY_DIR}" CMOCKA_DLL_PATH)
+
+        if (TARGET_SYSTEM_EMULATOR)
+            set(DLL_PATH_ENV "WINEPATH=${CMOCKA_DLL_PATH};$ENV{WINEPATH}")
+        else()
+            set(DLL_PATH_ENV "PATH=${CMOCKA_DLL_PATH};$ENV{PATH}")
+        endif()
+        #
+        # IMPORTANT NOTE: The set_tests_properties(), below, internally
+        # stores its name/value pairs with a semicolon delimiter.
+        # because of this we must protect the semicolons in the path
+        #
+        string(REPLACE ";" "\\;" DLL_PATH_ENV "${DLL_PATH_ENV}")
+
+        set_tests_properties(${_TARGET_NAME}
+                             PROPERTIES
+                                ENVIRONMENT
+                                    "${DLL_PATH_ENV}")
+    endif()
+endfunction()

--- a/sdk/tests/core/CMakeLists.txt
+++ b/sdk/tests/core/CMakeLists.txt
@@ -7,7 +7,7 @@ project (az_core_test LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 
-include(AddTestCMocka)
+include(AddCMockaTest)
 
 # -ld link option is only available for gcc
 if(UNIT_TESTING_MOCKS)
@@ -17,6 +17,11 @@ else()
 endif()
 
 create_map_file(az_core_test.map)
+
+set(MATH_LIB_UNIX "")
+if (UNIX)
+    set(MATH_LIB_UNIX "m")
+endif()
 
 add_cmocka_test(az_core_test SOURCES
                 main.c
@@ -28,8 +33,11 @@ add_cmocka_test(az_core_test SOURCES
                 test_az_policy.c
                 test_az_span.c
                 test_az_url_encode.c
-                COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS}
-                LINK_OPTIONS ${WRAP_FUNCTIONS}
-                # grant access to Private functions to test az_json_private
-                PRIVATE_ACCESS ON
-                LINK_TARGETS az_core ${PAL} az_nohttp)
+                COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS} ${NO_CLOBBERED_WARNING}
+                LINK_LIBRARIES ${CMOCKA_LIBRARIES} ${MATH_LIB_UNIX} az_core ${PAL} az_nohttp
+                LINK_OPTIONS ${WRAP_FUNCTIONS}  
+                # include cmoka headers and private folder headers
+                INCLUDE_DIRECTORIES ${CMOCKA_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/sdk/src/azure/core/
+                )
+
+add_cmocka_test_environment(az_core_test)

--- a/sdk/tests/iot/common/CMakeLists.txt
+++ b/sdk/tests/iot/common/CMakeLists.txt
@@ -7,15 +7,18 @@ project (az_iot_common_test LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 
-include(AddTestCMocka)
+include(AddCMockaTest)
 
 create_map_file(az_iot_common_test.map)
 
 add_cmocka_test(az_iot_common_test SOURCES
                 main.c
                 test_az_iot_common.c
-                COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS}
-                LINK_TARGETS
+                COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS} ${NO_CLOBBERED_WARNING}
+                LINK_LIBRARIES ${CMOCKA_LIBRARIES}
                     az_iot_common
                     az_core
+                INCLUDE_DIRECTORIES ${CMOCKA_INCLUDE_DIR}
                 )
+
+add_cmocka_test_environment(az_iot_common_test)

--- a/sdk/tests/iot/hub/CMakeLists.txt
+++ b/sdk/tests/iot/hub/CMakeLists.txt
@@ -7,7 +7,7 @@ project (az_iot_hub_test LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 
-include(AddTestCMocka)
+include(AddCMockaTest)
 
 create_map_file(az_iot_hub_test.map)
 
@@ -19,9 +19,12 @@ add_cmocka_test(az_iot_hub_test SOURCES
                 test_az_iot_hub_client.c
                 test_az_iot_hub_client_twin.c
                 test_az_iot_hub_client_methods.c
-                COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS}
-                LINK_TARGETS
+                COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS} ${NO_CLOBBERED_WARNING}
+                LINK_LIBRARIES ${CMOCKA_LIBRARIES}
                     az_iot_common
                     az_iot_hub
                     az_core
+                INCLUDE_DIRECTORIES ${CMOCKA_INCLUDE_DIR}
                 )
+
+add_cmocka_test_environment(az_iot_hub_test)

--- a/sdk/tests/iot/provisioning/CMakeLists.txt
+++ b/sdk/tests/iot/provisioning/CMakeLists.txt
@@ -7,7 +7,7 @@ project (az_iot_provisioning_test LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 
-include(AddTestCMocka)
+include(AddCMockaTest)
 
 create_map_file(az_iot_provisioning_test.map)
 
@@ -16,9 +16,12 @@ add_cmocka_test(az_iot_provisioning_test SOURCES
                 test_az_iot_provisioning_client.c
                 test_az_iot_provisioning_client_sas.c
                 test_az_iot_provisioning_client_parser.c
-                COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS}
-                LINK_TARGETS
+                COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS} ${NO_CLOBBERED_WARNING}
+                LINK_LIBRARIES ${CMOCKA_LIBRARIES}
                     az_iot_common
                     az_iot_provisioning
                     az_core
+                INCLUDE_DIRECTORIES ${CMOCKA_INCLUDE_DIR}
                 )
+
+add_cmocka_test_environment(az_iot_provisioning_test)


### PR DESCRIPTION
Removing the CMake module used to create cmocka tests. It was taken from some 3rd party instead of taking it directly from CMoka modules (https://gitlab.com/cmocka/cmocka/-/blob/master/cmake/Modules/AddCMockaTest.cmake)