### PR TITLE
Incorporate feedback from Azure SDK review board on PnP APIs.

### DIFF
--- a/sdk/inc/azure/az_iot.h
+++ b/sdk/inc/azure/az_iot.h
@@ -17,6 +17,7 @@
 
 #include <azure/iot/az_iot_common.h>
 #include <azure/iot/az_iot_hub_client.h>
+#include <azure/iot/az_iot_hub_client_properties.h>
 #include <azure/iot/az_iot_provisioning_client.h>
 
 #endif // _az_IOT_CORE_H

--- a/sdk/inc/azure/iot/az_iot_hub_client.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client.h
@@ -712,16 +712,14 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_patch_get_publish_topic(
 typedef enum
 {
   AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE
-  = AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_GET, /**< A response from a properties "GET" request. */
+  = 1, /**< A response from a properties "GET" request. */
   AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED
-  = AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES, /**< A message with a payload
-                                                                containing updated writable
-                                                                properties for the device to
-                                                                process. */
+  = 2, /**< A message with a payload containing updated writableproperties for the device to
+          process. */
   AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_ACKNOWLEDGEMENT
-  = AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES, /**< A response acknowledging the
-                                                                 service has received properties
-                                                                 that the device sent. */
+  = 3, /**< A response acknowledging the service has received properties that the device sent. */
+  AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_ERROR
+  = 4, /**< An error has occurred from the service processing properties. */
 } az_iot_hub_client_properties_message_type;
 
 /**
@@ -810,7 +808,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_document_get_publish_topic(
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic was retrieved successfully.
  */
-AZ_NODISCARD az_result az_iot_hub_client_properties_update_get_publish_topic(
+AZ_NODISCARD az_result az_iot_hub_client_properties_get_reported_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
     char* mqtt_topic,

--- a/sdk/inc/azure/iot/az_iot_hub_client_properties.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client_properties.h
@@ -4,7 +4,7 @@
 /**
  * @file
  *
- * @brief Definition for the Azure IoT Plug and Play properties builder and parsing routines.
+ * @brief Definition for the Azure IoT Plug and Play properties writer and parsing routines.
  *
  * @warning THIS LIBRARY IS IN PREVIEW. APIS ARE SUBJECT TO CHANGE UNTIL GENERAL AVAILABILITY.
  */
@@ -38,9 +38,9 @@
  * }
  * @endcode
  *
- * @note This API only builds the metadata for a component's properties.  The
+ * @note This API only writes the metadata for a component's properties.  The
  * application itself must specify the payload contents between calls
- * to this API and az_iot_hub_client_properties_builder_end_component() using
+ * to this API and az_iot_hub_client_properties_writer_end_component() using
  * \p ref_json_writer to specify the JSON payload.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
@@ -55,7 +55,7 @@
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The JSON payload was prefixed successfully.
  */
-AZ_NODISCARD az_result az_iot_hub_client_properties_builder_begin_component(
+AZ_NODISCARD az_result az_iot_hub_client_properties_writer_begin_component(
     az_iot_hub_client const* client,
     az_json_writer* ref_json_writer,
     az_span component_name);
@@ -65,7 +65,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_builder_begin_component(
  * component.
  *
  * @note This API should be used in conjunction with
- * az_iot_hub_client_properties_builder_begin_component().
+ * az_iot_hub_client_properties_writer_begin_component().
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in,out] ref_json_writer The #az_json_writer to append the necessary characters for an IoT
@@ -77,7 +77,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_builder_begin_component(
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The JSON payload was suffixed successfully.
  */
-AZ_NODISCARD az_result az_iot_hub_client_properties_builder_end_component(
+AZ_NODISCARD az_result az_iot_hub_client_properties_writer_end_component(
     az_iot_hub_client const* client,
     az_json_writer* ref_json_writer);
 
@@ -95,9 +95,9 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_builder_end_component(
  * @code
  * {
  *   "<property_name>":{
- *     "ac": <ack_code>,
- *     "av": <ack_version>,
- *     "ad": "<ack_description>",
+ *     "ac": <status_code>,
+ *     "av": <version>,
+ *     "ad": "<description>",
  *     "value": <user_value>
  *   }
  * }
@@ -109,9 +109,9 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_builder_end_component(
  *   "<component_name>": {
  *     "__t": "c",
  *     "<property_name>": {
- *       "ac": <ack_code>,
- *       "av": <ack_version>,
- *       "ad": "<ack_description>",
+ *       "ac": <status_code>,
+ *       "av": <version>,
+ *       "ad": "<description>",
  *       "value": <user_value>
  *     }
  *   }
@@ -119,32 +119,32 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_builder_end_component(
  * @endcode
  *
  * To send a status for properties belonging to a component, first call the
- * az_iot_hub_client_properties_builder_begin_component() API to prefix the payload with the
+ * az_iot_hub_client_properties_writer_begin_component() API to prefix the payload with the
  * necessary identification. The API call flow would look like the following with the listed JSON
  * payload being generated.
  *
  * @code
- * az_iot_hub_client_properties_builder_begin_component()
- * az_iot_hub_client_properties_builder_begin_response_status()
+ * az_iot_hub_client_properties_writer_begin_component()
+ * az_iot_hub_client_properties_writer_begin_response_status()
  * // Append user value here (<user_value>) using ref_json_writer directly.
- * az_iot_hub_client_properties_builder_end_response_status()
- * az_iot_hub_client_properties_builder_end_component()
+ * az_iot_hub_client_properties_writer_end_response_status()
+ * az_iot_hub_client_properties_writer_end_component()
  * @endcode
  *
- * @note This API only builds the metadata for the properties response.  The
+ * @note This API only writes the metadata for the properties response.  The
  * application itself must specify the payload contents between calls
- * to this API and az_iot_hub_client_properties_builder_end_response_status() using
+ * to this API and az_iot_hub_client_properties_writer_end_response_status() using
  * \p ref_json_writer to specify the JSON payload.
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in,out] ref_json_writer The initialized #az_json_writer to append data to.
- * @param[in] property_name The name of the property to build a response payload for.
- * @param[in] ack_code The HTTP-like status code to respond with. See #az_iot_status for
+ * @param[in] property_name The name of the property to write a response payload for.
+ * @param[in] status_code The HTTP-like status code to respond with. See #az_iot_status for
  * possible supported values.
- * @param[in] ack_version The version of the property the application is acknowledging.
+ * @param[in] version The version of the property the application is acknowledging.
  * This can be retrieved from the service request by
  * calling az_iot_hub_client_properties_get_properties_version.
- * @param[in] ack_description An optional description detailing the context or any details about
+ * @param[in] description An optional description detailing the context or any details about
  * the acknowledgement. This can be #AZ_SPAN_EMPTY.
  *
  * @pre \p client must not be `NULL`.
@@ -154,19 +154,19 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_builder_end_component(
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The JSON payload was prefixed successfully.
  */
-AZ_NODISCARD az_result az_iot_hub_client_properties_builder_begin_response_status(
+AZ_NODISCARD az_result az_iot_hub_client_properties_writer_begin_response_status(
     az_iot_hub_client const* client,
     az_json_writer* ref_json_writer,
     az_span property_name,
-    int32_t ack_code,
-    int32_t ack_version,
-    az_span ack_description);
+    int32_t status_code,
+    int32_t version,
+    az_span description);
 
 /**
  * @brief End a properties response payload with confirmation status.
  *
  * @note This API should be used in conjunction with
- * az_iot_hub_client_properties_builder_begin_response_status().
+ * az_iot_hub_client_properties_writer_begin_response_status().
  *
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in,out] ref_json_writer The initialized #az_json_writer to append data to.
@@ -177,7 +177,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_builder_begin_response_statu
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The JSON payload was suffixed successfully.
  */
-AZ_NODISCARD az_result az_iot_hub_client_properties_builder_end_response_status(
+AZ_NODISCARD az_result az_iot_hub_client_properties_writer_end_response_status(
     az_iot_hub_client const* client,
     az_json_writer* ref_json_writer);
 
@@ -217,9 +217,9 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_get_properties_version(
 typedef enum
 {
   /** @brief Property was originally reported from the device. */
-  AZ_IOT_HUB_CLIENT_PROPERTY_REPORTED_FROM_DEVICE = 1,
+  AZ_IOT_HUB_CLIENT_PROPERTY_REPORTED_FROM_DEVICE,
   /** @brief Property was received from the service. */
-  AZ_IOT_HUB_CLIENT_PROPERTY_WRITABLE = 2
+  AZ_IOT_HUB_CLIENT_PROPERTY_WRITABLE
 } az_iot_hub_client_property_type;
 
 /**

--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -593,7 +593,7 @@ This section provides an overview of the different samples available to run and 
 
 - *Executable:* `paho_iot_pnp_sample`
 
-  This [sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/paho_iot_pnp_sample.c) connects an Azure IoT Plug and Play enabled device simulating a thermostat directly to the Azure IoT Hub.  This device is described via the Digital Twin Model ID (DTMI) detailed [here](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/Thermostat.json). This sample demonstrates sending telemetry and properties from the device and receiving commands and writeable properties from the service.  X509 authentication is used.
+  This [sample](https://github.com/Azure/azure-sdk-for-c/blob/feature/iot_pnp/sdk/samples/iot/paho_iot_pnp_sample.c) connects an Azure IoT Plug and Play enabled device simulating a thermostat directly to the Azure IoT Hub.  This device is described via the Digital Twin Model ID (DTMI) detailed [here](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/Thermostat.json). This sample demonstrates sending telemetry and properties from the device and receiving commands and writeable properties from the service.  X509 authentication is used.
 
   <details><summary><i>How to interact with the Plug and Play sample:</i></summary>
 
@@ -617,13 +617,13 @@ This section provides an overview of the different samples available to run and 
 
 - *Executable:* `paho_iot_pnp_with_provisioning_sample`
 
-  This [sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c) has the same functionality as the `paho_iot_pnp_sample` but uses the Azure Device Provisioning Service for authentication. The same steps above should be followed for interacting with the sample in Azure IoT Explorer.
+  This [sample](https://github.com/Azure/azure-sdk-for-c/blob/feature/iot_pnp/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c) has the same functionality as the `paho_iot_pnp_sample` but uses the Azure Device Provisioning Service for authentication. The same steps above should be followed for interacting with the sample in Azure IoT Explorer.
 
 ### IoT Plug and Play Multiple Component Sample
 
 - *Executable:* `paho_iot_pnp_component_sample`
 
-  This [sample](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/paho_iot_pnp_component_sample.c) connects an Azure IoT Plug and Play enabled device simulating a temperature controller directly to Azure IoT Hub.  This device is described via the Digital Twin Model ID (DTMI) detailed [here](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json).  X509 authentication is used.
+  This [sample](https://github.com/Azure/azure-sdk-for-c/blob/feature/iot_pnp/sdk/samples/iot/paho_iot_pnp_component_sample.c) connects an Azure IoT Plug and Play enabled device simulating a temperature controller directly to Azure IoT Hub.  This device is described via the Digital Twin Model ID (DTMI) detailed [here](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json).  X509 authentication is used.
   
   This Temperature Controller is made up of multiple components.  These are implemented in the [./pnp](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/pnp) subdirectory.
 

--- a/sdk/samples/iot/paho_iot_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_component_sample.c
@@ -460,18 +460,10 @@ static void process_device_property_message(
     az_span property_message_span,
     az_iot_hub_client_properties_message_type message_type)
 {
-  az_result rc = az_iot_hub_client_properties_get_reported_publish_topic(
-      &hub_client,
-      pnp_mqtt_get_request_id(),
-      publish_message.topic,
-      publish_message.topic_length,
-      NULL);
-  IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc, "Failed to get the property update topic");
-
   az_json_reader jr;
   az_span component_name;
   int32_t version = 0;
-  rc = az_json_reader_init(&jr, property_message_span, NULL);
+  az_result rc = az_json_reader_init(&jr, property_message_span, NULL);
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc, "Could not initialize the json reader");
 
   rc = az_iot_hub_client_properties_get_properties_version(
@@ -552,6 +544,11 @@ static void handle_device_property_message(
     // server acknowledges this.
     case AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_ACKNOWLEDGEMENT:
       IOT_SAMPLE_LOG("Message Type: Previous property update from device acknowledged by IoT Hub");
+      break;
+
+    // An error has occurred
+    case AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_ERROR:
+      IOT_SAMPLE_LOG_ERROR("Message Type: Request Error");
       break;
   }
 }

--- a/sdk/samples/iot/paho_iot_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_component_sample.c
@@ -460,7 +460,7 @@ static void process_device_property_message(
     az_span property_message_span,
     az_iot_hub_client_properties_message_type message_type)
 {
-  az_result rc = az_iot_hub_client_properties_update_get_publish_topic(
+  az_result rc = az_iot_hub_client_properties_get_reported_publish_topic(
       &hub_client,
       pnp_mqtt_get_request_id(),
       publish_message.topic,

--- a/sdk/samples/iot/paho_iot_pnp_sample_common.c
+++ b/sdk/samples/iot/paho_iot_pnp_sample_common.c
@@ -390,6 +390,11 @@ static void handle_device_property_message(
     case AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_ACKNOWLEDGEMENT:
       IOT_SAMPLE_LOG("Message Type: IoT Hub has acknowledged properties that the device sent");
       break;
+
+    // An error has occurred
+    case AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_ERROR:
+      IOT_SAMPLE_LOG_ERROR("Message Type: Request Error");
+      break;
   }
 }
 

--- a/sdk/samples/iot/pnp/pnp_device_info_component.c
+++ b/sdk/samples/iot/pnp/pnp_device_info_component.c
@@ -45,21 +45,21 @@ static double const total_storage_property_value = 1024.0;
 static az_span const total_memory_property_name = AZ_SPAN_LITERAL_FROM_STR("totalMemory");
 static double const total_memory_property_value = 128;
 
-// pnp_device_info_build_property_payload builds the JSON payload that contains simulated
+// pnp_device_info_write_property_payload writes the JSON payload that contains simulated
 // device information.
-static void pnp_device_info_build_property_payload(
+static void pnp_device_info_write_property_payload(
     az_iot_hub_client* hub_client,
     az_span payload,
     az_span* out_payload)
 {
-  char const* const log_message = "Failed to build reported property payload for device info";
+  char const* const log_message = "Failed to write reported property payload for device info";
 
   az_json_writer jw;
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(az_json_writer_init(&jw, payload, NULL), log_message);
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(az_json_writer_append_begin_object(&jw), log_message);
 
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(
-      az_iot_hub_client_properties_builder_begin_component(
+      az_iot_hub_client_properties_writer_begin_component(
           hub_client, &jw, deviceInformation_1_name),
       log_message);
 
@@ -99,7 +99,7 @@ static void pnp_device_info_build_property_payload(
       log_message);
 
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(
-      az_iot_hub_client_properties_builder_end_component((az_iot_hub_client const*)0x1, &jw),
+      az_iot_hub_client_properties_writer_end_component((az_iot_hub_client const*)0x1, &jw),
       log_message);
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(az_json_writer_append_end_object(&jw), log_message);
 
@@ -113,7 +113,7 @@ void pnp_device_info_send_reported_properties(az_iot_hub_client* hub_client, MQT
       pnp_mqtt_message_init(&publish_message), "Failed to initialize pnp_mqtt_message");
 
   // Get the property topic to send a reported property update.
-  az_result rc = az_iot_hub_client_properties_update_get_publish_topic(
+  az_result rc = az_iot_hub_client_properties_get_reported_publish_topic(
       hub_client,
       pnp_mqtt_get_request_id(),
       publish_message.topic,
@@ -122,7 +122,7 @@ void pnp_device_info_send_reported_properties(az_iot_hub_client* hub_client, MQT
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc, "Failed to get the property update topic");
 
   // Get the payload to send
-  pnp_device_info_build_property_payload(
+  pnp_device_info_write_property_payload(
       hub_client, publish_message.payload, &publish_message.out_payload);
 
   // Publish the device info reported property update.

--- a/sdk/samples/iot/pnp/pnp_protocol.c
+++ b/sdk/samples/iot/pnp/pnp_protocol.c
@@ -221,7 +221,7 @@ void pnp_build_reported_property_with_status(
     pnp_append_property_callback append_callback,
     void* context,
     int32_t ack_code,
-    int32_t ack_version,
+    int32_t version,
     az_span ack_description,
     az_span* out_span)
 {
@@ -255,7 +255,7 @@ void pnp_build_reported_property_with_status(
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(az_json_writer_append_int32(&jw, ack_code), log, property_name);
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(
       az_json_writer_append_property_name(&jw, desired_temp_ack_version_name), log, property_name);
-  IOT_SAMPLE_EXIT_IF_AZ_FAILED(az_json_writer_append_int32(&jw, ack_version), log, property_name);
+  IOT_SAMPLE_EXIT_IF_AZ_FAILED(az_json_writer_append_int32(&jw, version), log, property_name);
 
   if (az_span_size(ack_description) != 0)
   {

--- a/sdk/samples/iot/pnp/pnp_temperature_controller_component.c
+++ b/sdk/samples/iot/pnp/pnp_temperature_controller_component.c
@@ -110,7 +110,7 @@ void pnp_temperature_controller_send_serial_number(
       pnp_mqtt_message_init(&publish_message), "Failed to initialize pnp_mqtt_message");
 
   // Get the property update topic to send a reported property update.
-  az_result rc = az_iot_hub_client_properties_update_get_publish_topic(
+  az_result rc = az_iot_hub_client_properties_get_reported_publish_topic(
       hub_client,
       pnp_mqtt_get_request_id(),
       publish_message.topic,

--- a/sdk/samples/iot/pnp/pnp_thermostat_component.c
+++ b/sdk/samples/iot/pnp/pnp_thermostat_component.c
@@ -295,7 +295,7 @@ void pnp_thermostat_update_maximum_temperature_property(
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(
       pnp_mqtt_message_init(&publish_message), "Failed to initialize pnp_mqtt_message");
 
-  // Get the property update topic to send a reported property update.
+  // Get the property update topic to send a property update.
   az_result rc = az_iot_hub_client_properties_get_reported_publish_topic(
       hub_client,
       pnp_mqtt_get_request_id(),
@@ -407,6 +407,15 @@ void pnp_thermostat_process_property_update(
   pnp_mqtt_message publish_message;
   IOT_SAMPLE_EXIT_IF_AZ_FAILED(
       pnp_mqtt_message_init(&publish_message), "Failed to initialize pnp_mqtt_message");
+
+  // Get the property update topic to send a writable property update.
+  az_result rc = az_iot_hub_client_properties_get_reported_publish_topic(
+      hub_client,
+      pnp_mqtt_get_request_id(),
+      publish_message.topic,
+      publish_message.topic_length,
+      NULL);
+  IOT_SAMPLE_EXIT_IF_AZ_FAILED(rc, "Failed to get the property update topic");
 
   if (!az_json_token_is_text_equal(
           &property_name_and_value->token, property_desired_temperature_property_name))

--- a/sdk/src/azure/iot/az_iot_hub_client_properties.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_properties.c
@@ -17,7 +17,7 @@ static const az_span properties_ack_description_name = AZ_SPAN_LITERAL_FROM_STR(
 static const az_span component_properties_label_name = AZ_SPAN_LITERAL_FROM_STR("__t");
 static const az_span component_properties_label_value = AZ_SPAN_LITERAL_FROM_STR("c");
 
-AZ_NODISCARD az_result az_iot_hub_client_properties_update_get_publish_topic(
+AZ_NODISCARD az_result az_iot_hub_client_properties_get_reported_publish_topic(
     az_iot_hub_client const* client,
     az_span request_id,
     char* mqtt_topic,
@@ -60,7 +60,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_parse_received_topic(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_properties_builder_begin_component(
+AZ_NODISCARD az_result az_iot_hub_client_properties_writer_begin_component(
     az_iot_hub_client const* client,
     az_json_writer* ref_json_writer,
     az_span component_name)
@@ -81,7 +81,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_builder_begin_component(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_properties_builder_end_component(
+AZ_NODISCARD az_result az_iot_hub_client_properties_writer_end_component(
     az_iot_hub_client const* client,
     az_json_writer* ref_json_writer)
 {
@@ -93,13 +93,13 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_builder_end_component(
   return az_json_writer_append_end_object(ref_json_writer);
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_properties_builder_begin_response_status(
+AZ_NODISCARD az_result az_iot_hub_client_properties_writer_begin_response_status(
     az_iot_hub_client const* client,
     az_json_writer* ref_json_writer,
     az_span property_name,
-    int32_t ack_code,
-    int32_t ack_version,
-    az_span ack_description)
+    int32_t status_code,
+    int32_t version,
+    az_span description)
 {
   _az_PRECONDITION_NOT_NULL(client);
   _az_PRECONDITION_NOT_NULL(ref_json_writer);
@@ -111,16 +111,16 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_builder_begin_response_statu
   _az_RETURN_IF_FAILED(az_json_writer_append_begin_object(ref_json_writer));
   _az_RETURN_IF_FAILED(
       az_json_writer_append_property_name(ref_json_writer, properties_ack_code_name));
-  _az_RETURN_IF_FAILED(az_json_writer_append_int32(ref_json_writer, ack_code));
+  _az_RETURN_IF_FAILED(az_json_writer_append_int32(ref_json_writer, status_code));
   _az_RETURN_IF_FAILED(
       az_json_writer_append_property_name(ref_json_writer, properties_ack_version_name));
-  _az_RETURN_IF_FAILED(az_json_writer_append_int32(ref_json_writer, ack_version));
+  _az_RETURN_IF_FAILED(az_json_writer_append_int32(ref_json_writer, version));
 
-  if (az_span_size(ack_description) != 0)
+  if (az_span_size(description) != 0)
   {
     _az_RETURN_IF_FAILED(
         az_json_writer_append_property_name(ref_json_writer, properties_ack_description_name));
-    _az_RETURN_IF_FAILED(az_json_writer_append_string(ref_json_writer, ack_description));
+    _az_RETURN_IF_FAILED(az_json_writer_append_string(ref_json_writer, description));
   }
 
   _az_RETURN_IF_FAILED(
@@ -129,7 +129,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_builder_begin_response_statu
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_iot_hub_client_properties_builder_end_response_status(
+AZ_NODISCARD az_result az_iot_hub_client_properties_writer_end_response_status(
     az_iot_hub_client const* client,
     az_json_writer* ref_json_writer)
 {

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_properties.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_properties.c
@@ -383,16 +383,16 @@ static void test_az_iot_hub_client_properties_document_get_publish_topic_NULL_ou
       &client, test_device_request_id, test_buf, 0, &test_length));
 }
 
-static void test_az_iot_hub_client_properties_update_get_publish_topic_NULL_client_fails()
+static void test_az_iot_hub_client_properties_get_reported_publish_topic_NULL_client_fails()
 {
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_update_get_publish_topic(
+  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_get_reported_publish_topic(
       NULL, test_device_request_id, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_properties_update_get_publish_topic_invalid_request_id_fails()
+static void test_az_iot_hub_client_properties_get_reported_publish_topic_invalid_request_id_fails()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -409,11 +409,11 @@ static void test_az_iot_hub_client_properties_update_get_publish_topic_invalid_r
       = az_span_create(test_bad_request_id_buf, _az_COUNTOF(test_bad_request_id_buf));
   test_bad_request_id._internal.ptr = NULL;
 
-  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_update_get_publish_topic(
+  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_get_reported_publish_topic(
       &client, test_bad_request_id, test_buf, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_properties_update_get_publish_topic_NULL_char_buf_fails()
+static void test_az_iot_hub_client_properties_get_reported_publish_topic_NULL_char_buf_fails()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -425,11 +425,11 @@ static void test_az_iot_hub_client_properties_update_get_publish_topic_NULL_char
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_update_get_publish_topic(
+  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_get_reported_publish_topic(
       &client, test_device_request_id, NULL, sizeof(test_buf), &test_length));
 }
 
-static void test_az_iot_hub_client_properties_update_get_publish_topic_NULL_out_span_fails()
+static void test_az_iot_hub_client_properties_get_reported_publish_topic_NULL_out_span_fails()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -441,7 +441,7 @@ static void test_az_iot_hub_client_properties_update_get_publish_topic_NULL_out_
   char test_buf[TEST_SPAN_BUFFER_SIZE];
   size_t test_length;
 
-  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_update_get_publish_topic(
+  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_get_reported_publish_topic(
       &client, test_device_request_id, test_buf, 0, &test_length));
 }
 
@@ -481,14 +481,14 @@ static void test_az_iot_hub_client_properties_parse_received_topic_NULL_response
       &client, test_property_received_topic_desired_success, NULL));
 }
 
-static void test_az_iot_hub_client_properties_builder_begin_component_NULL_client_fails()
+static void test_az_iot_hub_client_properties_writer_begin_component_NULL_client_fails()
 {
   az_json_writer jw;
   ASSERT_PRECONDITION_CHECKED(
-      az_iot_hub_client_properties_builder_begin_component(NULL, &jw, test_component_one));
+      az_iot_hub_client_properties_writer_begin_component(NULL, &jw, test_component_one));
 }
 
-static void test_az_iot_hub_client_properties_builder_begin_component_NULL_jw_fails()
+static void test_az_iot_hub_client_properties_writer_begin_component_NULL_jw_fails()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -498,10 +498,10 @@ static void test_az_iot_hub_client_properties_builder_begin_component_NULL_jw_fa
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
   ASSERT_PRECONDITION_CHECKED(
-      az_iot_hub_client_properties_builder_begin_component(&client, NULL, test_component_one));
+      az_iot_hub_client_properties_writer_begin_component(&client, NULL, test_component_one));
 }
 
-static void test_az_iot_hub_client_properties_builder_begin_component_NULL_component_name_fails()
+static void test_az_iot_hub_client_properties_writer_begin_component_NULL_component_name_fails()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -512,16 +512,16 @@ static void test_az_iot_hub_client_properties_builder_begin_component_NULL_compo
 
   az_json_writer jw;
   ASSERT_PRECONDITION_CHECKED(
-      az_iot_hub_client_properties_builder_begin_component(&client, &jw, AZ_SPAN_EMPTY));
+      az_iot_hub_client_properties_writer_begin_component(&client, &jw, AZ_SPAN_EMPTY));
 }
 
-static void test_az_iot_hub_client_properties_builder_end_component_NULL_client_fails()
+static void test_az_iot_hub_client_properties_writer_end_component_NULL_client_fails()
 {
   az_json_writer jw;
-  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_builder_end_component(NULL, &jw));
+  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_writer_end_component(NULL, &jw));
 }
 
-static void test_az_iot_hub_client_properties_builder_end_component_NULL_jw_fails()
+static void test_az_iot_hub_client_properties_writer_end_component_NULL_jw_fails()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -530,7 +530,7 @@ static void test_az_iot_hub_client_properties_builder_end_component_NULL_jw_fail
   assert_int_equal(
       az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
 
-  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_builder_end_component(&client, NULL));
+  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_writer_end_component(&client, NULL));
 }
 
 static void test_az_iot_hub_client_properties_get_properties_version_NULL_client_fails()
@@ -644,6 +644,27 @@ test_az_iot_hub_client_properties_get_next_component_property_get_desired_proper
 
 #endif // AZ_NO_PRECONDITION_CHECKING
 
+// The values in the enumeration of az_iot_hub_client_properties_message_type must map directly
+// to az_iot_hub_client_twin_response_type values.  We do not want to directly set the value
+// in the header so as to not overwhelm the users with concepts they won't need.
+// TODO: Change this to static_assert style mechanism once
+// https://github.com/Azure/azure-sdk-for-c/issues/1784 is addressed.  For now test at runtime.
+static void test_az_iot_hub_client_properties_enums_equal()
+{
+  assert_int_equal(
+      AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_GET,
+      AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE);
+  assert_int_equal(
+      AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES,
+      AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED);
+  assert_int_equal(
+      AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES,
+      AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_ACKNOWLEDGEMENT);
+  assert_int_equal(
+      AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_REQUEST_ERROR,
+      AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_ERROR);
+}
+
 static void test_az_iot_hub_client_properties_document_get_publish_topic_succeed()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
@@ -682,7 +703,7 @@ static void test_az_iot_hub_client_properties_document_get_publish_topic_small_b
       AZ_ERROR_NOT_ENOUGH_SPACE);
 }
 
-static void test_az_iot_hub_client_properties_update_get_publish_topic_succeed()
+static void test_az_iot_hub_client_properties_get_reported_publish_topic_succeed()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -695,14 +716,14 @@ static void test_az_iot_hub_client_properties_update_get_publish_topic_succeed()
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_properties_update_get_publish_topic(
+      az_iot_hub_client_properties_get_reported_publish_topic(
           &client, test_device_request_id, test_buf, sizeof(test_buf), &test_length),
       AZ_OK);
   assert_string_equal(test_correct_property_patch_pub_topic, test_buf);
   assert_int_equal(sizeof(test_correct_property_patch_pub_topic) - 1, test_length);
 }
 
-static void test_az_iot_hub_client_properties_update_get_publish_topic_small_buffer_fails()
+static void test_az_iot_hub_client_properties_get_reported_publish_topic_small_buffer_fails()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -715,7 +736,7 @@ static void test_az_iot_hub_client_properties_update_get_publish_topic_small_buf
   size_t test_length;
 
   assert_int_equal(
-      az_iot_hub_client_properties_update_get_publish_topic(
+      az_iot_hub_client_properties_get_reported_publish_topic(
           &client, test_device_request_id, test_buf, sizeof(test_buf), &test_length),
       AZ_ERROR_NOT_ENOUGH_SPACE);
 }
@@ -810,7 +831,7 @@ static void test_az_iot_hub_client_properties_parse_received_topic_not_found_pre
       AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
-static void test_az_iot_hub_client_properties_builder_begin_component_succeed()
+static void test_az_iot_hub_client_properties_writer_begin_component_succeed()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -824,12 +845,11 @@ static void test_az_iot_hub_client_properties_builder_begin_component_succeed()
   assert_int_equal(az_json_writer_append_begin_object(&jw), AZ_OK);
 
   assert_int_equal(
-      az_iot_hub_client_properties_builder_begin_component(&client, &jw, test_component_one),
-      AZ_OK);
+      az_iot_hub_client_properties_writer_begin_component(&client, &jw, test_component_one), AZ_OK);
   assert_string_equal(json_buffer, "{\"component_one\":{\"__t\":\"c\"");
 }
 
-static void test_az_iot_hub_client_properties_builder_end_component_succeed()
+static void test_az_iot_hub_client_properties_writer_end_component_succeed()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -843,13 +863,12 @@ static void test_az_iot_hub_client_properties_builder_end_component_succeed()
   assert_int_equal(az_json_writer_append_begin_object(&jw), AZ_OK);
 
   assert_int_equal(
-      az_iot_hub_client_properties_builder_begin_component(&client, &jw, test_component_one),
-      AZ_OK);
-  assert_int_equal(az_iot_hub_client_properties_builder_end_component(&client, &jw), AZ_OK);
+      az_iot_hub_client_properties_writer_begin_component(&client, &jw, test_component_one), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_writer_end_component(&client, &jw), AZ_OK);
   assert_string_equal(json_buffer, "{\"component_one\":{\"__t\":\"c\"}");
 }
 
-static void test_az_iot_hub_client_properties_builder_end_component_with_user_data_succeed()
+static void test_az_iot_hub_client_properties_writer_end_component_with_user_data_succeed()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -863,15 +882,14 @@ static void test_az_iot_hub_client_properties_builder_end_component_with_user_da
   assert_int_equal(az_json_writer_append_begin_object(&jw), AZ_OK);
 
   assert_int_equal(
-      az_iot_hub_client_properties_builder_begin_component(&client, &jw, test_component_one),
-      AZ_OK);
+      az_iot_hub_client_properties_writer_begin_component(&client, &jw, test_component_one), AZ_OK);
   assert_int_equal(az_json_writer_append_property_name(&jw, AZ_SPAN_FROM_STR("prop")), AZ_OK);
   assert_int_equal(az_json_writer_append_int32(&jw, 100), AZ_OK);
-  assert_int_equal(az_iot_hub_client_properties_builder_end_component(&client, &jw), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_writer_end_component(&client, &jw), AZ_OK);
   assert_string_equal(json_buffer, "{\"component_one\":{\"__t\":\"c\",\"prop\":100}");
 }
 
-static void test_az_iot_hub_client_properties_builder_begin_response_status_succeed()
+static void test_az_iot_hub_client_properties_writer_begin_response_status_succeed()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -885,7 +903,7 @@ static void test_az_iot_hub_client_properties_builder_begin_response_status_succ
   assert_int_equal(az_json_writer_append_begin_object(&jw), AZ_OK);
 
   assert_int_equal(
-      az_iot_hub_client_properties_builder_begin_response_status(
+      az_iot_hub_client_properties_writer_begin_response_status(
           &client,
           &jw,
           AZ_SPAN_FROM_STR("targetTemperature"),
@@ -898,7 +916,7 @@ static void test_az_iot_hub_client_properties_builder_begin_response_status_succ
       json_buffer, "{\"targetTemperature\":{\"ac\":200,\"av\":29,\"ad\":\"success\",\"value\":");
 }
 
-static void test_az_iot_hub_client_properties_builder_end_response_status_succeed()
+static void test_az_iot_hub_client_properties_writer_end_response_status_succeed()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -912,7 +930,7 @@ static void test_az_iot_hub_client_properties_builder_end_response_status_succee
   assert_int_equal(az_json_writer_append_begin_object(&jw), AZ_OK);
 
   assert_int_equal(
-      az_iot_hub_client_properties_builder_begin_response_status(
+      az_iot_hub_client_properties_writer_begin_response_status(
           &client,
           &jw,
           AZ_SPAN_FROM_STR("targetTemperature"),
@@ -921,7 +939,7 @@ static void test_az_iot_hub_client_properties_builder_end_response_status_succee
           AZ_SPAN_FROM_STR("success")),
       AZ_OK);
   assert_int_equal(az_json_writer_append_int32(&jw, 50), AZ_OK);
-  assert_int_equal(az_iot_hub_client_properties_builder_end_response_status(&client, &jw), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_writer_end_response_status(&client, &jw), AZ_OK);
 
   assert_int_equal(az_json_writer_append_end_object(&jw), AZ_OK);
 
@@ -930,7 +948,7 @@ static void test_az_iot_hub_client_properties_builder_end_response_status_succee
       "{\"targetTemperature\":{\"ac\":200,\"av\":29,\"ad\":\"success\",\"value\":50}}");
 }
 
-static void test_az_iot_hub_client_properties_builder_begin_response_status_with_component_succeed()
+static void test_az_iot_hub_client_properties_writer_begin_response_status_with_component_succeed()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -944,16 +962,16 @@ static void test_az_iot_hub_client_properties_builder_begin_response_status_with
 
   assert_int_equal(az_json_writer_append_begin_object(&jw), AZ_OK);
   assert_int_equal(
-      az_iot_hub_client_properties_builder_begin_component(
+      az_iot_hub_client_properties_writer_begin_component(
           &client, &jw, AZ_SPAN_FROM_STR("component_one")),
       AZ_OK);
   assert_int_equal(
-      az_iot_hub_client_properties_builder_begin_response_status(
+      az_iot_hub_client_properties_writer_begin_response_status(
           &client, &jw, AZ_SPAN_FROM_STR("targetTemperature"), 200, 5, AZ_SPAN_FROM_STR("success")),
       AZ_OK);
   assert_int_equal(az_json_writer_append_int32(&jw, 23), AZ_OK);
-  assert_int_equal(az_iot_hub_client_properties_builder_end_response_status(&client, &jw), AZ_OK);
-  assert_int_equal(az_iot_hub_client_properties_builder_end_component(&client, &jw), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_writer_end_response_status(&client, &jw), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_writer_end_component(&client, &jw), AZ_OK);
 
   assert_int_equal(az_json_writer_append_end_object(&jw), AZ_OK);
 
@@ -964,7 +982,7 @@ static void test_az_iot_hub_client_properties_builder_begin_response_status_with
 }
 
 static void
-test_az_iot_hub_client_properties_builder_begin_response_status_with_component_multiple_values_succeed()
+test_az_iot_hub_client_properties_writer_begin_response_status_with_component_multiple_values_succeed()
 {
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.model_id = test_model_id;
@@ -978,25 +996,25 @@ test_az_iot_hub_client_properties_builder_begin_response_status_with_component_m
 
   assert_int_equal(az_json_writer_append_begin_object(&jw), AZ_OK);
   assert_int_equal(
-      az_iot_hub_client_properties_builder_begin_component(
+      az_iot_hub_client_properties_writer_begin_component(
           &client, &jw, AZ_SPAN_FROM_STR("component_one")),
       AZ_OK);
 
   assert_int_equal(
-      az_iot_hub_client_properties_builder_begin_response_status(
+      az_iot_hub_client_properties_writer_begin_response_status(
           &client, &jw, AZ_SPAN_FROM_STR("targetTemperature"), 200, 5, AZ_SPAN_FROM_STR("success")),
       AZ_OK);
   assert_int_equal(az_json_writer_append_int32(&jw, 23), AZ_OK);
-  assert_int_equal(az_iot_hub_client_properties_builder_end_response_status(&client, &jw), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_writer_end_response_status(&client, &jw), AZ_OK);
 
   assert_int_equal(
-      az_iot_hub_client_properties_builder_begin_response_status(
+      az_iot_hub_client_properties_writer_begin_response_status(
           &client, &jw, AZ_SPAN_FROM_STR("targetHumidity"), 200, 8, AZ_SPAN_FROM_STR("success")),
       AZ_OK);
   assert_int_equal(az_json_writer_append_int32(&jw, 95), AZ_OK);
-  assert_int_equal(az_iot_hub_client_properties_builder_end_response_status(&client, &jw), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_writer_end_response_status(&client, &jw), AZ_OK);
 
-  assert_int_equal(az_iot_hub_client_properties_builder_end_component(&client, &jw), AZ_OK);
+  assert_int_equal(az_iot_hub_client_properties_writer_end_component(&client, &jw), AZ_OK);
   assert_int_equal(az_json_writer_append_end_object(&jw), AZ_OK);
 
   assert_string_equal(
@@ -1807,22 +1825,23 @@ int test_az_iot_hub_client_properties()
     cmocka_unit_test(test_az_iot_hub_client_properties_document_get_publish_topic_NULL_span_fails),
     cmocka_unit_test(
         test_az_iot_hub_client_properties_document_get_publish_topic_NULL_out_span_fails),
-    cmocka_unit_test(test_az_iot_hub_client_properties_update_get_publish_topic_NULL_client_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_properties_update_get_publish_topic_invalid_request_id_fails),
+        test_az_iot_hub_client_properties_get_reported_publish_topic_NULL_client_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_properties_update_get_publish_topic_NULL_char_buf_fails),
+        test_az_iot_hub_client_properties_get_reported_publish_topic_invalid_request_id_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_properties_update_get_publish_topic_NULL_out_span_fails),
+        test_az_iot_hub_client_properties_get_reported_publish_topic_NULL_char_buf_fails),
+    cmocka_unit_test(
+        test_az_iot_hub_client_properties_get_reported_publish_topic_NULL_out_span_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_parse_received_topic_NULL_client_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_parse_received_topic_NULL_rec_topic_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_parse_received_topic_NULL_response_fails),
-    cmocka_unit_test(test_az_iot_hub_client_properties_builder_begin_component_NULL_client_fails),
-    cmocka_unit_test(test_az_iot_hub_client_properties_builder_begin_component_NULL_jw_fails),
+    cmocka_unit_test(test_az_iot_hub_client_properties_writer_begin_component_NULL_client_fails),
+    cmocka_unit_test(test_az_iot_hub_client_properties_writer_begin_component_NULL_jw_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_properties_builder_begin_component_NULL_component_name_fails),
-    cmocka_unit_test(test_az_iot_hub_client_properties_builder_end_component_NULL_client_fails),
-    cmocka_unit_test(test_az_iot_hub_client_properties_builder_end_component_NULL_jw_fails),
+        test_az_iot_hub_client_properties_writer_begin_component_NULL_component_name_fails),
+    cmocka_unit_test(test_az_iot_hub_client_properties_writer_end_component_NULL_client_fails),
+    cmocka_unit_test(test_az_iot_hub_client_properties_writer_end_component_NULL_jw_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_get_properties_version_NULL_client_fails),
     cmocka_unit_test(
         test_az_iot_hub_client_properties_get_properties_version_NULL_json_reader_fails),
@@ -1836,11 +1855,13 @@ int test_az_iot_hub_client_properties()
     cmocka_unit_test(
         test_az_iot_hub_client_properties_get_next_component_property_get_desired_properties_with_query_for_reported_fails),
 #endif // AZ_NO_PRECONDITION_CHECKING
+    cmocka_unit_test(test_az_iot_hub_client_properties_enums_equal),
     cmocka_unit_test(test_az_iot_hub_client_properties_document_get_publish_topic_succeed),
     cmocka_unit_test(
         test_az_iot_hub_client_properties_document_get_publish_topic_small_buffer_fails),
-    cmocka_unit_test(test_az_iot_hub_client_properties_update_get_publish_topic_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_properties_update_get_publish_topic_small_buffer_fails),
+    cmocka_unit_test(test_az_iot_hub_client_properties_get_reported_publish_topic_succeed),
+    cmocka_unit_test(
+        test_az_iot_hub_client_properties_get_reported_publish_topic_small_buffer_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_parse_received_topic_desired_found_succeed),
     cmocka_unit_test(
         test_az_iot_hub_client_properties_parse_received_topic_get_response_found_succeed),
@@ -1849,10 +1870,9 @@ int test_az_iot_hub_client_properties()
     cmocka_unit_test(test_az_iot_hub_client_properties_parse_received_topic_not_found_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_parse_received_topic_not_found_prefix_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_logging_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_properties_builder_begin_component_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_properties_builder_end_component_succeed),
-    cmocka_unit_test(
-        test_az_iot_hub_client_properties_builder_end_component_with_user_data_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_properties_writer_begin_component_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_properties_writer_end_component_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_properties_writer_end_component_with_user_data_succeed),
     cmocka_unit_test(test_az_iot_hub_client_properties_get_properties_version_succeed),
     cmocka_unit_test(test_az_iot_hub_client_properties_get_properties_version_long_succeed),
     cmocka_unit_test(test_az_iot_hub_client_properties_get_properties_version_out_of_order_succeed),
@@ -1877,12 +1897,12 @@ int test_az_iot_hub_client_properties()
         test_az_iot_hub_client_properties_get_next_component_property_long_with_version_succeed),
     cmocka_unit_test(
         test_az_iot_hub_client_properties_get_next_component_property_long_with_version_chunked_json_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_properties_builder_begin_response_status_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_properties_writer_begin_response_status_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_properties_builder_begin_response_status_with_component_succeed),
+        test_az_iot_hub_client_properties_writer_begin_response_status_with_component_succeed),
     cmocka_unit_test(
-        test_az_iot_hub_client_properties_builder_begin_response_status_with_component_multiple_values_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_properties_builder_end_response_status_succeed),
+        test_az_iot_hub_client_properties_writer_begin_response_status_with_component_multiple_values_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_properties_writer_end_response_status_succeed),
   };
 
   return cmocka_run_group_tests_name("az_iot_hub_client_property", tests, NULL, NULL);


### PR DESCRIPTION
Highligts of changes:
* Prefer the word "write" to "build" when writing JSON properties.  Samples also prefer "write" for JSON creation.
* Remove "_ack" from writable response names.  So status_code instead of ack_code, e.g.
* az_iot.h includes reference to properties header for the one-stop-shopper.
* Have the properties enums be hard-coded #'s, and not point at the underlying twin values they cast from.
  * Adding a UT for now to make sure they're equal.
  * Longer term https://github.com/Azure/azure-sdk-for-c/issues/1784 tracks adding a static_assert style mechanism for this.
* `az_iot_hub_client_properties_update_get_publish_topic` => `az_iot_hub_client_properties_get_reported_publish_topic`.  There's not an ideal way to represent this, but what's in this PR is an improvement over original.