### PR TITLE
Create readme headers for certificate creation section

### DIFF
--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -222,18 +222,18 @@ This approach must be used for the following samples: `paho_iot_hub_c2d_sample`,
 1. Enter the directory `azure-sdk-for-c/sdk/samples/iot/`.
 1. Run the following commands:
 
-  ```bash
-  openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
-  openssl req -new -days 30 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -config x509_config.cfg -subj "/CN=paho-sample-device1"
-  openssl x509 -noout -text -in device_ec_cert.pem
+    ```bash
+    openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
+    openssl req -new -days 30 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -config x509_config.cfg -subj "/CN=paho-sample-device1"
+    openssl x509 -noout -text -in device_ec_cert.pem
 
-  rm -f device_cert_store.pem
-  cat device_ec_cert.pem device_ec_key.pem > device_cert_store.pem
+    rm -f device_cert_store.pem
+    cat device_ec_cert.pem device_ec_key.pem > device_cert_store.pem
 
-  openssl x509 -noout -fingerprint -in device_ec_cert.pem | sed 's/://g'| sed 's/\(SHA1 Fingerprint=\)//g' | tee fingerprint.txt
+    openssl x509 -noout -fingerprint -in device_ec_cert.pem | sed 's/://g'| sed 's/\(SHA1 Fingerprint=\)//g' | tee fingerprint.txt
 
-  export AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH=$(pwd)/device_cert_store.pem
-  ```
+    export AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH=$(pwd)/device_cert_store.pem
+    ```
 
 1. The resulting thumbprint will be placed in `fingerprint.txt` and the generated pem file is named `device_ec_cert.pem`.
 
