### PR TITLE
Use windows-static-md triplet universally on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,9 +305,9 @@ cd vcpkg
 # build vcpkg (remove .bat on Linux/Mac)
 .\bootstrap-vcpkg.bat
 # install dependencies (remove .exe in Linux/Mac) and update triplet
-.\vcpkg.exe install --triplet x64-windows-static curl[winssl] cmocka paho-mqtt
+.\vcpkg.exe install --triplet x64-windows-static-md curl[winssl] cmocka paho-mqtt
 # Add this environment variables to link this VCPKG folder with cmake:
-# VCPKG_DEFAULT_TRIPLET=x64-windows-static
+# VCPKG_DEFAULT_TRIPLET=x64-windows-static-md
 # VCPKG_ROOT=PATH_TO_VCPKG (replace PATH_TO_VCPKG for where vcpkg is installed)
 ```
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -14,14 +14,14 @@ jobs:
         Win_x86_with_samples:
           OSVmImage: 'windows-2019'
           vcpkg.deps: 'curl[winssl]'
-          VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
+          VCPKG_DEFAULT_TRIPLET: 'x86-windows-static-md'
           CMAKE_GENERATOR: 'Visual Studio 16 2019'
           CMAKE_GENERATOR_PLATFORM: Win32
           build.args: ' -DTRANSPORT_CURL=ON -DAZ_PLATFORM_IMPL=WIN32'
         Win_x64_with_samples:
           OSVmImage: 'windows-2019'
           vcpkg.deps: 'curl[winssl]'
-          VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
+          VCPKG_DEFAULT_TRIPLET: 'x64-windows-static-md'
           CMAKE_GENERATOR: 'Visual Studio 16 2019'
           CMAKE_GENERATOR_PLATFORM: x64
           build.args: ' -DTRANSPORT_CURL=ON -DAZ_PLATFORM_IMPL=WIN32'

--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -98,7 +98,7 @@ To run the samples, ensure you have the following programs and tools installed o
     git clone https://github.com/Microsoft/vcpkg.git
     cd vcpkg
     .\bootstrap-vcpkg.bat
-    .\vcpkg.exe install --triplet x64-windows-static curl[winssl] cmocka paho-mqtt # Update triplet per your system.
+    .\vcpkg.exe install --triplet x64-windows-static-md curl[winssl] cmocka paho-mqtt # Update triplet per your system.
     ```
 
     </p>
@@ -123,7 +123,7 @@ To run the samples, ensure you have the following programs and tools installed o
 
       ```powershell
       # NOT RECOMMENDED to use for production-level code.
-      $env:PATH=$env:PATH + ';<FULL PATH to vcpkg>\installed\x64-windows-static\tools\openssl' # Update complete path as needed.
+      $env:PATH=$env:PATH + ';<FULL PATH to vcpkg>\installed\x64-windows-static-md\tools\openssl' # Update complete path as needed.
       ```
 
     </p>
@@ -522,7 +522,7 @@ Set the following environment variables for all samples:
       Windows (PowerShell):
 
       ```powershell
-      $env:VCPKG_DEFAULT_TRIPLET='x64-windows-static' # Update triplet to match what was used during vcpkg install.
+      $env:VCPKG_DEFAULT_TRIPLET='x64-windows-static-md' # Update triplet to match what was used during vcpkg install.
       $env:VCPKG_ROOT='<FULL PATH to vcpkg>'
       ```
 

--- a/sdk/samples/iot/docs/how_to_iot_hub_samples_windows.md
+++ b/sdk/samples/iot/docs/how_to_iot_hub_samples_windows.md
@@ -52,14 +52,14 @@ To run the samples, ensure you have the following programs and tools installed o
     PS C:\> git clone https://github.com/Microsoft/vcpkg.git
     PS C:\> cd vcpkg
     PS C:\vcpkg> .\bootstrap-vcpkg.bat
-    PS C:\vcpkg> .\vcpkg.exe install --triplet x64-windows-static curl[winssl] cmocka paho-mqtt # Update triplet per your system.
+    PS C:\vcpkg> .\vcpkg.exe install --triplet x64-windows-static-md curl[winssl] cmocka paho-mqtt # Update triplet per your system.
     PS C:\vcpkg> cd ..
     ```
 
 2. Set the vcpkg environment variables.
 
     ```powershell
-    PS C:\> $env:VCPKG_DEFAULT_TRIPLET='x64-windows-static'
+    PS C:\> $env:VCPKG_DEFAULT_TRIPLET='x64-windows-static-md'
     PS C:\> $env:VCPKG_ROOT='C:\vcpkg'
     ```
 
@@ -71,7 +71,7 @@ To run the samples, ensure you have the following programs and tools installed o
 
     ```powershell
     # NOT RECOMMENDED to use for production-level code.
-    PS C:\> $env:PATH=$env:PATH + ';C:\vcpkg\installed\x64-windows-static\tools\openssl' # Update complete path as needed.
+    PS C:\> $env:PATH=$env:PATH + ';C:\vcpkg\installed\x64-windows-static-md\tools\openssl' # Update complete path as needed.
     ```
 
 4. Clone the Azure SDK for Embedded C IoT repository.


### PR DESCRIPTION
Finishing what https://github.com/Azure/azure-sdk-for-c/pull/1338 did. Alternative to https://github.com/Azure/azure-sdk-for-c/pull/1380.

Update docs (and live tests) to use windows-static-md triplet, so we use it everywhere on Windows.