### PR TITLE
Revert "Update semver validation regex to be more flexible and allow the prerelease label to contain a "feature." string"

### DIFF
--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -23,7 +23,7 @@ class AzureEngSemanticVersion {
   [bool] $IsSemVerFormat
   [string] $DefaultPrereleaseLabel
   # Regex inspired but simplified from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-  static [string] $SEMVER_REGEX = "(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:(?<presep>-?)(?<prelabel>([a-zA-Z-]*).[a-zA-Z-]*)(?<prenumsep>\.?)(?<prenumber>0|[1-9]\d*))?"
+  static [string] $SEMVER_REGEX = "(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:(?<presep>-?)(?<prelabel>[a-zA-Z-]*)(?<prenumsep>\.?)(?<prenumber>0|[1-9]\d*))?"
 
   static [AzureEngSemanticVersion] ParseVersionString([string] $versionString)
   {

--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -14,7 +14,7 @@ param (
 . (Join-Path $PSScriptRoot common.ps1)
 
 # Regex inspired but simplified from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-$SEMVER_REGEX = "^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-?(?<prelabel>([a-zA-Z-]*).[a-zA-Z-]*)(?:\.?(?<prenumber>0|[1-9]\d*))?)?$"
+$SEMVER_REGEX = "^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-?(?<prelabel>[a-zA-Z-]*)(?:\.?(?<prenumber>0|[1-9]\d*))?)?$"
 
 function ToSemVer($version){
     if ($version -match $SEMVER_REGEX)


### PR DESCRIPTION
Now that we have published the docs for `1.1.0-pnp.beta.2`, reverts the temporary workaround from Azure/azure-sdk-for-c#1497

If we want to support `<feature>.<beta>.<rev>` versioning long term, we should follow the [eng/common workflow](https://github.com/Azure/azure-sdk-tools/blob/2c58ce43e5133a9dfa681652151e41d09e25f5c5/doc/common/common_engsys.md#workflow) and make such a fix again using that approach, starting in `azure-sdk-tools`.

