### PR TITLE
Fix compilation error C4576 with C++ and MSVC 2019 (19.28.29913)

### DIFF
--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -285,7 +285,7 @@ typedef struct
  */
 AZ_NODISCARD AZ_INLINE az_json_writer_options az_json_writer_options_default()
 {
-  az_json_writer_options options = (az_json_writer_options) {
+  az_json_writer_options options = {
     ._internal = {
       .unused = false,
     },
@@ -593,7 +593,7 @@ typedef struct
  */
 AZ_NODISCARD AZ_INLINE az_json_reader_options az_json_reader_options_default()
 {
-  az_json_reader_options options = (az_json_reader_options) {
+  az_json_reader_options options = {
     ._internal = {
       .unused = false,
     },


### PR DESCRIPTION
When using this SDK with MS C++ 2019 (19.28.29913), including the header file `az_json.h` into a C++ file yields the following error:

```
azure/core/az_json.h(292): error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax
azure/core/az_json.h(600): error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax
```

Example code to reproduce:

```
#include <azure/core/az_json.h>

int main(void)
{
}
```

compile above using this command line from VS 2019 command prompt:
```
cl -I sdk/inc /std:c++latest main.cpp
```

Removing the redundant C-style type casts in the initialisers fixes this compilation error.
