### PR TITLE
Manually increment version for C SDK releases to 1.4.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.4.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.3.1 (2022-04-05)
 
 ### Bugs Fixed

--- a/sdk/inc/azure/core/az_version.h
+++ b/sdk/inc/azure/core/az_version.h
@@ -17,19 +17,18 @@
 
 /// The version in string format used for telemetry following the `semver.org` standard
 /// (https://semver.org).
-#define AZ_SDK_VERSION_STRING "1.3.1"
+#define AZ_SDK_VERSION_STRING "1.4.0-beta.1"
 
 /// Major numeric identifier.
 #define AZ_SDK_VERSION_MAJOR 1
 
 /// Minor numeric identifier.
-#define AZ_SDK_VERSION_MINOR 3
+#define AZ_SDK_VERSION_MINOR 4
 
 /// Patch numeric identifier.
-#define AZ_SDK_VERSION_PATCH 1
+#define AZ_SDK_VERSION_PATCH 0
 
 /// Optional pre-release identifier. SDK is in a pre-release state when present.
-#define AZ_SDK_VERSION_PRERELEASE
-#undef AZ_SDK_VERSION_PRERELEASE
+#define AZ_SDK_VERSION_PRERELEASE "beta.1"
 
 #endif //_az_VERSION_H


### PR DESCRIPTION
Supersedes https://github.com/Azure/azure-sdk-for-c/pull/2170

Needed as a workaround for https://github.com/Azure/azure-sdk-for-c/issues/2108