### PR TITLE
PnP API Update - az_iot_pnp_client_property_get_next_component_property

### DIFF
--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -742,6 +742,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_get_property_version(
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK If the function returned a valid #az_json_reader pointing to the property name and
  * the #az_span with a component name.
+ * @retval #AZ_ERROR_JSON_INVALID_STATE If the json reader is passed in at an unexpected location.
  * @retval #AZ_ERROR_IOT_END_OF_PROPERTIES If there are no more properties left for the component.
  */
 AZ_NODISCARD az_result az_iot_pnp_client_property_get_next_component_property(

--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -711,6 +711,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_get_property_version(
  *     az_json_reader_next_token(&jr);
  *
  *     // Get the property value here
+ *     // Example: az_json_token_get_int32(&jr.token, &user_int);
  *
  *     // Skip to next property value
  *     az_json_reader_next_token(&jr);

--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -718,8 +718,7 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_get_next_component_property(
     az_iot_pnp_client const* client,
     az_json_reader* ref_json_reader,
     az_iot_pnp_client_property_response_type response_type,
-    az_span* out_component_name,
-    az_json_reader* out_property_name_and_value);
+    az_span* out_component_name);
 
 #include <azure/core/_az_cfg_suffix.h>
 

--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -705,9 +705,8 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_get_property_version(
  * while (az_result_succeeded(az_iot_pnp_client_property_get_next_component_property(
  *       &pnp_client, &jr, response_type, &component_name)))
  * {
- *   // Check if property is of interest (sub user_property for your own)
- *   if (az_json_token_is_text_equal(
- *           &jr.token, user_property))
+ *   // Check if property is of interest (substitute user_property for your own property name)
+ *   if (az_json_token_is_text_equal(&jr.token, user_property))
  *   {
  *     az_json_reader_next_token(&jr);
  *
@@ -720,6 +719,8 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_get_property_version(
  *   {
  *     // The JSON reader must be advanced regardless of whether the property
  *     // is of interest or not.
+ *     az_json_reader_next_token(&jr);
+ *
  *     // Skip children in case the property value is an object
  *     az_json_reader_skip_children(&jr);
  *     az_json_reader_next_token(&jr);

--- a/sdk/inc/azure/iot/az_iot_pnp_client.h
+++ b/sdk/inc/azure/iot/az_iot_pnp_client.h
@@ -710,9 +710,9 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_get_property_version(
  *           &jr.token, user_property))
  *   {
  *     az_json_reader_next_token(&jr);
- * 
+ *
  *     // Get the property value here
- * 
+ *
  *     // Skip to next property value
  *     az_json_reader_next_token(&jr);
  *   }

--- a/sdk/samples/iot/paho_iot_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_component_sample.c
@@ -790,12 +790,10 @@ static void process_property_message(
             "Could not begin the property with status");
 
         IOT_SAMPLE_EXIT_IF_AZ_FAILED(
-            az_json_reader_next_token(&jr),
-            "Could not advance to property value");
+            az_json_reader_next_token(&jr), "Could not advance to property value");
 
         IOT_SAMPLE_EXIT_IF_AZ_FAILED(
-            append_simple_json_token(&jw, &jr.token),
-            "Could not append the property");
+            append_simple_json_token(&jw, &jr.token), "Could not append the property");
 
         IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             az_iot_pnp_client_property_builder_end_reported_status(&pnp_client, &jw),

--- a/sdk/samples/iot/paho_iot_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_component_sample.c
@@ -812,6 +812,10 @@ static void process_property_message(
         IOT_SAMPLE_LOG_SUCCESS(
             "Client sent Temperature Controller error status reported property message:");
         IOT_SAMPLE_LOG_AZ_SPAN("Payload:", publish_message.out_payload);
+
+        // Advance to next property name
+        IOT_SAMPLE_EXIT_IF_AZ_FAILED(
+            az_json_reader_next_token(&jr), "Could not move to next property name");
       }
     }
     else

--- a/sdk/samples/iot/paho_iot_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_component_sample.c
@@ -492,7 +492,6 @@ static void receive_messages(void)
     if (thermostat_1.send_maximum_temperature_property)
     {
       // Get the property PATCH topic to send a reported property update.
-
       rc = az_iot_pnp_client_property_patch_get_publish_topic(
           &pnp_client,
           pnp_mqtt_get_request_id(),

--- a/sdk/samples/iot/paho_iot_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_component_sample.c
@@ -775,9 +775,12 @@ static void process_property_message(
         IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             az_json_writer_append_begin_object(&jw), "Could not append the begin object");
 
-        IOT_SAMPLE_EXIT_IF_AZ_FAILED(
-            az_iot_pnp_client_property_builder_begin_component(&pnp_client, &jw, component_name),
-            "Could not begin the property component");
+        if (az_span_size(component_name) > 0)
+        {
+          IOT_SAMPLE_EXIT_IF_AZ_FAILED(
+              az_iot_pnp_client_property_builder_begin_component(&pnp_client, &jw, component_name),
+              "Could not begin the property component");
+        }
 
         IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             az_iot_pnp_client_property_builder_begin_reported_status(
@@ -799,12 +802,17 @@ static void process_property_message(
             az_iot_pnp_client_property_builder_end_reported_status(&pnp_client, &jw),
             "Could not end the property with status");
 
-        IOT_SAMPLE_EXIT_IF_AZ_FAILED(
-            az_iot_pnp_client_property_builder_end_component(&pnp_client, &jw),
-            "Could not end the property component");
+        if (az_span_size(component_name) > 0)
+        {
+          IOT_SAMPLE_EXIT_IF_AZ_FAILED(
+              az_iot_pnp_client_property_builder_end_component(&pnp_client, &jw),
+              "Could not end the property component");
+        }
 
         IOT_SAMPLE_EXIT_IF_AZ_FAILED(
             az_json_writer_append_end_object(&jw), "Could not append end the object");
+
+        publish_message.out_payload = az_json_writer_get_bytes_used_in_destination(&jw);
 
         // Send error response to the updated property.
         publish_mqtt_message(

--- a/sdk/samples/iot/paho_iot_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_component_sample.c
@@ -436,9 +436,6 @@ static void send_device_info(void)
   IOT_SAMPLE_LOG_SUCCESS("Client sent reported property message for device info.");
   IOT_SAMPLE_LOG_AZ_SPAN("Payload:", publish_message.out_payload);
   IOT_SAMPLE_LOG(" "); // Formatting
-
-  // Receive the response from the server.
-  receive_mqtt_message();
 }
 
 static void send_serial_number(void)
@@ -465,9 +462,6 @@ static void send_serial_number(void)
       az_span_ptr(reported_property_serial_number_name));
   IOT_SAMPLE_LOG_AZ_SPAN("Payload:", publish_message.out_payload);
   IOT_SAMPLE_LOG(" "); // Formatting
-
-  // Receive the response from the server.
-  receive_mqtt_message();
 }
 
 static void request_all_properties(void)
@@ -486,9 +480,6 @@ static void request_all_properties(void)
   // Publish the property document request.
   publish_mqtt_message(publish_message.topic, AZ_SPAN_EMPTY, IOT_SAMPLE_MQTT_PUBLISH_QOS);
   IOT_SAMPLE_LOG(" "); // Formatting
-
-  // Receive the response from the server.
-  receive_mqtt_message();
 }
 
 static void receive_messages(void)
@@ -530,9 +521,6 @@ static void receive_messages(void)
       IOT_SAMPLE_LOG(" "); // Formatting
 
       thermostat_1.send_maximum_temperature_property = false; // Only send again if new max set.
-
-      // Receive the response from the server.
-      receive_mqtt_message();
     }
 
     if (thermostat_2.send_maximum_temperature_property)
@@ -567,9 +555,6 @@ static void receive_messages(void)
       IOT_SAMPLE_LOG(" "); // Formatting
 
       thermostat_2.send_maximum_temperature_property = false; // Only send again if new max set.
-
-      // Receive the response from the server.
-      receive_mqtt_message();
     }
 
     // Send telemetry messages. No response requested from server.
@@ -745,9 +730,6 @@ static void process_property_message(
               publish_message.topic, publish_message.out_payload, IOT_SAMPLE_MQTT_PUBLISH_QOS);
           IOT_SAMPLE_LOG_SUCCESS("Client sent Temperature Sensor 1 reported property message:");
           IOT_SAMPLE_LOG_AZ_SPAN("Payload:", publish_message.out_payload);
-
-          // Receive the response from the server.
-          receive_mqtt_message();
         }
       }
       else if (az_span_is_content_equal(component_name, thermostat_2_name))
