### PR TITLE
Increment version for C SDK releases and add date to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
+## 1.2.0-beta.2 (Unreleased)
+
+
+## 1.2.0-beta.1 (2021-07-09)
 
 ### New Features
 

--- a/sdk/inc/azure/core/az_version.h
+++ b/sdk/inc/azure/core/az_version.h
@@ -17,7 +17,7 @@
 
 /// The version in string format used for telemetry following the `semver.org` standard
 /// (https://semver.org).
-#define AZ_SDK_VERSION_STRING "1.2.0-beta.1"
+#define AZ_SDK_VERSION_STRING "1.2.0-beta.2"
 
 /// Major numeric identifier.
 #define AZ_SDK_VERSION_MAJOR 1
@@ -29,6 +29,6 @@
 #define AZ_SDK_VERSION_PATCH 0
 
 /// Optional pre-release identifier. SDK is in a pre-release state when present.
-#define AZ_SDK_VERSION_PRERELEASE "beta.1"
+#define AZ_SDK_VERSION_PRERELEASE "beta.2"
 
 #endif //_az_VERSION_H


### PR DESCRIPTION
Making the change to main instead of in the feature branch, rather than doing https://github.com/Azure/azure-sdk-for-c/pull/1826
