### PR TITLE
Fix order of arguments for _az_http_policy_apiversion_options

### DIFF
--- a/sdk/inc/azure/core/internal/az_http_internal.h
+++ b/sdk/inc/azure/core/internal/az_http_internal.h
@@ -83,9 +83,9 @@ AZ_NODISCARD AZ_INLINE _az_http_policy_apiversion_options
 _az_http_policy_apiversion_options_default()
 {
   return (_az_http_policy_apiversion_options){
-    ._internal = { .option_location = _az_http_policy_apiversion_option_location_header,
-                   .name = AZ_SPAN_EMPTY,
-                   .version = AZ_SPAN_EMPTY }
+    ._internal = { .name = AZ_SPAN_EMPTY,
+                   .version = AZ_SPAN_EMPTY,
+                   .option_location = _az_http_policy_apiversion_option_location_header }
   };
 }
 


### PR DESCRIPTION
The current order is different than what the structure defines, and that may cause compiler issues.
E.g.: without this fix the build fails for ESP32 xtensa compiler.