### PR TITLE
Update Plug and Play find version API

### DIFF
--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -664,9 +664,9 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_builder_end_reported_status(
  * az_iot_pnp_client_property_get_next_component_property().
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
- * @param[in] ref_json_reader The #az_json_reader used to parse through the JSON payload. An
+ * @param[in] ref_json_reader The #az_json_reader* used to parse through the JSON payload. An
  * internal copy is made to maintain the index of \p ref_json_reader.
- * @param[in] response_type The #az_iot_pnp_client_property_response_type* representing the message
+ * @param[in] response_type The #az_iot_pnp_client_property_response_type representing the message
  * type associated with the payload.
  * @param[out] out_version The numeric version of the properties in the JSON payload.
  *

--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -664,14 +664,14 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_builder_end_reported_status(
  * az_iot_pnp_client_property_get_next_component_property().
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.
- * @param[in] json_reader The #az_json_reader used to parse through the JSON payload. An internal
- * copy is made to maintain the index of \p json_reader.
+ * @param[in] ref_json_reader The #az_json_reader used to parse through the JSON payload. An
+ * internal copy is made to maintain the index of \p ref_json_reader.
  * @param[in] response_type The #az_iot_pnp_client_property_response_type* representing the message
  * type associated with the payload.
  * @param[out] out_version The numeric version of the properties in the JSON payload.
  *
  * @pre \p client must not be `NULL`.
- * @pre \p json_reader must not be `NULL`.
+ * @pre \p ref_json_reader must not be `NULL`.
  * @pre \p out_version must not be `NULL`.
  *
  * @return An #az_result value indicating the result of the operation.
@@ -679,7 +679,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_builder_end_reported_status(
  */
 AZ_NODISCARD az_result az_iot_pnp_client_property_get_property_version(
     az_iot_pnp_client const* client,
-    az_json_reader* json_reader,
+    az_json_reader* ref_json_reader,
     az_iot_pnp_client_property_response_type response_type,
     int32_t* out_version);
 

--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -658,6 +658,11 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_builder_end_reported_status(
 /**
  * @brief Read the IoT Plug and Play property version.
  *
+ * @warning This modifies the state of the json reader. To then use the same json reader
+ * with az_iot_pnp_client_property_get_next_component_property(), you must call
+ * az_json_reader_init() after this call and before the call to
+ * az_iot_pnp_client_property_get_next_component_property().
+ *
  * @param[in] client The #az_iot_pnp_client to use for this call.
  * @param[in] json_reader The #az_json_reader used to parse through the JSON payload. An internal
  * copy is made to maintain the index of \p json_reader.

--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -660,7 +660,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_builder_end_reported_status(
  *
  * @warning This modifies the state of the json reader. To then use the same json reader
  * with az_iot_pnp_client_property_get_next_component_property(), you must call
- * az_json_reader_init() after this call and before the call to
+ * az_json_reader_init() again after this call and before the call to
  * az_iot_pnp_client_property_get_next_component_property().
  *
  * @param[in] client The #az_iot_pnp_client to use for this call.

--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -661,7 +661,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_builder_end_reported_status(
  * @param[in] client The #az_iot_pnp_client to use for this call.
  * @param[in] json_reader The #az_json_reader used to parse through the JSON payload. An internal
  * copy is made to maintain the index of \p json_reader.
- * @param[in] response_type The #az_iot_pnp_client_property_response_type representing the message
+ * @param[in] response_type The #az_iot_pnp_client_property_response_type* representing the message
  * type associated with the payload.
  * @param[out] out_version The numeric version of the properties in the JSON payload.
  *
@@ -674,7 +674,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_builder_end_reported_status(
  */
 AZ_NODISCARD az_result az_iot_pnp_client_property_get_property_version(
     az_iot_pnp_client const* client,
-    az_json_reader json_reader,
+    az_json_reader* json_reader,
     az_iot_pnp_client_property_response_type response_type,
     int32_t* out_version);
 

--- a/sdk/samples/iot/paho_iot_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_component_sample.c
@@ -708,7 +708,10 @@ static void process_property_message(
   rc = az_json_reader_init(&jr, property_message_span, NULL);
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc, "Could not initialize the json reader");
 
-  rc = az_iot_pnp_client_property_get_property_version(&pnp_client, jr, response_type, &version);
+  rc = az_iot_pnp_client_property_get_property_version(&pnp_client, &jr, response_type, &version);
+  IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc, "Could not initialize the json reader");
+
+  rc = az_json_reader_init(&jr, property_message_span, NULL);
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc, "Could not initialize the json reader");
 
   while (az_result_succeeded(

--- a/sdk/samples/iot/paho_iot_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_component_sample.c
@@ -709,7 +709,7 @@ static void process_property_message(
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc, "Could not initialize the json reader");
 
   rc = az_iot_pnp_client_property_get_property_version(&pnp_client, &jr, response_type, &version);
-  IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc, "Could not initialize the json reader");
+  IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc, "Could not get the property version");
 
   rc = az_json_reader_init(&jr, property_message_span, NULL);
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc, "Could not initialize the json reader");

--- a/sdk/samples/iot/paho_iot_pnp_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_sample.c
@@ -533,8 +533,11 @@ static void process_device_property_message(
 
   int32_t version_number;
   rc = az_iot_pnp_client_property_get_property_version(
-      &pnp_client, jr, response_type, &version_number);
+      &pnp_client, &jr, response_type, &version_number);
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc, "Could not get property version");
+
+  rc = az_json_reader_init(&jr, message_span, NULL);
+  IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc, "Could not initialize json reader");
 
   double desired_temperature;
   az_span component_name;

