### PR TITLE
construct version string automatically

### DIFF
--- a/sdk/inc/azure/core/az_version.h
+++ b/sdk/inc/azure/core/az_version.h
@@ -32,10 +32,8 @@
 
 /// The version in string format used for telemetry following the `semver.org` standard
 /// (https://semver.org).
-#define AZ_SDK_VERSION_STRING \
-    _az_STRINGIFY( AZ_SDK_VERSION_MAJOR ) "." \
-    _az_STRINGIFY( AZ_SDK_VERSION_MINOR ) "." \
-    _az_STRINGIFY( AZ_SDK_VERSION_PATCH ) "-" \
-    AZ_SDK_VERSION_PRERELEASE
+#define AZ_SDK_VERSION_STRING                                                                    \
+  _az_STRINGIFY(AZ_SDK_VERSION_MAJOR) "." _az_STRINGIFY(AZ_SDK_VERSION_MINOR) "." _az_STRINGIFY( \
+      AZ_SDK_VERSION_PATCH) "-" AZ_SDK_VERSION_PRERELEASE
 
 #endif //_az_VERSION_H

--- a/sdk/inc/azure/core/az_version.h
+++ b/sdk/inc/azure/core/az_version.h
@@ -15,9 +15,8 @@
 #ifndef _az_VERSION_H
 #define _az_VERSION_H
 
-/// The version in string format used for telemetry following the `semver.org` standard
-/// (https://semver.org).
-#define AZ_SDK_VERSION_STRING "1.2.0-beta.1"
+#define _az_STRINGIFY2(x) #x
+#define _az_STRINGIFY(x) _az_STRINGIFY2(x)
 
 /// Major numeric identifier.
 #define AZ_SDK_VERSION_MAJOR 1
@@ -30,5 +29,13 @@
 
 /// Optional pre-release identifier. SDK is in a pre-release state when present.
 #define AZ_SDK_VERSION_PRERELEASE "beta.1"
+
+/// The version in string format used for telemetry following the `semver.org` standard
+/// (https://semver.org).
+#define AZ_SDK_VERSION_STRING \
+    _az_STRINGIFY( AZ_SDK_VERSION_MAJOR ) "." \
+    _az_STRINGIFY( AZ_SDK_VERSION_MINOR ) "." \
+    _az_STRINGIFY( AZ_SDK_VERSION_PATCH ) "-" \
+    AZ_SDK_VERSION_PRERELEASE
 
 #endif //_az_VERSION_H


### PR DESCRIPTION
Unfortunately the autoformatter makes this look ugly (I'd rather vertically align) but anyways.

We have it set up this way on the middleware since it creates one source of truth. This way the separate values can't get out of sync with the string.