@@ -766,9 +748,6 @@ static void process_property_message(
               publish_message.topic, publish_message.out_payload, IOT_SAMPLE_MQTT_PUBLISH_QOS);
           IOT_SAMPLE_LOG_SUCCESS("Client sent Temperature Sensor 2 reported property message:");
           IOT_SAMPLE_LOG_AZ_SPAN("Payload:", publish_message.out_payload);
-
-          // Receive the response from the server.
-          receive_mqtt_message();
         }
       }
       else
@@ -836,9 +815,6 @@ static void process_property_message(
         IOT_SAMPLE_LOG_SUCCESS(
             "Client sent Temperature Controller error status reported property message:");
         IOT_SAMPLE_LOG_AZ_SPAN("Payload:", publish_message.out_payload);
-
-        // Receive the response from the server.
-        receive_mqtt_message();
       }
     }
     else

--- a/sdk/samples/iot/paho_iot_pnp_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_sample.c
@@ -594,7 +594,7 @@ static void process_device_property_message(
       rc = az_json_reader_next_token(&jr);
       if (az_result_failed(rc))
       {
-        IOT_SAMPLE_LOG_ERROR("Could not move to next property name");
+        IOT_SAMPLE_LOG_ERROR("Invalid JSON. Could not move to next property name");
       }
     }
     else
@@ -605,20 +605,20 @@ static void process_device_property_message(
       rc = az_json_reader_next_token(&jr);
       if (az_result_failed(rc))
       {
-        IOT_SAMPLE_LOG_ERROR("Could not move to next property value");
+        IOT_SAMPLE_LOG_ERROR("Invalid JSON. Could not move to next property value");
       }
 
       // Skip children in case the property value is an object
       rc = az_json_reader_skip_children(&jr);
       if (az_result_failed(rc))
       {
-        IOT_SAMPLE_LOG_ERROR("Could not skip children");
+        IOT_SAMPLE_LOG_ERROR("Invalid JSON. Could not skip children");
       }
 
       rc = az_json_reader_next_token(&jr);
       if (az_result_failed(rc))
       {
-        IOT_SAMPLE_LOG_ERROR("Could not move to next property name");
+        IOT_SAMPLE_LOG_ERROR("Invalid JSON. Could not move to next property name");
       }
     }
   }

