### PR TITLE
Remove failure if version not present in the reported properties response

### DIFF
--- a/sdk/src/azure/iot/az_iot_hub_client_twin.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_twin.c
@@ -173,8 +173,9 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
       {
         // Is a reported prop response
         out_response->response_type = AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES;
-        _az_RETURN_IF_FAILED(az_iot_message_properties_find(
-            &props, az_iot_hub_twin_version_prop, &out_response->version));
+        // Version only present if response is from IoT Hub. Version is absent via IoT Edge.
+        az_iot_message_properties_find(
+            &props, az_iot_hub_twin_version_prop, &out_response->version);
       }
       else // 200 or 202
       {

--- a/sdk/src/azure/iot/az_iot_hub_client_twin.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_twin.c
@@ -173,16 +173,16 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
       {
         // Is a reported prop response
         out_response->response_type = AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES;
-        
+
         result = az_iot_message_properties_find(
             &props, az_iot_hub_twin_version_prop, &out_response->version);
         if (result == AZ_ERROR_ITEM_NOT_FOUND)
         {
-            out_response->version = AZ_SPAN_EMPTY;
+          out_response->version = AZ_SPAN_EMPTY;
         }
         else
         {
-             _az_RETURN_IF_FAILED(result);
+          _az_RETURN_IF_FAILED(result);
         }
       }
       else // 200 or 202

--- a/sdk/src/azure/iot/az_iot_hub_client_twin.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_twin.c
@@ -173,9 +173,17 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
       {
         // Is a reported prop response
         out_response->response_type = AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES;
-        out_response->version = AZ_SPAN_EMPTY;
-        az_iot_message_properties_find(
+        
+        az_result result = az_iot_message_properties_find(
             &props, az_iot_hub_twin_version_prop, &out_response->version);
+        if (result == AZ_ERROR_ITEM_NOT_FOUND)
+        {
+            out_response->version = AZ_SPAN_EMPTY;
+        }
+        else
+        {
+             _az_RETURN_IF_FAILED(result);
+        }
       }
       else // 200 or 202
       {

--- a/sdk/src/azure/iot/az_iot_hub_client_twin.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_twin.c
@@ -173,7 +173,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
       {
         // Is a reported prop response
         out_response->response_type = AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES;
-        // Version only present if response is from IoT Hub. Version is absent via IoT Edge.
+        out_response->version = AZ_SPAN_EMPTY;
         az_iot_message_properties_find(
             &props, az_iot_hub_twin_version_prop, &out_response->version);
       }

--- a/sdk/src/azure/iot/az_iot_hub_client_twin.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_twin.c
@@ -174,7 +174,7 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
         // Is a reported prop response
         out_response->response_type = AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES;
         
-        az_result result = az_iot_message_properties_find(
+        result = az_iot_message_properties_find(
             &props, az_iot_hub_twin_version_prop, &out_response->version);
         if (result == AZ_ERROR_ITEM_NOT_FOUND)
         {

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
@@ -38,7 +38,7 @@ static const az_span test_twin_received_topic_reported_response_version_success
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/204/?$rid=id_one&$version=16");
 static const az_span test_twin_received_topic_reported_response_no_version_success 
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/204/?$rid=id_one");
-    
+
 static const char test_correct_twin_get_request_topic[] = "$iothub/twin/GET/?$rid=id_one";
 static const char test_correct_twin_patch_pub_topic[]
     = "$iothub/twin/PATCH/properties/reported/?$rid=id_one";
@@ -275,7 +275,7 @@ static void test_az_iot_hub_client_twin_parse_received_topic_get_response_found_
 
   assert_int_equal(
       az_iot_hub_client_twin_parse_received_topic(
-          &client, test_twin_received_get_response_success, &response),
+          &client, test_twin_received_topic_get_response_success, &response),
       AZ_OK);
   assert_true(az_span_is_content_equal(response.request_id, test_device_request_id));
   assert_true(az_span_is_content_equal(response.version, AZ_SPAN_EMPTY));
@@ -341,7 +341,7 @@ static void test_az_iot_hub_client_twin_parse_received_topic_not_found_incomplet
 
   assert_int_equal(
       az_iot_hub_client_twin_parse_received_topic(
-          &client, test_twin_received_topic_reported_incomplete_fail, &response),
+          &client, test_twin_received_topic_incomplete_fail, &response),
       AZ_ERROR_UNEXPECTED_END);
 }
 

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
@@ -26,11 +26,11 @@ static const az_span test_device_request_id = AZ_SPAN_LITERAL_FROM_STR("id_one")
 static const az_span test_twin_received_topic_desired_success
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/PATCH/properties/desired/?$version=id_one");
 static const az_span test_twin_received_topic_fail
-    = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/rez/200"); // rez DNE
+    = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/rez/200"); // rez does not exist.
 static const az_span test_twin_received_topic_incomplete_fail
-    = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/200"); // Missing rid
+    = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/200"); // Missing rid.
 static const az_span test_twin_received_topic_prefix_fail
-    = AZ_SPAN_LITERAL_FROM_STR("$iothub/contoso/res/200"); // contoso DNE
+    = AZ_SPAN_LITERAL_FROM_STR("$iothub/contoso/res/200"); // contoso dones not exist.
 
 static const az_span test_twin_received_topic_get_response_success
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/200/?$rid=id_one");

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
@@ -25,18 +25,20 @@ static const az_span test_device_hostname = AZ_SPAN_LITERAL_FROM_STR("myiothub.a
 static const az_span test_device_request_id = AZ_SPAN_LITERAL_FROM_STR("id_one");
 static const az_span test_twin_received_topic_desired_success
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/PATCH/properties/desired/?$version=id_one");
-static const az_span test_twin_received_get_response_success
-    = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/200/?$rid=id_one");
 static const az_span test_twin_received_topic_fail
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/rez/200"); // rez DNE
+static const az_span test_twin_received_topic_incomplete_fail
+    = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/200"); // Missing rid
 static const az_span test_twin_received_topic_prefix_fail
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/contoso/res/200"); // contoso DNE
-static const az_span test_twin_received_topic_reported_incomplete_fail
-    = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/200"); // Missing rid
+
+static const az_span test_twin_received_topic_get_response_success
+    = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/200/?$rid=id_one");
 static const az_span test_twin_received_topic_reported_response_version_success
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/204/?$rid=id_one&$version=16");
 static const az_span test_twin_received_topic_reported_response_no_version_success 
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/204/?$rid=id_one");
+    
 static const char test_correct_twin_get_request_topic[] = "$iothub/twin/GET/?$rid=id_one";
 static const char test_correct_twin_patch_pub_topic[]
     = "$iothub/twin/PATCH/properties/reported/?$rid=id_one";

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
@@ -37,8 +37,6 @@ static const az_span test_twin_received_topic_reported_response_version_success
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/204/?$rid=id_one&$version=16");
 static const az_span test_twin_received_topic_reported_response_no_version_success 
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/204/?$rid=id_one");
-static const az_span test_twin_received_topic_bad_request_success
-    = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/400/?$rid=id_one");
 static const char test_correct_twin_get_request_topic[] = "$iothub/twin/GET/?$rid=id_one";
 static const char test_correct_twin_patch_pub_topic[]
     = "$iothub/twin/PATCH/properties/reported/?$rid=id_one";
@@ -358,25 +356,6 @@ static void test_az_iot_hub_client_twin_parse_received_topic_not_found_prefix_fa
       AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
-static void test_az_iot_hub_client_twin_parse_received_topic_request_error_succeed()
-{
-  az_iot_hub_client client;
-  assert_int_equal(
-      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
-  az_iot_hub_client_twin_response response;
-
- assert_int_equal(
-      az_iot_hub_client_twin_parse_received_topic(
-          &client, test_twin_received_topic_bad_request_success, &response),
-      AZ_OK);
-
-  assert_true(az_span_is_content_equal(response.request_id, test_device_request_id));
-  assert_true(az_span_is_content_equal(response.version, AZ_SPAN_EMPTY));
-  assert_true(response.status >= AZ_IOT_STATUS_BAD_REQUEST);
-  assert_int_equal(response.response_type, AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_REQUEST_ERROR);
-}
-
-
 static int _log_invoked_topic = 0;
 static void _log_listener(az_log_classification classification, az_span message)
 {
@@ -497,7 +476,6 @@ int test_az_iot_hub_client_twin()
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_not_found_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_not_found_incomplete_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_not_found_prefix_fails),
-    cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_request_error_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_logging_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_no_logging_succeed),
   };

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
@@ -36,7 +36,7 @@ static const az_span test_twin_received_topic_get_response_success
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/200/?$rid=id_one");
 static const az_span test_twin_received_topic_reported_response_version_success
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/204/?$rid=id_one&$version=16");
-static const az_span test_twin_received_topic_reported_response_no_version_success 
+static const az_span test_twin_received_topic_reported_response_no_version_success
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/204/?$rid=id_one");
 
 static const char test_correct_twin_get_request_topic[] = "$iothub/twin/GET/?$rid=id_one";
@@ -301,7 +301,8 @@ static void test_az_iot_hub_client_twin_parse_received_topic_reported_props_vers
       response.response_type, AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_REPORTED_PROPERTIES);
 }
 
