### PR TITLE
Remove `en-us` from microsoft links, and fix a couple of dead links

### DIFF
--- a/sdk/inc/azure/core/internal/az_precondition_internal.h
+++ b/sdk/inc/azure/core/internal/az_precondition_internal.h
@@ -51,7 +51,7 @@ az_precondition_failed_fn az_precondition_failed_get_callback();
 // earlier without verifying, because if __analysis_assume() is not available on earlier compiler
 // version, there will be a compilation error.
 // For more info, see
-// https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/using-the--analysis-assume-function-to-suppress-false-defects
+// https://docs.microsoft.com/windows-hardware/drivers/devtest/using-the--analysis-assume-function-to-suppress-false-defects
 #if _MSC_VER >= 1920
 #define _az_ANALYSIS_ASSUME(statement) __analysis_assume(statement)
 #else

--- a/sdk/inc/azure/iot/az_iot_common.h
+++ b/sdk/inc/azure/iot/az_iot_common.h
@@ -68,7 +68,7 @@ enum
 /**
  * @brief Azure IoT service status codes.
  *
- * @note https://docs.microsoft.com/en-us/azure/iot-central/core/troubleshoot-connection#error-codes
+ * @note https://docs.microsoft.com/azure/iot-central/core/troubleshoot-connection#error-codes
  *
  */
 typedef enum
@@ -115,7 +115,7 @@ typedef enum
 
 /// Used in distributed tracing.
 /// @note More information here:
-/// https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-distributed-tracing.
+/// https://docs.microsoft.com/azure/iot-hub/iot-hub-distributed-tracing.
 /// @note It can be used with IoT message property APIs by wrapping the macro in a
 /// #AZ_SPAN_FROM_STR macro as a parameter, where needed.
 #define AZ_IOT_MESSAGE_PROPERTIES_CORRELATION_ID "%24.cid"

--- a/sdk/inc/azure/iot/az_iot_hub_client.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client.h
@@ -6,7 +6,7 @@
  *
  * @brief Definition for the Azure IoT Hub client.
  * @note The IoT Hub MQTT protocol is described at
- * https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support
+ * https://docs.microsoft.com/azure/iot-hub/iot-hub-mqtt-support
  *
  * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
@@ -212,7 +212,7 @@ AZ_NODISCARD az_result az_iot_hub_client_get_client_id(
  * @note This API should be used in conjunction with az_iot_hub_client_sas_get_password().
  *
  * @note More information available at
- * https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#security-tokens
+ * https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-security#security-tokens
  *
  * A typical flow for using these two APIs might look something like the following (note the size
  * of buffers and non-SDK APIs are for demo purposes only):

--- a/sdk/inc/azure/iot/az_iot_hub_client_properties.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client_properties.h
@@ -83,7 +83,7 @@ AZ_NODISCARD az_result az_iot_hub_client_properties_writer_end_component(
  * This API should be used in response to an incoming writable properties. More details can be
  * found here:
  *
- * https://docs.microsoft.com/en-us/azure/iot-pnp/concepts-convention#writable-properties
+ * https://docs.microsoft.com/azure/iot-pnp/concepts-convention#writable-properties
  *
  * The payload will be of the form:
  *

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -6,7 +6,7 @@
  *
  * @brief Definition for the Azure Device Provisioning client.
  * @remark The Device Provisioning MQTT protocol is described at
- * https://docs.microsoft.com/en-us/azure/iot-dps/iot-dps-mqtt-support
+ * https://docs.microsoft.com/azure/iot-dps/iot-dps-mqtt-support
  *
  * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
@@ -152,7 +152,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_get_client_id(
  * HMAC-SHA256 using the Shared Access Key as password then Base64 encode the result.
  *
  * @remark More information available at
- * https://docs.microsoft.com/en-us/azure/iot-dps/concepts-symmetric-key-attestation#detailed-attestation-process
+ * https://docs.microsoft.com/azure/iot-dps/concepts-symmetric-key-attestation#detailed-attestation-process
  *
  * @param[in] client The #az_iot_provisioning_client to use for this call.
  * @param[in] token_expiration_epoch_time The time, in seconds, from 1/1/1970.
@@ -376,7 +376,7 @@ AZ_INLINE bool az_iot_provisioning_client_operation_complete(
  * @brief Gets the MQTT topic that must be used to submit a Register request.
  * @remark The payload of the MQTT publish message may contain a JSON document formatted according
  * to the [Provisioning Service's Device Registration document]
- * (https://docs.microsoft.com/en-us/rest/api/iot-dps/runtimeregistration/registerdevice#deviceregistration)
+ * (https://docs.microsoft.com/rest/api/iot-dps/device/runtime-registration/register-device#deviceregistration)
  * specification.
  *
  * @param[in] client The #az_iot_provisioning_client to use for this call.

--- a/sdk/src/azure/iot/az_iot_provisioning_client.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client.c
@@ -19,7 +19,7 @@ static const az_span str_get_iotdps_get_operationstatus
     = AZ_SPAN_LITERAL_FROM_STR("GET/iotdps-get-operationstatus/?$rid=1&operationId=");
 
 // From the protocol described in
-// https://docs.microsoft.com/en-us/azure/iot-dps/iot-dps-mqtt-support#registering-a-device
+// https://docs.microsoft.com/azure/iot-dps/iot-dps-mqtt-support#registering-a-device
 static const az_span prov_registration_id_label = AZ_SPAN_LITERAL_FROM_STR("registrationId");
 static const az_span prov_payload_label = AZ_SPAN_LITERAL_FROM_STR("payload");
 
@@ -248,7 +248,7 @@ AZ_INLINE az_iot_status _az_iot_status_from_extended_status(uint32_t extended_st
 
 /*
 Documented at
-https://docs.microsoft.com/en-us/rest/api/iot-dps/runtimeregistration/registerdevice#deviceregistrationresult
+https://docs.microsoft.com/rest/api/iot-dps/device/runtime-registration/register-device#deviceregistrationresult
   "registrationState":{
     "x509":{},
     "registrationId":"paho-sample-device1",


### PR DESCRIPTION
Closes #1979