--- a/sdk/samples/iot/paho_iot_pnp_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_sample.c
@@ -605,14 +605,14 @@ static void process_device_property_message(
       rc = az_json_reader_next_token(&jr);
       if (az_result_failed(rc))
       {
-        IOT_SAMPLE_LOG_ERROR("Could not move to next property name");
+        IOT_SAMPLE_LOG_ERROR("Could not move to next property value");
       }
 
       // Skip children in case the property value is an object
       rc = az_json_reader_skip_children(&jr);
       if (az_result_failed(rc))
       {
-        IOT_SAMPLE_LOG_ERROR("Could not move to next property name");
+        IOT_SAMPLE_LOG_ERROR("Could not skip children");
       }
 
       rc = az_json_reader_next_token(&jr);

--- a/sdk/samples/iot/paho_iot_pnp_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_sample.c
@@ -555,21 +555,20 @@ static void process_device_property_message(
 
   double desired_temperature;
   az_span component_name;
-  az_json_reader property_name_and_value;
 
   while (az_result_succeeded(az_iot_pnp_client_property_get_next_component_property(
-      &pnp_client, &jr, response_type, &component_name, &property_name_and_value)))
+      &pnp_client, &jr, response_type, &component_name)))
   {
     if (az_json_token_is_text_equal(
-            &property_name_and_value.token, property_desired_temperature_name))
+            &jr.token, property_desired_temperature_name))
     {
-      rc = az_json_reader_next_token(&property_name_and_value);
+      rc = az_json_reader_next_token(&jr);
       if (az_result_failed(rc))
       {
         IOT_SAMPLE_LOG_ERROR("Could not move to property value");
       }
 
-      rc = az_json_token_get_double(&property_name_and_value.token, &desired_temperature);
+      rc = az_json_token_get_double(&jr.token, &desired_temperature);
       if (az_result_failed(rc))
       {
         IOT_SAMPLE_LOG_ERROR("Could not get property value");
@@ -590,6 +589,37 @@ static void process_device_property_message(
         confirm = false;
         send_reported_property(
             property_reported_maximum_temperature_name, device_maximum_temperature, -1, confirm);
+      }
+
+      // Skip to next property value
+      rc = az_json_reader_next_token(&jr);
+      if (az_result_failed(rc))
+      {
+        IOT_SAMPLE_LOG_ERROR("Could not move to next property name");
+      }
+    }
+    else
+    {
+      IOT_SAMPLE_LOG_AZ_SPAN("Unknown Property Received:", jr.token.slice);
+      // The JSON reader must be advanced regardless of whether the property
+      // is of interest or not.
+      rc = az_json_reader_next_token(&jr);
+      if (az_result_failed(rc))
+      {
+        IOT_SAMPLE_LOG_ERROR("Could not move to next property name");
+      }
+
+      // Skip children in case the property value is an array
+      rc = az_json_reader_skip_children(&jr);
+      if (az_result_failed(rc))
+      {
+        IOT_SAMPLE_LOG_ERROR("Could not move to next property name");
+      }
+
+      rc = az_json_reader_next_token(&jr);
+      if (az_result_failed(rc))
+      {
+        IOT_SAMPLE_LOG_ERROR("Could not move to next property name");
       }
     }
   }

