### PR TITLE
Make az_curl's dependency on libcurl public

### DIFF
--- a/sdk/src/azure/platform/CMakeLists.txt
+++ b/sdk/src/azure/platform/CMakeLists.txt
@@ -69,6 +69,7 @@ if (TRANSPORT_CURL)
   # make sure that users can consume the project as a library.
   add_library (az::curl ALIAS az_curl)
 
-  target_link_libraries(az_curl PRIVATE CURL::libcurl)
+  target_link_libraries(az_curl PUBLIC CURL::libcurl)
+  target_include_directories(az_curl INTERFACE ${CURL_INCLUDE_DIR})
 
 endif()


### PR DESCRIPTION
This is gonna be required by #1960's sample.

It makes sense: when you link with az_curl, you don't need to additionally and explicitly link with libcurl. And also you can go and include `curl/curl.h` to call `cleanup()`.

C++ SDK also links to libcurl as `PUBLIC`: https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/core/azure-core/CMakeLists.txt#L156