### PR TITLE
Fix for ESP8266 sample

### DIFF
--- a/sdk/samples/iot/aziot_esp8266/New-ArduinoZipLibrary.ps1
+++ b/sdk/samples/iot/aziot_esp8266/New-ArduinoZipLibrary.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+
 git clone https://github.com/Azure/azure-sdk-for-c sdkrepo
 mkdir azure-sdk-for-c
 

--- a/sdk/samples/iot/aziot_esp8266/New-TrustedCertHeader.ps1
+++ b/sdk/samples/iot/aziot_esp8266/New-TrustedCertHeader.ps1
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+function New-XxdHeader
+{
+    param($InFile, $OutFile, $BytesPerColumn = 12)
+
+    $Hex = Format-Hex -Path $InFile
+
+    Out-File -Force -Encoding ascii -NoNewline -FilePath $OutFile -InputObject "unsigned char ca_pem[] = {"
+    
+    $Index = 0;
+    while ($Index -LT ($Hex.Bytes.Count - 1))
+    {
+        if (($Index % ($BytesPerColumn)) -EQ 0)
+        {
+            Out-File -Append -Encoding ascii -NoNewline -FilePath $OutFile -InputObject "`n "
+        }
+
+        Out-File -Append -Encoding ascii -FilePath $OutFile -NoNewline -InputObject $(" 0x{00:x2}," -f $Hex.Bytes[$Index])
+
+        $Index++;
+    }
+
+    if (($Index % ($BytesPerColumn)) -EQ 0)
+    {
+        Out-File -Append -Encoding ascii -NoNewline -FilePath $OutFile -InputObject "`n "
+    }
+
+    Out-File -Append -Encoding ascii -FilePath $OutFile -InputObject $(" 0x{00:x2}" -f $Hex.Bytes[$Index])
+    
+    Out-File -Append -Encoding ascii -FilePath $OutFile -InputObject "};"
+
+    Out-File -Append -Encoding ascii -FilePath $OutFile -InputObject "unsigned int ca_pem_len = $($Hex.Bytes.Count);"
+}
+
+echo "It will take a few seconds, please wait."
+
+Invoke-WebRequest -Uri https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem -OutFile ca.pem
+
+New-XxdHeader -InFile ".\ca.pem" -OutFile ".\ca.h"
+
+Remove-Item -Force -Confirm:$false ".\ca.pem"

--- a/sdk/samples/iot/aziot_esp8266/create_trusted_cert_header.sh
+++ b/sdk/samples/iot/aziot_esp8266/create_trusted_cert_header.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+command -v xxd >/dev/null 2>&1 || { echo >&2 "Please install xxd."; exit 1; }
+
+wget https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem -O ca.pem
+xxd -i ca.pem ca.h

--- a/sdk/samples/iot/aziot_esp8266/generate_arduino_zip_library.sh
+++ b/sdk/samples/iot/aziot_esp8266/generate_arduino_zip_library.sh
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 command -v zip >/dev/null 2>&1 || { echo >&2 "Please install zip."; exit 1; }
-command -v xxd >/dev/null 2>&1 || { echo >&2 "Please install xxd."; exit 1; }
 
 git clone https://github.com/Azure/azure-sdk-for-c sdkrepo
 mkdir azure-sdk-for-c
@@ -23,6 +22,3 @@ zip -r9 azure-sdk-for-c azure-sdk-for-c/
 
 rm -rf azure-sdk-for-c
 rm -rf sdkrepo/
-
-wget https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem -O ca.pem
-xxd -i ca.pem ca.h

--- a/sdk/samples/iot/docs/how_to_iot_hub_esp8266_nodemcu.md
+++ b/sdk/samples/iot/docs/how_to_iot_hub_esp8266_nodemcu.md
@@ -40,19 +40,20 @@ _The following was run on Windows 10 and Ubuntu Desktop 20.04 environments, with
 
     On Windows:
 
-        Download and install: https://aka.ms/installazurecliwindows
+      Download and install: https://aka.ms/installazurecliwindows
 
-        ```cmd
-        PS C:\>az extension add --name azure-iot
-        ```
+      ```powershell
+      PS C:\>az extension add --name azure-iot
+      ```
 
     On Linux:
-        ```bash
-        $ curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-        $ az extension add --name azure-iot
-        ```
 
-        A list of all the Azure IoT CLI extension commands can be found [here](https://docs.microsoft.com/cli/azure/iot?view=azure-cli-latest).
+      ```bash
+      $ curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      $ az extension add --name azure-iot
+      ```
+
+      A list of all the Azure IoT CLI extension commands can be found [here](https://docs.microsoft.com/cli/azure/iot?view=azure-cli-latest).
 
   - The most recent version of [Azure IoT Explorer](https://github.com/Azure/azure-iot-explorer/releases) installed. More instruction on its usage can be found [here](https://docs.microsoft.com/azure/iot-pnp/howto-use-iot-explorer).
 
@@ -109,7 +110,31 @@ _The following was run on Windows 10 and Ubuntu Desktop 20.04 environments, with
 
 5. Create a sketch on Arduino IDE for the IoT Hub telemetry sample.
 
-    - Clone the [Azure SDK for Embedded C](https://github.com/Azure/azure-sdk-for-c) repository locally and then open the [ESP8266 sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/aziot_esp8266) (from the local clone) on the Arduino IDE.
+    - Clone the [Azure SDK for Embedded C](https://github.com/Azure/azure-sdk-for-c) repository locally
+
+    - Generate the `ca.h` header (in the ESP8266 sample folder!) with the public root CA for server certificate validation
+
+      - Navigate to the ESP8266 sample in your local cloned repo
+
+        ```bash
+        cd <cloned repo root>/sdk/samples/iot/aziot_esp8266
+        ```
+
+      - Run the script to generate the `ca.h` header.
+
+        On Windows (using Poweshell):
+
+        ```powershell
+        .\New-TrustedCertHeader.ps1
+        ```
+
+        On Linux:
+
+        ```bash
+        ./create_trusted_cert_header.sh
+        ```
+
+    - Open the [ESP8266 sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/aziot_esp8266) (from the local clone) on the Arduino IDE.
 
     - Edit the following parameters in `iot_configs.h`, filling in your own information:
 


### PR DESCRIPTION
- Separate the root CA header generation from the script that creates the
Arduino package;
- Create similar script to generate CA cert header on Windows Powershell
- Update Quick Guide to reflect the additional steps