### PR TITLE
Update readme around vcpkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ First, ensure that you have the latest `gcc` installed:
     brew install gcc
     brew cleanup
 
-Follow next steps to install VCPKG and have it linked to cmake. 
+Use the following steps to install Vcpkg and have it linked to CMake.
 
 > **Note:** The Azure SDK is only officially supported against certain versions of Vcpkg. Use the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt) to get a known working version.
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,9 @@ files and start again.
 vcpkg is the easiest way to have dependencies installed. It downloads packages sources, headers and build libraries for whatever TRIPLET is set up (platform/arq).
 VCPKG maintains any installed package inside its own folder, allowing to have multiple vcpkg folder with different dependencies installed on each. This is also great because you don't have to install dependencies globally on your system.
 
-Follow next steps to install VCPKG and have it linked to cmake. The vcpkg repository is checked out at the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt). Azure SDK code in this version is known to work at that vcpkg commit.
+Follow next steps to install VCPKG and have it linked to cmake.
+
+>Note The Azure SDK is only officially supported against certain versions of VCPKG.  Use the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt) to get a known working version.
 
 ```bash
 # Clone vcpkg:
@@ -300,11 +302,11 @@ git clone https://github.com/Microsoft/vcpkg.git
 # (consider this path as PATH_TO_VCPKG)
 cd vcpkg
 # Checkout the vcpkg commit from the vcpkg-commit.txt file (link above)
-git checkout <vcpkg commit>
+git checkout <vcpkg commit> 
 
-# build vcpkg (remove .bat on Linux/Mac)
+# build vcpkg
 .\bootstrap-vcpkg.bat
-# install dependencies (remove .exe in Linux/Mac) and update triplet
+# install dependencies and update triplet
 .\vcpkg.exe install --triplet x64-windows-static curl[winssl] cmocka paho-mqtt
 # Add this environment variables to link this VCPKG folder with cmake:
 # VCPKG_DEFAULT_TRIPLET=x64-windows-static
@@ -342,7 +344,9 @@ Right after opening project, Visual Studio will read cmake files and generate ca
 VCPKG can be used to download packages sources, headers and build libraries for whatever TRIPLET is set up (platform/architecture).
 VCPKG maintains any installed package inside its own folder, allowing to have multiple vcpkg folder with different dependencies installed on each. This is also great because you don't have to install dependencies globally on your system.
 
-Follow next steps to install VCPKG and have it linked to cmake. The vcpkg repository is checked out at the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt). Azure SDK code in this version is known to work at that vcpkg commit.
+Follow next steps to install VCPKG and have it linked to cmake. 
+
+>Note The Azure SDK is only officially supported against certain versions of VCPKG.  Use the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt) to get a known working version.
 
 ```bash
 # Clone vcpkg:
@@ -350,6 +354,7 @@ git clone https://github.com/Microsoft/vcpkg.git
 # (consider this path as PATH_TO_VCPKG)
 cd vcpkg
 # Checkout the vcpkg commit from the vcpkg-commit.txt file (link above)
+# Note: Azure SDK is only officially supported against this commit
 git checkout <vcpkg commit>
 
 # build vcpkg
@@ -397,7 +402,9 @@ First, ensure that you have the latest `gcc` installed:
     brew install gcc
     brew cleanup
 
-Follow next steps to install VCPKG and have it linked to cmake. The vcpkg repository is checked out at the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt). Azure SDK code in this version is known to work at that vcpkg commit.
+Follow next steps to install VCPKG and have it linked to cmake. 
+
+>Note The Azure SDK is only officially supported against certain versions of VCPKG.  Use the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt) to get a known working version.
 
 ```bash
 # Clone vcpkg:
@@ -405,6 +412,7 @@ git clone https://github.com/Microsoft/vcpkg.git
 # (consider this path as PATH_TO_VCPKG)
 cd vcpkg
 # Checkout the vcpkg commit from the vcpkg-commit.txt file (link above)
+# Note: Azure SDK is only officially supported against this commit
 git checkout <vcpkg commit>
 
 # build vcpkg

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ git clone https://github.com/Microsoft/vcpkg.git
 # (consider this path as PATH_TO_VCPKG)
 cd vcpkg
 # Checkout the vcpkg commit from the vcpkg-commit.txt file (link above)
-git checkout <vcpkg commit> 
+git checkout <vcpkg commit>
 
 # build vcpkg
 .\bootstrap-vcpkg.bat

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ VCPKG maintains any installed package inside its own folder, allowing to have mu
 
 Use the following steps to install Vcpkg and have it linked to CMake.
 
->Note The Azure SDK is only officially supported against certain versions of VCPKG.  Use the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt) to get a known working version.
+> **Note:** The Azure SDK is only officially supported against certain versions of Vcpkg. Use the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt) to get a known working version.
 
 ```bash
 # Clone vcpkg:

