### PR TITLE
Fix Windows to use /MT when building static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,13 @@ if(DEFINED ENV{VCPKG_DEFAULT_TRIPLET} AND NOT DEFINED VCPKG_TARGET_TRIPLET)
   set(VCPKG_TARGET_TRIPLET "$ENV{VCPKG_DEFAULT_TRIPLET}" CACHE STRING "")
 endif()
 
+# Use the static runtime libraries when building statically for consistency with vcpkg's
+# arch-windows-static triplets:
+cmake_policy(SET CMP0091 NEW) # https://cmake.org/cmake/help/v3.15/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html
+if (NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+
 project(az LANGUAGES C)
 enable_testing ()
 
@@ -104,7 +111,7 @@ if (UNIT_TESTING)
   if (CMAKE_C_COMPILER_ID MATCHES "GNU")
     set(NO_CLOBBERED_WARNING "-Wno-clobbered")
   endif()
-  
+
   # Core
   add_subdirectory(sdk/tests/core)
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -81,7 +81,7 @@ jobs:
       WindowsX86_Release_MapFiles_UnitTests:
         OSVmImage: 'windows-2019'
         vcpkg.deps: 'cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static-md'
+        VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: Win32
@@ -169,7 +169,7 @@ jobs:
       Windows_Preconditions_UnitTests_Samples:
         OSVmImage: 'windows-2019'
         vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static-md'
+        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON -DLOGGING=OFF'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64
@@ -215,7 +215,7 @@ jobs:
       Windows_Release_MapFiles:
         OSVmImage: 'windows-2019'
         vcpkg.deps: ''
-        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static-md'
+        VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DLOGGING=OFF'
         CMAKE_GENERATOR: 'Visual Studio 16 2019'
         CMAKE_GENERATOR_PLATFORM: x64


### PR DESCRIPTION
Follow up on https://github.com/Azure/azure-sdk-for-c/pull/1338