### PR TITLE
Update the changelog for the 1.1.0 beta 1 release and add date.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.0-beta.1 (2020-10-05)
+## 1.1.0-beta.1 (2020-10-06)
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
+## 1.1.0-beta.1 (2020-10-05)
 
 ### New Features
 
 - Added an `az_log_classification_filter_fn` callback function type along with a setter `az_log_set_classification_filter_callback()`, allowing the caller to filter log messages.
+
+### Bug Fixes
+
+- Fix bounds check while processing incomplete JSON string containing \uXXXX characters to avoid out-of-range access.
+- Fix Windows to use /MT when building the CRT and static libraries.
+- Fail gracefully on invalid/incomplete HTTP response processing by avoiding reading from size 0 span.
 
 ## 1.0.0 (2020-09-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@
 
 ### Bug Fixes
 
-- Fix bounds check while processing incomplete JSON string containing \uXXXX characters to avoid out-of-range access.
+- Fix bounds check while processing incomplete JSON string containing escaped characters to avoid out-of-range access.
 - Fix Windows to use /MT when building the CRT and static libraries.
 - Fail gracefully on invalid/incomplete HTTP response processing by avoiding reading from size 0 span.
+
+### Other Changes and Improvements
+
+- Add precondition check to validate clients are initialized before passed in to public APIs.
+- Add high-level and simplified az_core.h and az_iot.h files for simpler include experience for customers.
 
 ## 1.0.0 (2020-09-21)
 


### PR DESCRIPTION
I am going through all the commits from the 1.0.0 GA release to the latest commit and captured any major customer facing changes:
https://github.com/Azure/azure-sdk-for-c/compare/5e9d7b96dbd98ce7125e4beed385959a32b4c6c1...9610c0e22990a5cc3fbe126ab2ee071d7db1426c

Please review and let me know if I missed something or if you'd like to re-word an item.