### PR TITLE
Update azureClientSample.c

### DIFF
--- a/sdk/samples/iot/vxworks/azureClientSample.c
+++ b/sdk/samples/iot/vxworks/azureClientSample.c
@@ -1082,7 +1082,7 @@ static struct mosquitto* mqttClientCreate(
   }
 
   /* create an MQTT client */
-  mqttClient = mosquitto_new(azureClientId, true, &azureClient);
+  mqttClient = mosquitto_new(azureClientId, true, azureClient);
   if (mqttClient != NULL)
   {
     printf_s("mosquitto_new OK.\n");


### PR DESCRIPTION
When creating the MQTT client the third parameter of `mosquitto_new() `is later passed to all MQTT callback functions. In this case it should be a pointer to the azure client.

In this example the third parameter is wrong!
It should be
`mqqtClient = mosquitto_new(azureClientId, true, azureClient);`
instead of
`mqqtClient = mosquitto_new(azureClientId, true, &azureClient);`

Uwe