-static void test_az_iot_hub_client_twin_parse_received_topic_reported_props_no_version_found_succeed()
+static void
+test_az_iot_hub_client_twin_parse_received_topic_reported_props_no_version_found_succeed()
 {
   az_iot_hub_client client;
   assert_int_equal(
@@ -473,8 +474,10 @@ int test_az_iot_hub_client_twin()
     cmocka_unit_test(test_az_iot_hub_client_twin_patch_get_publish_topic_small_buffer_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_desired_found_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_get_response_found_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_reported_props_version_found_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_reported_props_no_version_found_succeed),
+    cmocka_unit_test(
+        test_az_iot_hub_client_twin_parse_received_topic_reported_props_version_found_succeed),
+    cmocka_unit_test(
+        test_az_iot_hub_client_twin_parse_received_topic_reported_props_no_version_found_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_not_found_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_not_found_incomplete_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_not_found_prefix_fails),

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
@@ -35,7 +35,7 @@ static const az_span test_twin_received_topic_reported_incomplete_fail
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/200"); // Missing rid
 static const az_span test_twin_received_topic_reported_response_version_success
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/204/?$rid=id_one&$version=16");
-static const az_span test_twin_received_topic_reported_response_no_version_success = 
+static const az_span test_twin_received_topic_reported_response_no_version_success 
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/204/?$rid=id_one");
 static const az_span test_twin_received_topic_bad_request_success
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/400/?$rid=id_one");
@@ -492,10 +492,12 @@ int test_az_iot_hub_client_twin()
     cmocka_unit_test(test_az_iot_hub_client_twin_patch_get_publish_topic_small_buffer_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_desired_found_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_get_response_found_succeed),
-    cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_reported_props_found_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_reported_props_version_found_succeed),
+    cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_reported_props_no_version_found_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_not_found_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_not_found_incomplete_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_not_found_prefix_fails),
+    cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_request_error_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_logging_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_no_logging_succeed),
   };


### PR DESCRIPTION
Remove the failure if version is not present in the reported properties response. 
It will be present from IoT Hub, but absent from IoT Edge.