--- a/sdk/samples/iot/paho_iot_pnp_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_sample.c
@@ -559,8 +559,7 @@ static void process_device_property_message(
   while (az_result_succeeded(az_iot_pnp_client_property_get_next_component_property(
       &pnp_client, &jr, response_type, &component_name)))
   {
-    if (az_json_token_is_text_equal(
-            &jr.token, property_desired_temperature_name))
+    if (az_json_token_is_text_equal(&jr.token, property_desired_temperature_name))
     {
       rc = az_json_reader_next_token(&jr);
       if (az_result_failed(rc))

--- a/sdk/samples/iot/paho_iot_pnp_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_sample.c
@@ -608,7 +608,7 @@ static void process_device_property_message(
         IOT_SAMPLE_LOG_ERROR("Could not move to next property name");
       }
 
-      // Skip children in case the property value is an array
+      // Skip children in case the property value is an object
       rc = az_json_reader_skip_children(&jr);
       if (az_result_failed(rc))
       {

--- a/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
@@ -878,21 +878,20 @@ static void process_device_property_message(
 
   double desired_temperature;
   az_span component_name;
-  az_json_reader property_name_and_value;
 
   while (az_result_succeeded(az_iot_pnp_client_property_get_next_component_property(
-      &pnp_client, &jr, response_type, &component_name, &property_name_and_value)))
+      &pnp_client, &jr, response_type, &component_name)))
   {
     if (az_json_token_is_text_equal(
-            &property_name_and_value.token, property_desired_temperature_name))
+            &jr.token, property_desired_temperature_name))
     {
-      rc = az_json_reader_next_token(&property_name_and_value);
+      rc = az_json_reader_next_token(&jr);
       if (az_result_failed(rc))
       {
         IOT_SAMPLE_LOG_ERROR("Could not move to property value");
       }
 
-      rc = az_json_token_get_double(&property_name_and_value.token, &desired_temperature);
+      rc = az_json_token_get_double(&jr.token, &desired_temperature);
       if (az_result_failed(rc))
       {
         IOT_SAMPLE_LOG_ERROR("Could not get property value");

--- a/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
@@ -882,8 +882,7 @@ static void process_device_property_message(
   while (az_result_succeeded(az_iot_pnp_client_property_get_next_component_property(
       &pnp_client, &jr, response_type, &component_name)))
   {
-    if (az_json_token_is_text_equal(
-            &jr.token, property_desired_temperature_name))
+    if (az_json_token_is_text_equal(&jr.token, property_desired_temperature_name))
     {
       rc = az_json_reader_next_token(&jr);
       if (az_result_failed(rc))

--- a/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
@@ -913,6 +913,30 @@ static void process_device_property_message(
             property_reported_maximum_temperature_name, device_maximum_temperature, -1, confirm);
       }
     }
+    else
+    {
+      IOT_SAMPLE_LOG_AZ_SPAN("Unknown Property Received:", jr.token.slice);
+      // The JSON reader must be advanced regardless of whether the property
+      // is of interest or not.
+      rc = az_json_reader_next_token(&jr);
+      if (az_result_failed(rc))
+      {
+        IOT_SAMPLE_LOG_ERROR("Could not move to next property value");
+      }
+
+      // Skip children in case the property value is an object
+      rc = az_json_reader_skip_children(&jr);
+      if (az_result_failed(rc))
+      {
+        IOT_SAMPLE_LOG_ERROR("Could not skip children");
+      }
+
+      rc = az_json_reader_next_token(&jr);
+      if (az_result_failed(rc))
+      {
+        IOT_SAMPLE_LOG_ERROR("Could not move to next property name");
+      }
+    }
   }
 }
 

--- a/sdk/samples/iot/pnp/pnp_thermostat_component.c
+++ b/sdk/samples/iot/pnp/pnp_thermostat_component.c
@@ -251,6 +251,8 @@ az_result pnp_thermostat_process_property_update(
     IOT_SAMPLE_EXIT_IF_AZ_FAILED(
         az_json_token_get_double(&property_name_and_value->token, &parsed_property_value), log);
 
+    IOT_SAMPLE_EXIT_IF_AZ_FAILED(az_json_reader_next_token(property_name_and_value), log);
+
     // Update variables locally.
     ref_thermostat_component->current_temperature = parsed_property_value;
     if (ref_thermostat_component->current_temperature

--- a/sdk/src/azure/iot/az_iot_pnp_client_property.c
+++ b/sdk/src/azure/iot/az_iot_pnp_client_property.c
@@ -282,12 +282,6 @@ static az_result check_if_skippable(
         || (response_type == AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_GET
             && jr->_internal.bit_stack._internal.current_depth == 3))
     {
-      if (jr->token.kind != AZ_JSON_TOKEN_PROPERTY_NAME
-          && jr->token.kind != AZ_JSON_TOKEN_END_OBJECT)
-      {
-        return AZ_ERROR_JSON_INVALID_STATE;
-      }
-
       if (az_json_token_is_text_equal(&jr->token, component_property_label_name))
       {
         // Skip label property name and property value

--- a/sdk/src/azure/iot/az_iot_pnp_client_property.c
+++ b/sdk/src/azure/iot/az_iot_pnp_client_property.c
@@ -313,7 +313,7 @@ static bool is_invalid_json_position(
     az_iot_pnp_client_property_response_type response_type,
     az_span component_name)
 {
-  // Position is not on a property name or end of object
+  // Not on a property name or end of object
   if (jr->_internal.bit_stack._internal.current_depth != 0
       && (jr->token.kind != AZ_JSON_TOKEN_PROPERTY_NAME
           && jr->token.kind != AZ_JSON_TOKEN_END_OBJECT))
@@ -321,7 +321,7 @@ static bool is_invalid_json_position(
     return true;
   }
 
-  // Position is in user property value object
+  // Component property - In user property value object
   if ((response_type == AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_DESIRED_PROPERTIES
        && jr->_internal.bit_stack._internal.current_depth > 2)
       || (response_type == AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_GET
@@ -330,7 +330,7 @@ static bool is_invalid_json_position(
     return true;
   }
 
-  // Non-component property and in user property value object
+  // Non-component property - In user property value object
   if ((az_span_size(component_name) == 0)
       && ((response_type == AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_DESIRED_PROPERTIES
            && jr->_internal.bit_stack._internal.current_depth > 1)

--- a/sdk/src/azure/iot/az_iot_pnp_client_property.c
+++ b/sdk/src/azure/iot/az_iot_pnp_client_property.c
@@ -395,6 +395,11 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_get_next_component_property(
       || (response_type == AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_GET
           && ref_json_reader->_internal.bit_stack._internal.current_depth == 2))
   {
+    if (ref_json_reader->token.kind != AZ_JSON_TOKEN_PROPERTY_NAME && ref_json_reader->token.kind != AZ_JSON_TOKEN_END_OBJECT)
+    {
+      return AZ_ERROR_JSON_INVALID_STATE;
+    }
+
     if (is_component_in_model(client, &ref_json_reader->token, out_component_name))
     {
       _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));

--- a/sdk/src/azure/iot/az_iot_pnp_client_property.c
+++ b/sdk/src/azure/iot/az_iot_pnp_client_property.c
@@ -395,7 +395,8 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_get_next_component_property(
       || (response_type == AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_GET
           && ref_json_reader->_internal.bit_stack._internal.current_depth == 2))
   {
-    if (ref_json_reader->token.kind != AZ_JSON_TOKEN_PROPERTY_NAME && ref_json_reader->token.kind != AZ_JSON_TOKEN_END_OBJECT)
+    if (ref_json_reader->token.kind != AZ_JSON_TOKEN_PROPERTY_NAME
+        && ref_json_reader->token.kind != AZ_JSON_TOKEN_END_OBJECT)
     {
       return AZ_ERROR_JSON_INVALID_STATE;
     }

--- a/sdk/src/azure/iot/az_iot_pnp_client_property.c
+++ b/sdk/src/azure/iot/az_iot_pnp_client_property.c
@@ -352,13 +352,11 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_get_next_component_property(
     az_iot_pnp_client const* client,
     az_json_reader* ref_json_reader,
     az_iot_pnp_client_property_response_type response_type,
-    az_span* out_component_name,
-    az_json_reader* out_property_name_and_value)
+    az_span* out_component_name)
 {
   _az_PRECONDITION_NOT_NULL(client);
   _az_PRECONDITION_NOT_NULL(ref_json_reader);
   _az_PRECONDITION_NOT_NULL(out_component_name);
-  _az_PRECONDITION_NOT_NULL(out_property_name_and_value);
 
   (void)client;
 
@@ -408,12 +406,6 @@ AZ_NODISCARD az_result az_iot_pnp_client_property_get_next_component_property(
       *out_component_name = AZ_SPAN_EMPTY;
     }
   }
-
-  *out_property_name_and_value = *ref_json_reader;
-
-  // Skip the property value array (if applicable) and move to next token
-  _az_RETURN_IF_FAILED(az_json_reader_skip_children(ref_json_reader));
-  _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
 
   return AZ_OK;
 }

--- a/sdk/src/azure/iot/az_iot_pnp_client_property.c
+++ b/sdk/src/azure/iot/az_iot_pnp_client_property.c
@@ -282,6 +282,12 @@ static az_result check_if_skippable(
         || (response_type == AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_GET
             && jr->_internal.bit_stack._internal.current_depth == 3))
     {
+      if (jr->token.kind != AZ_JSON_TOKEN_PROPERTY_NAME
+          && jr->token.kind != AZ_JSON_TOKEN_END_OBJECT)
+      {
+        return AZ_ERROR_JSON_INVALID_STATE;
+      }
+
       if (az_json_token_is_text_equal(&jr->token, component_property_label_name))
       {
         // Skip label property name and property value

--- a/sdk/tests/iot/pnp/test_az_iot_pnp_client_property.c
+++ b/sdk/tests/iot/pnp/test_az_iot_pnp_client_property.c
@@ -827,71 +827,84 @@ static void test_az_iot_pnp_client_property_get_next_component_property_succeed(
   az_iot_pnp_client_property_response_type response_type
       = AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_DESIRED_PROPERTIES;
   az_span component_name;
-  az_json_reader property_name_and_value;
   int32_t value;
 
   // First component
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_component_one));
   assert_true(
-      az_json_token_is_text_equal(&property_name_and_value.token, AZ_SPAN_FROM_STR("prop_one")));
-  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
-  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
+      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_one")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 1);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
 
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_component_one));
   assert_true(
-      az_json_token_is_text_equal(&property_name_and_value.token, AZ_SPAN_FROM_STR("prop_two")));
-  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_two")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_true(
-      az_json_token_is_text_equal(&property_name_and_value.token, AZ_SPAN_FROM_STR("string")));
+      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("string")));
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
 
   // Second component
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_component_two));
   assert_true(
-      az_json_token_is_text_equal(&property_name_and_value.token, AZ_SPAN_FROM_STR("prop_three")));
-  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
-  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
+      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_three")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 45);
-  // assert_int_equal(version, 5);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
 
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(
-      az_json_token_is_text_equal(&property_name_and_value.token, AZ_SPAN_FROM_STR("prop_four")));
-  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
+      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_four")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_true(
-      az_json_token_is_text_equal(&property_name_and_value.token, AZ_SPAN_FROM_STR("string")));
+      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("string")));
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
 
   // Not a component
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, AZ_SPAN_EMPTY));
   assert_true(az_json_token_is_text_equal(
-      &property_name_and_value.token, AZ_SPAN_FROM_STR("not_component")));
-  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
-  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
+      &jr.token, AZ_SPAN_FROM_STR("not_component")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 42);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
 
   // End of components (skipping version)
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_ERROR_IOT_END_OF_PROPERTIES);
 }
 
