### PR TITLE
Add unit test to make sure internal state of json writer is set correctly.

### DIFF
--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -368,6 +368,20 @@ static void test_json_writer_append_nested(void** state)
     {
       TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
       TEST_EXPECT_SUCCESS(az_json_writer_append_begin_array(&writer));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("1")));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("2")));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("3")));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_end_array(&writer));
+
+      az_span_to_str((char*)array, 200, az_json_writer_get_bytes_used_in_destination(&writer));
+      assert_int_equal(7, az_span_size(az_json_writer_get_bytes_used_in_destination(&writer)));
+      assert_int_equal(7, writer._internal.total_bytes_written);
+      assert_string_equal(array, "[1,2,3]");
+    }
+
+    {
+      TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+      TEST_EXPECT_SUCCESS(az_json_writer_append_begin_array(&writer));
       TEST_EXPECT_SUCCESS(az_json_writer_append_json_text(&writer, AZ_SPAN_FROM_STR("123  ")));
       TEST_EXPECT_SUCCESS(az_json_writer_append_end_array(&writer));
 


### PR DESCRIPTION
Follow-up to https://github.com/Azure/azure-sdk-for-c/pull/1905