--- a/sdk/src/azure/iot/az_iot_pnp_client_property.c
+++ b/sdk/src/azure/iot/az_iot_pnp_client_property.c
@@ -203,7 +203,7 @@ static bool is_component_in_model(
 
 AZ_NODISCARD az_result az_iot_pnp_client_property_get_property_version(
     az_iot_pnp_client const* client,
-    az_json_reader* json_reader,
+    az_json_reader* ref_json_reader,
     az_iot_pnp_client_property_response_type response_type,
     int32_t* out_version)
 {
@@ -211,23 +211,23 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_get_property_version(
 
   (void)client;
 
-  _az_RETURN_IF_FAILED(az_json_reader_next_token(json_reader));
+  _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
 
-  if (json_reader->token.kind != AZ_JSON_TOKEN_BEGIN_OBJECT)
+  if (ref_json_reader->token.kind != AZ_JSON_TOKEN_BEGIN_OBJECT)
   {
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
 
-  _az_RETURN_IF_FAILED(az_json_reader_next_token(json_reader));
+  _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
 
   if (response_type == AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_GET)
   {
-    _az_RETURN_IF_FAILED(json_child_token_move(json_reader, iot_hub_property_desired));
-    _az_RETURN_IF_FAILED(az_json_reader_next_token(json_reader));
+    _az_RETURN_IF_FAILED(json_child_token_move(ref_json_reader, iot_hub_property_desired));
+    _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
   }
 
-  _az_RETURN_IF_FAILED(json_child_token_move(json_reader, iot_hub_property_desired_version));
-  _az_RETURN_IF_FAILED(az_json_token_get_int32(&json_reader->token, out_version));
+  _az_RETURN_IF_FAILED(json_child_token_move(ref_json_reader, iot_hub_property_desired_version));
+  _az_RETURN_IF_FAILED(az_json_token_get_int32(&ref_json_reader->token, out_version));
 
   return AZ_OK;
 }

--- a/sdk/src/azure/iot/az_iot_pnp_client_property.c
+++ b/sdk/src/azure/iot/az_iot_pnp_client_property.c
@@ -203,7 +203,7 @@ static bool is_component_in_model(
 
 AZ_NODISCARD az_result az_iot_pnp_client_property_get_property_version(
     az_iot_pnp_client const* client,
-    az_json_reader json_reader,
+    az_json_reader* json_reader,
     az_iot_pnp_client_property_response_type response_type,
     int32_t* out_version)
 {
@@ -211,23 +211,23 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_get_property_version(
 
   (void)client;
 
-  _az_RETURN_IF_FAILED(az_json_reader_next_token(&json_reader));
+  _az_RETURN_IF_FAILED(az_json_reader_next_token(json_reader));
 
-  if (json_reader.token.kind != AZ_JSON_TOKEN_BEGIN_OBJECT)
+  if (json_reader->token.kind != AZ_JSON_TOKEN_BEGIN_OBJECT)
   {
     return AZ_ERROR_UNEXPECTED_CHAR;
   }
 
-  _az_RETURN_IF_FAILED(az_json_reader_next_token(&json_reader));
+  _az_RETURN_IF_FAILED(az_json_reader_next_token(json_reader));
 
   if (response_type == AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_GET)
   {
-    _az_RETURN_IF_FAILED(json_child_token_move(&json_reader, iot_hub_property_desired));
-    _az_RETURN_IF_FAILED(az_json_reader_next_token(&json_reader));
+    _az_RETURN_IF_FAILED(json_child_token_move(json_reader, iot_hub_property_desired));
+    _az_RETURN_IF_FAILED(az_json_reader_next_token(json_reader));
   }
 
-  _az_RETURN_IF_FAILED(json_child_token_move(&json_reader, iot_hub_property_desired_version));
-  _az_RETURN_IF_FAILED(az_json_token_get_int32(&json_reader.token, out_version));
+  _az_RETURN_IF_FAILED(json_child_token_move(json_reader, iot_hub_property_desired_version));
+  _az_RETURN_IF_FAILED(az_json_token_get_int32(&json_reader->token, out_version));
 
   return AZ_OK;
 }

--- a/sdk/tests/iot/pnp/test_az_iot_pnp_client_property.c
+++ b/sdk/tests/iot/pnp/test_az_iot_pnp_client_property.c
@@ -745,7 +745,7 @@ static void test_az_iot_pnp_client_property_get_property_version_succeed()
   assert_int_equal(az_json_reader_init(&jr, test_property_payload, NULL), AZ_OK);
 
   assert_int_equal(
-      az_iot_pnp_client_property_get_property_version(&client, jr, response_type, &version), AZ_OK);
+      az_iot_pnp_client_property_get_property_version(&client, &jr, response_type, &version), AZ_OK);
   assert_int_equal(version, 5);
 }
 
@@ -767,7 +767,7 @@ static void test_az_iot_pnp_client_property_get_property_version_long_succeed()
   assert_int_equal(az_json_reader_init(&jr, test_property_payload_long, NULL), AZ_OK);
 
   assert_int_equal(
-      az_iot_pnp_client_property_get_property_version(&client, jr, response_type, &version), AZ_OK);
+      az_iot_pnp_client_property_get_property_version(&client, &jr, response_type, &version), AZ_OK);
   assert_int_equal(version, 30);
 }
 
@@ -789,7 +789,7 @@ static void test_az_iot_pnp_client_property_get_property_version_out_of_order_su
   assert_int_equal(az_json_reader_init(&jr, test_property_payload_out_of_order, NULL), AZ_OK);
 
   assert_int_equal(
-      az_iot_pnp_client_property_get_property_version(&client, jr, response_type, &version), AZ_OK);
+      az_iot_pnp_client_property_get_property_version(&client, &jr, response_type, &version), AZ_OK);
   assert_int_equal(version, 4);
 }
 