@@ -912,24 +925,26 @@ static void test_az_iot_pnp_client_property_get_next_component_property_two_succ
   az_iot_pnp_client_property_response_type response_type
       = AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_GET;
   az_span component_name;
-  az_json_reader property_name_and_value;
   int32_t value;
   // First component
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_one));
   assert_true(az_json_token_is_text_equal(
-      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
-  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
+      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 47);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
 
   // End of components (skipping version and reported properties section)
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_ERROR_IOT_END_OF_PROPERTIES);
 }
 
@@ -950,24 +965,26 @@ static void test_az_iot_pnp_client_property_get_next_component_property_out_of_o
   az_iot_pnp_client_property_response_type response_type
       = AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_GET;
   az_span component_name;
-  az_json_reader property_name_and_value;
   int32_t value;
   // First component
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_one));
   assert_true(az_json_token_is_text_equal(
-      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
-  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
+      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 47);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
 
   // End of components (skipping version and reported properties section)
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_ERROR_IOT_END_OF_PROPERTIES);
 }
 
@@ -988,48 +1005,56 @@ static void test_az_iot_pnp_client_property_get_next_component_property_long_suc
   az_iot_pnp_client_property_response_type response_type
       = AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_GET;
   az_span component_name;
-  az_json_reader property_name_and_value;
   int32_t value;
   // First component
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_two));
   assert_true(az_json_token_is_text_equal(
-      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
-  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
+      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 50);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
 
   // Second component
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_one));
   assert_true(az_json_token_is_text_equal(
-      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
-  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
+      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 90);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
 
   // Not a component
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, AZ_SPAN_EMPTY));
   assert_true(az_json_token_is_text_equal(
-      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
-  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
+      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 54);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
 
   // End of components (skipping version and reported properties section)
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_ERROR_IOT_END_OF_PROPERTIES);
 }
 