@@ -242,17 +242,17 @@ This approach must be used for the following samples: `paho_iot_hub_c2d_sample`,
 1. Enter the directory `azure-sdk-for-c\sdk\samples\iot\`.
 1. Run the following commands:
 
-  ```powershell
-  openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
-  openssl req -new -days 30 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -config x509_config.cfg -subj "/CN=paho-sample-device1"
-  openssl x509 -noout -text -in device_ec_cert.pem
+    ```powershell
+    openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
+    openssl req -new -days 30 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -config x509_config.cfg -subj "/CN=paho-sample-device1"
+    openssl x509 -noout -text -in device_ec_cert.pem
 
-  Get-Content device_ec_cert.pem, device_ec_key.pem | Set-Content device_cert_store.pem
+    Get-Content device_ec_cert.pem, device_ec_key.pem | Set-Content device_cert_store.pem
 
-  openssl x509 -noout -fingerprint -in device_ec_cert.pem | % {$_.replace(":", "")} | % {$_.replace("SHA1 Fingerprint=", "")} | Tee-Object fingerprint.txt
+    openssl x509 -noout -fingerprint -in device_ec_cert.pem | % {$_.replace(":", "")} | % {$_.replace("SHA1 Fingerprint=", "")} | Tee-Object fingerprint.txt
 
-  $env:AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH=$(Resolve-Path device_cert_store.pem)
-  ```
+    $env:AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH=$(Resolve-Path device_cert_store.pem)
+    ```
 
 1. The resulting thumbprint will be placed in `fingerprint.txt` and the generated pem file is named `device_ec_cert.pem`.
 

--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -10,6 +10,7 @@
   - [Getting Started](#getting-started)
     - [Create an Authenticated Device](#create-an-authenticated-device)
       - [Create a Device Using X.509 Self-Signed Certificate Authentication](#create-a-device-using-x509-self-signed-certificate-authentication)
+        - [Generate a certificate](#generate-a-certificate)
         - [Linux Certificate Creation](#linux-certificate-creation)
         - [Windows Certificate Creation](#windows-certificate-creation)
         - [Create a device](#create-a-device)
@@ -211,11 +212,11 @@ Next you must create and connect an authenticated device. You can authenticate i
 
 This approach must be used for the following samples: `paho_iot_hub_c2d_sample`, `paho_iot_hub_methods_sample`, `paho_iot_hub_telemetry_sample`, `paho_iot_hub_twin_sample`, `paho_iot_hub_pnp_sample`, `paho_iot_hub_pnp_component_sample`, `paho_iot_provisioning_sample`
 
-1. Generate a certificate
+##### Generate a certificate
 
-   As a convenience, we provide a series of commands below for you to create a temporary certificate in order to run the samples. These certificates expire after 30 days and are provided ONLY to help you easily understand CA Certificates. When productizing against CA Certificates, you will need to use your own security best practices for certificate creation and lifetime management.
+As a convenience, we provide a series of commands below for you to create a temporary certificate in order to run the samples. These certificates expire after 30 days and are provided ONLY to help you easily understand CA Certificates. When productizing against CA Certificates, you will need to use your own security best practices for certificate creation and lifetime management.
 
-    **WARNING: Certificates created by these commands MUST NOT be used in production-level code.**
+**WARNING: Certificates created by these commands MUST NOT be used in production-level code.**
 
 ##### Linux Certificate Creation
 

--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -10,6 +10,9 @@
   - [Getting Started](#getting-started)
     - [Create an Authenticated Device](#create-an-authenticated-device)
       - [Create a Device Using X.509 Self-Signed Certificate Authentication](#create-a-device-using-x509-self-signed-certificate-authentication)
+        - [Linux Certificate Creation](#linux-certificate-creation)
+        - [Windows Certificate Creation](#windows-certificate-creation)
+        - [Create a device](#create-a-device)
       - [Create a Device Using Symmetric Key (SAS) Authentication](#create-a-device-using-symmetric-key-sas-authentication)
     - [Set Environment Variables](#set-environment-variables)
       - [All-Samples](#all-samples)
@@ -217,62 +220,49 @@ This approach must be used for the following samples: `paho_iot_hub_c2d_sample`,
 
     **WARNING: Certificates created by these commands MUST NOT be used in production-level code.**
 
-    <details><summary><i>Certificate Generation Commands:</i></summary>
-    <p>
+##### Linux Certificate Creation
 
-    <details><summary>Linux:</summary>
-    <p>
+1. Enter the directory `azure-sdk-for-c/sdk/samples/iot/`.
+1. Run the following commands:
 
-    1. Enter the directory `azure-sdk-for-c/sdk/samples/iot/`.
-    2. Run the following commands:
+  ```bash
+  openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
+  openssl req -new -days 30 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -config x509_config.cfg -subj "/CN=paho-sample-device1"
+  openssl x509 -noout -text -in device_ec_cert.pem
 
-        ```bash
-        openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
-        openssl req -new -days 30 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -config x509_config.cfg -subj "/CN=paho-sample-device1"
-        openssl x509 -noout -text -in device_ec_cert.pem
+  rm -f device_cert_store.pem
+  cat device_ec_cert.pem device_ec_key.pem > device_cert_store.pem
 
-        rm -f device_cert_store.pem
-        cat device_ec_cert.pem device_ec_key.pem > device_cert_store.pem
+  openssl x509 -noout -fingerprint -in device_ec_cert.pem | sed 's/://g'| sed 's/\(SHA1 Fingerprint=\)//g' | tee fingerprint.txt
 
-        openssl x509 -noout -fingerprint -in device_ec_cert.pem | sed 's/://g'| sed 's/\(SHA1 Fingerprint=\)//g' | tee fingerprint.txt
+  export AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH=$(pwd)/device_cert_store.pem
+  ```
 
-        export AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH=$(pwd)/device_cert_store.pem
-        ```
+1. The resulting thumbprint will be placed in `fingerprint.txt` and the generated pem file is named `device_ec_cert.pem`.
 
-    3. The resulting thumbprint will be placed in `fingerprint.txt` and the generated pem file is named `device_ec_cert.pem`.
+##### Windows Certificate Creation
 
-    </p>
-    </details>
+1. Enter the directory `azure-sdk-for-c\sdk\samples\iot\`.
+1. Run the following commands:
 
-    <details><summary>Windows (PowerShell):</summary>
-    <p>
+  ```powershell
+  openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
+  openssl req -new -days 30 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -config x509_config.cfg -subj "/CN=paho-sample-device1"
+  openssl x509 -noout -text -in device_ec_cert.pem
 
