### PR TITLE
Better naming of PnP property related enums/sample

### DIFF
--- a/sdk/inc/azure/iot/az_iot_hub_client.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client.h
@@ -712,12 +712,15 @@ typedef enum
 {
   AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_GET
   = AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_GET, /**< A response from a properties "GET" request. */
-  AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES
+  AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE
   = AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES, /**< A "PATCH" response with a payload
-                                                                containing desired properties. */
-  AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_REPORTED_PROPERTIES
-  = AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES, /**< A response with the result of the
-                                                                 earlier reported properties. */
+                                                                containing updated writeable
+                                                                properties for the device to
+                                                                process. */
+  AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_ACKNOWLEDGEMENT
+  = AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES, /**< A response acknowledging the
+                                                                 service has received a properties
+                                                                 that the device sent. */
 } az_iot_hub_client_properties_response_type;
 
 /**

--- a/sdk/samples/iot/paho_iot_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_component_sample.c
@@ -541,14 +541,14 @@ static void handle_device_property_message(
       break;
 
     // An update to the desired properties with the properties as a payload.
-    case AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES:
+    case AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE:
       IOT_SAMPLE_LOG("Message Type: Desired Properties");
       (void)process_device_property_message(message_span, property_response->response_type);
       break;
 
     // A response from a property reported properties publish message.
-    case AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_REPORTED_PROPERTIES:
-      IOT_SAMPLE_LOG("Message Type: Reported Properties");
+    case AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_ACKNOWLEDGEMENT:
+      IOT_SAMPLE_LOG("Message Type: Previous property update from device acknowledged by IoT Hub");
       break;
   }
 }

--- a/sdk/samples/iot/paho_iot_pnp_sample_common.c
+++ b/sdk/samples/iot/paho_iot_pnp_sample_common.c
@@ -378,14 +378,14 @@ static void handle_device_property_message(
       break;
 
     // An update to the desired properties with the properties as a payload.
-    case AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES:
+    case AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE:
       IOT_SAMPLE_LOG("Message Type: Desired Properties");
       process_device_property_message(message_span, property_response->response_type);
       break;
 
     // A response from a reported properties publish message.
-    case AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_REPORTED_PROPERTIES:
-      IOT_SAMPLE_LOG("Message Type: Reported Properties");
+    case AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_ACKNOWLEDGEMENT:
+      IOT_SAMPLE_LOG("Message Type: Previous property update from device acknowledged by IoT Hub");
       break;
   }
 }

--- a/sdk/src/azure/iot/az_iot_hub_client_properties.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_properties.c
@@ -278,7 +278,7 @@ static az_result skip_metadata_if_needed(
   while (true)
   {
     // Within the "root" or "component name" section
-    if ((response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES
+    if ((response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE
          && jr->_internal.bit_stack._internal.current_depth == 1)
         || (response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_GET
             && jr->_internal.bit_stack._internal.current_depth == 2))
@@ -298,7 +298,7 @@ static az_result skip_metadata_if_needed(
     }
     // Within the property value section
     else if (
-        (response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES
+        (response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE
          && jr->_internal.bit_stack._internal.current_depth == 2)
         || (response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_GET
             && jr->_internal.bit_stack._internal.current_depth == 3))
@@ -341,7 +341,7 @@ static az_result verify_valid_json_position(
   }
 
   // Component property - In user property value object
-  if ((response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES
+  if ((response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE
        && jr->_internal.bit_stack._internal.current_depth > 2)
       || (response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_GET
           && jr->_internal.bit_stack._internal.current_depth > 3))
@@ -351,7 +351,7 @@ static az_result verify_valid_json_position(
 
   // Non-component property - In user property value object
   if ((az_span_size(component_name) == 0)
-      && ((response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES
+      && ((response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE
            && jr->_internal.bit_stack._internal.current_depth > 1)
           || (response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_GET
               && jr->_internal.bit_stack._internal.current_depth > 2)))
@@ -365,7 +365,7 @@ static az_result verify_valid_json_position(
 /*
 Assuming a JSON of either the below types
 
-AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES:
+AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE:
 
 {
   //ROOT COMPONENT or COMPONENT NAME section
@@ -434,7 +434,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_get_next_component_property(
     if (ref_json_reader->token.kind == AZ_JSON_TOKEN_END_OBJECT)
     {
       // We've read all the children of the current object we're traversing.
-      if ((response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES
+      if ((response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE
            && ref_json_reader->_internal.bit_stack._internal.current_depth == 0)
           || (response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_GET
               && ref_json_reader->_internal.bit_stack._internal.current_depth == 1))
@@ -451,7 +451,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_get_next_component_property(
     break;
   }
 
-  if ((response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES
+  if ((response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE
        && ref_json_reader->_internal.bit_stack._internal.current_depth == 1)
       || (response_type == AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_GET
           && ref_json_reader->_internal.bit_stack._internal.current_depth == 2))

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_properties.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_properties.c
@@ -637,7 +637,7 @@ test_az_iot_hub_client_properties_get_next_component_property_get_desired_proper
   ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_get_next_component_property(
       &client,
       &jr,
-      AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES,
+      AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE,
       AZ_IOT_HUB_CLIENT_PROPERTY_REPORTED_FROM_DEVICE,
       &component_name));
 }
@@ -736,8 +736,7 @@ static void test_az_iot_hub_client_properties_parse_received_topic_desired_found
       AZ_OK);
   assert_true(az_span_is_content_equal(response.request_id, AZ_SPAN_EMPTY));
   assert_int_equal(response.status, AZ_IOT_STATUS_OK);
-  assert_int_equal(
-      response.response_type, AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES);
+  assert_int_equal(response.response_type, AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE);
 }
 
 static void test_az_iot_hub_client_properties_parse_received_topic_get_response_found_succeed()
@@ -776,7 +775,7 @@ static void test_az_iot_hub_client_properties_parse_received_topic_reported_prop
   assert_true(az_span_is_content_equal(response.request_id, test_device_request_id));
   assert_int_equal(response.status, AZ_IOT_STATUS_NO_CONTENT);
   assert_int_equal(
-      response.response_type, AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_REPORTED_PROPERTIES);
+      response.response_type, AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_ACKNOWLEDGEMENT);
 }
 
 static void test_az_iot_hub_client_properties_parse_received_topic_not_found_fails()
@@ -1074,7 +1073,7 @@ static void test_az_iot_hub_client_properties_get_properties_version_succeed()
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
   az_iot_hub_client_properties_response_type response_type
-      = AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES;
+      = AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE;
   az_json_reader jr;
   int32_t version;
   assert_int_equal(az_json_reader_init(&jr, test_property_payload, NULL), AZ_OK);
@@ -1196,7 +1195,7 @@ static void test_az_iot_hub_client_properties_get_next_component_property_succee
   assert_int_equal(az_json_reader_init(&jr, test_property_payload, NULL), AZ_OK);
 
   az_iot_hub_client_properties_response_type response_type
-      = AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES;
+      = AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE;
   az_span component_name;
 
   test_get_next_component_property(
@@ -1255,7 +1254,7 @@ static void test_az_iot_hub_client_properties_get_next_component_property_user_n
   assert_int_equal(az_json_reader_init(&jr, test_property_payload, NULL), AZ_OK);
 
   az_iot_hub_client_properties_response_type response_type
-      = AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES;
+      = AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE;
   az_span component_name;
   int32_t value;
 
@@ -1290,7 +1289,7 @@ test_az_iot_hub_client_properties_get_next_component_property_user_not_advance_i
   assert_int_equal(az_json_reader_init(&jr, test_property_payload_with_user_object, NULL), AZ_OK);
 
   az_iot_hub_client_properties_response_type response_type
-      = AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES;
+      = AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE;
   az_span component_name;
 
   test_get_next_component_property(
@@ -1336,7 +1335,7 @@ test_az_iot_hub_client_properties_get_next_component_property_user_not_advance_i
   assert_int_equal(az_json_reader_init(&jr, test_property_payload_with_user_object, NULL), AZ_OK);
 
   az_iot_hub_client_properties_response_type response_type
-      = AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES;
+      = AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE;
   az_span component_name;
 
   // First component
@@ -1403,7 +1402,7 @@ test_az_iot_hub_client_properties_get_next_component_property_user_not_advance_r
   assert_int_equal(az_json_reader_init(&jr, test_property_payload, NULL), AZ_OK);
 
   az_iot_hub_client_properties_response_type response_type
-      = AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_DESIRED_PROPERTIES;
+      = AZ_IOT_HUB_CLIENT_PROPERTIES_RESPONSE_TYPE_WRITEABLE;
   az_span component_name;
   int32_t value;
 


### PR DESCRIPTION
Further review of PnP headers suggests that the naming around properties needed to be more clear.

Specifically remove "desired" which is a very Twin concept and replace with "writeable."  

Further use word "acknowledgement" when we're getting service ACK's of properties that are init'd from device, which I think has clearer intent.
