### PR TITLE
Adding API deprecation markers.

### DIFF
--- a/sdk/inc/azure/core/_az_cfg.h
+++ b/sdk/inc/azure/core/_az_cfg.h
@@ -88,4 +88,36 @@
 // Get the number of elements in an array
 #define _az_COUNTOF(array) (sizeof(array) / sizeof((array)[0]))
 
+/**
+ * @brief Deprecate functions.
+ * 
+ */
+#ifdef __has_c_attribute
+#if __has_c_attribute(deprecated)
+#define AZ_DEPRECATED [[deprecated]]
+#endif
+#endif
+
+#ifndef AZ_DEPRECATED
+#if defined(_MSC_VER)
+#define AZ_DEPRECATED __declspec(deprecated)
+#elif defined(__GNUC__)
+#define AZ_DEPRECATED __attribute__((deprecated))
+#endif
+#endif
+
+#ifdef _MSC_VER
+#define AZ_IGNORE_DEPRECATIONS \
+    _Pragma("warning(push)") \
+    _Pragma("warning(disable:4996)")
+#define AZ_POP_WARNINGS \
+    _Pragma("warning(pop)")
+#else
+#define AZ_IGNORE_DEPRECATIONS \
+  _Pragma("GCC diagnostic push") \
+  _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define AZ_POP_WARNINGS \
+  _Pragma("GCC diagnostic pop")
+#endif
+
 #endif // _az_CFG_H

--- a/sdk/inc/azure/core/_az_cfg.h
+++ b/sdk/inc/azure/core/_az_cfg.h
@@ -90,7 +90,7 @@
 
 /**
  * @brief Deprecate functions.
- * 
+ *
  */
 #ifdef __has_c_attribute
 #if __has_c_attribute(deprecated)
@@ -107,17 +107,12 @@
 #endif
 
 #ifdef _MSC_VER
-#define AZ_IGNORE_DEPRECATIONS \
-    _Pragma("warning(push)") \
-    _Pragma("warning(disable:4996)")
-#define AZ_POP_WARNINGS \
-    _Pragma("warning(pop)")
+#define AZ_IGNORE_DEPRECATIONS _Pragma("warning(push)") _Pragma("warning(disable:4996)")
+#define AZ_POP_WARNINGS _Pragma("warning(pop)")
 #else
 #define AZ_IGNORE_DEPRECATIONS \
-  _Pragma("GCC diagnostic push") \
-  _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#define AZ_POP_WARNINGS \
-  _Pragma("GCC diagnostic pop")
+  _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define AZ_POP_WARNINGS _Pragma("GCC diagnostic pop")
 #endif
 
 #endif // _az_CFG_H

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -500,9 +500,8 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(
     size_t mqtt_payload_size,
     size_t* out_mqtt_payload_length);
 
-// TODO: * @deprecated since 1.4.0-beta.1.
-
 /**
+ * @deprecated since 1.4.0-beta.1.
  * @see az_iot_provisioning_client_register_get_request_payload
  * @brief Builds the optional payload for a provisioning request.
  * @remark Use this API to build an MQTT payload during registration.
@@ -531,7 +530,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(
  * @retval #AZ_OK The payload was created successfully.
  * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small.
  */