-    1. Enter the directory `azure-sdk-for-c\sdk\samples\iot\`.
-    2. Run the following commands:
+  Get-Content device_ec_cert.pem, device_ec_key.pem | Set-Content device_cert_store.pem
 
-        ```powershell
-        openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
-        openssl req -new -days 30 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -config x509_config.cfg -subj "/CN=paho-sample-device1"
-        openssl x509 -noout -text -in device_ec_cert.pem
+  openssl x509 -noout -fingerprint -in device_ec_cert.pem | % {$_.replace(":", "")} | % {$_.replace("SHA1 Fingerprint=", "")} | Tee-Object fingerprint.txt
 
-        Get-Content device_ec_cert.pem, device_ec_key.pem | Set-Content device_cert_store.pem
+  $env:AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH=$(Resolve-Path device_cert_store.pem)
+  ```
 
-        openssl x509 -noout -fingerprint -in device_ec_cert.pem | % {$_.replace(":", "")} | % {$_.replace("SHA1 Fingerprint=", "")} | Tee-Object fingerprint.txt
+1. The resulting thumbprint will be placed in `fingerprint.txt` and the generated pem file is named `device_ec_cert.pem`.
 
-        $env:AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH=$(Resolve-Path device_cert_store.pem)
-        ```
-    3. The resulting thumbprint will be placed in `fingerprint.txt` and the generated pem file is named `device_ec_cert.pem`.
+##### Create a device
 
