### PR TITLE
Revert the user agent property name from dct to DeviceClientType

### DIFF
--- a/sdk/src/azure/iot/az_iot_hub_client.c
+++ b/sdk/src/azure/iot/az_iot_hub_client.c
@@ -21,7 +21,7 @@ static const az_span hub_client_param_equals_span = AZ_SPAN_LITERAL_FROM_STR("="
 
 static const az_span hub_digital_twin_model_id = AZ_SPAN_LITERAL_FROM_STR("model-id");
 static const az_span hub_service_api_version = AZ_SPAN_LITERAL_FROM_STR("/?api-version=2020-09-30");
-static const az_span client_sdk_device_client_type_name = AZ_SPAN_LITERAL_FROM_STR("dct");
+static const az_span client_sdk_device_client_type_name = AZ_SPAN_LITERAL_FROM_STR("DeviceClientType");
 static const az_span client_sdk_version_default_value
     = AZ_SPAN_LITERAL_FROM_STR("azsdk-c%2F" AZ_SDK_VERSION_STRING);
 

--- a/sdk/src/azure/iot/az_iot_hub_client.c
+++ b/sdk/src/azure/iot/az_iot_hub_client.c
@@ -21,7 +21,8 @@ static const az_span hub_client_param_equals_span = AZ_SPAN_LITERAL_FROM_STR("="
 
 static const az_span hub_digital_twin_model_id = AZ_SPAN_LITERAL_FROM_STR("model-id");
 static const az_span hub_service_api_version = AZ_SPAN_LITERAL_FROM_STR("/?api-version=2020-09-30");
-static const az_span client_sdk_device_client_type_name = AZ_SPAN_LITERAL_FROM_STR("DeviceClientType");
+static const az_span client_sdk_device_client_type_name
+    = AZ_SPAN_LITERAL_FROM_STR("DeviceClientType");
 static const az_span client_sdk_version_default_value
     = AZ_SPAN_LITERAL_FROM_STR("azsdk-c%2F" AZ_SDK_VERSION_STRING);
 

--- a/sdk/tests/iot/hub/test_az_iot_hub_client.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client.c
@@ -32,16 +32,16 @@ static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_ID_ST
 static const az_span test_hub_hostname = AZ_SPAN_LITERAL_FROM_STR(TEST_HUB_HOSTNAME_STR);
 
 static const char test_correct_user_name[]
-    = "myiothub.azure-devices.net/my_device/?api-version=2020-09-30&dct=" PLATFORM_USER_AGENT;
+    = "myiothub.azure-devices.net/my_device/?api-version=2020-09-30&DeviceClientType=" PLATFORM_USER_AGENT;
 static const char test_correct_user_name_with_model_id[]
-    = "myiothub.azure-devices.net/my_device/?api-version=2020-09-30&dct=" PLATFORM_USER_AGENT
+    = "myiothub.azure-devices.net/my_device/?api-version=2020-09-30&DeviceClientType=" PLATFORM_USER_AGENT
       "&model-id=dtmi%3AYOUR_COMPANY_NAME_HERE%3Asample_device%3B1";
 static const char test_correct_user_name_with_model_id_with_module_id[]
     = "myiothub.azure-devices.net/my_device/my_module_id/"
-      "?api-version=2020-09-30&dct=azrtos&model-id=dtmi%3AYOUR_COMPANY_NAME_HERE%"
+      "?api-version=2020-09-30&DeviceClientType=azrtos&model-id=dtmi%3AYOUR_COMPANY_NAME_HERE%"
       "3Asample_device%3B1";
 static const char test_correct_user_name_with_module_id[]
-    = "myiothub.azure-devices.net/my_device/my_module_id/?api-version=2020-09-30&dct=azrtos";
+    = "myiothub.azure-devices.net/my_device/my_module_id/?api-version=2020-09-30&DeviceClientType=azrtos";
 static const char test_correct_client_id[] = "my_device";
 static const char test_correct_client_id_with_module_id[] = "my_device/my_module_id";
 

--- a/sdk/tests/iot/hub/test_az_iot_hub_client.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client.c
@@ -32,16 +32,19 @@ static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_ID_ST
 static const az_span test_hub_hostname = AZ_SPAN_LITERAL_FROM_STR(TEST_HUB_HOSTNAME_STR);
 
 static const char test_correct_user_name[]
-    = "myiothub.azure-devices.net/my_device/?api-version=2020-09-30&DeviceClientType=" PLATFORM_USER_AGENT;
+    = "myiothub.azure-devices.net/my_device/"
+      "?api-version=2020-09-30&DeviceClientType=" PLATFORM_USER_AGENT;
 static const char test_correct_user_name_with_model_id[]
-    = "myiothub.azure-devices.net/my_device/?api-version=2020-09-30&DeviceClientType=" PLATFORM_USER_AGENT
+    = "myiothub.azure-devices.net/my_device/"
+      "?api-version=2020-09-30&DeviceClientType=" PLATFORM_USER_AGENT
       "&model-id=dtmi%3AYOUR_COMPANY_NAME_HERE%3Asample_device%3B1";
 static const char test_correct_user_name_with_model_id_with_module_id[]
     = "myiothub.azure-devices.net/my_device/my_module_id/"
       "?api-version=2020-09-30&DeviceClientType=azrtos&model-id=dtmi%3AYOUR_COMPANY_NAME_HERE%"
       "3Asample_device%3B1";
 static const char test_correct_user_name_with_module_id[]
-    = "myiothub.azure-devices.net/my_device/my_module_id/?api-version=2020-09-30&DeviceClientType=azrtos";
+    = "myiothub.azure-devices.net/my_device/my_module_id/"
+      "?api-version=2020-09-30&DeviceClientType=azrtos";
 static const char test_correct_client_id[] = "my_device";
 static const char test_correct_client_id_with_module_id[] = "my_device/my_module_id";
 


### PR DESCRIPTION
Azure IoT Hub parses the user agent information using the property
name DeviceClientType, so the client must send it with that name
otherwise the user agent string is not properly stored on Azure.
A change in the property name to "dct" can only be done after the hub is
also updated to support that name/alias.