### PR TITLE
Re-enable agent OS verification

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -42,7 +42,7 @@ jobs:
     matrix:
       LinuxARM_Release_Logging:
         Pool: azsdk-pool-mms-ubuntu-1804-general
-        OSVmImage:
+        OSVmImage: MMSUbuntu18.04
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -53,7 +53,7 @@ jobs:
 
       LinuxARM:
         Pool: azsdk-pool-mms-ubuntu-1804-general
-        OSVmImage:
+        OSVmImage: MMSUbuntu18.04
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -64,7 +64,7 @@ jobs:
 
       Linux_Release_MapFiles_Logging_UnitTests_Mocks:
         Pool: azsdk-pool-mms-ubuntu-1804-general
-        OSVmImage:
+        OSVmImage: MMSUbuntu18.04
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON'
@@ -75,7 +75,7 @@ jobs:
 
       Linux_Logging_UnitTests_Mocks_Samples:
         Pool: azsdk-pool-mms-ubuntu-1804-general
-        OSVmImage:
+        OSVmImage: MMSUbuntu18.04
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON'
@@ -84,7 +84,7 @@ jobs:
 
       WindowsX86_Release_MapFiles_UnitTests:
         Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage:
+        OSVmImage: MMS2019
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF'
@@ -96,7 +96,7 @@ jobs:
         BuildType: Release
 
       MacOS_Release_MapFiles_Logging_UnitTests_Samples:
-        Pool:
+        Pool: Azure Pipelines
         OSVmImage: 'macOS-10.15'
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
@@ -106,7 +106,7 @@ jobs:
         BuildType: Release
 
       MacOS_Logging_UnitTests_Samples:
-        Pool:
+        Pool: Azure Pipelines
         OSVmImage: 'macOS-10.15'
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
@@ -116,7 +116,7 @@ jobs:
 
       LinuxGCC5_Release_MapFiles_UnitTests:
         Pool: azsdk-pool-mms-ubuntu-1604-general
-        OSVmImage:
+        OSVmImage: MMSUbuntu16.04
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF'
@@ -128,7 +128,7 @@ jobs:
 
       LinuxGCC5_UnitTests_Samples:
         Pool: azsdk-pool-mms-ubuntu-1604-general
-        OSVmImage:
+        OSVmImage: MMSUbuntu16.04
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF'
@@ -138,7 +138,7 @@ jobs:
 
       LinuxARM_Release_Preconditions:
         Pool: azsdk-pool-mms-ubuntu-1804-general
-        OSVmImage:
+        OSVmImage: MMSUbuntu18.04
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -149,7 +149,7 @@ jobs:
 
       LinuxARM_Preconditions_Logging:
         Pool: azsdk-pool-mms-ubuntu-1804-general
-        OSVmImage:
+        OSVmImage: MMSUbuntu18.04
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -160,7 +160,7 @@ jobs:
 
       Linux_Release_Preconditions_Logging_UnitTests_Mocks_Samples:
         Pool: azsdk-pool-mms-ubuntu-1804-general
-        OSVmImage:
+        OSVmImage: MMSUbuntu18.04
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON'
@@ -169,7 +169,7 @@ jobs:
 
       Linux_Preconditions_Logging_UnitTests_Mocks_CodeCov_Linter:
         Pool: azsdk-pool-mms-ubuntu-1804-general
-        OSVmImage:
+        OSVmImage: MMSUbuntu18.04
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcovr lcov'
@@ -181,7 +181,7 @@ jobs:
 
       Windows_Preconditions_UnitTests_Samples:
         Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage:
+        OSVmImage: MMS2019
         vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON -DLOGGING=OFF'
@@ -191,7 +191,7 @@ jobs:
         BuildType: Debug
 
       MacOS_Release_Preconditions_Logging_UnitTests_Samples:
-        Pool:
+        Pool: Azure Pipelines
         OSVmImage: 'macOS-10.15'
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
@@ -200,7 +200,7 @@ jobs:
         BuildType: Release
 
       MacOS_Preconditions_Logging_UnitTests:
-        Pool:
+        Pool: Azure Pipelines
         OSVmImage: 'macOS-10.15'
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-osx'
@@ -211,7 +211,7 @@ jobs:
 
       LinuxGCC5_Release_Preconditions_UnitTests_Samples:
         Pool: azsdk-pool-mms-ubuntu-1604-general
-        OSVmImage:
+        OSVmImage: MMSUbuntu16.04
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DLOGGING=OFF'
@@ -221,7 +221,7 @@ jobs:
 
       LinuxGCC5_Preconditions_UnitTests:
         Pool: azsdk-pool-mms-ubuntu-1604-general
-        OSVmImage:
+        OSVmImage: MMSUbuntu16.04
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DUNIT_TESTING=ON -DLOGGING=OFF'
@@ -232,7 +232,7 @@ jobs:
 
       Windows_Release_MapFiles:
         Pool: azsdk-pool-mms-win-2019-general
-        OSVmImage:
+        OSVmImage: MMS2019
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DLOGGING=OFF'
@@ -252,6 +252,11 @@ jobs:
   steps:
   - checkout: self
     submodules: recursive
+
+  - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
+    parameters:
+      AgentPool: $(Pool)
+      AgentImage: $(OSVmImage)
 
   # Install apt dependencies (if appropriate)
   - bash: sudo apt install -y $(AptDependencies)

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -255,7 +255,6 @@ jobs:
 
   - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
     parameters:
