### PR TITLE
Generate manifest alongside build artifacts

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -408,6 +408,25 @@ jobs:
     displayName: Validate Clang Format
     condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
+  - pwsh: |
+      $artifactName = "$(Agent.JobName)"
+      $parts = $artifactName -split ' '
+      if ($parts[1]) {
+        $artifactName = $parts[1]
+      }
+      Write-Host "##vso[task.setvariable variable=BomArtifactName;]$artifactName"
+    displayName: Set bom file artifact name
+
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'Generate BOM'
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
+
+  - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+    parameters:
+      ArtifactPath: '$(Build.ArtifactStagingDirectory)/_manifest'
+      ArtifactName: 'bom_manifest_$(BomArtifactName)'
+
 - job: GenerateReleaseArtifacts
   pool:
     name: azsdk-pool-mms-win-2019-general
@@ -495,7 +514,6 @@ jobs:
 
       displayName: Generate artifacts for docs.ms
 
-
     - pwsh: |
         New-Item -ItemType directory -Path $(Build.ArtifactStagingDirectory) -Name docs
         New-Item -ItemType directory -Path $(Build.ArtifactStagingDirectory) -Name docs.ms
@@ -518,17 +536,6 @@ jobs:
         Copy-Item -Path $packageInfoPath -Destination $(Join-Path -Path $(Build.ArtifactStagingDirectory) /docs/package-info.json)
       displayName: Copy package-info.json to documentation path
 
-    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-      displayName: 'Generate BOM'
-      inputs:
-        BuildDropPath: $(Build.ArtifactStagingDirectory)
-
-    - task: PublishPipelineArtifact@1
-      displayName: 'Publish BOM'
-      inputs:
-        artifact: 'manifest'
-        path: $(Build.ArtifactStagingDirectory)/_manifest
-
     - task: PublishPipelineArtifact@1
       inputs:
         artifactName: docs
@@ -546,3 +553,13 @@ jobs:
       displayName: 'Component Detection'
 
     - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
+
+    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+      displayName: 'Generate BOM'
+      inputs:
+        BuildDropPath: $(Build.ArtifactStagingDirectory)
+
+    - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+      parameters:
+        ArtifactPath: '$(Build.ArtifactStagingDirectory)/_manifest'
+        ArtifactName: 'release_artifact_manifest'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -412,6 +412,8 @@ jobs:
   pool:
     name: azsdk-pool-mms-win-2019-general
     vmImage: MMS2019
+  variables:
+    Package.EnableSBOMSigning: true
   steps:
     - template: /eng/common/pipelines/templates/steps/check-spelling.yml
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -521,13 +521,13 @@ jobs:
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: 'Generate BOM'
       inputs:
-        BuildDropPath: $(Build.SourcesDirectory)/build
+        BuildDropPath: $(Build.ArtifactStagingDirectory)
 
     - task: PublishPipelineArtifact@1
       displayName: 'Publish BOM'
       inputs:
         artifact: 'manifest'
-        path: $(Build.SourcesDirectory)/build/_manifest
+        path: $(Build.ArtifactStagingDirectory)/_manifest
 
     - task: PublishPipelineArtifact@1
       inputs:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -527,10 +527,6 @@ jobs:
         artifact: 'manifest'
         path: $(Build.SourcesDirectory)/build/_manifest
 
-    - publish: ${{ parameters.ServiceDirectory }}/_manifest
-      displayName: 'Publish BOM Manifest'
-      artifact: 'manifest'
-
     - task: PublishPipelineArtifact@1
       inputs:
         artifactName: docs

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -377,7 +377,7 @@ jobs:
 
       # Show info about the total files that needs attention.
       echo Files found with non-ASCII characters: $files_with_non_ascii
-      
+
       # Remove the grepResults file.
       rm grepResults
 
@@ -515,6 +515,21 @@ jobs:
         $packageInfoPath = Join-Path -Path $(Build.ArtifactStagingDirectory) release-info/package-info.json
         Copy-Item -Path $packageInfoPath -Destination $(Join-Path -Path $(Build.ArtifactStagingDirectory) /docs/package-info.json)
       displayName: Copy package-info.json to documentation path
+
+    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+      displayName: 'Generate BOM'
+      inputs:
+        BuildDropPath: $(Build.SourcesDirectory)/build
+
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish BOM'
+      inputs:
+        artifact: 'manifest'
+        path: $(Build.SourcesDirectory)/build/_manifest
+
+    - publish: ${{ parameters.ServiceDirectory }}/_manifest
+      displayName: 'Publish BOM Manifest'
+      artifact: 'manifest'
 
     - task: PublishPipelineArtifact@1
       inputs:


### PR DESCRIPTION
Related to Azure/azure-sdk-tools#2273

@danieljurek I have a bad bad feeling about what is going to happen if we attempt to run the manifest generation tool on some of the more esoteric platforms that C runs against. We probably will need to add a platform specific condition.

EDIT: and an additional concern. Will the `build/` folder have been supplanted by the docs pieces? I should probably place this publish _before_ the docs builds yes?