### PR TITLE
Check for active hub between e2e deployment steps

### DIFF
--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -59,6 +59,7 @@ Get-Content -Path device_ec_cert.pem, device_ec_key.pem | Set-Content -Path devi
 openssl x509 -noout -fingerprint -in device_ec_cert.pem | % {$_.replace(":", "")} | % {$_.replace("SHA1 Fingerprint=", "")} | Tee-Object -FilePath fingerprint.txt
 $fingerprint = Get-Content -Path .\fingerprint.txt
 
+Write-Host "Waiting for active IoT Hub"
 $hub_obj = waitForActiveHub
 
 # Pass fingerprint to IoTHub
@@ -86,6 +87,7 @@ if ($LASTEXITCODE -ne 0)
   exit $LASTEXITCODE
 }
 
+Write-Host "Waiting for active IoT Hub"
 $hub_obj = waitForActiveHub
 
 ###### SaS setup ######
@@ -102,6 +104,7 @@ if ($LASTEXITCODE -ne 0)
   exit $LASTEXITCODE
 }
 
+Write-Host "Waiting for active IoT Hub"
 $hub_obj = waitForActiveHub
 
 Write-Host "Getting connection string for SAS device"

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -17,7 +17,7 @@ param (
     $RemainingArguments
 )
 
-$globalRetryCount = 8
+$globalRetryCount = 6
 
 function waitForActiveHub
 {

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -75,7 +75,8 @@ do
   -DeviceId $deviceID `
   -AuthMethod "x509_thumbprint" `
   -PrimaryThumbprint $fingerprint `
-  -SecondaryThumbprint $fingerprint
+  -SecondaryThumbprint $fingerprint `
+  -ErrorAction Continue
 
   if ($LASTEXITCODE -ne 0)
   {
@@ -114,6 +115,7 @@ do
   -InputObject $hub_obj `
   -DeviceId $deviceIDSaS `
   -AuthMethod "shared_private_key"
+  -ErrorAction Continue
 
   if ($LASTEXITCODE -ne 0)
   {
@@ -129,6 +131,7 @@ if ($LASTEXITCODE -ne 0)
   exit $LASTEXITCODE
 }
 
+$retryCount = 0
 do
 {
   $retryCount++
@@ -136,7 +139,7 @@ do
   Start-Sleep -Seconds $retryCount
 
   # Create IoT SaS Device
-  $deviceSaSConnectionString = Get-AzIotHubDeviceConnectionString -InputObject $hub_obj -deviceId $deviceIDSaS
+  $deviceSaSConnectionString = Get-AzIotHubDeviceConnectionString -InputObject $hub_obj -deviceId $deviceIDSaS -ErrorAction Continue
 
   if ($LASTEXITCODE -ne 0)
   {

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -114,7 +114,7 @@ do
   Add-AzIotHubDevice `
   -InputObject $hub_obj `
   -DeviceId $deviceIDSaS `
-  -AuthMethod "shared_private_key"
+  -AuthMethod "shared_private_key" `
   -ErrorAction Continue
 
   if ($LASTEXITCODE -ne 0)

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -62,14 +62,22 @@ $fingerprint = Get-Content -Path .\fingerprint.txt
 Write-Host "Waiting for active IoT Hub"
 $hub_obj = waitForActiveHub
 
-# Pass fingerprint to IoTHub
-Write-Host "Adding cert device to the allocated hub"
-Add-AzIotHubDevice `
--InputObject $hub_obj `
--DeviceId $deviceID `
--AuthMethod "x509_thumbprint" `
--PrimaryThumbprint $fingerprint `
--SecondaryThumbprint $fingerprint
+$retryCount = 0
+do
+{
+  $retryCount++
+  Write-Host "Adding cert device to the allocated hub: attempt #$retryCount"
+  Start-Sleep -Seconds $retryCount
+
+  # Pass fingerprint to IoTHub
+  Add-AzIotHubDevice `
+  -InputObject $hub_obj `
+  -DeviceId $deviceID `
+  -AuthMethod "x509_thumbprint" `
+  -PrimaryThumbprint $fingerprint `
+  -SecondaryThumbprint $fingerprint
+}
+while ($retryCount -lt 3 -and $LASTEXITCODE -ne 0)
 
 if ($LASTEXITCODE -ne 0)
 {
@@ -87,16 +95,24 @@ if ($LASTEXITCODE -ne 0)
   exit $LASTEXITCODE
 }
 
-Write-Host "Waiting for active IoT Hub"
-$hub_obj = waitForActiveHub
+# Write-Host "Waiting for active IoT Hub"
+# $hub_obj = waitForActiveHub
 
 ###### SaS setup ######
-# Create IoT SaS Device
-Write-Host "Adding SAS Key device to the allocated hub"
-Add-AzIotHubDevice `
--InputObject $hub_obj `
--DeviceId $deviceIDSaS `
--AuthMethod "shared_private_key"
+$retryCount = 0
+do
+{
+  $retryCount++
+  Write-Host "Adding SAS Key device to the allocated hub: attempt #$retryCount"
+  Start-Sleep -Seconds $retryCount
+
+  # Create IoT SaS Device
+  Add-AzIotHubDevice `
+  -InputObject $hub_obj `
+  -DeviceId $deviceIDSaS `
+  -AuthMethod "shared_private_key"
+}
+while ($retryCount -lt 3 -and $LASTEXITCODE -ne 0)
 
 if ($LASTEXITCODE -ne 0)
 {
@@ -104,12 +120,19 @@ if ($LASTEXITCODE -ne 0)
   exit $LASTEXITCODE
 }
 
-Write-Host "Waiting for active IoT Hub"
-$hub_obj = waitForActiveHub
+# Write-Host "Waiting for active IoT Hub"
+# $hub_obj = waitForActiveHub
 
-Write-Host "Getting connection string for SAS device"
+do
+{
+  $retryCount++
+  Write-Host "Getting connection string for SAS device: attempt #$retryCount"
+  Start-Sleep -Seconds $retryCount
 
-$deviceSaSConnectionString = Get-AzIotHubDeviceConnectionString -InputObject $hub_obj -deviceId $deviceIDSaS
+  # Create IoT SaS Device
+  $deviceSaSConnectionString = Get-AzIotHubDeviceConnectionString -InputObject $hub_obj -deviceId $deviceIDSaS
+}
+while ($retryCount -lt 3 -and $LASTEXITCODE -ne 0)
 
 if ($LASTEXITCODE -ne 0)
 {

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -83,7 +83,7 @@ do
     Write-Host "Adding cert device failed: trying again."
   }
 }
-while ($retryCount -lt 3 -and $? -ne $true)
+while ($retryCount -lt 4 -and $? -ne $true)
 
 if ($? -ne $true)
 {
@@ -121,7 +121,7 @@ do
     Write-Host "Adding SAS key device failed: trying again."
   }
 }
