### PR TITLE
[CI test] Revert windows fix for building static libraries with /MT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,13 +44,6 @@ if(DEFINED ENV{VCPKG_DEFAULT_TRIPLET} AND NOT DEFINED VCPKG_TARGET_TRIPLET)
   set(VCPKG_TARGET_TRIPLET "$ENV{VCPKG_DEFAULT_TRIPLET}" CACHE STRING "")
 endif()
 
-# Use the static runtime libraries when building statically for consistency with vcpkg's
-# arch-windows-static triplets:
-cmake_policy(SET CMP0091 NEW) # https://cmake.org/cmake/help/v3.15/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html
-if (NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-endif()
-
 project(az LANGUAGES C)
 enable_testing ()
 


### PR DESCRIPTION
Reverting part of https://github.com/Azure/azure-sdk-for-c/pull/1394 to test if CI will fail.