-AZ_NODISCARD az_result az_iot_provisioning_client_get_request_payload(
+AZ_DEPRECATED AZ_NODISCARD az_result az_iot_provisioning_client_get_request_payload(
     az_iot_provisioning_client const* client,
     az_span custom_payload_property,
     az_iot_provisioning_client_payload_options const* options,

--- a/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
@@ -259,7 +259,7 @@ static void register_device_with_provisioning_service(void)
       sizeof(mqtt_payload),
       &mqtt_payload_length);
   AZ_POP_WARNINGS
-  
+
   if (az_result_failed(rc))
   {
     IOT_SAMPLE_LOG_ERROR(

--- a/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
@@ -250,6 +250,7 @@ static void register_device_with_provisioning_service(void)
   uint8_t mqtt_payload[MQTT_PAYLOAD_BUFFER_LENGTH];
   size_t mqtt_payload_length;
 
+  AZ_IGNORE_DEPRECATIONS
   rc = az_iot_provisioning_client_get_request_payload(
       &provisioning_client,
       custom_registration_payload_property,
@@ -257,6 +258,8 @@ static void register_device_with_provisioning_service(void)
       mqtt_payload,
       sizeof(mqtt_payload),
       &mqtt_payload_length);
+  AZ_POP_WARNINGS
+  
   if (az_result_failed(rc))
   {
     IOT_SAMPLE_LOG_ERROR(

--- a/sdk/tests/iot/provisioning/CMakeLists.txt
+++ b/sdk/tests/iot/provisioning/CMakeLists.txt
@@ -15,7 +15,9 @@ add_cmocka_test(az_iot_provisioning_test SOURCES
                 test_az_iot_provisioning_client_sas.c
                 test_az_iot_provisioning_client_parser.c
                 test_az_iot_provisioning_client_register_get_request_payload.c
-                COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS} ${NO_CLOBBERED_WARNING}
+                COMPILE_OPTIONS 
+                    ${DEFAULT_C_COMPILE_FLAGS} 
+                    ${NO_CLOBBERED_WARNING} 
                 LINK_LIBRARIES ${CMOCKA_LIBRARIES}
                     az_iot_common
                     az_iot_provisioning

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
@@ -66,8 +66,10 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_client_fail
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
+  AZ_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       NULL, AZ_SPAN_EMPTY, NULL, payload, sizeof(payload), &payload_len));
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_non_NULL_reserved_fails()
@@ -84,6 +86,7 @@ static void test_az_iot_provisioning_client_get_request_payload_non_NULL_reserve
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
+  AZ_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client,
       AZ_SPAN_EMPTY,
@@ -91,6 +94,7 @@ static void test_az_iot_provisioning_client_get_request_payload_non_NULL_reserve
       payload,
       sizeof(payload),
       &payload_len));
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_NULL_mqtt_payload_fails()
@@ -106,8 +110,10 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_mqtt_payloa
 
   size_t payload_len;
 
+  AZ_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, NULL, 1, &payload_len));
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_zero_payload_size_fails()
@@ -124,8 +130,10 @@ static void test_az_iot_provisioning_client_get_request_payload_zero_payload_siz
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
+  AZ_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, 0, &payload_len));
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_NULL_payload_length_fails()
@@ -141,8 +149,10 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_payload_len
 
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
 
+  AZ_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, 1, NULL));
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_register_get_request_payload_NULL_options_fails()
@@ -183,8 +193,10 @@ static void test_az_iot_provisioning_client_get_request_payload_no_custom_payloa
   memset(payload, 0xCC, sizeof(payload));
   size_t payload_len = 0xBAADC0DE;
 
+  AZ_IGNORE_DEPRECATIONS
   ret = az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, sizeof(payload), &payload_len);
+  AZ_POP_WARNINGS
   assert_int_equal(AZ_OK, ret);
   assert_int_equal(payload_len, expected_payload_len);
   assert_memory_equal(expected_payload, payload, expected_payload_len);
@@ -210,12 +222,14 @@ static void test_az_iot_provisioning_client_get_request_payload_custom_payload()
   memset(payload, 0xCC, sizeof(payload));
   size_t payload_len = 0xBAADC0DE;
 
+  AZ_IGNORE_DEPRECATIONS
   ret = az_iot_provisioning_client_get_request_payload(
       &client, test_custom_payload, NULL, payload, sizeof(payload), &payload_len);
   assert_int_equal(AZ_OK, ret);
   assert_int_equal(payload_len, expected_payload_len);
   assert_memory_equal(expected_payload, payload, expected_payload_len);
   assert_int_equal((uint8_t)0xCC, payload[expected_payload_len]);
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_register_get_request_payload_with_csr()


### PR DESCRIPTION
Adding standard deprecation documentation and compilation markers for `az_iot_provisioning_client_get_request_payload`, deprecated in favor of `az_iot_provisioning_client_register_get_request_payload`.

Tested on Linux / GCC and Windows.