### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.0-pnp.beta.2 (2020-11-10)
+## 1.1.0-beta.2 (2020-11-10)
 
 ### New Features
 


### PR DESCRIPTION
For infrastructure reasons we need to keep the version simply as beta.2.  For now we will use a single version throughout the repo and branches.