### PR TITLE
Update semver validation regex to be more flexible and allow the prerelease label to contain a "feature." string

### DIFF
--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -23,7 +23,7 @@ class AzureEngSemanticVersion {
   [bool] $IsSemVerFormat
   [string] $DefaultPrereleaseLabel
   # Regex inspired but simplified from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-  static [string] $SEMVER_REGEX = "(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:(?<presep>-?)(?<prelabel>[a-zA-Z-]*)(?<prenumsep>\.?)(?<prenumber>0|[1-9]\d*))?"
+  static [string] $SEMVER_REGEX = "(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:(?<presep>-?)(?<prelabel>([a-zA-Z-]*).[a-zA-Z-]*)(?<prenumsep>\.?)(?<prenumber>0|[1-9]\d*))?"
 
   static [AzureEngSemanticVersion] ParseVersionString([string] $versionString)
   {

--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -14,7 +14,7 @@ param (
 . (Join-Path $PSScriptRoot common.ps1)
 
 # Regex inspired but simplified from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-$SEMVER_REGEX = "^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-?(?<prelabel>[a-zA-Z-]*)(?:\.?(?<prenumber>0|[1-9]\d*))?)?$"
+$SEMVER_REGEX = "^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-?(?<prelabel>([a-zA-Z-]*).[a-zA-Z-]*)(?:\.?(?<prenumber>0|[1-9]\d*))?)?$"
 
 function ToSemVer($version){
     if ($version -match $SEMVER_REGEX)


### PR DESCRIPTION
Temporary workaround to get the docs published for the current release version, which is: `1.1.0-pnp.beta.2`

`Major.Minor.Build-<feature>.beta.<rev>`

https://github.com/Azure/azure-sdk-for-c/blob/33c6415268fb1031327f3ed1b67d5b30ca57e3c1/sdk/inc/azure/core/az_version.h#L20

Open to other viable suggestions.

The regex in https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string **does** allow such a version string.