### PR TITLE
Fix bounds check while processing JSON string to avoid out-of-range access.

### DIFF
--- a/sdk/src/azure/core/az_json_reader.c
+++ b/sdk/src/azure/core/az_json_reader.c
@@ -294,7 +294,7 @@ AZ_NODISCARD static az_result _az_json_reader_process_string(az_json_reader* ref
         // Expecting 4 hex digits to follow the escaped 'u'
         for (int32_t i = 0; i < 4; i++)
         {
-          if (current_index > remaining_size)
+          if (current_index >= remaining_size)
           {
             _az_RETURN_IF_FAILED(_az_json_reader_get_next_buffer(ref_json_reader, &token, false));
             current_index = 0;

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -1531,6 +1531,18 @@ static void test_json_reader_invalid(void** state)
       AZ_SPAN_FROM_STR("{\r\n\"isActive\":false \"\r\n}"), AZ_ERROR_UNEXPECTED_CHAR);
 }
 
+static void temp_fuzz_test(az_span json, az_result expected_result)
+{
+  az_json_reader reader = { 0 };
+  TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, json, NULL));
+  az_result result = AZ_OK;
+  while (result == AZ_OK)
+  {
+    result = az_json_reader_next_token(&reader);
+  }
+  assert_int_equal(result, expected_result);
+}
+
 // Using a macro instead of a helper function to retain line number
 // in call stack to help debug which line/test case failed.
 #define TEST_JSON_READER_INVALID_HELPER(json, expected_result)     \
@@ -1563,6 +1575,29 @@ static void test_json_reader_incomplete(void** state)
   TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("f"), AZ_ERROR_UNEXPECTED_END);
   TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("fals"), AZ_ERROR_UNEXPECTED_END);
   TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("\"name"), AZ_ERROR_UNEXPECTED_END);
+  TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("\"name\\"), AZ_ERROR_UNEXPECTED_END);
+  TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("\"name\\u"), AZ_ERROR_UNEXPECTED_END);
+  TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("\"name\\u1"), AZ_ERROR_UNEXPECTED_END);
+  TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("\"name\\u12"), AZ_ERROR_UNEXPECTED_END);
+  TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("\"name\\u123"), AZ_ERROR_UNEXPECTED_END);
+  TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("\"name\\u1234"), AZ_ERROR_UNEXPECTED_END);
+  temp_fuzz_test(
+      AZ_SPAN_FROM_STR(
+          "{\"id\":1,\"vallist_value\":[],\"zb�je\":1.34,\"descrip\":1,\"val�e\":1.34,"
+          "\"besczivaluF�p\":34,\"des\":1.34,\"desjje\":1.34,\"descrip\":1,\"val�e\":1.34,"
+          "\"besczivaluF�p\":34,\"des\":1.34,\"descrip\":1,\"value\":1.34,\"bescrivaluF�mple "
+          "jid\":1,\"v\":1.34,\"dzb�je\":1.34,\"descrip\":1,\"val�e\":1.34,\"besczivaluF�p\":34,"
+          "\"des\":1.34,\"desjje\":1.34,\"descrip\":1,\"val�e\":1.34,\"besczivaluF�p\":34,\"des\":"
+          "1.34,\"descrip\":1,\"value\":1.34,\"bescrivaluF�mple "
+          "jid\":1,\"v\":1.34,\"descrivalue�mple "
+          "alue\":1.34,\"descrivalue\":1.34,\"descrip\":1,\"val�e\":1.34,\"besczivp\":1,\"value\":"
+          "1.34,\"bescrivaluF�mple jid\":1,\"v\":1.34,\"descrivalue�mple "
+          "alue\":1.34,\"descrivalue\":1.34,\"descri\":34,\"des\":1.34,\"desjje\":1.34,\"descrip\":"
+          "1,\"val�e\":1.34,\"besczivaluF�p\":34,\"des\":1.34,\"descrip\":1,\"value\":1.34,"
+          "\"bescrivaluF�mple jid\":1,\"v\":1.34,\"descrivalue�mple "
+          "alue\":1.34,\"descrivalue\":1.34,\"descrip\":1,\"val�e\":1.34,\"besczivp\":1,\"value\":"
+          "1.34,\"bescrivaluF�mple jid\":1,\"v\":1.34,\"descriva\\u"),
+      AZ_ERROR_UNEXPECTED_END);
   TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("-"), AZ_ERROR_UNEXPECTED_END);
   TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("-123."), AZ_ERROR_UNEXPECTED_END);
   TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("-123.1e"), AZ_ERROR_UNEXPECTED_END);

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -1531,18 +1531,6 @@ static void test_json_reader_invalid(void** state)
       AZ_SPAN_FROM_STR("{\r\n\"isActive\":false \"\r\n}"), AZ_ERROR_UNEXPECTED_CHAR);
 }
 
