### PR TITLE
Update codespace launch.json

### DIFF
--- a/.vscode-config/codespaces-launch.json
+++ b/.vscode-config/codespaces-launch.json
@@ -23,8 +23,8 @@
               {"name": "AZ_IOT_HUB_HOSTNAME","value": "${input:hostname}"},
               {"name": "AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH","value": "${workspaceFolder}/cert/device_cert_store.pem"},
             ],
-            "preLaunchTask": "build",
-            "cwd": "${workspaceRoot}"
+            "cwd": "${workspaceRoot}",
+            "preLaunchTask": "build"
         },
 
         {

--- a/.vscode-config/codespaces-launch.json
+++ b/.vscode-config/codespaces-launch.json
@@ -15,55 +15,56 @@
     "configurations": [
         {
             "name": "IoT Telemetry",
-            "type": "gdb",
+            "type": "cppdbg",
+            "program": "${workspaceFolder}/build/sdk/samples/iot/paho_iot_hub_telemetry_sample",
             "request": "launch",
-            "env": {
-                "AZ_IOT_HUB_DEVICE_ID": "${input:device_id}",
-                "AZ_IOT_HUB_HOSTNAME": "${input:hostname}",
-                "AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH": "/workspaces/azure-sdk-for-c/cert/device_cert_store.pem"
-            },
-            "target": "./build/sdk/samples/iot/paho_iot_hub_telemetry_sample",
-            "cwd": "${workspaceRoot}",
-            "preLaunchTask": "build"
+            "environment": [
+              {"name": "AZ_IOT_HUB_DEVICE_ID","value": "${input:device_id}"},
+              {"name": "AZ_IOT_HUB_HOSTNAME","value": "${input:hostname}"},
+              {"name": "AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH","value": "${workspaceFolder}/cert/device_cert_store.pem"},
+            ],
+            "preLaunchTask": "build",
+            "cwd": "${workspaceRoot}"
         },
+
         {
             "name": "IoT C2D",
-            "type": "gdb",
+            "type": "cppdbg",
+            "program": "${workspaceFolder}/build/sdk/samples/iot/paho_iot_hub_c2d_sample",
             "request": "launch",
-            "env": {
-                "AZ_IOT_HUB_DEVICE_ID": "${input:device_id}",
-                "AZ_IOT_HUB_HOSTNAME": "${input:hostname}",
-                "AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH": "/workspaces/azure-sdk-for-c/cert/device_cert_store.pem"
-            },
-            "target": "./build/sdk/samples/iot/paho_iot_hub_c2d_sample",
+            "environment": [
+              {"name": "AZ_IOT_HUB_DEVICE_ID","value": "${input:device_id}"},
+              {"name": "AZ_IOT_HUB_HOSTNAME","value": "${input:hostname}"},
+              {"name": "AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH","value": "${workspaceFolder}/cert/device_cert_store.pem"},
+            ],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "build"
         },
 
         {
             "name": "IoT Methods",
-            "type": "gdb",
+            "type": "cppdbg",
+            "program": "${workspaceFolder}/build/sdk/samples/iot/paho_iot_hub_methods_sample",
             "request": "launch",
-            "env": {
-                "AZ_IOT_HUB_DEVICE_ID": "${input:device_id}",
-                "AZ_IOT_HUB_HOSTNAME": "${input:hostname}",
-                "AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH": "/workspaces/azure-sdk-for-c/cert/device_cert_store.pem"
-            },
-            "target": "./build/sdk/samples/iot/paho_iot_hub_methods_sample",
+            "environment": [
+              {"name": "AZ_IOT_HUB_DEVICE_ID","value": "${input:device_id}"},
+              {"name": "AZ_IOT_HUB_HOSTNAME","value": "${input:hostname}"},
+              {"name": "AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH","value": "${workspaceFolder}/cert/device_cert_store.pem"},
+            ],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "build"
         },
 
         {
             "name": "IoT Twin",
-            "type": "gdb",
+            "type": "cppdbg",
+            "program": "${workspaceFolder}/build/sdk/samples/iot/paho_iot_hub_twin_sample",
             "request": "launch",
-            "env": {
-                "AZ_IOT_HUB_DEVICE_ID": "${input:device_id}",
-                "AZ_IOT_HUB_HOSTNAME": "${input:hostname}",
-                "AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH": "/workspaces/azure-sdk-for-c/cert/device_cert_store.pem"
-            },
-            "target": "./build/sdk/samples/iot/paho_iot_hub_twin_sample",
+            "environment": [
+              {"name": "AZ_IOT_HUB_DEVICE_ID","value": "${input:device_id}"},
+              {"name": "AZ_IOT_HUB_HOSTNAME","value": "${input:hostname}"},
+              {"name": "AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH","value": "${workspaceFolder}/cert/device_cert_store.pem"},
+            ],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "build"
         }


### PR DESCRIPTION
This updates the launch file to use the newer C/C++ launch primitives. Note as in this issue (https://github.com/Azure/azure-sdk-for-c/issues/1895) that codespaces itself is broken right now. This works locally in VSCode as a `launch.json`.