@@ -1058,48 +1083,56 @@ static void test_az_iot_pnp_client_property_get_next_component_property_long_wit
   assert_int_equal(az_json_reader_init(&jr, test_property_payload_long, NULL), AZ_OK);
 
   az_span component_name;
-  az_json_reader property_name_and_value;
   int32_t value;
   // First component
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_two));
   assert_true(az_json_token_is_text_equal(
-      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
-  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
+      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 50);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
 
   // Second component
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_one));
   assert_true(az_json_token_is_text_equal(
-      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
-  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
+      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 90);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
 
   // Not a component
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, AZ_SPAN_EMPTY));
   assert_true(az_json_token_is_text_equal(
-      &property_name_and_value.token, AZ_SPAN_FROM_STR("targetTemperature")));
-  assert_int_equal(az_json_reader_next_token(&property_name_and_value), AZ_OK);
-  assert_int_equal(az_json_token_get_int32(&property_name_and_value.token, &value), AZ_OK);
+      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 54);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
 
   // End of components (skipping version and reported properties section)
   assert_int_equal(
       az_iot_pnp_client_property_get_next_component_property(
-          &client, &jr, response_type, &component_name, &property_name_and_value),
+          &client, &jr, response_type, &component_name),
       AZ_ERROR_IOT_END_OF_PROPERTIES);
 }
 

--- a/sdk/tests/iot/pnp/test_az_iot_pnp_client_property.c
+++ b/sdk/tests/iot/pnp/test_az_iot_pnp_client_property.c
@@ -908,6 +908,43 @@ static void test_az_iot_pnp_client_property_get_next_component_property_succeed(
       AZ_ERROR_IOT_END_OF_PROPERTIES);
 }
 
+static void test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_fail()
+{
+  az_iot_pnp_client client;
+  az_iot_pnp_client_options options = az_iot_pnp_client_options_default();
+  options.component_names = test_components;
+  options.component_names_length = test_components_length;
+  assert_int_equal(
+      az_iot_pnp_client_init(
+          &client, test_device_hostname, test_device_id, test_model_id, &options),
+      AZ_OK);
+
+  az_json_reader jr;
+  assert_int_equal(az_json_reader_init(&jr, test_property_payload, NULL), AZ_OK);
+
+  az_iot_pnp_client_property_response_type response_type
+      = AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_DESIRED_PROPERTIES;
+  az_span component_name;
+  int32_t value;
+
+  // First component
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_OK);
+  assert_true(az_span_is_content_equal(component_name, test_component_one));
+  assert_true(
+      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_one")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
+  assert_int_equal(value, 1);
+
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_ERROR_JSON_INVALID_STATE);
+}
+
 static void test_az_iot_pnp_client_property_get_next_component_property_two_succeed()
 {
   az_iot_pnp_client client;
@@ -1189,6 +1226,7 @@ int test_az_iot_pnp_client_property()
     cmocka_unit_test(test_az_iot_pnp_client_property_get_property_version_long_succeed),
     cmocka_unit_test(test_az_iot_pnp_client_property_get_property_version_out_of_order_succeed),
     cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_succeed),
+    cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_fail),
     cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_two_succeed),
     cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_long_succeed),
     cmocka_unit_test(

--- a/sdk/tests/iot/pnp/test_az_iot_pnp_client_property.c
+++ b/sdk/tests/iot/pnp/test_az_iot_pnp_client_property.c
@@ -945,6 +945,101 @@ static void test_az_iot_pnp_client_property_get_next_component_property_user_not
       AZ_ERROR_JSON_INVALID_STATE);
 }
 
+static void test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_root_fail()
+{
+  az_iot_pnp_client client;
+  az_iot_pnp_client_options options = az_iot_pnp_client_options_default();
+  options.component_names = test_components;
+  options.component_names_length = test_components_length;
+  assert_int_equal(
+      az_iot_pnp_client_init(
+          &client, test_device_hostname, test_device_id, test_model_id, &options),
+      AZ_OK);
+
+  az_json_reader jr;
+  assert_int_equal(az_json_reader_init(&jr, test_property_payload, NULL), AZ_OK);
+
+  az_iot_pnp_client_property_response_type response_type
+      = AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_DESIRED_PROPERTIES;
+  az_span component_name;
+  int32_t value;
+
+  // First component
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_OK);
+  assert_true(az_span_is_content_equal(component_name, test_component_one));
+  assert_true(
+      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_one")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
+  assert_int_equal(value, 1);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_OK);
+  assert_true(az_span_is_content_equal(component_name, test_component_one));
+  assert_true(
+      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_two")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_true(
+      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("string")));
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+
+  // Second component
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_OK);
+  assert_true(az_span_is_content_equal(component_name, test_component_two));
+  assert_true(
+      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_three")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
+  assert_int_equal(value, 45);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_OK);
+  assert_true(
+      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_four")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_true(
+      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("string")));
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+
+  // Not a component
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_OK);
+  assert_true(az_span_is_content_equal(component_name, AZ_SPAN_EMPTY));
+  assert_true(az_json_token_is_text_equal(
+      &jr.token, AZ_SPAN_FROM_STR("not_component")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
+  assert_int_equal(value, 42);
+
+  // End of components (skipping version)
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_ERROR_JSON_INVALID_STATE);
+}
+
 static void test_az_iot_pnp_client_property_get_next_component_property_two_succeed()
 {
   az_iot_pnp_client client;
@@ -1227,6 +1322,7 @@ int test_az_iot_pnp_client_property()
     cmocka_unit_test(test_az_iot_pnp_client_property_get_property_version_out_of_order_succeed),
     cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_succeed),
     cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_fail),