-    </p>
-    </details>
-
-    </p>
-    </details>
-
-2. Create a device
-
-     - To add a new device via Azure IoT Hub, see instructions [here](https://docs.microsoft.com/azure/iot-hub/iot-hub-security-x509-get-started#create-an-x509-device-for-your-iot-hub). However, **DO NOT** select X.509 CA Signed as the authentication type. Select **X.509 Self-Signed**. For the Thumbprint, use the recently generated fingerprint, which has been placed in the file `fingerprint.txt`.
-     - To add a new individual device enrollment via Azure IoT Hub DPS, see instructions [here](https://docs.microsoft.com/azure/iot-dps/quick-create-simulated-device-x509#create-a-device-enrollment-entry-in-the-portal). You will use the recently generated `device_ec_cert.pem` file. After creation, the Registration ID of your device should appear as `paho-sample-device1` in the Individual Enrollments tab.
+- To add a new device via Azure IoT Hub, see instructions [here](https://docs.microsoft.com/azure/iot-hub/iot-hub-security-x509-get-started#create-an-x509-device-for-your-iot-hub). However, **DO NOT** select X.509 CA Signed as the authentication type. Select **X.509 Self-Signed**. For the Thumbprint, use the recently generated fingerprint, which has been placed in the file `fingerprint.txt`.
+- To add a new individual device enrollment via Azure IoT Hub DPS, see instructions [here](https://docs.microsoft.com/azure/iot-dps/quick-create-simulated-device-x509#create-a-device-enrollment-entry-in-the-portal). You will use the recently generated `device_ec_cert.pem` file. After creation, the Registration ID of your device should appear as `paho-sample-device1` in the Individual Enrollments tab.
 
 </p>
 </details>

--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -211,9 +211,6 @@ Next you must create and connect an authenticated device. You can authenticate i
 
 This approach must be used for the following samples: `paho_iot_hub_c2d_sample`, `paho_iot_hub_methods_sample`, `paho_iot_hub_telemetry_sample`, `paho_iot_hub_twin_sample`, `paho_iot_hub_pnp_sample`, `paho_iot_hub_pnp_component_sample`, `paho_iot_provisioning_sample`
 
-<details><summary><i>Instructions to create a device using X.509 Self-Signed Certificate Authentication:</i></summary>
-<p>
-
 1. Generate a certificate
 
    As a convenience, we provide a series of commands below for you to create a temporary certificate in order to run the samples. These certificates expire after 30 days and are provided ONLY to help you easily understand CA Certificates. When productizing against CA Certificates, you will need to use your own security best practices for certificate creation and lifetime management.
@@ -264,23 +261,12 @@ This approach must be used for the following samples: `paho_iot_hub_c2d_sample`,
 - To add a new device via Azure IoT Hub, see instructions [here](https://docs.microsoft.com/azure/iot-hub/iot-hub-security-x509-get-started#create-an-x509-device-for-your-iot-hub). However, **DO NOT** select X.509 CA Signed as the authentication type. Select **X.509 Self-Signed**. For the Thumbprint, use the recently generated fingerprint, which has been placed in the file `fingerprint.txt`.
 - To add a new individual device enrollment via Azure IoT Hub DPS, see instructions [here](https://docs.microsoft.com/azure/iot-dps/quick-create-simulated-device-x509#create-a-device-enrollment-entry-in-the-portal). You will use the recently generated `device_ec_cert.pem` file. After creation, the Registration ID of your device should appear as `paho-sample-device1` in the Individual Enrollments tab.
 
-</p>
-</details>
-
 #### Create a Device Using Symmetric Key (SAS) Authentication
 
 This approach must be used for the following samples: `paho_iot_hub_sas_telemetry_sample`, `paho_iot_provisioning_sas_sample`,
 
-<details><summary><i>Instructions to create a device using Symmetric Key Authentication:</i></summary>
-<p>
-
 - To add a new device via Azure IoT Hub, see instructions [here](https://docs.microsoft.com/azure/iot-hub/iot-hub-create-through-portal#register-a-new-device-in-the-iot-hub).
 - To add a new individual device enrollment via Azure IoT Hub DPS, see instructions [here](https://docs.microsoft.com/azure/iot-dps/quick-create-simulated-device-symm-key#create-a-device-enrollment-entry-in-the-portal). After creation, the Registration ID of your device will appear in the Individual Enrollments tab.
-
-</p>
-</details>
-
-<br/>
 
 ### Set Environment Variables
 

--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -10,7 +10,6 @@
   - [Getting Started](#getting-started)
     - [Create an Authenticated Device](#create-an-authenticated-device)
       - [Create a Device Using X.509 Self-Signed Certificate Authentication](#create-a-device-using-x509-self-signed-certificate-authentication)
-        - [Generate a certificate](#generate-a-certificate)
         - [Linux Certificate Creation](#linux-certificate-creation)
         - [Windows Certificate Creation](#windows-certificate-creation)
         - [Create a device](#create-a-device)
@@ -211,8 +210,6 @@ Next you must create and connect an authenticated device. You can authenticate i
 #### Create a Device Using X.509 Self-Signed Certificate Authentication
 
 This approach must be used for the following samples: `paho_iot_hub_c2d_sample`, `paho_iot_hub_methods_sample`, `paho_iot_hub_telemetry_sample`, `paho_iot_hub_twin_sample`, `paho_iot_hub_pnp_sample`, `paho_iot_hub_pnp_component_sample`, `paho_iot_provisioning_sample`
-
-##### Generate a certificate
 
 As a convenience, we provide a series of commands below for you to create a temporary certificate in order to run the samples. These certificates expire after 30 days and are provided ONLY to help you easily understand CA Certificates. When productizing against CA Certificates, you will need to use your own security best practices for certificate creation and lifetime management.
 


### PR DESCRIPTION
There have been a few times where I have wanted to link people to our instructions on how to create self signed certs for samples and having the sections in collapsed HTML tags makes linking to them impossible (have to give instructions on what to expand instead of a direct link). This just opens them up to be able to be linked to.

To see how this section looks: https://github.com/danewalton/azure-sdk-for-c/tree/dane/updatecertreadme/sdk/samples/iot#create-an-authenticated-device