-static void temp_fuzz_test(az_span json, az_result expected_result)
-{
-  az_json_reader reader = { 0 };
-  TEST_EXPECT_SUCCESS(az_json_reader_init(&reader, json, NULL));
-  az_result result = AZ_OK;
-  while (result == AZ_OK)
-  {
-    result = az_json_reader_next_token(&reader);
-  }
-  assert_int_equal(result, expected_result);
-}
-
 // Using a macro instead of a helper function to retain line number
 // in call stack to help debug which line/test case failed.
 #define TEST_JSON_READER_INVALID_HELPER(json, expected_result)     \
@@ -1581,23 +1569,6 @@ static void test_json_reader_incomplete(void** state)
   TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("\"name\\u12"), AZ_ERROR_UNEXPECTED_END);
   TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("\"name\\u123"), AZ_ERROR_UNEXPECTED_END);
   TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("\"name\\u1234"), AZ_ERROR_UNEXPECTED_END);
-  temp_fuzz_test(
-      AZ_SPAN_FROM_STR(
-          "{\"id\":1,\"vallist_value\":[],\"zb�je\":1.34,\"descrip\":1,\"val�e\":1.34,"
-          "\"besczivaluF�p\":34,\"des\":1.34,\"desjje\":1.34,\"descrip\":1,\"val�e\":1.34,"
-          "\"besczivaluF�p\":34,\"des\":1.34,\"descrip\":1,\"value\":1.34,\"bescrivaluF�mple "
-          "jid\":1,\"v\":1.34,\"dzb�je\":1.34,\"descrip\":1,\"val�e\":1.34,\"besczivaluF�p\":34,"
-          "\"des\":1.34,\"desjje\":1.34,\"descrip\":1,\"val�e\":1.34,\"besczivaluF�p\":34,\"des\":"
-          "1.34,\"descrip\":1,\"value\":1.34,\"bescrivaluF�mple "
-          "jid\":1,\"v\":1.34,\"descrivalue�mple "
-          "alue\":1.34,\"descrivalue\":1.34,\"descrip\":1,\"val�e\":1.34,\"besczivp\":1,\"value\":"
-          "1.34,\"bescrivaluF�mple jid\":1,\"v\":1.34,\"descrivalue�mple "
-          "alue\":1.34,\"descrivalue\":1.34,\"descri\":34,\"des\":1.34,\"desjje\":1.34,\"descrip\":"
-          "1,\"val�e\":1.34,\"besczivaluF�p\":34,\"des\":1.34,\"descrip\":1,\"value\":1.34,"
-          "\"bescrivaluF�mple jid\":1,\"v\":1.34,\"descrivalue�mple "
-          "alue\":1.34,\"descrivalue\":1.34,\"descrip\":1,\"val�e\":1.34,\"besczivp\":1,\"value\":"
-          "1.34,\"bescrivaluF�mple jid\":1,\"v\":1.34,\"descriva\\u"),
-      AZ_ERROR_UNEXPECTED_END);
   TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("-"), AZ_ERROR_UNEXPECTED_END);
   TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("-123."), AZ_ERROR_UNEXPECTED_END);
   TEST_JSON_READER_INVALID_HELPER(AZ_SPAN_FROM_STR("-123.1e"), AZ_ERROR_UNEXPECTED_END);


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/1352