-while ($retryCount -lt 3 -and $? -ne $true)
+while ($retryCount -lt 4 -and $? -ne $true)
 
 if ($? -ne $true)
 {
@@ -144,9 +144,9 @@ do
     Write-Host "Getting connection string for SAS device failed: trying again."
   }
 }
-while ($retryCount -lt 3 -and $? -ne $true)
+while ($retryCount -lt 4 -and $? -ne $true)
 
-if (-and $? -ne $true)
+if ($? -ne $true)
 {
   Write-Host "Getting connection string for SAS device failed: LAST_ERROR_CODE=${LAST_ERROR_CODE}"
   exit $LASTEXITCODE

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -92,9 +92,13 @@ if ($LASTEXITCODE -ne 0)
   exit $LASTEXITCODE
 }
 
+Write-Host "Sleep to let device populate in IoT Hub"
+
+Start-Sleep -Seconds 5
+
 Write-Host "Getting connection string for SAS device"
 
-$deviceSaSConnectionString = Get-AzIotHubDeviceConnectionString -ResourceGroupName $ResourceGroupName -IotHubName $iothubName -deviceId $deviceIDSaS
+$deviceSaSConnectionString = Get-AzIotHubDeviceConnectionString -InputObject $hub_obj -deviceId $deviceIDSaS
 
 if ($LASTEXITCODE -ne 0)
 {

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -36,6 +36,8 @@ function waitForActiveHub
       Write-Error "AzIotHub instance is not yet active so later steps might fail as a result. If they fail often you can increase the retry count above."
       exit 1
     }
+
+    return $hub_obj
 }
 
 $DebugPreference = 'Continue'