--- a/README.md
+++ b/README.md
@@ -354,7 +354,6 @@ git clone https://github.com/Microsoft/vcpkg.git
 # (consider this path as PATH_TO_VCPKG)
 cd vcpkg
 # Checkout the vcpkg commit from the vcpkg-commit.txt file (link above)
-# Note: Azure SDK is only officially supported against this commit
 git checkout <vcpkg commit>
 
 # build vcpkg
@@ -412,7 +411,6 @@ git clone https://github.com/Microsoft/vcpkg.git
 # (consider this path as PATH_TO_VCPKG)
 cd vcpkg
 # Checkout the vcpkg commit from the vcpkg-commit.txt file (link above)
-# Note: Azure SDK is only officially supported against this commit
 git checkout <vcpkg commit>
 
 # build vcpkg

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ VCPKG maintains any installed package inside its own folder, allowing to have mu
 
 Follow next steps to install VCPKG and have it linked to cmake.
 
->Note The Azure SDK is only officially supported against certain versions of VCPKG.  Use the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt) to get a known working version.
+> **Note:** The Azure SDK is only officially supported against certain versions of Vcpkg. Use the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt) to get a known working version.
 
 ```bash
 # Clone vcpkg:

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Right after opening project, Visual Studio will read cmake files and generate ca
 VCPKG can be used to download packages sources, headers and build libraries for whatever TRIPLET is set up (platform/architecture).
 VCPKG maintains any installed package inside its own folder, allowing to have multiple vcpkg folder with different dependencies installed on each. This is also great because you don't have to install dependencies globally on your system.
 
-Follow next steps to install VCPKG and have it linked to cmake. 
+Use the following steps to install Vcpkg and have it linked to CMake.
 
 >Note The Azure SDK is only officially supported against certain versions of VCPKG.  Use the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt) to get a known working version.
 

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ First, ensure that you have the latest `gcc` installed:
 
 Follow next steps to install VCPKG and have it linked to cmake. 
 
->Note The Azure SDK is only officially supported against certain versions of VCPKG.  Use the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt) to get a known working version.
+> **Note:** The Azure SDK is only officially supported against certain versions of Vcpkg. Use the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt) to get a known working version.
 
 ```bash
 # Clone vcpkg:

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ files and start again.
 vcpkg is the easiest way to have dependencies installed. It downloads packages sources, headers and build libraries for whatever TRIPLET is set up (platform/arq).
 VCPKG maintains any installed package inside its own folder, allowing to have multiple vcpkg folder with different dependencies installed on each. This is also great because you don't have to install dependencies globally on your system.
 
-Follow next steps to install VCPKG and have it linked to cmake.
+Use the following steps to install Vcpkg and have it linked to CMake.
 
 > **Note:** The Azure SDK is only officially supported against certain versions of Vcpkg. Use the commit in [vcpkg-commit.txt](https://github.com/Azure/azure-sdk-for-c/blob/master/eng/vcpkg-commit.txt) to get a known working version.
 


### PR DESCRIPTION
* Remove "Linux/Mac" notes inside Windows vcpkg setup instructions, as Linux/Mac have separate sections anyway.

* Add a more explicit note about needing to use the correct vcpkg version supported.  Even though it was in setup instructions I had skipped it and spent a lot of time trying to debug issue.

I'd also considered trying to do something like "cat <sdkTree>\engg\vcpkg-commit.txt" to make this even more clear and maybe that would've been right(?), but since we don't seem to have user set <sdkTree> environment variable anywhere it wasn't necessarily natural.