### PR TITLE
Enable 1ES hosted pools.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -41,7 +41,8 @@ jobs:
   strategy:
     matrix:
       LinuxARM_Release_Logging:
-        OSVmImage: 'ubuntu-18.04'
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage:
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -51,7 +52,8 @@ jobs:
         BuildType: Release
 
       LinuxARM:
-        OSVmImage: 'ubuntu-18.04'
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage:
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -61,7 +63,8 @@ jobs:
         BuildType: Debug
 
       Linux_Release_MapFiles_Logging_UnitTests_Mocks:
-        OSVmImage: 'ubuntu-18.04'
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage:
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON'
@@ -71,7 +74,8 @@ jobs:
         BuildType: Release
 
       Linux_Logging_UnitTests_Mocks_Samples:
-        OSVmImage: 'ubuntu-18.04'
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage:
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON'
@@ -79,7 +83,8 @@ jobs:
         BuildType: Debug
 
       WindowsX86_Release_MapFiles_UnitTests:
-        OSVmImage: 'windows-2019'
+        Pool: azsdk-pool-mms-win-2019-general
+        OSVmImage:
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF'
@@ -91,6 +96,7 @@ jobs:
         BuildType: Release
 
       MacOS_Release_MapFiles_Logging_UnitTests_Samples:
+        Pool:
         OSVmImage: 'macOS-10.15'
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
@@ -100,6 +106,7 @@ jobs:
         BuildType: Release
 
       MacOS_Logging_UnitTests_Samples:
+        Pool:
         OSVmImage: 'macOS-10.15'
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
@@ -108,7 +115,8 @@ jobs:
         BuildType: Debug
 
       LinuxGCC5_Release_MapFiles_UnitTests:
-        OSVmImage: 'ubuntu-16.04'
+        Pool: azsdk-pool-mms-ubuntu-1604-general
+        OSVmImage:
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF'
@@ -119,7 +127,8 @@ jobs:
         BuildType: Release
 
       LinuxGCC5_UnitTests_Samples:
-        OSVmImage: 'ubuntu-16.04'
+        Pool: azsdk-pool-mms-ubuntu-1604-general
+        OSVmImage:
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF'
@@ -128,7 +137,8 @@ jobs:
         BuildType: Debug
 
       LinuxARM_Release_Preconditions:
-        OSVmImage: 'ubuntu-18.04'
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage:
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -138,7 +148,8 @@ jobs:
         BuildType: Release
 
       LinuxARM_Preconditions_Logging:
-        OSVmImage: 'ubuntu-18.04'
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage:
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -148,7 +159,8 @@ jobs:
         BuildType: Debug
 
       Linux_Release_Preconditions_Logging_UnitTests_Mocks_Samples:
-        OSVmImage: 'ubuntu-18.04'
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage:
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON'
@@ -156,7 +168,8 @@ jobs:
         BuildType: Release
 
       Linux_Preconditions_Logging_UnitTests_Mocks_CodeCov_Linter:
-        OSVmImage: 'ubuntu-18.04'
+        Pool: azsdk-pool-mms-ubuntu-1804-general
+        OSVmImage:
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcovr lcov'
@@ -167,7 +180,8 @@ jobs:
         BuildType: Debug
 
       Windows_Preconditions_UnitTests_Samples:
-        OSVmImage: 'windows-2019'
+        Pool: azsdk-pool-mms-win-2019-general
+        OSVmImage:
         vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON -DLOGGING=OFF'
@@ -177,6 +191,7 @@ jobs:
         BuildType: Debug
 
       MacOS_Release_Preconditions_Logging_UnitTests_Samples:
+        Pool:
         OSVmImage: 'macOS-10.15'
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
@@ -185,6 +200,7 @@ jobs:
         BuildType: Release
 
       MacOS_Preconditions_Logging_UnitTests:
+        Pool:
         OSVmImage: 'macOS-10.15'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
@@ -194,7 +210,8 @@ jobs:
         BuildType: Debug
 
       LinuxGCC5_Release_Preconditions_UnitTests_Samples:
-        OSVmImage: 'ubuntu-16.04'
+        Pool: azsdk-pool-mms-ubuntu-1604-general
+        OSVmImage:
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DLOGGING=OFF'
@@ -203,7 +220,8 @@ jobs:
         BuildType: Release
 
       LinuxGCC5_Preconditions_UnitTests:
-        OSVmImage: 'ubuntu-16.04'
+        Pool: azsdk-pool-mms-ubuntu-1604-general
+        OSVmImage:
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DUNIT_TESTING=ON -DLOGGING=OFF'
@@ -213,7 +231,8 @@ jobs:
         BuildType: Debug
 
       Windows_Release_MapFiles:
-        OSVmImage: 'windows-2019'
+        Pool: azsdk-pool-mms-win-2019-general
+        OSVmImage:
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DLOGGING=OFF'
@@ -224,6 +243,7 @@ jobs:
         MapFileArtifactSuffix: 'win-x64-rel-noprc-nolog'
         BuildType: Release
   pool:
+    name: $(Pool)
     vmImage: $(OSVmImage)
   variables:
     CMOCKA_XML_FILE: "%g-test-results.xml"
@@ -363,7 +383,7 @@ jobs:
 
 - job: GenerateReleaseArtifacts
   pool:
-    vmImage: windows-2019
+    name: azsdk-pool-mms-win-2019-general
   steps:
     - template: /eng/common/pipelines/templates/steps/verify-links.yml
       parameters:


### PR DESCRIPTION
This PR moves the Windows and Linux jobs over to the 1ES hosted pools (this has already been done for C#, Java, Python, and JS. The changes are roughly as follows:

1. Added WindowsPool and LinuxPool parameters to stage template and job template.
2. Added variables which contain the WindowsPool and LinuxPool values.
3. Used variables in the test matrix.
4. Other minor changes to support above.