### PR TITLE
update link regex to prevent false positive

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-links.yml
+++ b/eng/common/pipelines/templates/steps/verify-links.yml
@@ -6,7 +6,7 @@ parameters:
   Recursive: $false
   CheckLinkGuidance: $true
   Urls: '(Get-ChildItem -Path ./ -Recurse -Include *.md)'
-  BranchReplaceRegex: "^(${env:SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI}.*/(?:blob|tree)/)$(DefaultBranch)(/.*)$"
+  BranchReplaceRegex: "^(${env:SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI}/(?:blob|tree)/)$(DefaultBranch)(/.*)$"
   BranchReplacementName: "${env:SYSTEM_PULLREQUEST_SOURCECOMMITID}"
   Condition: succeeded() # If you want to run on failure for the link checker, set it to `Condition: succeededOrFailed()`.
 


### PR DESCRIPTION
note conversation here: https://github.com/Azure/azure-sdk-for-c/pull/2065#issuecomment-1019378327

The link verifier is lumping SDK urls with a suffix in with this sdk. So "azure-sdk-for-c-**arduino**" is getting lumped in with "azure-sdk-for-c".