### PR TITLE
Prevent BoM upload failure on failed builds

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -419,6 +419,7 @@ jobs:
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generate BOM'
+    condition: succeededOrFailed()
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
 
@@ -556,6 +557,7 @@ jobs:
 
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: 'Generate BOM'
+      condition: succeededOrFailed()
       inputs:
         BuildDropPath: $(Build.ArtifactStagingDirectory)
 


### PR DESCRIPTION
Same reasoning as PR Azure/azure-sdk-for-cpp#3256