### PR TITLE
Fixing sample remote server validation.

### DIFF
--- a/sdk/samples/iot/aziot_esp8266/aziot_esp8266.ino
+++ b/sdk/samples/iot/aziot_esp8266/aziot_esp8266.ino
@@ -20,7 +20,10 @@
 #include <az_iot_hub_client.h>
 
 #include "iot_configs.h"
+#include "ca.h"
 
+// Status LED: will remain high on error and pulled high for a short time for each successful send.
+#define LED_PIN 2
 #define sizeofarray(a) (sizeof(a) / sizeof(a[0]))
 #define ONE_HOUR_IN_SECS 3600
 #define NTP_SERVERS "pool.ntp.org", "time.nist.gov"
@@ -53,7 +56,6 @@ static void connectToWiFi()
   Serial.println(ssid);
 
   WiFi.mode(WIFI_STA);
-  WiFi.hostname(host);
   WiFi.begin(ssid, password);
   while (WiFi.status() != WL_CONNECTED)
   {
@@ -105,11 +107,11 @@ void receivedCallback(char* topic, byte* payload, unsigned int length)
 
 static void initializeClients()
 {
-  // This disables the client verification of server-side certificate during TLS
-  // negotiation. It is not recommended to be a production-level practice for
-  // connecting with Azure IoT servers.
-  // It has been disabled for simplifying the sample.
-  wifi_client.setInsecure();
+  if (!wifi_client.setCACert((const uint8_t*)ca_pem, ca_pem_len))
+  {
+    Serial.println("setCACert() FAILED");
+    return;
+  }
 
   if (az_result_failed(az_iot_hub_client_init(
           &client,
@@ -127,7 +129,7 @@ static void initializeClients()
 
 static uint32_t getSecondsSinceEpoch()
 {
-  return (uint32_t)time(NULL); // Don't do this at home.
+  return (uint32_t)time(NULL);
 }
 
 static int generateSasToken(char* sas_token, size_t size)
@@ -263,10 +265,14 @@ void establishConnection()
   {
     connectToAzureIoTHub();
   }
+
+  digitalWrite(LED_PIN, LOW);
 }
 
 void setup()
 {
+  pinMode(LED_PIN, OUTPUT);
+  digitalWrite(LED_PIN, HIGH);
   establishConnection();
 }
 
@@ -283,6 +289,9 @@ static char* getTelemetryPayload()
 
 static void sendTelemetry()
 {
+  digitalWrite(LED_PIN, HIGH);
+  Serial.print(millis());
+  Serial.print(" ESP8266 Sending telemetry . . . ");
   if (az_result_failed(az_iot_hub_client_telemetry_get_publish_topic(
           &client, NULL, telemetry_topic, sizeof(telemetry_topic), NULL)))
   {
@@ -291,6 +300,9 @@ static void sendTelemetry()
   }
 
   mqtt_client.publish(telemetry_topic, getTelemetryPayload(), false);
+  Serial.println("OK");
+  delay(100);
+  digitalWrite(LED_PIN, LOW);
 }
 
 void loop()
@@ -304,9 +316,10 @@ void loop()
     }
 
     sendTelemetry();
-
-    mqtt_client.loop();
-
     next_telemetry_send_time_ms = millis() + TELEMETRY_FREQUENCY_MILLISECS;
   }
+
+  // MQTT loop must be called to process Device-to-Cloud and Cloud-to-Device.
+  mqtt_client.loop();
+  delay(500);
 }

--- a/sdk/samples/iot/aziot_esp8266/generate_arduino_zip_library.sh
+++ b/sdk/samples/iot/aziot_esp8266/generate_arduino_zip_library.sh
@@ -1,4 +1,9 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+
 command -v zip >/dev/null 2>&1 || { echo >&2 "Please install zip."; exit 1; }
+command -v xxd >/dev/null 2>&1 || { echo >&2 "Please install xxd."; exit 1; }
 
 git clone https://github.com/Azure/azure-sdk-for-c sdkrepo
 mkdir azure-sdk-for-c
@@ -18,3 +23,6 @@ zip -r9 azure-sdk-for-c azure-sdk-for-c/
 
 rm -rf azure-sdk-for-c
 rm -rf sdkrepo/
+
+wget https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem -O ca.pem
+xxd -i ca.pem ca.h

--- a/sdk/samples/iot/paho_iot_hub_c2d_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_c2d_sample.c
@@ -137,6 +137,8 @@ static void connect_mqtt_client_to_iot_hub(void)
   mqtt_connect_options.keepAliveInterval = AZ_IOT_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS;
 
   MQTTClient_SSLOptions mqtt_ssl_options = MQTTClient_SSLOptions_initializer;
+  mqtt_ssl_options.verify = 1;
+  mqtt_ssl_options.enableServerCertAuth = 1;
   mqtt_ssl_options.keyStore = (char*)az_span_ptr(env_vars.x509_cert_pem_file_path);
   if (az_span_size(env_vars.x509_trust_pem_file_path) != 0) // Is only set if required by OS.
   {

--- a/sdk/samples/iot/paho_iot_hub_methods_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_methods_sample.c
@@ -153,6 +153,8 @@ static void connect_mqtt_client_to_iot_hub(void)
   mqtt_connect_options.keepAliveInterval = AZ_IOT_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS;
 
   MQTTClient_SSLOptions mqtt_ssl_options = MQTTClient_SSLOptions_initializer;
+  mqtt_ssl_options.verify = 1;
+  mqtt_ssl_options.enableServerCertAuth = 1;
   mqtt_ssl_options.keyStore = (char*)az_span_ptr(env_vars.x509_cert_pem_file_path);
   if (az_span_size(env_vars.x509_trust_pem_file_path) != 0) // Is only set if required by OS.
   {

--- a/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c
@@ -380,6 +380,8 @@ static void connect_mqtt_client_to_iot_hub(void)
   mqtt_connect_options.keepAliveInterval = AZ_IOT_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS;
 
   MQTTClient_SSLOptions mqtt_ssl_options = MQTTClient_SSLOptions_initializer;
+  mqtt_ssl_options.verify = 1;
+  mqtt_ssl_options.enableServerCertAuth = 1;
   mqtt_ssl_options.keyStore = (char*)az_span_ptr(env_vars.x509_cert_pem_file_path);
   if (az_span_size(env_vars.x509_trust_pem_file_path) != 0) // Is only set if required by OS.
   {

--- a/sdk/samples/iot/paho_iot_hub_pnp_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_pnp_sample.c
@@ -305,6 +305,8 @@ static void connect_mqtt_client_to_iot_hub(void)
   mqtt_connect_options.keepAliveInterval = AZ_IOT_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS;
 
   MQTTClient_SSLOptions mqtt_ssl_options = MQTTClient_SSLOptions_initializer;
+  mqtt_ssl_options.verify = 1;
+  mqtt_ssl_options.enableServerCertAuth = 1;
   mqtt_ssl_options.keyStore = (char*)az_span_ptr(env_vars.x509_cert_pem_file_path);
   if (az_span_size(env_vars.x509_trust_pem_file_path) != 0) // Is only set if required by OS.
   {

--- a/sdk/samples/iot/paho_iot_hub_sas_telemetry_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_sas_telemetry_sample.c
@@ -131,6 +131,8 @@ static void connect_mqtt_client_to_iot_hub(void)
   mqtt_connect_options.keepAliveInterval = AZ_IOT_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS;
 
   MQTTClient_SSLOptions mqtt_ssl_options = MQTTClient_SSLOptions_initializer;
+  mqtt_ssl_options.verify = 1;
+  mqtt_ssl_options.enableServerCertAuth = 1;
   if (az_span_size(env_vars.x509_trust_pem_file_path) != 0) // Is only set if required by OS.
   {
     mqtt_ssl_options.trustStore = (char*)az_span_ptr(env_vars.x509_trust_pem_file_path);

--- a/sdk/samples/iot/paho_iot_hub_telemetry_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_telemetry_sample.c
@@ -121,6 +121,8 @@ static void connect_mqtt_client_to_iot_hub(void)
   mqtt_connect_options.keepAliveInterval = AZ_IOT_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS;
 
   MQTTClient_SSLOptions mqtt_ssl_options = MQTTClient_SSLOptions_initializer;
+  mqtt_ssl_options.verify = 1;
+  mqtt_ssl_options.enableServerCertAuth = 1;
   mqtt_ssl_options.keyStore = (char*)az_span_ptr(env_vars.x509_cert_pem_file_path);
   if (az_span_size(env_vars.x509_trust_pem_file_path) != 0) // Is only set if required by OS.
   {

--- a/sdk/samples/iot/paho_iot_hub_twin_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_twin_sample.c
@@ -169,6 +169,8 @@ static void connect_mqtt_client_to_iot_hub(void)
   mqtt_connect_options.keepAliveInterval = AZ_IOT_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS;
 
   MQTTClient_SSLOptions mqtt_ssl_options = MQTTClient_SSLOptions_initializer;
+  mqtt_ssl_options.verify = 1;
+  mqtt_ssl_options.enableServerCertAuth = 1;
   mqtt_ssl_options.keyStore = (char*)az_span_ptr(env_vars.x509_cert_pem_file_path);
   if (az_span_size(env_vars.x509_trust_pem_file_path) != 0) // Is only set if required by OS.
   {

--- a/sdk/samples/iot/paho_iot_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_provisioning_sample.c
@@ -145,6 +145,8 @@ static void connect_mqtt_client_to_provisioning_service(void)
   mqtt_connect_options.keepAliveInterval = AZ_IOT_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS;
 
   MQTTClient_SSLOptions mqtt_ssl_options = MQTTClient_SSLOptions_initializer;
+  mqtt_ssl_options.verify = 1;
+  mqtt_ssl_options.enableServerCertAuth = 1;
   mqtt_ssl_options.keyStore = (char*)az_span_ptr(env_vars.x509_cert_pem_file_path);
   if (az_span_size(env_vars.x509_trust_pem_file_path) != 0) // Is only set if required by OS.
   {

--- a/sdk/samples/iot/paho_iot_provisioning_sas_sample.c
+++ b/sdk/samples/iot/paho_iot_provisioning_sas_sample.c
@@ -156,6 +156,8 @@ static void connect_mqtt_client_to_provisioning_service(void)
   mqtt_connect_options.keepAliveInterval = AZ_IOT_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS;
 
   MQTTClient_SSLOptions mqtt_ssl_options = MQTTClient_SSLOptions_initializer;
+  mqtt_ssl_options.verify = 1;
+  mqtt_ssl_options.enableServerCertAuth = 1;
   if (az_span_size(env_vars.x509_trust_pem_file_path) != 0) // Is only set if required by OS.
   {
     mqtt_ssl_options.trustStore = (char*)az_span_ptr(env_vars.x509_trust_pem_file_path);


### PR DESCRIPTION
- Enabling remote server validation for all Paho samples.
- Adding remote CA validation and hostname validation for the ESP8266 sample.
- Adding ESP status led and better UART logs to help debugging.
- Fixing ESP MQTT loop to process inbound MQTT messages.