-      AgentPool: $(Pool)
       AgentImage: $(OSVmImage)
 
   # Install apt dependencies (if appropriate)

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -388,6 +388,7 @@ jobs:
 - job: GenerateReleaseArtifacts
   pool:
     name: azsdk-pool-mms-win-2019-general
+    vmImage: MMS2019
   steps:
     - template: /eng/common/pipelines/templates/steps/verify-links.yml
       parameters:

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -8,13 +8,13 @@ jobs:
       matrix:
         Linux_x64_with_samples:
           Pool: azsdk-pool-mms-ubuntu-1804-general
-          OSVmImage: 'ubuntu-18.04'
+          OSVmImage: MMSUbuntu18.04
           vcpkg.deps: 'curl[ssl]'
           VCPKG_DEFAULT_TRIPLET: 'x64-linux'
           build.args: ' -DTRANSPORT_CURL=ON -DAZ_PLATFORM_IMPL=POSIX'
         Win_x86_with_samples:
           Pool: azsdk-pool-mms-win-2019-general
-          OSVmImage: 'windows-2019'
+          OSVmImage: MMS2019
           vcpkg.deps: 'curl[winssl]'
           VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
           CMAKE_GENERATOR: 'Visual Studio 16 2019'
@@ -22,7 +22,7 @@ jobs:
           build.args: ' -DTRANSPORT_CURL=ON -DAZ_PLATFORM_IMPL=WIN32'
         Win_x64_with_samples:
           Pool: azsdk-pool-mms-win-2019-general
-          OSVmImage: 'windows-2019'
+          OSVmImage: MMS2019
           vcpkg.deps: 'curl[winssl]'
           VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
           CMAKE_GENERATOR: 'Visual Studio 16 2019'

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -7,11 +7,13 @@ jobs:
     strategy:
       matrix:
         Linux_x64_with_samples:
+          Pool: azsdk-pool-mms-ubuntu-1804-general
           OSVmImage: 'ubuntu-18.04'
           vcpkg.deps: 'curl[ssl]'
           VCPKG_DEFAULT_TRIPLET: 'x64-linux'
           build.args: ' -DTRANSPORT_CURL=ON -DAZ_PLATFORM_IMPL=POSIX'
         Win_x86_with_samples:
+          Pool: azsdk-pool-mms-win-2019-general
           OSVmImage: 'windows-2019'
           vcpkg.deps: 'curl[winssl]'
           VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
@@ -19,6 +21,7 @@ jobs:
           CMAKE_GENERATOR_PLATFORM: Win32
           build.args: ' -DTRANSPORT_CURL=ON -DAZ_PLATFORM_IMPL=WIN32'
         Win_x64_with_samples:
+          Pool: azsdk-pool-mms-win-2019-general
           OSVmImage: 'windows-2019'
           vcpkg.deps: 'curl[winssl]'
           VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
@@ -26,15 +29,22 @@ jobs:
           CMAKE_GENERATOR_PLATFORM: x64
           build.args: ' -DTRANSPORT_CURL=ON -DAZ_PLATFORM_IMPL=WIN32'
         MacOS_x64_with_samples:
+          Pool: Azure Pipelines
           OSVmImage: 'macOS-10.15'
           vcpkg.deps: 'curl[ssl]'
           VCPKG_DEFAULT_TRIPLET: 'x64-osx'
           build.args: ' -DTRANSPORT_CURL=ON  -DAZ_PLATFORM_IMPL=POSIX'
 
     pool:
+      name: $(Pool)
       vmImage: $(OSVmImage)
 
     steps:
+      - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
+        parameters:
+          AgentPool: $(Pool)
+          AgentImage: $(OSVmImage)
+
       - template: /eng/pipelines/templates/steps/vcpkg.yml
         parameters:
           DependenciesVariableName: vcpkg.deps

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -42,7 +42,6 @@ jobs:
     steps:
       - template: /eng/common/pipelines/templates/steps/verify-agent-os.yml
         parameters:
-          AgentPool: $(Pool)
           AgentImage: $(OSVmImage)
 
       - template: /eng/pipelines/templates/steps/vcpkg.yml

--- a/eng/pipelines/templates/stages/archetype-c-release.yml
+++ b/eng/pipelines/templates/stages/archetype-c-release.yml
@@ -11,7 +11,8 @@ stages:
         environment: github
 
         pool:
-          vmImage: windows-2019
+          name: azsdk-pool-mms-win-2019-general
+          vmImage: MMS2019
 
         strategy:
           runOnce:
@@ -42,7 +43,8 @@ stages:
         environment: githubio
 
         pool:
-          vmImage: windows-2019
+          name: azsdk-pool-mms-win-2019-general
+          vmImage: MMS2019
 
         strategy:
           runOnce:
@@ -67,7 +69,8 @@ stages:
         environment: github
 
         pool:
-          vmImage: windows-2019
+          name: azsdk-pool-mms-win-2019-general
+          vmImage: MMS2019
 
         strategy:
           runOnce:


### PR DESCRIPTION
This PR enables agent OS verification (was disabled during 1ES pool onboarding). This requires the following PR to be merged first:

https://github.com/Azure/azure-sdk-tools/pull/1371