### PR TITLE
Fixing OpenSSL cert generation.

### DIFF
--- a/.devcontainer/post_build.sh
+++ b/.devcontainer/post_build.sh
@@ -7,7 +7,8 @@ mkdir cert
 cd cert
 
 openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
-openssl req -new -days 30 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -subj "/CN=paho-sample-device1"
+openssl req -new -days 30 -sha256 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -extensions client_auth -config ../sdk/samples/iot/x509_config.cfg -subj "/CN=paho-sample-device1"
+
 openssl x509 -noout -text -in device_ec_cert.pem
 
 rm -f device_cert_store.pem

--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -226,7 +226,7 @@ As a convenience, we provide a series of commands below for you to create a temp
 
     ```bash
     openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
-    openssl req -new -days 30 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -config x509_config.cfg -subj "/CN=paho-sample-device1"
+    openssl req -new -days 30 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -extensions client_auth -config x509_config.cfg -subj "/CN=paho-sample-device1"
     openssl x509 -noout -text -in device_ec_cert.pem
 
     rm -f device_cert_store.pem
@@ -246,7 +246,7 @@ As a convenience, we provide a series of commands below for you to create a temp
 
     ```powershell
     openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
-    openssl req -new -days 30 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -config x509_config.cfg -subj "/CN=paho-sample-device1"
+    openssl req -new -days 30 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -extensions client_auth -config x509_config.cfg -subj "/CN=paho-sample-device1"
     openssl x509 -noout -text -in device_ec_cert.pem
 
     Get-Content device_ec_cert.pem, device_ec_key.pem | Set-Content device_cert_store.pem

--- a/sdk/samples/iot/docs/how_to_iot_hub_samples_linux.md
+++ b/sdk/samples/iot/docs/how_to_iot_hub_samples_linux.md
@@ -114,7 +114,7 @@ To run the samples, ensure you have the following programs and tools installed o
     ~$ cd azure-sdk-for-c/sdk/samples/iot/
 
     ~/azure-sdk-for-c/sdk/samples/iot$ openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
-    ~/azure-sdk-for-c/sdk/samples/iot$ openssl req -new -days 1 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -config x509_config.cfg -subj "/CN=paho-sample-device1"
+    ~/azure-sdk-for-c/sdk/samples/iot$ openssl req -new -days 1 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -extensions client_auth -config x509_config.cfg -subj "/CN=paho-sample-device1"
     ~/azure-sdk-for-c/sdk/samples/iot$ openssl x509 -noout -text -in device_ec_cert.pem
     ```
 

--- a/sdk/samples/iot/docs/how_to_iot_hub_samples_windows.md
+++ b/sdk/samples/iot/docs/how_to_iot_hub_samples_windows.md
@@ -113,7 +113,7 @@ To run the samples, ensure you have the following programs and tools installed o
     PS C:\> cd .\azure-sdk-for-c\sdk\samples\iot\
 
     PS C:\azure-sdk-for-c\sdk\samples\iot> openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
-    PS C:\azure-sdk-for-c\sdk\samples\iot> openssl req -new -days 1 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -extensions client_auth -config x509_config.cfg -subj "/CN=paho-sample-device1"  
+    PS C:\azure-sdk-for-c\sdk\samples\iot> openssl req -new -days 1 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -extensions client_auth -config x509_config.cfg -subj "/CN=paho-sample-device1"
     PS C:\azure-sdk-for-c\sdk\samples\iot> openssl x509 -noout -text -in device_ec_cert.pem
     ```
 

--- a/sdk/samples/iot/docs/how_to_iot_hub_samples_windows.md
+++ b/sdk/samples/iot/docs/how_to_iot_hub_samples_windows.md
@@ -113,7 +113,7 @@ To run the samples, ensure you have the following programs and tools installed o
     PS C:\> cd .\azure-sdk-for-c\sdk\samples\iot\
 
     PS C:\azure-sdk-for-c\sdk\samples\iot> openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
-    PS C:\azure-sdk-for-c\sdk\samples\iot> openssl req -new -days 365 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -config x509_config.cfg -subj "/CN=paho-sample-device1"
+    PS C:\azure-sdk-for-c\sdk\samples\iot> openssl req -new -days 1 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -extensions client_auth -config x509_config.cfg -subj "/CN=paho-sample-device1"  
     PS C:\azure-sdk-for-c\sdk\samples\iot> openssl x509 -noout -text -in device_ec_cert.pem
     ```
 

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -30,7 +30,7 @@ $iothubName = $DeploymentOutputs['IOT_HUB_NAME']
 ###### X509 setup ######
 # Generate certificate
 openssl ecparam -out device_ec_key.pem -name prime256v1 -genkey
-openssl req -new -days 12 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -config x509_config.cfg -subj "/CN=$deviceID"
+openssl req -new -days 12 -nodes -x509 -key device_ec_key.pem -out device_ec_cert.pem -extensions client_auth -config x509_config.cfg -subj "/CN=$deviceID"
 
 Get-Content -Path device_ec_cert.pem, device_ec_key.pem | Set-Content -Path device_cert_store.pem
 openssl x509 -noout -fingerprint -in device_ec_cert.pem | % {$_.replace(":", "")} | % {$_.replace("SHA1 Fingerprint=", "")} | Tee-Object -FilePath fingerprint.txt

--- a/sdk/samples/iot/x509_config.cfg
+++ b/sdk/samples/iot/x509_config.cfg
@@ -1,8 +1,8 @@
-[req]
+[ req ]
 req_extensions = client_auth
 distinguished_name = req_distinguished_name
 
-[req_distinguished_name]
+[ req_distinguished_name ]
 
 [ client_auth ]
 basicConstraints = CA:FALSE


### PR DESCRIPTION
In Ubuntu 20.04, the current method doesn't take into account the OpenSSL configuration (this used to work in 18.04 and older).
The change is instructing OpenSSL to apply the `client_auth` section for extensions configuring CA=false and EKU=ClientAuth which are mandatory for DPS certificates.

