### PR TITLE
Fix broken GitHub links in Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ There are many ways that you can contribute to the Azure SDK for Embedded C proj
 
 - If you would like to become an active contributor to this project please follow the instructions provided in [Microsoft Azure Projects Contribution Guidelines](https://opensource.microsoft.com/collaborate).
 
-- To make code changes, or contribute something new, please follow the [GitHub Forks / Pull requests model](https://help.github.com/articles/fork-a-repo/): Fork the repo, make the change and propose it back by submitting a pull request.
+- To make code changes, or contribute something new, please follow the [GitHub Forks / Pull requests model](https://docs.github.com/articles/fork-a-repo/): Fork the repo, make the change and propose it back by submitting a pull request.
 
 - Refer to the [wiki](https://github.com/Azure/azure-sdk-for-c/wiki) to learn about how Azure SDK for Embedded C generates lint checker, doxygen, and code coverage reports.
 
@@ -46,7 +46,7 @@ There are many ways that you can contribute to the Azure SDK for Embedded C proj
 - **DO** submit all code changes via pull requests (PRs) rather than through a direct commit. PRs will be reviewed and potentially merged by the repo maintainers after a peer review that includes at least one maintainer.
 - **DO NOT** submit "work in progress" PRs.  A PR should only be submitted when it is considered ready for review and subsequent merging by the contributor.
 - **DO** give PRs short-but-descriptive names (e.g. "Improve code coverage for Azure.Core by 10%", not "Fix #1234")
-- **DO** refer to any relevant issues and include [keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) that automatically close issues when the PR is merged.
+- **DO** refer to any relevant issues and include [keywords](https://docs.github.com/articles/closing-issues-via-commit-messages/) that automatically close issues when the PR is merged.
 - **DO** tag any users that should know about and/or review the change.
 - **DO** ensure each commit successfully builds.  The entire PR must pass all tests in the Continuous Integration (CI) system before it'll be merged.
 - **DO** address PR feedback in an additional commit(s) rather than amending the existing commits, and only rebase/squash them when necessary.  This makes it easier for reviewers to track changes.


### PR DESCRIPTION
Similar to https://github.com/Azure/azure-sdk-for-cpp/pull/3299

These were broken recently and would 404:
https://dev.azure.com/azure-sdk/public/_build/results?buildId=1338368&view=logs&j=a129effc-2dd1-54d1-fb5a-ad7bdc0e851d&t=617ceecd-bf48-5ce3-83e2-7468b1632a13&l=92

```text
Found 27 links on page file:///D:/a/_work/1/s/CONTRIBUTING.md
##[warning][404] broken link https://help.github.com/articles/fork-a-repo/
##[debug]Processed: ##vso[task.LogIssue type=warning;][404] broken link https://help.github.com/articles/fork-a-repo/
##[warning][404] broken link https://help.github.com/articles/closing-issues-via-commit-messages/
##[debug]Processed: ##vso[task.LogIssue type=warning;][404] broken link https://help.github.com/articles/closing-issues-via-commit-messages/
Found 98 links on page file:///D:/a/_work/1/s/README.md
Found 12 links on page file:///D:/a/_work/1/s/SECURITY.md
Summary of broken links:
'file:///D:/a/_work/1/s/CONTRIBUTING.md' has 2 broken link(s):
  https://help.github.com/articles/fork-a-repo/
  https://help.github.com/articles/closing-issues-via-commit-messages/
##[error]Checked 275 links with 1 page(s) broken.
##[debug]Processed: ##vso[task.logissue type=error]Checked 275 links with 1 page(s) broken.

```