+    cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_root_fail),
     cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_two_succeed),
     cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_long_succeed),
     cmocka_unit_test(

--- a/sdk/tests/iot/pnp/test_az_iot_pnp_client_property.c
+++ b/sdk/tests/iot/pnp/test_az_iot_pnp_client_property.c
@@ -835,8 +835,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_succeed(
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_component_one));
-  assert_true(
-      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_one")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_one")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 1);
@@ -849,11 +848,9 @@ static void test_az_iot_pnp_client_property_get_next_component_property_succeed(
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_component_one));
-  assert_true(
-      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_two")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_two")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
-  assert_true(
-      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("string")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("string")));
 
   // Advance
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
@@ -864,8 +861,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_succeed(
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_component_two));
-  assert_true(
-      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_three")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_three")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 45);
@@ -877,11 +873,9 @@ static void test_az_iot_pnp_client_property_get_next_component_property_succeed(
       az_iot_pnp_client_property_get_next_component_property(
           &client, &jr, response_type, &component_name),
       AZ_OK);
-  assert_true(
-      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_four")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_four")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
-  assert_true(
-      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("string")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("string")));
 
   // Advance
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
@@ -892,8 +886,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_succeed(
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, AZ_SPAN_EMPTY));
-  assert_true(az_json_token_is_text_equal(
-      &jr.token, AZ_SPAN_FROM_STR("not_component")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("not_component")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 42);
@@ -933,8 +926,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_user_not
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_component_one));
-  assert_true(
-      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_one")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_one")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 1);
@@ -970,8 +962,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_user_not
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_component_one));
-  assert_true(
-      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_one")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_one")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 1);
@@ -984,11 +975,9 @@ static void test_az_iot_pnp_client_property_get_next_component_property_user_not
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_component_one));
-  assert_true(
-      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_two")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_two")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
-  assert_true(
-      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("string")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("string")));
 
   // Advance
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
@@ -999,8 +988,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_user_not
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_component_two));
-  assert_true(
-      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_three")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_three")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 45);
@@ -1012,11 +1000,9 @@ static void test_az_iot_pnp_client_property_get_next_component_property_user_not
       az_iot_pnp_client_property_get_next_component_property(
           &client, &jr, response_type, &component_name),
       AZ_OK);
-  assert_true(
-      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_four")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_four")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
-  assert_true(
-      az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("string")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("string")));
 
   // Advance
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
@@ -1027,8 +1013,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_user_not
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, AZ_SPAN_EMPTY));
-  assert_true(az_json_token_is_text_equal(
-      &jr.token, AZ_SPAN_FROM_STR("not_component")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("not_component")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 42);
@@ -1064,8 +1049,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_two_succ
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_one));
-  assert_true(az_json_token_is_text_equal(
-      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 47);
@@ -1104,8 +1088,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_out_of_o
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_one));
-  assert_true(az_json_token_is_text_equal(
-      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 47);
@@ -1144,8 +1127,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_long_suc
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_two));
-  assert_true(az_json_token_is_text_equal(
-      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 50);
@@ -1159,8 +1141,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_long_suc
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_one));
-  assert_true(az_json_token_is_text_equal(
-      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 90);
@@ -1174,8 +1155,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_long_suc
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, AZ_SPAN_EMPTY));
-  assert_true(az_json_token_is_text_equal(
-      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 54);
@@ -1222,8 +1202,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_long_wit
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_two));
-  assert_true(az_json_token_is_text_equal(
-      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 50);
@@ -1237,8 +1216,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_long_wit
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, test_temp_component_one));
-  assert_true(az_json_token_is_text_equal(
-      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 90);
@@ -1252,8 +1230,7 @@ static void test_az_iot_pnp_client_property_get_next_component_property_long_wit
           &client, &jr, response_type, &component_name),
       AZ_OK);
   assert_true(az_span_is_content_equal(component_name, AZ_SPAN_EMPTY));
-  assert_true(az_json_token_is_text_equal(
-      &jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("targetTemperature")));
   assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
   assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
   assert_int_equal(value, 54);
@@ -1321,8 +1298,10 @@ int test_az_iot_pnp_client_property()
     cmocka_unit_test(test_az_iot_pnp_client_property_get_property_version_long_succeed),
     cmocka_unit_test(test_az_iot_pnp_client_property_get_property_version_out_of_order_succeed),
     cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_succeed),