@@ -1034,8 +1034,10 @@ static void test_az_iot_pnp_client_property_get_next_component_property_long_wit
       = AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_GET;
   int32_t version;
   assert_int_equal(
-      az_iot_pnp_client_property_get_property_version(&client, jr, response_type, &version), AZ_OK);
+      az_iot_pnp_client_property_get_property_version(&client, &jr, response_type, &version), AZ_OK);
   assert_int_equal(version, 30);
+
+  assert_int_equal(az_json_reader_init(&jr, test_property_payload_long, NULL), AZ_OK);
 
   az_span component_name;
   az_json_reader property_name_and_value;

--- a/sdk/tests/iot/pnp/test_az_iot_pnp_client_property.c
+++ b/sdk/tests/iot/pnp/test_az_iot_pnp_client_property.c
@@ -745,7 +745,8 @@ static void test_az_iot_pnp_client_property_get_property_version_succeed()
   assert_int_equal(az_json_reader_init(&jr, test_property_payload, NULL), AZ_OK);
 
   assert_int_equal(
-      az_iot_pnp_client_property_get_property_version(&client, &jr, response_type, &version), AZ_OK);
+      az_iot_pnp_client_property_get_property_version(&client, &jr, response_type, &version),
+      AZ_OK);
   assert_int_equal(version, 5);
 }
 
@@ -767,7 +768,8 @@ static void test_az_iot_pnp_client_property_get_property_version_long_succeed()
   assert_int_equal(az_json_reader_init(&jr, test_property_payload_long, NULL), AZ_OK);
 
   assert_int_equal(
-      az_iot_pnp_client_property_get_property_version(&client, &jr, response_type, &version), AZ_OK);
+      az_iot_pnp_client_property_get_property_version(&client, &jr, response_type, &version),
+      AZ_OK);
   assert_int_equal(version, 30);
 }
 
@@ -789,7 +791,8 @@ static void test_az_iot_pnp_client_property_get_property_version_out_of_order_su
   assert_int_equal(az_json_reader_init(&jr, test_property_payload_out_of_order, NULL), AZ_OK);
 
   assert_int_equal(
-      az_iot_pnp_client_property_get_property_version(&client, &jr, response_type, &version), AZ_OK);
+      az_iot_pnp_client_property_get_property_version(&client, &jr, response_type, &version),
+      AZ_OK);
   assert_int_equal(version, 4);
 }
 
@@ -1034,7 +1037,8 @@ static void test_az_iot_pnp_client_property_get_next_component_property_long_wit
       = AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_GET;
   int32_t version;
   assert_int_equal(
-      az_iot_pnp_client_property_get_property_version(&client, &jr, response_type, &version), AZ_OK);
+      az_iot_pnp_client_property_get_property_version(&client, &jr, response_type, &version),
+      AZ_OK);
   assert_int_equal(version, 30);
 
   assert_int_equal(az_json_reader_init(&jr, test_property_payload_long, NULL), AZ_OK);


### PR DESCRIPTION
Changes the `az_iot_pnp_client_property_get_property_version()` to pass the json reader by reference instead of value. Few reasons:

1. This saves us another `az_json_reader` used on the stack.
2. Passing by value leads to stack corruption on the PIC sample (for reasons I'm still investigating). But this change rectifies the problem and with the memory savings, I believe it is worth it.

The user does have to call another `az_json_reader_init()` in between but it's a minor usage change.

cc @hihigupt @jspaith 