### PR TITLE
Fix up the changelog year for 1.2.0 to be 2021 instead of 2017

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0 (2021-09-08)
 
-### New Features
+### Features Added
 
 - Add `az_iot_provisioning_client_get_request_payload()` to create MQTT payload bodies during Device Provisioning.
 - This version provides new APIs to follow the IoT Plug and Play convention to implement Telemetry, Commands, Properties and Components defined in a DTDL model.
@@ -11,7 +11,7 @@
   - When responding to a command invocation the component name is automatically parsed and provided when available.
   - All new samples follow the IoT Plug and Play convention and can be connected to IoT Hub (with or without DPS), or IoT Central.
 
-### Bug Fixes
+### Bugs Fixed
 
 - [[#1905]](https://github.com/Azure/azure-sdk-for-c/pull/1905) Fix the internal state of the JSON writer during calls to `az_json_writer_append_json_text()` by taking into account the required buffer space for commas. (A community contribution, courtesy of _[hwmaier](https://github.com/hwmaier)_)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.2.0 (2017-09-08)
+## 1.2.0 (2021-09-08)
 
 ### New Features
 


### PR DESCRIPTION
Not sure how 2017 slipped by. We aren't shipping 4 years in the past :)

Caused the `Release Tag` step to fail:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1087689&view=logs&j=3a436053-4a16-53f7-04f5-8035fced657c&t=de8ae31b-8fe5-57d5-9801-e6cfdbe0bca0