-    cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_fail),
-    cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_root_fail),
+    cmocka_unit_test(
+        test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_fail),
+    cmocka_unit_test(
+        test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_root_fail),
     cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_two_succeed),
     cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_long_succeed),
     cmocka_unit_test(

--- a/sdk/tests/iot/pnp/test_az_iot_pnp_client_property.c
+++ b/sdk/tests/iot/pnp/test_az_iot_pnp_client_property.c
@@ -69,6 +69,33 @@ static const az_span test_property_payload = AZ_SPAN_LITERAL_FROM_STR(
 /*
 
 {
+  "component_one": {
+    "prop_one": 1,
+    "prop_two": {
+      "prop_one": "value_one",
+      "prop_two": "value_two"
+    }
+  },
+  "component_two": {
+    "prop_three": 45,
+    "prop_four": "string"
+  },
+  "not_component": {
+    "prop_one": "value_one",
+    "prop_two": "value_two"
+  },
+  "$version": 5
+}
+
+*/
+static const az_span test_property_payload_with_user_object = AZ_SPAN_LITERAL_FROM_STR(
+    "{\"component_one\":{\"prop_one\":1,\"prop_two\":{\"prop_one\":\"value_one\",\"prop_two\":"
+    "\"value_two\"}},\"component_two\":{\"prop_three\":45,\"prop_four\":\"string\"},\"not_"
+    "component\":{\"prop_one\":\"value_one\",\"prop_two\":\"value_two\"},\"$version\":5}");
+
+/*
+
+{
     "desired": {
         "thermostat1": {
             "__t": "c",
@@ -937,6 +964,157 @@ static void test_az_iot_pnp_client_property_get_next_component_property_user_not
       AZ_ERROR_JSON_INVALID_STATE);
 }
 
+static void
+test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_in_object_fail()
+{
+  az_iot_pnp_client client;
+  az_iot_pnp_client_options options = az_iot_pnp_client_options_default();
+  options.component_names = test_components;
+  options.component_names_length = test_components_length;
+  assert_int_equal(
+      az_iot_pnp_client_init(
+          &client, test_device_hostname, test_device_id, test_model_id, &options),
+      AZ_OK);
+
+  az_json_reader jr;
+  assert_int_equal(az_json_reader_init(&jr, test_property_payload_with_user_object, NULL), AZ_OK);
+
+  az_iot_pnp_client_property_response_type response_type
+      = AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_DESIRED_PROPERTIES;
+  az_span component_name;
+  int32_t value;
+
+  // First component
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_OK);
+  assert_true(az_span_is_content_equal(component_name, test_component_one));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_one")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
+  assert_int_equal(value, 1);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_OK);
+  assert_true(az_span_is_content_equal(component_name, test_component_one));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_two")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+
+  // Begin user object
+  assert_true(jr.token.kind == AZ_JSON_TOKEN_BEGIN_OBJECT);
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+
+  // At user property name
+  assert_true(jr.token.kind == AZ_JSON_TOKEN_PROPERTY_NAME);
+
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_ERROR_JSON_INVALID_STATE);
+}
+
+static void
+test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_in_top_level_object_fail()
+{
+  az_iot_pnp_client client;
+  az_iot_pnp_client_options options = az_iot_pnp_client_options_default();
+  options.component_names = test_components;
+  options.component_names_length = test_components_length;
+  assert_int_equal(
+      az_iot_pnp_client_init(
+          &client, test_device_hostname, test_device_id, test_model_id, &options),
+      AZ_OK);
+
+  az_json_reader jr;
+  assert_int_equal(az_json_reader_init(&jr, test_property_payload_with_user_object, NULL), AZ_OK);
+
+  az_iot_pnp_client_property_response_type response_type
+      = AZ_IOT_PNP_CLIENT_PROPERTY_RESPONSE_TYPE_DESIRED_PROPERTIES;
+  az_span component_name;
+  int32_t value;
+
+  // First component
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_OK);
+  assert_true(az_span_is_content_equal(component_name, test_component_one));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_one")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
+  assert_int_equal(value, 1);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_OK);
+  assert_true(az_span_is_content_equal(component_name, test_component_one));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_two")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+
+  // Skip over user object
+  assert_int_equal(az_json_reader_skip_children(&jr), AZ_OK);
+
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_OK);
+
+  // First component
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_OK);
+  assert_true(az_span_is_content_equal(component_name, test_component_two));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_three")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_int_equal(az_json_token_get_int32(&jr.token, &value), AZ_OK);
+  assert_int_equal(value, 45);
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_OK);
+  assert_true(az_span_is_content_equal(component_name, test_component_two));
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("prop_four")));
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_true(az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("string")));
+
+  // Advance
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+
+  // Non component property
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_OK);
+  assert_true(az_span_is_content_equal(component_name, AZ_SPAN_EMPTY));
+
+  // Advance to user object
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+  assert_true(jr.token.kind == AZ_JSON_TOKEN_BEGIN_OBJECT);
+
+  // Advance to non-component property name
+  assert_int_equal(az_json_reader_next_token(&jr), AZ_OK);
+
+  assert_int_equal(
+      az_iot_pnp_client_property_get_next_component_property(
+          &client, &jr, response_type, &component_name),
+      AZ_ERROR_JSON_INVALID_STATE);
+}
+
 static void test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_root_fail()
 {
   az_iot_pnp_client client;
@@ -1300,6 +1478,10 @@ int test_az_iot_pnp_client_property()
     cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_succeed),
     cmocka_unit_test(
         test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_fail),
+    cmocka_unit_test(
+        test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_in_object_fail),
+    cmocka_unit_test(
+        test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_in_top_level_object_fail),
     cmocka_unit_test(
         test_az_iot_pnp_client_property_get_next_component_property_user_not_advance_root_fail),
     cmocka_unit_test(test_az_iot_pnp_client_property_get_next_component_property_two_succeed),


### PR DESCRIPTION
This updates the `az_iot_pnp_client_property_get_next_component_property()` API to only require one JSON reader. This cuts the stack usage down from ~200 bytes to ~100 bytes. 

The trade off is that the only JSON reader is shared between the API and the user to read the properties. That means that if the user doesn't iterate correctly through the JSON, the API won't be able to recover. There is therefore more responsibility on the user to correctly process the properties and deliver it back to the API in an expected location. However, in order to properly read the properties in the first place, they would have had to already correctly call the JSON APIs. That means that the overhead is one call to `az_json_reader_next_token()` in the case of properties they care about and the following in the case they don't (which is detailed in the docs):

```c
 az_json_reader_skip_children(&jr);
 az_json_reader_next_token(&jr)
```