### PR TITLE
Critical changes for PnP GA

### DIFF
--- a/sdk/docs/iot/README.md
+++ b/sdk/docs/iot/README.md
@@ -36,7 +36,6 @@ The library targets made available via CMake are the following:
 
 - `az::iot::hub` - For Azure IoT Hub features ([API documentation here](https://azuresdkdocs.blob.core.windows.net/$web/c/az_iot/1.0.0/az__iot__hub__client_8h.html)).
 - `az::iot::provisioning` - For Azure IoT Provisioning features ([API documentation here](https://azuresdkdocs.blob.core.windows.net/$web/c/az_iot/1.0.0/az__iot__provisioning__client_8h.html)).
-- `az::iot::pnp` - **[BETA]** For Azure IoT Plug and Play features ([feature branch here](https://github.com/Azure/azure-sdk-for-c/tree/feature/iot_pnp)).
 
 ### Samples
 

--- a/sdk/inc/azure/iot/az_iot_hub_client_properties.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client_properties.h
@@ -197,7 +197,8 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_writer_end_response_status(
  *
  * @pre \p client must not be `NULL`.
  * @pre \p ref_json_reader must not be `NULL`.
- * @pre \p message_type must be `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED` or `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE`.
+ * @pre \p message_type must be `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED` or
+ * `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE`.
  * @pre \p out_version must not be `NULL`.
  *
  * @return An #az_result value indicating the result of the operation.
@@ -284,8 +285,10 @@ typedef enum
  * @pre \p client must not be `NULL`.
  * @pre \p ref_json_reader must not be `NULL`.
  * @pre \p out_component_name must not be `NULL`. It must point to an #az_span instance.
- * @pre \p message_type must be `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED` or `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE`.
- * @pre \p property_type must be `AZ_IOT_HUB_CLIENT_PROPERTY_REPORTED_FROM_DEVICE` or `AZ_IOT_HUB_CLIENT_PROPERTY_WRITABLE`.
+ * @pre \p message_type must be `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED` or
+ * `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE`.
+ * @pre \p property_type must be `AZ_IOT_HUB_CLIENT_PROPERTY_REPORTED_FROM_DEVICE` or
+ * `AZ_IOT_HUB_CLIENT_PROPERTY_WRITABLE`.
  * @pre \p If `AZ_IOT_HUB_CLIENT_PROPERTY_REPORTED_FROM_DEVICE` is specified in \p property_type,
  * then \p message_type must be `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE`.
  *

--- a/sdk/inc/azure/iot/az_iot_hub_client_properties.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client_properties.h
@@ -4,7 +4,7 @@
 /**
  * @file
  *
- * @brief Definition for the Azure IoT Plug and Play properties writer and parsing routines.
+ * @brief Definition for the IoT Plug and Play properties writer and parsing routines.
  */
 
 #ifndef _az_IOT_HUB_CLIENT_PROPERTIES_H
@@ -180,7 +180,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_writer_end_response_status(
     az_json_writer* ref_json_writer);
 
 /**
- * @brief Read the Azure IoT Plug and Play property version.
+ * @brief Read the IoT Plug and Play property version.
  *
  * @warning This modifies the state of the json reader. To then use the same json reader
  * with az_iot_hub_client_properties_get_next_component_property(), you must call
@@ -223,7 +223,7 @@ typedef enum
 } az_iot_hub_client_property_type;
 
 /**
- * @brief Iteratively read the Azure IoT Plug and Play component properties.
+ * @brief Iteratively read the IoT Plug and Play component properties.
  *
  * Note that between calls, the #az_span pointed to by \p out_component_name shall not be modified,
  * only checked and compared. Internally, the #az_span is only changed if the component name changes

--- a/sdk/inc/azure/iot/az_iot_hub_client_properties.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client_properties.h
@@ -5,8 +5,6 @@
  * @file
  *
  * @brief Definition for the Azure IoT Plug and Play properties writer and parsing routines.
- *
- * @warning THIS LIBRARY IS IN PREVIEW. APIS ARE SUBJECT TO CHANGE UNTIL GENERAL AVAILABILITY.
  */
 
 #ifndef _az_IOT_HUB_CLIENT_PROPERTIES_H
@@ -193,12 +191,13 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_writer_end_response_status(
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in,out] ref_json_reader The pointer to the #az_json_reader used to parse through the JSON
  * payload.
- * @param[in] response_type The #az_iot_hub_client_properties_message_type representing the message
+ * @param[in] message_type The #az_iot_hub_client_properties_message_type representing the message
  * type associated with the payload.
  * @param[out] out_version The numeric version of the properties in the JSON payload.
  *
  * @pre \p client must not be `NULL`.
  * @pre \p ref_json_reader must not be `NULL`.
+ * @pre \p message_type must be `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED` or `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE`.
  * @pre \p out_version must not be `NULL`.
  *
  * @return An #az_result value indicating the result of the operation.
@@ -207,7 +206,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_writer_end_response_status(
 AZ_NODISCARD az_result az_iot_hub_client_properties_get_properties_version(
     az_iot_hub_client const* client,
     az_json_reader* ref_json_reader,
-    az_iot_hub_client_properties_message_type response_type,
+    az_iot_hub_client_properties_message_type message_type,
     int32_t* out_version);
 
 /**
@@ -241,7 +240,7 @@ typedef enum
  * @code
  *
  * while (az_result_succeeded(az_iot_hub_client_properties_get_next_component_property(
- *       &hub_client, &jr, response_type, AZ_IOT_HUB_CLIENT_PROPERTY_WRITABLE, &component_name)))
+ *       &hub_client, &jr, message_type, AZ_IOT_HUB_CLIENT_PROPERTY_WRITABLE, &component_name)))
  * {
  *   // Check if property is of interest (substitute user_property for your own property name)
  *   if (az_json_token_is_text_equal(&jr.token, user_property))
@@ -277,7 +276,7 @@ typedef enum
  * @param[in] client The #az_iot_hub_client to use for this call.
  * @param[in,out] ref_json_reader The #az_json_reader to parse through. The ownership of iterating
  * through this json reader is shared between the user and this API.
- * @param[in] response_type The #az_iot_hub_client_properties_message_type representing the message
+ * @param[in] message_type The #az_iot_hub_client_properties_message_type representing the message
  * type associated with the payload.
  * @param[in] property_type The #az_iot_hub_client_property_type to scan for.
  * @param[out] out_component_name The #az_span* representing the value of the component.
@@ -285,8 +284,10 @@ typedef enum
  * @pre \p client must not be `NULL`.
  * @pre \p ref_json_reader must not be `NULL`.
  * @pre \p out_component_name must not be `NULL`. It must point to an #az_span instance.
+ * @pre \p message_type must be `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED` or `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE`.
+ * @pre \p property_type must be `AZ_IOT_HUB_CLIENT_PROPERTY_REPORTED_FROM_DEVICE` or `AZ_IOT_HUB_CLIENT_PROPERTY_WRITABLE`.
  * @pre \p If `AZ_IOT_HUB_CLIENT_PROPERTY_REPORTED_FROM_DEVICE` is specified in \p property_type,
- * then \p response_type must be `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE`.
+ * then \p message_type must be `AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE`.
  *
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK If the function returned a valid #az_json_reader pointing to the property name and
@@ -297,7 +298,7 @@ typedef enum
 AZ_NODISCARD az_result az_iot_hub_client_properties_get_next_component_property(
     az_iot_hub_client const* client,
     az_json_reader* ref_json_reader,
-    az_iot_hub_client_properties_message_type response_type,
+    az_iot_hub_client_properties_message_type message_type,
     az_iot_hub_client_property_type property_type,
     az_span* out_component_name);
 

--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -196,7 +196,7 @@ To run the samples, ensure you have the following programs and tools installed o
 - If running a DPS sample: `paho_iot_provisioning_sample`, `paho_iot_pnp_with_provisioning_sample`.
   - Have an [Azure IoT Hub Device Provisioning Service (DPS)](https://docs.microsoft.com/azure/iot-dps/quick-setup-auto-provision) created.
 
-- If running a Plug and Play sample: `paho_iot_pnp_sample`, `paho_iot_pnp_with_provisioning_sample`, `paho_iot_pnp_component_sample`.
+- If running an IoT Plug and Play sample: `paho_iot_pnp_sample`, `paho_iot_pnp_with_provisioning_sample`, `paho_iot_pnp_component_sample`.
   - Have the most recent version of [Azure IoT Explorer](https://github.com/Azure/azure-iot-explorer/releases) installed and connected to your Azure IoT Hub. More instructions on can be found [here](https://docs.microsoft.com/azure/iot-pnp/howto-use-iot-explorer).
 
 
@@ -608,7 +608,7 @@ This section provides an overview of the different samples available to run and 
 
   This [sample](https://github.com/Azure/azure-sdk-for-c/blob/main/sdk/samples/iot/paho_iot_hub_pnp_sample.c) connects an IoT Plug and Play enabled device (a thermostat) with the Digital Twin Model ID (DTMI) detailed [here](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/Thermostat.json). If a timeout occurs while waiting for a message from the Azure IoT Explorer, the sample will continue. If 3 timeouts occur consecutively, the sample will disconnect. X509 authentication is used.
 
-  <details><summary><i>How to interact with the Plug and Play sample:</i></summary>
+  <details><summary><i>How to interact with the IoT Plug and Play sample:</i></summary>
 
   The easiest way to interact with this sample from the service side is to use Azure IoT Explorer.  To use the sample:
 
@@ -620,7 +620,7 @@ This section provides an overview of the different samples available to run and 
     - [Configure your hub](https://github.com/Azure/azure-iot-explorer/#configure-an-iot-hub-connection).  Once you've created your thermostat device, you should see it listed in the UX.
     - Go to `IoT Plug and Play Settings` on the home screen, select `Local Folder` for the location of the model definitions, and point to the folder you downloaded the thermostat model.
     - Go to the devices list and select your thermostat device.  Now select `IoT Plug and Play components` and then `Default Component`.
-    - You will now be able to interact with the Plug and Play device.
+    - You will now be able to interact with the IoT Plug and Play device.
 
   Additional instructions for Azure IoT Explorer, including screenshots, are available [here](https://github.com/Azure/azure-iot-explorer/#plug-and-play).
 
@@ -636,7 +636,7 @@ This section provides an overview of the different samples available to run and 
 
   This [sample](https://github.com/Azure/azure-sdk-for-c/blob/main/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c) extends the IoT Hub Plug and Play Sample above to mimic a Temperature Controller and connects the IoT Plug and Play enabled device (the Temperature Controller) with the Digital Twin Model ID (DTMI) detailed [here](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json). If a timeout occurs while waiting for a message from the Azure IoT Explorer, the sample will continue. If 3 timeouts occur consecutively, the sample will disconnect. X509 authentication is used.
 
-  This [sample](https://github.com/Azure/azure-sdk-for-c/blob/main/sdk/samples/iot/paho_iot_pnp_component_sample.c) connects an Azure IoT Plug and Play enabled device simulating a temperature controller directly to Azure IoT Hub.  This device is described via the Digital Twin Model ID (DTMI) detailed [here](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json).  X509 authentication is used.
+  This [sample](https://github.com/Azure/azure-sdk-for-c/blob/main/sdk/samples/iot/paho_iot_pnp_component_sample.c) connects an IoT Plug and Play enabled device simulating a temperature controller directly to Azure IoT Hub.  This device is described via the Digital Twin Model ID (DTMI) detailed [here](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json).  X509 authentication is used.
   
   This Temperature Controller is made up of multiple components.  These are implemented in the [./pnp](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/pnp) subdirectory.
 
@@ -645,7 +645,7 @@ This section provides an overview of the different samples available to run and 
   - [Temperature Sensor 2](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/Thermostat.json)
   - The properties, commands, and telemetry of the Temperature Controller itself.
 
-  <details><summary><i>How to interact with the Plug and Play Multiple Component sample:</i></summary>
+  <details><summary><i>How to interact with the IoT Plug and Play Multiple Component sample:</i></summary>
 
   The easiest way to interact with this sample from the service side is to use Azure IoT Explorer.  To use the sample:
 
@@ -657,7 +657,7 @@ This section provides an overview of the different samples available to run and 
     - [Configure your hub](https://github.com/Azure/azure-iot-explorer/#configure-an-iot-hub-connection).  Once you've created your thermostat device, you should see it listed in the UX.
     - Go to `IoT Plug and Play Settings` on the home screen, select `Local Folder` for the location of the model definitions, and point to the folder you downloaded the thermostat model.
     - Go to the devices list and select your thermostat device.  Now select `IoT Plug and Play components` and then `Default Component`.
-    - You will now be able to interact with the Plug and Play device.
+    - You will now be able to interact with the IoT Plug and Play device.
 
     Additional instructions for Azure IoT Explorer, including screenshots, are available [here](https://github.com/Azure/azure-iot-explorer/#plug-and-play).
 

--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -630,13 +630,13 @@ This section provides an overview of the different samples available to run and 
 
 - *Executable:* `paho_iot_pnp_with_provisioning_sample`
 
-  This [sample](https://github.com/Azure/azure-sdk-for-c/blob/main/iot_pnp/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c) has the same functionality as the `paho_iot_pnp_sample` but uses the Azure Device Provisioning Service for authentication. The same steps above should be followed for interacting with the sample in Azure IoT Explorer.
+  This [sample](https://github.com/Azure/azure-sdk-for-c/blob/main/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c) has the same functionality as the `paho_iot_pnp_sample` but uses the Azure Device Provisioning Service for authentication. The same steps above should be followed for interacting with the sample in Azure IoT Explorer.
 
 ### IoT Plug and Play Multiple Component Sample
 
   This [sample](https://github.com/Azure/azure-sdk-for-c/blob/main/sdk/samples/iot/paho_iot_hub_pnp_component_sample.c) extends the IoT Hub Plug and Play Sample above to mimic a Temperature Controller and connects the IoT Plug and Play enabled device (the Temperature Controller) with the Digital Twin Model ID (DTMI) detailed [here](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json). If a timeout occurs while waiting for a message from the Azure IoT Explorer, the sample will continue. If 3 timeouts occur consecutively, the sample will disconnect. X509 authentication is used.
 
-  This [sample](https://github.com/Azure/azure-sdk-for-c/blob/main/iot_pnp/sdk/samples/iot/paho_iot_pnp_component_sample.c) connects an Azure IoT Plug and Play enabled device simulating a temperature controller directly to Azure IoT Hub.  This device is described via the Digital Twin Model ID (DTMI) detailed [here](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json).  X509 authentication is used.
+  This [sample](https://github.com/Azure/azure-sdk-for-c/blob/main/sdk/samples/iot/paho_iot_pnp_component_sample.c) connects an Azure IoT Plug and Play enabled device simulating a temperature controller directly to Azure IoT Hub.  This device is described via the Digital Twin Model ID (DTMI) detailed [here](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/TemperatureController.json).  X509 authentication is used.
   
   This Temperature Controller is made up of multiple components.  These are implemented in the [./pnp](https://github.com/Azure/azure-sdk-for-c/blob/master/sdk/samples/iot/pnp) subdirectory.
 

--- a/sdk/samples/iot/paho_iot_pnp_component_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_component_sample.c
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 /*
- * This sample connects an Azure IoT Plug and Play enabled device.
+ * This sample connects an IoT Plug and Play enabled device.
  *
- * Azure IoT Plug and Play requires the device to advertise its capabilities in a device model. This
+ * IoT Plug and Play requires the device to advertise its capabilities in a device model. This
  * sample implements the modeled declared by dtmi:com:example:TemperatureController;1.  See the
  * readme for more information on this model.  For more information about IoT Plug and Play, see
  * https://aka.ms/iotpnp.

--- a/sdk/samples/iot/paho_iot_pnp_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_sample.c
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 /*
- * This sample connects an Azure IoT Plug and Play enabled device.
+ * This sample connects an IoT Plug and Play enabled device.
  *
- * Azure IoT Plug and Play requires the device to advertise its capabilities in a device model. This
+ * IoT Plug and Play requires the device to advertise its capabilities in a device model. This
  * sample's model is available in
  * https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/Thermostat.json. See
  * the sample README for more information on this model. For more information about IoT Plug and

--- a/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
@@ -243,14 +243,21 @@ static void register_device_with_provisioning_service(void)
     exit(rc);
   }
 
-  // Devices registering a ModelId while using Device Provisioning Service must specify 
+  // Devices registering a ModelId while using Device Provisioning Service must specify
   // their ModelId in an MQTT payload sent during registration.
   uint8_t mqtt_payload[MQTT_PAYLOAD_BUFFER_LENGTH];
   size_t mqtt_payload_length;
 
-  az_span custom_payload_property = AZ_SPAN_FROM_STR("{\"modelId\":\"dtmi:com:example:Thermostat;1\"}");
-  
-  rc = az_iot_provisioning_client_get_request_payload(&provisioning_client, custom_payload_property, NULL, mqtt_payload, sizeof(mqtt_payload), &mqtt_payload_length);
+  az_span custom_payload_property
+      = AZ_SPAN_FROM_STR("{\"modelId\":\"dtmi:com:example:Thermostat;1\"}");
+
+  rc = az_iot_provisioning_client_get_request_payload(
+      &provisioning_client,
+      custom_payload_property,
+      NULL,
+      mqtt_payload,
+      sizeof(mqtt_payload),
+      &mqtt_payload_length);
   if (az_result_failed(rc))
   {
     IOT_SAMPLE_LOG_ERROR(

--- a/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 /*
- * This sample connects an Azure IoT Plug and Play enabled device.
+ * This sample connects an IoT Plug and Play enabled device.
  *
- * Azure IoT Plug and Play requires the device to advertise its capabilities in a device model. This
+ * IoT Plug and Play requires the device to advertise its capabilities in a device model. This
  * sample's model is available in
  * https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/Thermostat.json. See
  * the sample README for more information on this model. For more information about IoT Plug and

--- a/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
@@ -42,6 +42,7 @@
 #define QUERY_TOPIC_BUFFER_LENGTH 256
 #define REGISTER_TOPIC_BUFFER_LENGTH 128
 #define PROVISIONING_ENDPOINT_BUFFER_LENGTH 256
+#define MQTT_PAYLOAD_BUFFER_LENGTH 256
 
 // The model this device implements
 static az_span const model_id = AZ_SPAN_LITERAL_FROM_STR("dtmi:com:example:Thermostat;1");
@@ -242,10 +243,25 @@ static void register_device_with_provisioning_service(void)
     exit(rc);
   }
 
+  // Devices registering a ModelId while using Device Provisioning Service must specify 
+  // their ModelId in an MQTT payload sent during registration.
+  uint8_t mqtt_payload[MQTT_PAYLOAD_BUFFER_LENGTH];
+  size_t mqtt_payload_length;
+
+  az_span custom_payload_property = AZ_SPAN_FROM_STR("{\"modelId\":\"dtmi:com:example:Thermostat;1\"}");
+  
+  rc = az_iot_provisioning_client_get_request_payload(&provisioning_client, custom_payload_property, NULL, mqtt_payload, sizeof(mqtt_payload), &mqtt_payload_length);
+  if (az_result_failed(rc))
+  {
+    IOT_SAMPLE_LOG_ERROR(
+        "Failed to initialize provisioning client: az_result return code 0x%08x.", rc);
+    exit(rc);
+  }
+
   // Set MQTT message options.
   MQTTClient_message pubmsg = MQTTClient_message_initializer;
-  pubmsg.payload = NULL; // Empty payload
-  pubmsg.payloadlen = 0;
+  pubmsg.payload = mqtt_payload;
+  pubmsg.payloadlen = (int)mqtt_payload_length;
   pubmsg.qos = 1;
   pubmsg.retained = 0;
 

--- a/sdk/src/azure/iot/az_iot_hub_client_properties.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_properties.c
@@ -203,7 +203,9 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_get_properties_version(
 {
   _az_PRECONDITION_NOT_NULL(client);
   _az_PRECONDITION_NOT_NULL(ref_json_reader);
-  _az_PRECONDITION((message_type == AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED) || (message_type == AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE));
+  _az_PRECONDITION(
+      (message_type == AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED)
+      || (message_type == AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE));
   _az_PRECONDITION_NOT_NULL(out_version);
 
   (void)client;
@@ -419,8 +421,12 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_get_next_component_property(
   _az_PRECONDITION_NOT_NULL(client);
   _az_PRECONDITION_NOT_NULL(ref_json_reader);
   _az_PRECONDITION_NOT_NULL(out_component_name);
-  _az_PRECONDITION((message_type == AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED) || (message_type == AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE));
-  _az_PRECONDITION((property_type == AZ_IOT_HUB_CLIENT_PROPERTY_REPORTED_FROM_DEVICE) || (property_type == AZ_IOT_HUB_CLIENT_PROPERTY_WRITABLE));
+  _az_PRECONDITION(
+      (message_type == AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED)
+      || (message_type == AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE));
+  _az_PRECONDITION(
+      (property_type == AZ_IOT_HUB_CLIENT_PROPERTY_REPORTED_FROM_DEVICE)
+      || (property_type == AZ_IOT_HUB_CLIENT_PROPERTY_WRITABLE));
   _az_PRECONDITION(
       (property_type == AZ_IOT_HUB_CLIENT_PROPERTY_WRITABLE)
       || ((property_type == AZ_IOT_HUB_CLIENT_PROPERTY_REPORTED_FROM_DEVICE)

--- a/sdk/src/azure/iot/az_iot_hub_client_properties.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_properties.c
@@ -203,6 +203,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_get_properties_version(
 {
   _az_PRECONDITION_NOT_NULL(client);
   _az_PRECONDITION_NOT_NULL(ref_json_reader);
+  _az_PRECONDITION((message_type == AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED) || (message_type == AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE));
   _az_PRECONDITION_NOT_NULL(out_version);
 
   (void)client;
@@ -418,6 +419,8 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_get_next_component_property(
   _az_PRECONDITION_NOT_NULL(client);
   _az_PRECONDITION_NOT_NULL(ref_json_reader);
   _az_PRECONDITION_NOT_NULL(out_component_name);
+  _az_PRECONDITION((message_type == AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED) || (message_type == AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE));
+  _az_PRECONDITION((property_type == AZ_IOT_HUB_CLIENT_PROPERTY_REPORTED_FROM_DEVICE) || (property_type == AZ_IOT_HUB_CLIENT_PROPERTY_WRITABLE));
   _az_PRECONDITION(
       (property_type == AZ_IOT_HUB_CLIENT_PROPERTY_WRITABLE)
       || ((property_type == AZ_IOT_HUB_CLIENT_PROPERTY_REPORTED_FROM_DEVICE)

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_properties.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_properties.c
@@ -558,17 +558,17 @@ static void test_az_iot_hub_client_properties_get_properties_version_NULL_json_r
 
 static void test_az_iot_hub_client_properties_get_properties_version_invalid_message_type_fails()
 {
-    az_json_reader jr;
-    int32_t version;
-    az_iot_hub_client_options options = az_iot_hub_client_options_default();
-    options.model_id = test_model_id;
-    
-    az_iot_hub_client client;
-    assert_int_equal(
-        az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
-    
-    ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_get_properties_version(
-        &client, &jr, AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_ERROR, &version));
+  az_json_reader jr;
+  int32_t version;
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  options.model_id = test_model_id;
+
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
+
+  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_get_properties_version(
+      &client, &jr, AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_ERROR, &version));
 }
 
 static void test_az_iot_hub_client_properties_get_properties_version_NULL_version_fails()

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_properties.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_properties.c
@@ -556,6 +556,21 @@ static void test_az_iot_hub_client_properties_get_properties_version_NULL_json_r
       &client, NULL, AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_GET_RESPONSE, &version));
 }
 
+static void test_az_iot_hub_client_properties_get_properties_version_invalid_message_type_fails()
+{
+    az_json_reader jr;
+    int32_t version;
+    az_iot_hub_client_options options = az_iot_hub_client_options_default();
+    options.model_id = test_model_id;
+    
+    az_iot_hub_client client;
+    assert_int_equal(
+        az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
+    
+    ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_get_properties_version(
+        &client, &jr, AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_ERROR, &version));
+}
+
 static void test_az_iot_hub_client_properties_get_properties_version_NULL_version_fails()
 {
   az_json_reader jr;
@@ -622,7 +637,7 @@ test_az_iot_hub_client_properties_get_next_component_property_NULL_component_nam
 }
 
 static void
-test_az_iot_hub_client_properties_get_next_component_property_get_desired_properties_with_query_for_reported_fails()
+test_az_iot_hub_client_properties_get_next_component_property_invalid_message_report_combination_fails()
 {
   az_json_reader jr;
 
@@ -639,6 +654,48 @@ test_az_iot_hub_client_properties_get_next_component_property_get_desired_proper
       &jr,
       AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED,
       AZ_IOT_HUB_CLIENT_PROPERTY_REPORTED_FROM_DEVICE,
+      &component_name));
+}
+
+static void
+test_az_iot_hub_client_properties_get_next_component_property_invalid_message_type_fails()
+{
+  az_json_reader jr;
+
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  options.model_id = test_model_id;
+
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
+
+  az_span component_name;
+  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_get_next_component_property(
+      &client,
+      &jr,
+      AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_ERROR,
+      AZ_IOT_HUB_CLIENT_PROPERTY_WRITABLE,
+      &component_name));
+}
+
+static void
+test_az_iot_hub_client_properties_get_next_component_property_invalid_property_type_fails()
+{
+  az_json_reader jr;
+
+  az_iot_hub_client_options options = az_iot_hub_client_options_default();
+  options.model_id = test_model_id;
+
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, &options), AZ_OK);
+
+  az_span component_name;
+  ASSERT_PRECONDITION_CHECKED(az_iot_hub_client_properties_get_next_component_property(
+      &client,
+      &jr,
+      AZ_IOT_HUB_CLIENT_PROPERTIES_MESSAGE_TYPE_WRITABLE_UPDATED,
+      (az_iot_hub_client_property_type)25,
       &component_name));
 }
 
@@ -1845,6 +1902,8 @@ int test_az_iot_hub_client_properties()
     cmocka_unit_test(test_az_iot_hub_client_properties_get_properties_version_NULL_client_fails),
     cmocka_unit_test(
         test_az_iot_hub_client_properties_get_properties_version_NULL_json_reader_fails),
+    cmocka_unit_test(
+        test_az_iot_hub_client_properties_get_properties_version_invalid_message_type_fails),
     cmocka_unit_test(test_az_iot_hub_client_properties_get_properties_version_NULL_version_fails),
     cmocka_unit_test(
         test_az_iot_hub_client_properties_get_next_component_property_NULL_client_fails),
@@ -1853,7 +1912,11 @@ int test_az_iot_hub_client_properties()
     cmocka_unit_test(
         test_az_iot_hub_client_properties_get_next_component_property_NULL_component_name_fails),
     cmocka_unit_test(
-        test_az_iot_hub_client_properties_get_next_component_property_get_desired_properties_with_query_for_reported_fails),
+        test_az_iot_hub_client_properties_get_next_component_property_invalid_message_report_combination_fails),
+    cmocka_unit_test(
+        test_az_iot_hub_client_properties_get_next_component_property_invalid_message_type_fails),
+    cmocka_unit_test(
+        test_az_iot_hub_client_properties_get_next_component_property_invalid_property_type_fails),
 #endif // AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(test_az_iot_hub_client_properties_enums_equal),
     cmocka_unit_test(test_az_iot_hub_client_properties_document_get_publish_topic_succeed),


### PR DESCRIPTION
Ahead of the PnP GA, some critical changes we need to get in:
* Additional `_az_PRECONDITION` to check enum validity.
* Fixup the branding.  It's "IoT Plug and Play", not "Azure IoT Plug and Play"
* Get PnP provisioning samples to consume `az_iot_provisioning_client_get_request_payload`.
* `response_type ` => `message_type` in parameters list.