@@ -57,7 +59,7 @@ Get-Content -Path device_ec_cert.pem, device_ec_key.pem | Set-Content -Path devi
 openssl x509 -noout -fingerprint -in device_ec_cert.pem | % {$_.replace(":", "")} | % {$_.replace("SHA1 Fingerprint=", "")} | Tee-Object -FilePath fingerprint.txt
 $fingerprint = Get-Content -Path .\fingerprint.txt
 
-waitForActiveHub
+$hub_obj = waitForActiveHub
 
 # Pass fingerprint to IoTHub
 Write-Host "Adding cert device to the allocated hub"
@@ -84,7 +86,7 @@ if ($LASTEXITCODE -ne 0)
   exit $LASTEXITCODE
 }
 
-waitForActiveHub
+$hub_obj = waitForActiveHub
 
 ###### SaS setup ######
 # Create IoT SaS Device
@@ -100,7 +102,7 @@ if ($LASTEXITCODE -ne 0)
   exit $LASTEXITCODE
 }
 
-waitForActiveHub
+$hub_obj = waitForActiveHub
 
 Write-Host "Getting connection string for SAS device"
 

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -26,7 +26,7 @@ function waitForActiveHub
     {
       $retryCount++
       Write-Host "AzIotHub is not yet active so sleeping for $retryCount seconds."
-      Start-Sleep -Seconds [double][math]::Pow(2, $retryCount)
+      Start-Sleep -Seconds Math.Pow(2, $retryCount)
 
       # Get the hub as an object
       $hub_obj = Get-AzIotHub -ResourceGroupName $ResourceGroupName -Name $iothubName
@@ -69,7 +69,7 @@ do
 {
   $retryCount++
   Write-Host "Adding cert device to the allocated hub: attempt #$retryCount"
-  Start-Sleep -Seconds [double][math]::Pow(2, $retryCount)
+  Start-Sleep -Seconds Math.Pow(2, $retryCount)
 
   # Pass fingerprint to IoTHub
   Add-AzIotHubDevice `
@@ -104,7 +104,7 @@ do
 {
   $retryCount++
   Write-Host "Adding SAS Key device to the allocated hub: attempt #$retryCount"
-  Start-Sleep -Seconds [double][math]::Pow(2, $retryCount)
+  Start-Sleep -Seconds Math.Pow(2, $retryCount)
 
   # Create IoT SaS Device
   Add-AzIotHubDevice `
@@ -126,7 +126,7 @@ do
 {
   $retryCount++
   Write-Host "Getting connection string for SAS device: attempt #$retryCount"
-  Start-Sleep -Seconds [double][math]::Pow(2, $retryCount)
+  Start-Sleep -Seconds Math.Pow(2, $retryCount)
 
   # Create IoT SaS Device
   $deviceSaSConnectionString = Get-AzIotHubDeviceConnectionString -InputObject $hub_obj -deviceId $deviceIDSaS -ErrorAction Continue

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -17,6 +17,8 @@ param (
     $RemainingArguments
 )
 
+$globalRetryCount = 8
+
 function waitForActiveHub
 {
     $retryCount = 0
@@ -24,12 +26,12 @@ function waitForActiveHub
     {
       $retryCount++
       Write-Host "AzIotHub is not yet active so sleeping for $retryCount seconds."
-      Start-Sleep -Seconds $retryCount
+      Start-Sleep -Seconds [int][Math]::Pow(2, $retryCount)
 
       # Get the hub as an object
       $hub_obj = Get-AzIotHub -ResourceGroupName $ResourceGroupName -Name $iothubName
     }
-    while ($retryCount -lt 8 -and $hub_obj.Properties.State -ne "Active")
+    while ($retryCount -lt $globalRetryCount -and $hub_obj.Properties.State -ne "Active")
 
     if ($hub_obj.Properties.State -ne "Active")
     {
@@ -67,7 +69,7 @@ do
 {
   $retryCount++
   Write-Host "Adding cert device to the allocated hub: attempt #$retryCount"
-  Start-Sleep -Seconds $retryCount
+  Start-Sleep -Seconds [int][Math]::Pow(2, $retryCount)
 
   # Pass fingerprint to IoTHub
   Add-AzIotHubDevice `
@@ -78,7 +80,7 @@ do
   -SecondaryThumbprint $fingerprint `
   -ErrorAction Continue
 }
-while ($retryCount -lt 4 -and $? -ne $true)
+while ($retryCount -lt $globalRetryCount -and $? -ne $true)
 
 if ($? -ne $true)
 {
@@ -102,7 +104,7 @@ do
 {
   $retryCount++
   Write-Host "Adding SAS Key device to the allocated hub: attempt #$retryCount"
-  Start-Sleep -Seconds $retryCount
+  Start-Sleep -Seconds [int][Math]::Pow(2, $retryCount)
 
   # Create IoT SaS Device
   Add-AzIotHubDevice `
@@ -111,7 +113,7 @@ do
   -AuthMethod "shared_private_key" `
   -ErrorAction Continue
 }
-while ($retryCount -lt 4 -and $? -ne $true)
+while ($retryCount -lt $globalRetryCount -and $? -ne $true)
 
 if ($? -ne $true)
 {
@@ -124,12 +126,12 @@ do
 {
   $retryCount++
   Write-Host "Getting connection string for SAS device: attempt #$retryCount"
-  Start-Sleep -Seconds $retryCount
+  Start-Sleep -Seconds [int][Math]::Pow(2, $retryCount)
 
   # Create IoT SaS Device
   $deviceSaSConnectionString = Get-AzIotHubDeviceConnectionString -InputObject $hub_obj -deviceId $deviceIDSaS -ErrorAction Continue
 }
-while ($retryCount -lt 4 -and $? -ne $true)
+while ($retryCount -lt $globalRetryCount -and $? -ne $true)
 
 if ($? -ne $true)
 {

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -76,6 +76,12 @@ do
   -AuthMethod "x509_thumbprint" `
   -PrimaryThumbprint $fingerprint `
   -SecondaryThumbprint $fingerprint
+
+  if ($LASTEXITCODE -ne 0)
+  {
+    Write-Host "Adding cert device failed: trying again."
+    exit $LASTEXITCODE
+  }
 }
 while ($retryCount -lt 3 -and $LASTEXITCODE -ne 0)
 
@@ -95,9 +101,6 @@ if ($LASTEXITCODE -ne 0)
   exit $LASTEXITCODE
 }
 
-# Write-Host "Waiting for active IoT Hub"
-# $hub_obj = waitForActiveHub
-
 ###### SaS setup ######
 $retryCount = 0
 do
@@ -111,6 +114,12 @@ do
   -InputObject $hub_obj `
   -DeviceId $deviceIDSaS `
   -AuthMethod "shared_private_key"
+
+  if ($LASTEXITCODE -ne 0)
+  {
+    Write-Host "Adding SAS key device failed: trying again."
+    exit $LASTEXITCODE
+  }
 }
 while ($retryCount -lt 3 -and $LASTEXITCODE -ne 0)
 
@@ -120,9 +129,6 @@ if ($LASTEXITCODE -ne 0)
   exit $LASTEXITCODE
 }
 
-# Write-Host "Waiting for active IoT Hub"
-# $hub_obj = waitForActiveHub
-
 do
 {
   $retryCount++
@@ -131,6 +137,12 @@ do
 
   # Create IoT SaS Device
   $deviceSaSConnectionString = Get-AzIotHubDeviceConnectionString -InputObject $hub_obj -deviceId $deviceIDSaS
+
+  if ($LASTEXITCODE -ne 0)
+  {
+    Write-Host "Getting connection string for SAS device failed: trying again."
+    exit $LASTEXITCODE
+  }
 }
 while ($retryCount -lt 3 -and $LASTEXITCODE -ne 0)
 

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -26,7 +26,7 @@ function waitForActiveHub
     {
       $retryCount++
       Write-Host "AzIotHub is not yet active so sleeping for $retryCount seconds."
-      Start-Sleep -Seconds [int][Math]::Pow(2, $retryCount)
+      Start-Sleep -Seconds [double][math]::Pow(2, $retryCount)
 
       # Get the hub as an object
       $hub_obj = Get-AzIotHub -ResourceGroupName $ResourceGroupName -Name $iothubName
@@ -69,7 +69,7 @@ do
 {
   $retryCount++
   Write-Host "Adding cert device to the allocated hub: attempt #$retryCount"
-  Start-Sleep -Seconds [int][Math]::Pow(2, $retryCount)
+  Start-Sleep -Seconds [double][math]::Pow(2, $retryCount)
 
   # Pass fingerprint to IoTHub
   Add-AzIotHubDevice `
@@ -104,7 +104,7 @@ do
 {
   $retryCount++
   Write-Host "Adding SAS Key device to the allocated hub: attempt #$retryCount"
-  Start-Sleep -Seconds [int][Math]::Pow(2, $retryCount)
+  Start-Sleep -Seconds [double][math]::Pow(2, $retryCount)
 
   # Create IoT SaS Device
   Add-AzIotHubDevice `
@@ -126,7 +126,7 @@ do
 {
   $retryCount++
   Write-Host "Getting connection string for SAS device: attempt #$retryCount"
-  Start-Sleep -Seconds [int][Math]::Pow(2, $retryCount)
+  Start-Sleep -Seconds [double][math]::Pow(2, $retryCount)
 
   # Create IoT SaS Device
   $deviceSaSConnectionString = Get-AzIotHubDeviceConnectionString -InputObject $hub_obj -deviceId $deviceIDSaS -ErrorAction Continue

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -78,15 +78,14 @@ do
   -SecondaryThumbprint $fingerprint `
   -ErrorAction Continue
 
-  if ($LASTEXITCODE -ne 0)
+  if ($? -ne $true)
   {
     Write-Host "Adding cert device failed: trying again."
-    exit $LASTEXITCODE
   }
 }
-while ($retryCount -lt 3 -and $LASTEXITCODE -ne 0)
+while ($retryCount -lt 3 -and $? -ne $true)
 
-if ($LASTEXITCODE -ne 0)
+if ($? -ne $true)
 {
   Write-Host "Adding cert device failed: LAST_ERROR_CODE=${LAST_ERROR_CODE}"
   exit $LASTEXITCODE
@@ -96,7 +95,7 @@ if ($LASTEXITCODE -ne 0)
 Write-Host "Downloading Baltimore root cert"
 curl https://cacerts.digicert.com/BaltimoreCyberTrustRoot.crt.pem > $sourcesDir\BaltimoreCyberTrustRoot.crt.pem
 
-if ($LASTEXITCODE -ne 0)
+if ($? -ne $true)
 {
   Write-Host "Downloading root cert failed: LAST_ERROR_CODE=${LAST_ERROR_CODE}"
   exit $LASTEXITCODE
@@ -117,15 +116,14 @@ do
   -AuthMethod "shared_private_key" `
   -ErrorAction Continue
 
-  if ($LASTEXITCODE -ne 0)
+  if ($? -ne $true)
   {
     Write-Host "Adding SAS key device failed: trying again."
-    exit $LASTEXITCODE
   }
 }
-while ($retryCount -lt 3 -and $LASTEXITCODE -ne 0)
+while ($retryCount -lt 3 -and $? -ne $true)
 
-if ($LASTEXITCODE -ne 0)
+if ($? -ne $true)
 {
   Write-Host "Adding SAS key device failed: LAST_ERROR_CODE=${LAST_ERROR_CODE}"
   exit $LASTEXITCODE
@@ -141,15 +139,14 @@ do
   # Create IoT SaS Device
   $deviceSaSConnectionString = Get-AzIotHubDeviceConnectionString -InputObject $hub_obj -deviceId $deviceIDSaS -ErrorAction Continue
 
-  if ($LASTEXITCODE -ne 0)
+  if ($? -ne $true)
   {
     Write-Host "Getting connection string for SAS device failed: trying again."
-    exit $LASTEXITCODE
   }
 }
-while ($retryCount -lt 3 -and $LASTEXITCODE -ne 0)
+while ($retryCount -lt 3 -and $? -ne $true)
 
-if ($LASTEXITCODE -ne 0)
+if (-and $? -ne $true)
 {
   Write-Host "Getting connection string for SAS device failed: LAST_ERROR_CODE=${LAST_ERROR_CODE}"
   exit $LASTEXITCODE

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -25,8 +25,9 @@ function waitForActiveHub
     do
     {
       $retryCount++
-      Write-Host "AzIotHub is not yet active so sleeping for $retryCount seconds."
       $sleepForSeconds = [math]::Pow(2, $retryCount)
+      Write-Host "AzIotHub is not yet active so sleeping for $sleepForSeconds seconds."
+      
       Start-Sleep -Seconds $sleepForSeconds
 
       # Get the hub as an object

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -77,11 +77,6 @@ do
   -PrimaryThumbprint $fingerprint `
   -SecondaryThumbprint $fingerprint `
   -ErrorAction Continue
-
-  if ($? -ne $true)
-  {
-    Write-Host "Adding cert device failed: trying again."
-  }
 }
 while ($retryCount -lt 4 -and $? -ne $true)
 
@@ -115,11 +110,6 @@ do
   -DeviceId $deviceIDSaS `
   -AuthMethod "shared_private_key" `
   -ErrorAction Continue
-
-  if ($? -ne $true)
-  {
-    Write-Host "Adding SAS key device failed: trying again."
-  }
 }
 while ($retryCount -lt 4 -and $? -ne $true)
 
@@ -138,11 +128,6 @@ do
 
   # Create IoT SaS Device
   $deviceSaSConnectionString = Get-AzIotHubDeviceConnectionString -InputObject $hub_obj -deviceId $deviceIDSaS -ErrorAction Continue
-
-  if ($? -ne $true)
-  {
-    Write-Host "Getting connection string for SAS device failed: trying again."
-  }
 }
 while ($retryCount -lt 4 -and $? -ne $true)
 

--- a/sdk/samples/iot/templates/iothub/test-resources-post.ps1
+++ b/sdk/samples/iot/templates/iothub/test-resources-post.ps1
@@ -26,7 +26,8 @@ function waitForActiveHub
     {
       $retryCount++
       Write-Host "AzIotHub is not yet active so sleeping for $retryCount seconds."
-      Start-Sleep -Seconds Math.Pow(2, $retryCount)
+      $sleepForSeconds = [math]::Pow(2, $retryCount)
+      Start-Sleep -Seconds $sleepForSeconds
 
       # Get the hub as an object
       $hub_obj = Get-AzIotHub -ResourceGroupName $ResourceGroupName -Name $iothubName
@@ -69,7 +70,8 @@ do
 {
   $retryCount++
   Write-Host "Adding cert device to the allocated hub: attempt #$retryCount"
-  Start-Sleep -Seconds Math.Pow(2, $retryCount)
+  $sleepForSeconds = [math]::Pow(2, $retryCount)
+  Start-Sleep -Seconds $sleepForSeconds
 
   # Pass fingerprint to IoTHub
   Add-AzIotHubDevice `
@@ -104,7 +106,8 @@ do
 {
   $retryCount++
   Write-Host "Adding SAS Key device to the allocated hub: attempt #$retryCount"
-  Start-Sleep -Seconds Math.Pow(2, $retryCount)
+  $sleepForSeconds = [math]::Pow(2, $retryCount)
+  Start-Sleep -Seconds $sleepForSeconds
 
   # Create IoT SaS Device
   Add-AzIotHubDevice `
@@ -126,7 +129,8 @@ do
 {
   $retryCount++
   Write-Host "Getting connection string for SAS device: attempt #$retryCount"
-  Start-Sleep -Seconds Math.Pow(2, $retryCount)
+  $sleepForSeconds = [math]::Pow(2, $retryCount)
+  Start-Sleep -Seconds $sleepForSeconds
 
   # Create IoT SaS Device
   $deviceSaSConnectionString = Get-AzIotHubDeviceConnectionString -InputObject $hub_obj -deviceId $deviceIDSaS -ErrorAction Continue


### PR DESCRIPTION
The script looks to be moving on to other steps before the hub is ready. This waits after each IoT Hub request before moving on to another one. Below are highlights of the lines that run and links to the gate where they happen in sequence (as intended):
 
![screenshot](https://user-images.githubusercontent.com/36710865/149434797-666f5ca9-ae8c-49f5-9fa3-807398f6cfb8.png)


Downloading root cert: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1295131&view=logs&j=4a578679-1661-5a93-5c59-ed624155db79&t=1f2fb40b-90ba-571a-2ae0-17483be8b3ca&l=3603
Waiting for active hub: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1295131&view=logs&j=4a578679-1661-5a93-5c59-ed624155db79&t=1f2fb40b-90ba-571a-2ae0-17483be8b3ca&l=3609
Adding SAS device: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1295131&view=logs&j=4a578679-1661-5a93-5c59-ed624155db79&t=1f2fb40b-90ba-571a-2ae0-17483be8b3ca&l=3815
