### PR TITLE
Changing az_iot_provisioning_client_register_get_request_payload options behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,22 @@
 
 ### Features Added
 
+- Adding _preview_ support for Azure IoT Device Provisioning Client Certificate Issuance (CSR).
+  - New APIs: `az_iot_provisioning_client_register_get_request_payload()`; `az_iot_provisioning_client_payload_options.certificate_signing_request` and   `az_iot_provisioning_client_registration_state.issued_client_certificate`.
+- Adding _preview_ support for Azure IoT Device Provisioning Client Trust Bundle CA distribution system.
+  - New APIs: `az_iot_provisioning_client_registration_state.trust_bundle`.
+- Adding IoT Device Provisioning support for [Custom Allocation Payload](https://docs.microsoft.com/azure/iot-dps/how-to-send-additional-data). 
+  - New APIs: `az_iot_provisioning_client_register_get_request_payload()` and  `az_iot_provisioning_client_registration_state.payload`.
+
 ### Breaking Changes
 
 ### Bugs Fixed
 
+- Azure IoT Samples now display errors following the _source file:line number_ format, allowing Visual Studio Code to automatically create links from the output log.
+
 ### Other Changes
+
+- Azure IoT Device Provisioning Client API __deprecation__: `az_iot_provisioning_client_get_request_payload()` is deprecated in favor of `az_iot_provisioning_client_register_get_request_payload()`. The new API _requires_ an initialized `az_iot_provisioning_client_payload_options` structure (using `az_iot_provisioning_client_payload_options_default()`).
 
 ## 1.3.0 (2022-02-08)
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -393,9 +393,9 @@ jobs:
 
   # Validate all the files are formatted correctly according to the .clang-format file.
   - bash: |
-      # Run clang-format recursively on each source and header file within the repo.
-      clang-format --version
-      find . \( -iname '*.h' -o -iname '*.c' \) -exec clang-format -i {} \;
+      # Run clang-format-9 recursively on each source and header file within the repo.
+      clang-format-9 --version
+      find . \( -iname '*.h' -o -iname '*.c' \) -exec clang-format-9 -i {} \;
 
       git status --untracked-files=no --porcelain
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -401,8 +401,8 @@ jobs:
 
       if [[ `git status --untracked-files=no --porcelain` ]]; then
         echo Some files were not formatted correctly according to the .clang-format file.
-        echo Please run clang-format to fix the issue by using this bash command at the root of the repo:
-        echo "find . \( -iname '*.h' -o -iname '*.c' \) -exec clang-format -i {} \;"
+        echo Please run clang-format-9 to fix the issue by using this bash command at the root of the repo:
+        echo "find . \( -iname '*.h' -o -iname '*.c' \) -exec clang-format-9 -i {} \;"
         exit 1
       fi
 

--- a/sdk/docs/iot/resources/csr.puml
+++ b/sdk/docs/iot/resources/csr.puml
@@ -1,0 +1,28 @@
+@startuml dpsCSR
+Device -> Device: Generate **operational** ECC/RSA key-pair
+Device -> Device: Creates Certificate Signing Request using **operational** key-pair
+Device -> DPS: Authenticate using SAS, TPM or Client X509 **onboarding** credentials
+DPS -> Device: ACK
+Device -> DPS: register (registrationId, Body: **operational** CSR)
+DPS -> Device: ACK
+DPS -> CertificateAuthority: **operational** CSR
+DPS <- CertificateAuthority: **operational** X509 Certificate
+Device -> DPS: query [...]
+DPS -> Device: hubFQDN, deviceId, **operational** X509 Certificate
+DPS <- Device: MQTT Disconnect
+Device -> HUB: Authenticate using **operational** X509 Certificate
+HUB->HUB: Device **operational** X509 Certificate expired.
+Device <- HUB: MQTT Disconnect
+note left
+  MQTT 3 does not contain 
+  additional disconnect reason.
+end note
+Device -> HUB: Auth using **operational** X509 Certificate
+Device <- HUB: Authentication Failure
+note left
+  This step necessary only 
+  when using MQTT 3.
+end note
+Device -> Device: Restart flow
+
+@enduml

--- a/sdk/docs/iot/resources/trust_bundle_application.puml
+++ b/sdk/docs/iot/resources/trust_bundle_application.puml
@@ -1,0 +1,42 @@
+@startuml
+frame "Low Privilege" {
+  [Provisioning Component]
+  [Hub Component]
+}
+
+package "Elevated Privilege"{
+    [Certificate Installer]
+}
+
+cloud {
+  [Device Provisioning Service]
+  [IoT Hub]
+}
+
+
+database "Trusted Certificate Store" {
+    [Azure IoT CA Root]
+    [Edge CA Root]
+    [Local Service CA Root]
+}
+
+database "Certificate Installer Data" {
+    [last version (etag)]
+    [list of installed certificates]
+}
+
+[Device Provisioning Service] <--[Provisioning Component]
+[IoT Hub] <-- [Hub Component]
+[Provisioning Component] --> [Certificate Installer]
+[Certificate Installer] --> [Edge CA Root]
+[Certificate Installer] --> [Local Service CA Root]
+[Certificate Installer] <-> [last version (etag)]
+[Certificate Installer] <-> [list of installed certificates]
+
+note right of "Provisioning Component": Linked with the C-SDK
+note top of "Hub Component"
+Uses the Device Trusted Certificate Store.
+Linked with the C-SDK.
+end note
+
+@enduml

--- a/sdk/docs/iot/using_certificate_signing_requests.md
+++ b/sdk/docs/iot/using_certificate_signing_requests.md
@@ -1,0 +1,85 @@
+# Using Azure IoT Device Provisioning Certificate Signing Requests
+
+Device Provisioning Service can be configured to provision operational X509 
+certificates to IoT devices. These operational certificates must be used to authenticate with the 
+allocated IoT Hub. An onboarding authentication mechanism (either SAS token or X509 Client 
+Certificate) is still required to authenticate the device with DPS.
+
+## Certificate Signing Request Flow
+
+![dpsCSR](https://www.plantuml.com/plantuml/png/ZPFVJy8m4CVVzrVSeoumJOmF4aCOGzGO331CJ8mFPJsWSRQpxKJ-Uwyhc3cNu5j_tETxtxjh1yOoRSlt77XXadGUZF1JP0ZTFlXL3svHecOM8GnLuLP2IPQ78TmaoTayZU4DTzs22Tt29Xg9D92Wjc8bCYUJYhKKSWrp_2ZHM2YDspN5sqIdQG_YqcvGMY_bqJHEEx2OJa1fI791j_1yUNxb9ELICSqfY1GpZToHB3S1ITLjnib3Cu_6jJ0MDPpubRTsppimL7pN--ENUdVQAkkFQWrm5IWjRBj81Lnt_mbKTTP2crLGX_KENg8eUcsQsvJByMpqs05U7RZAZgjxRmU9oMonW94mcP8ICrjBVlSqR1tLqGm4TliLlHSxHW1-5O8c6nsoax-ARvgJYe9pNDa0_Dq5S4LFayw1OYmJ4kYASIvyCk0_CBq6PfIC0fJS0TXMwdzBRFYiTOaG63EHbnf_sLriX05wZ0MG6JI6qKoLp7VExvRWVMPVLQl9myJcMFrtMELg6mG3YgIl_mq0 "dpsCSR")
+
+## Public API
+
+```C
+// Building the DPS register MQTT payload containing the operational X509 Certificate Signing Request:
+az_iot_provisioning_client_payload_options options;
+az_iot_provisioning_client_payload_options_default();
+
+options.certificate_signing_request = AZ_SPAN_FROM_BUFFER(CSR_IN_PEM_FORMAT);
+
+az_iot_provisioning_client_register_get_request_payload(
+    dps_client,
+    NULL,
+    &options,
+    uint8_t* mqtt_payload,
+    size_t mqtt_payload_size,
+    size_t* out_mqtt_payload_length)
+
+// Perform DPS registration.
+// [...]
+
+az_iot_provisioning_client_register_response register_response; // parsed during registration.
+
+if (az_span_size(register_response->registration_state.issued_client_certificate) > 0)
+{
+    // issued_client_certificate contains the CA signed *operational* certificate in PEM format.
+}
+
+```
+
+## Sample
+
+The `paho_iot_provisioning_csr_trustbundle_sample` demonstrates how to use the public API to submit a certificate 
+signing request then display the provisioned device certificate that can be used to connect to Azure IoT Hub (using any of the `paho_iot_hub_*` samples using X509 authentication).
+
+### 1. Generate a CSR
+
+1. Generate either an ECC or RSA key-pair
+
+```
+# Generate an ECC P-256 keypair:
+openssl ecparam -out key.pem -name prime256v1 -genkey
+
+# Generate an RSA 4096 bit keypair:
+openssl genrsa -out key.pem 4096
+```
+
+2. Generate a PKCS#10 Certificate Signing Request (CSR) from the keypair:
+
+Below, replace `my-device-id` with the device ID.
+
+_Important:_ The device ID *must* match the one configured for the registration ID. Devices are not allowed to submit requests with Subject Certificate Name other than the configured device ID.
+
+```
+openssl req -new -key key.pem -out request.csr -subj '/CN=my-device-id'
+```
+
+Additionally, to read the information from a CSR file use:
+
+```
+openssl req -noout -text -in request.csr
+```
+
+For more information on OpenSSL CSR support, see https://www.openssl.org/docs/man1.1.1/man1/openssl-req.html
+
+### 2. Set the environment for CSR sample
+
+```sh
+export AZ_IOT_PROVISIONING_ID_SCOPE=0ne?????
+export AZ_IOT_PROVISIONING_REGISTRATION_ID=<registration_id>
+# Onboarding Certificate and Key:
+export AZ_IOT_DEVICE_X509_CERT_PEM_FILE_PATH=path_to_certificate_store.pem
+# Operational Certificate Signing Request:
+export AZ_IOT_DEVICE_X509_OPERATIONAL_CSR_PEM_FILE_PATH=path_to_csr_request.pem
+```

--- a/sdk/docs/iot/using_trustbundle.md
+++ b/sdk/docs/iot/using_trustbundle.md
@@ -1,0 +1,53 @@
+# Provisioning CA Certificates to Devices using TrustBundle
+
+In general, Azure IoT Edge devices do not have server certificates signed by authorities trusted by 
+the leaf device. To allow the device to connect securely to an Azure IoT Edge device, new 
+certificates must be installed within the Trusted Root Certification Authority (CA) store of the 
+leaf device. 
+
+The TrustBundle feature in Azure Device Provisioning Service feature allows IoT administrators to 
+manage the device CA certificate store remotely.
+
+Also see https://azure.github.io/iot-identity-service/
+
+## Application Architecture
+
+_For security reasons, it is recommended to install certificates using a separate, elevated 
+privilege process instead of granting more permissions to the Provisioning or Hub application 
+components:_
+
+![trust_bundle_application](https://www.plantuml.com/plantuml/png/XPF1Ri8m38RlUGghf-rG7c124mYGXiO13NQQTWYjAH4XHabQf4sy-vpGGQkrx5RP_lpRlzEHyzBwyg35rie3GhAW4oojgfJ60XFu5W0VIqkLSegCCWLCw70aWyP_XjHBkMb6pa8SPRQN1NUQQQoanxpHBdHZQ8BMgwtAE0jpmnDeZJR2cQOoluXEiL8PGajxXJO4e_ASri3g4HEvz78Z7QkkRUc2Q5DZvSdMkp0u_Yejwp8-6SCRKLo4uxESfsw75fH9_QjwovsRWftBm9JpLqKjdOSARLW37j3Buh4Mq8epj0LLWpbajtOkAjqr0ePfsdkUgqMXwi-f-Z18q-VU4_N4BqpRmBkbFSRsCSF0TBfud_Z7NM68AQkANInBkXr9dc2Xp9xfa_8xy3iUE5rDNo-qfsDaM-ucujsXYwNrzNgVvK1qDXy8D3a41I56_Cb_w0y0 "trust_bundle_application")
+
+
+The Certificate Installer component must be able to persist the last TrustBundle version (etag) as 
+well as the list of installed certificates. When a new version of the TrustBundle is received, 
+the Certificate Installer must first remove previous TrustBundle certificates that are no longer 
+part of the current TrustBundle then install new certificates from the TrustBundle. 
+
+__Important:__ Accidentally deleting the Azure IoT CA root on the device will result in permanent 
+Azure IoT service connectivity loss.
+
+## Public API
+
+```C
+az_iot_provisioning_client_registration_state.trust_bundle
+```
+
+## Sample
+
+The `paho_iot_provisioning_csr_trustbundle_sample` demonstrates how to use the SDK public API as well as parse the 
+TrustBundle to extract the PEM certificates. Device Provisioning Service configuration is required
+to enable and configure a TrustBundle for the individual or group device enrollments.
+
+### Example output
+
+```
+SUCCESS:        Trust Bundle received:
+                        [1] CA Certificate data:
+                         -----BEGIN CERTIFICATE-----(...)
+                        Subject: CN=root-contoso, OU=contoso, O=contoso, C=16148
+                        Thumbprint: 5C57EB7EED8E278B1EAE278AAE1C6083EC2861B0
+                        Issuer: CN=root-contoso, OU=contoso, O=contoso, C=16148
+                TrustBundle ID: myTrustBundle1
+                TrustBundle eTag: \"1f00c05d-0000-0600-0000-623a4b200000\"
+...

--- a/sdk/inc/azure/core/_az_cfg.h
+++ b/sdk/inc/azure/core/_az_cfg.h
@@ -88,4 +88,36 @@
 // Get the number of elements in an array
 #define _az_COUNTOF(array) (sizeof(array) / sizeof((array)[0]))
 
+/**
+ * @brief Deprecate functions.
+ * 
+ */
+#ifdef __has_c_attribute
+#if __has_c_attribute(deprecated)
+#define AZ_DEPRECATED [[deprecated]]
+#endif
+#endif
+
+#ifndef AZ_DEPRECATED
+#if defined(_MSC_VER)
+#define AZ_DEPRECATED __declspec(deprecated)
+#elif defined(__GNUC__)
+#define AZ_DEPRECATED __attribute__((deprecated))
+#endif
+#endif
+
+#ifdef _MSC_VER
+#define AZ_IGNORE_DEPRECATIONS \
+    _Pragma("warning(push)") \
+    _Pragma("warning(disable:4996)")
+#define AZ_POP_WARNINGS \
+    _Pragma("warning(pop)")
+#else
+#define AZ_IGNORE_DEPRECATIONS \
+  _Pragma("GCC diagnostic push") \
+  _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define AZ_POP_WARNINGS \
+  _Pragma("GCC diagnostic pop")
+#endif
+
 #endif // _az_CFG_H

--- a/sdk/inc/azure/core/_az_cfg.h
+++ b/sdk/inc/azure/core/_az_cfg.h
@@ -90,7 +90,7 @@
 
 /**
  * @brief Deprecate functions.
- * 
+ *
  */
 #ifdef __has_c_attribute
 #if __has_c_attribute(deprecated)
@@ -107,17 +107,12 @@
 #endif
 
 #ifdef _MSC_VER
-#define AZ_IGNORE_DEPRECATIONS \
-    _Pragma("warning(push)") \
-    _Pragma("warning(disable:4996)")
-#define AZ_POP_WARNINGS \
-    _Pragma("warning(pop)")
+#define AZ_IGNORE_DEPRECATIONS _Pragma("warning(push)") _Pragma("warning(disable:4996)")
+#define AZ_POP_WARNINGS _Pragma("warning(pop)")
 #else
 #define AZ_IGNORE_DEPRECATIONS \
-  _Pragma("GCC diagnostic push") \
-  _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#define AZ_POP_WARNINGS \
-  _Pragma("GCC diagnostic pop")
+  _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define AZ_POP_WARNINGS _Pragma("GCC diagnostic pop")
 #endif
 
 #endif // _az_CFG_H

--- a/sdk/inc/azure/core/_az_cfg.h
+++ b/sdk/inc/azure/core/_az_cfg.h
@@ -107,10 +107,10 @@
 #endif
 
 #ifdef _MSC_VER
-#define AZ_IGNORE_DEPRECATIONS _Pragma("warning(push)") _Pragma("warning(disable:4996)")
+#define AZ_PUSH_IGNORE_DEPRECATIONS  _Pragma("warning(push)") _Pragma("warning(disable:4996)")
 #define AZ_POP_WARNINGS _Pragma("warning(pop)")
 #else
-#define AZ_IGNORE_DEPRECATIONS \
+#define AZ_PUSH_IGNORE_DEPRECATIONS  \
   _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
 #define AZ_POP_WARNINGS _Pragma("GCC diagnostic pop")
 #endif

--- a/sdk/inc/azure/iot/az_iot_hub_client.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client.h
@@ -102,10 +102,10 @@ AZ_NODISCARD az_iot_hub_client_options az_iot_hub_client_options_default();
  * topic names (listed below) and of the IoT Hub (listed below)
  * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106
  * https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#device-identity-properties
- * @param[in] options A reference to an #az_iot_hub_client_options structure. If `NULL` is passed,
- * the hub client will use the default options. If using custom options, please initialize first by
- * calling az_iot_hub_client_options_default() and then populating relevant options with your own
- * values.
+ * @param[in] options __[nullable]__ A reference to an #az_iot_hub_client_options structure. If
+ * `NULL` is passed, the hub client will use the default options. If using custom options, please
+ * initialize first by calling az_iot_hub_client_options_default() and then populating relevant
+ * options with your own values.
  * @pre \p client must not be `NULL`.
  * @pre \p iot_hub_hostname must be a valid span of size greater than 0.
  * @pre \p device_id must be a valid span of size greater than 0.

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -29,7 +29,7 @@
 /**
  * @brief The client is fixed to a specific version of the Azure IoT Provisioning service.
  */
-#define AZ_IOT_PROVISIONING_SERVICE_VERSION "2019-03-31"
+#define AZ_IOT_PROVISIONING_SERVICE_VERSION "2021-11-01-preview"
 
 /**
  * @brief Azure IoT Provisioning Client options.
@@ -262,6 +262,22 @@ typedef struct
    * Submit this timestamp when asking for Azure IoT service-desk help.
    */
   az_span error_timestamp;
+
+  /**
+   * An optional custom payload received from the service.
+   */
+  az_span payload;
+
+  /**
+   * An optional set of X509 Certification Authorities received from the service.
+   */
+  az_span trust_bundle;
+
+  /**
+   * An optional response to a Certificate Signing Request containing a signed X509 Certificate.
+   */
+  az_span issued_client_certificate;
+
 } az_iot_provisioning_client_registration_state;
 
 /**
@@ -332,6 +348,7 @@ typedef struct
    * and device id in case of success.
    */
   az_iot_provisioning_client_registration_state registration_state;
+
 } az_iot_provisioning_client_register_response;
 
 /**
@@ -426,19 +443,67 @@ AZ_NODISCARD az_result az_iot_provisioning_client_query_status_get_publish_topic
 
 /**
  * @brief Azure IoT Provisioning Client options for
- * az_iot_provisioning_client_get_request_payload(). Not currently used.  Reserved for future use.
- *
+ * az_iot_provisioning_client_get_request_payload().
  */
 typedef struct
 {
-  struct
-  {
-    /// Currently, this is unused, but needed as a placeholder since we can't have an empty struct.
-    bool unused;
-  } _internal;
+  /**
+   * An optional X.509 Certificate Signing Request formatted as PEM PKCS#10.
+   */
+  az_span certificate_signing_request;
 } az_iot_provisioning_client_payload_options;
 
 /**
+ * @brief Gets the default az_iot_provisioning_client_payload_options.
+ * @details Call this to obtain an initialized #az_iot_provisioning_client_payload_options structure
+ * that can be afterwards modified and passed to
+ * #az_iot_provisioning_client_register_get_request_payload.
+ *
+ * @return #az_iot_provisioning_client_payload_options.
+ */
+AZ_NODISCARD az_iot_provisioning_client_payload_options
+az_iot_provisioning_client_payload_options_default();
+
+/**
+ * @brief Builds the optional payload for a provisioning request.
+ * @remark Use this API to build an MQTT payload during registration.
+ *         This call is optional for most scenarios. Some service
+ *         applications may require `custom_payload_property` specified during
+ *         registration to take additional decisions during provisioning time.
+ *         For example, if you need to register an IoT Plug and Play device you must
+ *         specify its model_id with this API via the `custom_payload_property`
+ *         `{"modelId":"your_model_id"}`.
+ *
+ * @param[in] client The #az_iot_provisioning_client to use for this call.
+ * @param[in] custom_payload_property __[nullable]__ Custom JSON to be added to this payload.
+ * Can be `NULL`.
+ * @param[in] options __[nullable]__ Reserved field for future options to this function.  Must be
+ * `NULL`.
+ * @param[out] mqtt_payload A buffer with sufficient capacity to hold the MQTT payload.
+ * @param[in] mqtt_payload_size The size, in bytes of \p mqtt_payload.
+ * @param[out] out_mqtt_payload_length Contains the length, in bytes, written to \p mqtt_payload on
+ * success.
+ * @pre \p client must not be `NULL`.
+ * @pre \p options must be `NULL`.
+ * @pre \p mqtt_payload must not be `NULL`.
+ * @pre \p mqtt_payload_size must be greater than 0.
+ * @pre \p out_mqtt_payload_length must not be `NULL`.
+ * @return An #az_result value indicating the result of the operation.
+ * @retval #AZ_OK The payload was created successfully.
+ * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small.
+ */
+AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(
+    az_iot_provisioning_client const* client,
+    az_span custom_payload_property,
+    az_iot_provisioning_client_payload_options const* options,
+    uint8_t* mqtt_payload,
+    size_t mqtt_payload_size,
+    size_t* out_mqtt_payload_length);
+
+// TODO: * @deprecated since 1.4.0-beta.1.
+
+/**
+ * @see az_iot_provisioning_client_register_get_request_payload
  * @brief Builds the optional payload for a provisioning request.
  * @remark Use this API to build an MQTT payload during registration.
  *         This call is optional for most scenarios. Some service

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -500,9 +500,8 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(
     size_t mqtt_payload_size,
     size_t* out_mqtt_payload_length);
 
-// TODO: * @deprecated since 1.4.0-beta.1.
-
 /**
+ * @deprecated since 1.4.0-beta.1.
  * @see az_iot_provisioning_client_register_get_request_payload
  * @brief Builds the optional payload for a provisioning request.
  * @remark Use this API to build an MQTT payload during registration.
@@ -531,7 +530,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(
  * @retval #AZ_OK The payload was created successfully.
  * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small.
  */
-AZ_NODISCARD az_result az_iot_provisioning_client_get_request_payload(
+AZ_DEPRECATED AZ_NODISCARD az_result az_iot_provisioning_client_get_request_payload(
     az_iot_provisioning_client const* client,
     az_span custom_payload_property,
     az_iot_provisioning_client_payload_options const* options,

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -477,14 +477,15 @@ az_iot_provisioning_client_payload_options_default();
  * @param[in] client The #az_iot_provisioning_client to use for this call.
  * @param[in] custom_payload_property __[nullable]__ Custom JSON to be added to this payload.
  * Can be `NULL`.
- * @param[in] options __[nullable]__ Reserved field for future options to this function.  Must be
- * `NULL`.
+ * @param[in] options __[nullable]__ A reference to an #az_iot_provisioning_client_payload_options
+ * structure. If `NULL` is passed, the function will use the default options. If using custom
+ * options, please initialize first by calling az_iot_provisioning_client_payload_options_default()
+ * and then populating relevant options with your own values.
  * @param[out] mqtt_payload A buffer with sufficient capacity to hold the MQTT payload.
  * @param[in] mqtt_payload_size The size, in bytes of \p mqtt_payload.
  * @param[out] out_mqtt_payload_length Contains the length, in bytes, written to \p mqtt_payload on
  * success.
  * @pre \p client must not be `NULL`.
- * @pre \p options must be `NULL`.
  * @pre \p mqtt_payload must not be `NULL`.
  * @pre \p mqtt_payload_size must be greater than 0.
  * @pre \p out_mqtt_payload_length must not be `NULL`.

--- a/sdk/samples/iot/CMakeLists.txt
+++ b/sdk/samples/iot/CMakeLists.txt
@@ -175,4 +175,16 @@ target_link_libraries(paho_iot_provisioning_sas_sample
 
 create_map_file(paho_iot_provisioning_sas_sample paho_iot_provisioning_sas_sample.map)
 
+# Provisioning CSR and TrustBundle Sample
+add_executable (paho_iot_provisioning_csr_trustbundle_sample
+  ${CMAKE_CURRENT_LIST_DIR}/paho_iot_provisioning_csr_trustbundle_sample.c
+)
+
+target_link_libraries(paho_iot_provisioning_csr_trustbundle_sample
+  PRIVATE
+    az::iot::sample::common
+)
+
+create_map_file(paho_iot_provisioning_csr_trustbundle_sample paho_iot_provisioning_csr_trustbundle_sample.map)
+
 endif() # TRANSPORT_PAHO

--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -347,7 +347,7 @@ Set the following environment variables if running any of these samples: `paho_i
     Access your Azure IoT Hub from either your Azure Portal or Azure IoT Explorer.
 
     - `AZ_IOT_HUB_DEVICE_ID`: From the IoT devices tab, select your device. Copy its Device Id.
-    - `AZ_IOT_HUB_HOSTNAME`: From the Overiview tab, copy your Azure IoT hub Hostname.
+    - `AZ_IOT_HUB_HOSTNAME`: From the Overview tab, copy your Azure IoT hub Hostname.
 
 2. Set the variables:
 
@@ -414,7 +414,7 @@ Set the following environment variables if running the sample:  `paho_iot_hub_sa
 
     - `AZ_IOT_HUB_SAS_DEVICE_ID`: From the IoT devices tab, select your device. Copy its Device Id.
     - `AZ_IOT_HUB_SAS_KEY`: From the same page, copy its Primary Key.
-    - `AZ_IOT_HUB_HOSTNAME`: From the Overiview tab, copy your Azure IoT hub Hostname.
+    - `AZ_IOT_HUB_HOSTNAME`: From the Overview tab, copy your Azure IoT hub Hostname.
 
 2. Set the variables:
 
@@ -652,7 +652,16 @@ This section provides an overview of the different samples available to run and 
 
   This [sample](https://github.com/Azure/azure-sdk-for-c/blob/main/sdk/samples/iot/paho_iot_provisioning_sas_sample.c) registers a device with the Azure IoT Device Provisioning Service. It will wait to receive the registration status before disconnecting. SAS authentication is used.
 
+### *Preview* IoT Provisioning CSR and TrustBundle Sample
+
+- *Executable:* `paho_iot_provisioning_csr_trustbundle_sample`
+
+  This sample registers a device with the Azure IoT Device Provisioning Service. X509 onboarding authentication (X509 in this case) is used to submit a *certificate signing request* (CSR) for an operational certificate. The sample shows usage for *custom allocation payload*, *Trust Bundle* and obtaining the *operational X509 client certificate*.
+
+  For more information see using_trustbundle.md and using_certificate_signing_requests.md.
+
 ## Using IoT Hub with an ECC Server Certificate Chain
+
 To work with the new Azure Cloud ECC server certificate chain, the TLS stack must be configured to prevent RSA cipher-suites from being advertised, as described [here](https://docs.microsoft.com/azure/iot-hub/iot-hub-tls-support#elliptic-curve-cryptography-ecc-server-tls-certificate-preview).
 
 When using Paho MQTT for C, modify the samples by adding the following TLS option:

--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -656,9 +656,9 @@ This section provides an overview of the different samples available to run and 
 
 - *Executable:* `paho_iot_provisioning_csr_trustbundle_sample`
 
-  This sample registers a device with the Azure IoT Device Provisioning Service. X509 onboarding authentication (X509 in this case) is used to submit a *certificate signing request* (CSR) for an operational certificate. The sample shows usage for *custom allocation payload*, *Trust Bundle* and obtaining the *operational X509 client certificate*.
+  This [sample](https://github.com/Azure/azure-sdk-for-c/blob/feature/iot-certificate-management/sdk/samples/iot/paho_iot_provisioning_csr_trustbundle_sample.c) registers a device with the Azure IoT Device Provisioning Service. X509 onboarding authentication (X509 in this case) is used to submit a *certificate signing request* (CSR) for an operational certificate. The sample shows usage for *custom allocation payload*, *Trust Bundle* and obtaining the *operational X509 client certificate*.
 
-  For more information see using_trustbundle.md and using_certificate_signing_requests.md.
+  For more information see [using_trustbundle.md](https://github.com/Azure/azure-sdk-for-c/blob/feature/iot-certificate-management/sdk/docs/iot/using_trustbundle.md) and [using_certificate_signing_requests.md](https://github.com/Azure/azure-sdk-for-c/blob/feature/iot-certificate-management/sdk/docs/iot/using_certificate_signing_requests.md).
 
 ## Using IoT Hub with an ECC Server Certificate Chain
 

--- a/sdk/samples/iot/iot_sample_common.h
+++ b/sdk/samples/iot/iot_sample_common.h
@@ -22,7 +22,7 @@
 #define IOT_SAMPLE_LOG_ERROR(...)                                                  \
   do                                                                               \
   {                                                                                \
-    (void)fprintf(stderr, "ERROR:\t\t%s:%s():%d: ", __FILE__, __func__, __LINE__); \
+    (void)fprintf(stderr, "ERROR:\t\t%s:%d %s(): ", __FILE__, __LINE__, __func__); \
     (void)fprintf(stderr, __VA_ARGS__);                                            \
     (void)fprintf(stderr, "\n");                                                   \
     fflush(stdout);                                                                \
@@ -115,6 +115,11 @@ bool get_az_span(az_span* out_span, char const* const error_message, ...);
 // This is usually not needed on Linux or Mac but needs to be set on Windows.
 #define IOT_SAMPLE_ENV_DEVICE_X509_TRUST_PEM_FILE_PATH "AZ_IOT_DEVICE_X509_TRUST_PEM_FILE_PATH"
 
+// The path to a PEM file containing the Certificate Signing Request (CSR) for the operational
+// certificate.
+#define IOT_SAMPLE_ENV_DEVICE_X509_OPERATIONAL_CSR_PEM_FILE_PATH \
+  "AZ_IOT_DEVICE_X509_OPERATIONAL_CSR_PEM_FILE_PATH"
+
 typedef struct
 {
   az_span hub_device_id;
@@ -126,6 +131,7 @@ typedef struct
   az_span x509_cert_pem_file_path;
   az_span x509_trust_pem_file_path;
   uint32_t sas_key_duration_minutes;
+  az_span x509_operational_csr_pem;
 } iot_sample_environment_variables;
 
 typedef enum
@@ -145,7 +151,8 @@ typedef enum
   PAHO_IOT_PNP_WITH_PROVISIONING_SAMPLE,
   PAHO_IOT_PNP_COMPONENT_SAMPLE,
   PAHO_IOT_PROVISIONING_SAMPLE,
-  PAHO_IOT_PROVISIONING_SAS_SAMPLE
+  PAHO_IOT_PROVISIONING_SAS_SAMPLE,
+  PAHO_IOT_PROVISIONING_CSR_SAMPLE
 } iot_sample_name;
 
 extern bool is_device_operational;

--- a/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
@@ -259,7 +259,7 @@ static void register_device_with_provisioning_service(void)
       sizeof(mqtt_payload),
       &mqtt_payload_length);
   AZ_POP_WARNINGS
-  
+
   if (az_result_failed(rc))
   {
     IOT_SAMPLE_LOG_ERROR(

--- a/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
@@ -250,6 +250,7 @@ static void register_device_with_provisioning_service(void)
   uint8_t mqtt_payload[MQTT_PAYLOAD_BUFFER_LENGTH];
   size_t mqtt_payload_length;
 
+  AZ_IGNORE_DEPRECATIONS
   rc = az_iot_provisioning_client_get_request_payload(
       &provisioning_client,
       custom_registration_payload_property,
@@ -257,6 +258,8 @@ static void register_device_with_provisioning_service(void)
       mqtt_payload,
       sizeof(mqtt_payload),
       &mqtt_payload_length);
+  AZ_POP_WARNINGS
+  
   if (az_result_failed(rc))
   {
     IOT_SAMPLE_LOG_ERROR(

--- a/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
@@ -250,7 +250,7 @@ static void register_device_with_provisioning_service(void)
   uint8_t mqtt_payload[MQTT_PAYLOAD_BUFFER_LENGTH];
   size_t mqtt_payload_length;
 
-  AZ_IGNORE_DEPRECATIONS
+  AZ_PUSH_IGNORE_DEPRECATIONS 
   rc = az_iot_provisioning_client_get_request_payload(
       &provisioning_client,
       custom_registration_payload_property,

--- a/sdk/samples/iot/paho_iot_provisioning_csr_trustbundle_sample.c
+++ b/sdk/samples/iot/paho_iot_provisioning_csr_trustbundle_sample.c
@@ -1,0 +1,584 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+// warning C4201: nonstandard extension used: nameless struct/union
+#pragma warning(disable : 4201)
+#endif
+#include <paho-mqtt/MQTTClient.h>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+#include <azure/az_core.h>
+#include <azure/az_iot.h>
+
+#include "iot_sample_common.h"
+
+#define SAMPLE_TYPE PAHO_IOT_PROVISIONING
+#define SAMPLE_NAME PAHO_IOT_PROVISIONING_CSR_SAMPLE
+
+#define MQTT_PAYLOAD_BUFFER_LENGTH 1024
+#define MQTT_TIMEOUT_RECEIVE_MS (60 * 1000)
+#define MQTT_TIMEOUT_DISCONNECT_MS (10 * 1000)
+
+static az_span custom_registration_json_payload
+    = AZ_SPAN_LITERAL_FROM_STR("{\"myKey\":\"myValue\"}");
+
+static iot_sample_environment_variables env_vars;
+static az_iot_provisioning_client provisioning_client;
+static MQTTClient mqtt_client;
+static char mqtt_client_username_buffer[128];
+
+// Functions
+static void create_and_configure_mqtt_client(void);
+static void connect_mqtt_client_to_provisioning_service(void);
+static void subscribe_mqtt_client_to_provisioning_service_topics(void);
+static void register_device_with_provisioning_service(void);
+static void receive_device_registration_status_message(void);
+static void disconnect_mqtt_client_from_provisioning_service(void);
+
+static void parse_device_registration_status_message(
+    char* topic,
+    int topic_len,
+    MQTTClient_message const* message,
+    az_iot_provisioning_client_register_response* out_register_response);
+static void send_operation_query_message(
+    az_iot_provisioning_client_register_response const* response);
+static void handle_device_registration_status_message(
+    az_iot_provisioning_client_register_response* register_response,
+    bool* ref_is_operation_complete);
+static void handle_trust_bundle(az_span trust_bundle);
+
+/*
+ * This sample registers a device with the Azure IoT Device Provisioning Service. It will wait to
+ * receive the registration status before disconnecting. X509 self-certification is used.
+ */
+int main(void)
+{
+  create_and_configure_mqtt_client();
+  IOT_SAMPLE_LOG_SUCCESS("Client created and configured.");
+
+  connect_mqtt_client_to_provisioning_service();
+  IOT_SAMPLE_LOG_SUCCESS("Client connected to provisioning service.");
+
+  subscribe_mqtt_client_to_provisioning_service_topics();
+  IOT_SAMPLE_LOG_SUCCESS("Client subscribed to provisioning service topics.");
+
+  register_device_with_provisioning_service();
+  IOT_SAMPLE_LOG_SUCCESS("Client registering with provisioning service.");
+
+  receive_device_registration_status_message();
+  IOT_SAMPLE_LOG_SUCCESS("Client received registration status message.");
+
+  disconnect_mqtt_client_from_provisioning_service();
+  IOT_SAMPLE_LOG_SUCCESS("Client disconnected from provisioning service.");
+
+  return 0;
+}
+
+static void create_and_configure_mqtt_client(void)
+{
+  int rc;
+
+  // Reads in environment variables set by user for purposes of running sample.
+  iot_sample_read_environment_variables(SAMPLE_TYPE, SAMPLE_NAME, &env_vars);
+
+  // Build an MQTT endpoint c-string.
+  char mqtt_endpoint_buffer[256];
+  iot_sample_create_mqtt_endpoint(
+      SAMPLE_TYPE, &env_vars, mqtt_endpoint_buffer, sizeof(mqtt_endpoint_buffer));
+
+  // Initialize the provisioning client with the provisioning global endpoint and the default
+  // connection options.
+  rc = az_iot_provisioning_client_init(
+      &provisioning_client,
+      az_span_create_from_str(mqtt_endpoint_buffer),
+      env_vars.provisioning_id_scope,
+      env_vars.provisioning_registration_id,
+      NULL);
+  if (az_result_failed(rc))
+  {
+    IOT_SAMPLE_LOG_ERROR(
+        "Failed to initialize provisioning client: az_result return code 0x%08x.", rc);
+    exit(rc);
+  }
+
+  // Get the MQTT client id used for the MQTT connection.
+  char mqtt_client_id_buffer[128];
+  rc = az_iot_provisioning_client_get_client_id(
+      &provisioning_client, mqtt_client_id_buffer, sizeof(mqtt_client_id_buffer), NULL);
+  if (az_result_failed(rc))
+  {
+    IOT_SAMPLE_LOG_ERROR("Failed to get MQTT client id: az_result return code 0x%08x.", rc);
+    exit(rc);
+  }
+
+  // Create the Paho MQTT client.
+  rc = MQTTClient_create(
+      &mqtt_client, mqtt_endpoint_buffer, mqtt_client_id_buffer, MQTTCLIENT_PERSISTENCE_NONE, NULL);
+  if (rc != MQTTCLIENT_SUCCESS)
+  {
+    IOT_SAMPLE_LOG_ERROR("Failed to create MQTT client: MQTTClient return code %d.", rc);
+    exit(rc);
+  }
+}
+
+static void connect_mqtt_client_to_provisioning_service(void)
+{
+  // Get the MQTT client username.
+  int rc = az_iot_provisioning_client_get_user_name(
+      &provisioning_client, mqtt_client_username_buffer, sizeof(mqtt_client_username_buffer), NULL);
+  if (az_result_failed(rc))
+  {
+    IOT_SAMPLE_LOG_ERROR("Failed to get MQTT client username: az_result return code 0x%08x.", rc);
+    exit(rc);
+  }
+
+  IOT_SAMPLE_LOG("MQTT client username: %s\n", mqtt_client_username_buffer);
+
+  // Set MQTT connection options.
+  MQTTClient_connectOptions mqtt_connect_options = MQTTClient_connectOptions_initializer;
+  mqtt_connect_options.username = mqtt_client_username_buffer;
+  mqtt_connect_options.password = NULL; // This sample uses x509 authentication.
+  mqtt_connect_options.cleansession = false; // Set to false so can receive any pending messages.
+  mqtt_connect_options.keepAliveInterval = AZ_IOT_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS;
+
+  MQTTClient_SSLOptions mqtt_ssl_options = MQTTClient_SSLOptions_initializer;
+  mqtt_ssl_options.verify = 1;
+  mqtt_ssl_options.enableServerCertAuth = 1;
+  mqtt_ssl_options.keyStore = (char*)az_span_ptr(env_vars.x509_cert_pem_file_path);
+  if (az_span_size(env_vars.x509_trust_pem_file_path) != 0) // Is only set if required by OS.
+  {
+    mqtt_ssl_options.trustStore = (char*)az_span_ptr(env_vars.x509_trust_pem_file_path);
+  }
+  mqtt_connect_options.ssl = &mqtt_ssl_options;
+
+  // Connect MQTT client to the Azure IoT Device Provisioning Service.
+  rc = MQTTClient_connect(mqtt_client, &mqtt_connect_options);
+  if (rc != MQTTCLIENT_SUCCESS)
+  {
+    IOT_SAMPLE_LOG_ERROR(
+        "Failed to connect: MQTTClient return code %d.\n"
+        "If on Windows, confirm the AZ_IOT_DEVICE_X509_TRUST_PEM_FILE_PATH environment variable is "
+        "set correctly.",
+        rc);
+    exit(rc);
+  }
+}
+
+static void subscribe_mqtt_client_to_provisioning_service_topics(void)
+{
+  // Messages received on the Register topic will be registration responses from the server.
+  int rc
+      = MQTTClient_subscribe(mqtt_client, AZ_IOT_PROVISIONING_CLIENT_REGISTER_SUBSCRIBE_TOPIC, 1);
+  if (rc != MQTTCLIENT_SUCCESS)
+  {
+    IOT_SAMPLE_LOG_ERROR(
+        "Failed to subscribe to the Register topic: MQTTClient return code %d.", rc);
+    exit(rc);
+  }
+}
+
+static void register_device_with_provisioning_service(void)
+{
+  int rc;
+
+  // Get the Register topic to publish the register request.
+  char register_topic_buffer[128];
+  rc = az_iot_provisioning_client_register_get_publish_topic(
+      &provisioning_client, register_topic_buffer, sizeof(register_topic_buffer), NULL);
+  if (az_result_failed(rc))
+  {
+    IOT_SAMPLE_LOG_ERROR("Failed to get the Register topic: az_result return code 0x%08x.", rc);
+    exit(rc);
+  }
+
+  uint8_t mqtt_payload[MQTT_PAYLOAD_BUFFER_LENGTH];
+  size_t mqtt_payload_length;
+
+  az_iot_provisioning_client_payload_options options
+      = az_iot_provisioning_client_payload_options_default();
+
+  options.certificate_signing_request = env_vars.x509_operational_csr_pem;
+
+  rc = az_iot_provisioning_client_register_get_request_payload(
+      &provisioning_client,
+      custom_registration_json_payload,
+      &options,
+      mqtt_payload,
+      sizeof(mqtt_payload),
+      &mqtt_payload_length);
+  if (az_result_failed(rc))
+  {
+    IOT_SAMPLE_LOG_ERROR(
+        "Failed to initialize provisioning client: az_result return code 0x%08x.", rc);
+    exit(rc);
+  }
+
+  // Set MQTT message options.
+  MQTTClient_message pubmsg = MQTTClient_message_initializer;
+  pubmsg.payload = mqtt_payload;
+  pubmsg.payloadlen = (int)mqtt_payload_length;
+  pubmsg.qos = 1;
+  pubmsg.retained = 0;
+
+  // Publish the register request.
+  rc = MQTTClient_publishMessage(mqtt_client, register_topic_buffer, &pubmsg, NULL);
+  if (rc != MQTTCLIENT_SUCCESS)
+  {
+    IOT_SAMPLE_LOG_ERROR("Failed to publish Register request: MQTTClient return code %d.", rc);
+    exit(rc);
+  }
+}
+
+static void receive_device_registration_status_message(void)
+{
+  char* topic = NULL;
+  int topic_len = 0;
+  MQTTClient_message* message = NULL;
+  bool is_operation_complete = false;
+
+  // Continue to parse incoming responses from the provisioning service until the device has been
+  // successfully provisioned or an error occurs.
+  do
+  {
+    IOT_SAMPLE_LOG(" "); // Formatting
+    IOT_SAMPLE_LOG("Waiting for registration status message.\n");
+
+    // MQTTCLIENT_SUCCESS or MQTTCLIENT_TOPICNAME_TRUNCATED if a message is received.
+    // MQTTCLIENT_SUCCESS can also indicate that the timeout expired, in which case message is NULL.
+    // MQTTCLIENT_TOPICNAME_TRUNCATED if the topic contains embedded NULL characters.
+    // An error code is returned if there was a problem trying to receive a message.
+    int rc = MQTTClient_receive(mqtt_client, &topic, &topic_len, &message, MQTT_TIMEOUT_RECEIVE_MS);
+    if ((rc != MQTTCLIENT_SUCCESS) && (rc != MQTTCLIENT_TOPICNAME_TRUNCATED))
+    {
+      IOT_SAMPLE_LOG_ERROR("Failed to receive message: MQTTClient return code %d.", rc);
+      exit(rc);
+    }
+    else if (message == NULL)
+    {
+      IOT_SAMPLE_LOG_ERROR("Receive message timeout expired: MQTTClient return code %d.", rc);
+      exit(rc);
+    }
+    else if (rc == MQTTCLIENT_TOPICNAME_TRUNCATED)
+    {
+      topic_len = (int)strlen(topic);
+    }
+    IOT_SAMPLE_LOG_SUCCESS("Client received a message from the provisioning service.");
+
+    // Parse registration status message.
+    az_iot_provisioning_client_register_response register_response;
+    parse_device_registration_status_message(topic, topic_len, message, &register_response);
+    IOT_SAMPLE_LOG_SUCCESS("Client parsed registration status message.");
+
+    handle_device_registration_status_message(&register_response, &is_operation_complete);
+
+    MQTTClient_freeMessage(&message);
+    MQTTClient_free(topic);
+
+  } while (!is_operation_complete); // Will loop to receive new operation message.
+}
+
+static void disconnect_mqtt_client_from_provisioning_service(void)
+{
+  int rc = MQTTClient_disconnect(mqtt_client, MQTT_TIMEOUT_DISCONNECT_MS);
+  if (rc != MQTTCLIENT_SUCCESS)
+  {
+    IOT_SAMPLE_LOG_ERROR("Failed to disconnect MQTT client: MQTTClient return code %d.", rc);
+    exit(rc);
+  }
+
+  MQTTClient_destroy(&mqtt_client);
+}
+
+static void parse_device_registration_status_message(
+    char* topic,
+    int topic_len,
+    MQTTClient_message const* message,
+    az_iot_provisioning_client_register_response* out_register_response)
+{
+  az_result rc;
+  az_span const topic_span = az_span_create((uint8_t*)topic, topic_len);
+  az_span const message_span = az_span_create((uint8_t*)message->payload, message->payloadlen);
+
+  // Parse message and retrieve register_response info.
+  rc = az_iot_provisioning_client_parse_received_topic_and_payload(
+      &provisioning_client, topic_span, message_span, out_register_response);
+  if (az_result_failed(rc))
+  {
+    IOT_SAMPLE_LOG_ERROR("Message from unknown topic: az_result return code 0x%08x.", rc);
+    IOT_SAMPLE_LOG_AZ_SPAN("Topic:", topic_span);
+    exit(rc);
+  }
+  IOT_SAMPLE_LOG_SUCCESS("Client received a valid topic response:");
+  IOT_SAMPLE_LOG_AZ_SPAN("Topic:", topic_span);
+  IOT_SAMPLE_LOG_AZ_SPAN("Payload:", message_span);
+  IOT_SAMPLE_LOG("Status: %d", out_register_response->status);
+}
+
+static void send_operation_query_message(
+    az_iot_provisioning_client_register_response const* register_response)
+{
+  int rc;
+
+  // Get the Query Status topic to publish the query status request.
+  char query_topic_buffer[256];
+  rc = az_iot_provisioning_client_query_status_get_publish_topic(
+      &provisioning_client,
+      register_response->operation_id,
+      query_topic_buffer,
+      sizeof(query_topic_buffer),
+      NULL);
+  if (az_result_failed(rc))
+  {
+    IOT_SAMPLE_LOG_ERROR(
+        "Unable to get query status publish topic: az_result return code 0x%08x.", rc);
+    exit(rc);
+  }
+
+  // IMPORTANT: Wait the recommended retry-after number of seconds before query.
+  IOT_SAMPLE_LOG("Querying after %u seconds...", register_response->retry_after_seconds);
+  iot_sample_sleep_for_seconds(register_response->retry_after_seconds);
+
+  // Publish the query status request.
+  rc = MQTTClient_publish(
+      mqtt_client, query_topic_buffer, 0, NULL, IOT_SAMPLE_MQTT_PUBLISH_QOS, 0, NULL);
+  if (rc != MQTTCLIENT_SUCCESS)
+  {
+    IOT_SAMPLE_LOG_ERROR("Failed to publish query status request: MQTTClient return code %d.", rc);
+    exit(rc);
+  }
+}
+
+static void handle_device_registration_status_message(
+    az_iot_provisioning_client_register_response* register_response,
+    bool* ref_is_operation_complete)
+{
+  *ref_is_operation_complete
+      = az_iot_provisioning_client_operation_complete(register_response->operation_status);
+
+  // If operation is not complete, send query. On return, will loop to receive new operation
+  // message.
+  if (!*ref_is_operation_complete)
+  {
+    IOT_SAMPLE_LOG("Operation is still pending.");
+
+    send_operation_query_message(register_response);
+    IOT_SAMPLE_LOG_SUCCESS("Client sent operation query message.");
+  }
+  else // Operation is complete.
+  {
+    if (register_response->operation_status
+        == AZ_IOT_PROVISIONING_STATUS_ASSIGNED) // Successful assignment
+    {
+      IOT_SAMPLE_LOG_SUCCESS("Device provisioned:");
+      IOT_SAMPLE_LOG_AZ_SPAN(
+          "Hub Hostname:", register_response->registration_state.assigned_hub_hostname);
+      IOT_SAMPLE_LOG_AZ_SPAN("Device Id:", register_response->registration_state.device_id);
+      IOT_SAMPLE_LOG(" "); // Formatting
+
+      if (az_span_size(register_response->registration_state.payload) > 0)
+      {
+        IOT_SAMPLE_LOG_SUCCESS("Payload received:");
+        IOT_SAMPLE_LOG_AZ_SPAN("\t", register_response->registration_state.payload);
+      }
+      else
+      {
+        IOT_SAMPLE_LOG_ERROR("Payload not received.");
+      }
+
+      if (az_span_size(register_response->registration_state.issued_client_certificate) > 0)
+      {
+        IOT_SAMPLE_LOG_SUCCESS(
+            "Issued Operational Certificate received (use to authenticate with IoT Hub):");
+        IOT_SAMPLE_LOG_AZ_SPAN(
+            "RAW PEM:", register_response->registration_state.issued_client_certificate);
+      }
+      else
+      {
+        IOT_SAMPLE_LOG_ERROR("Issued Operational Certificate not received.");
+      }
+
+      if (az_span_size(register_response->registration_state.trust_bundle) > 0)
+      {
+        IOT_SAMPLE_LOG_SUCCESS("Trust Bundle received:");
+        handle_trust_bundle(register_response->registration_state.trust_bundle);
+      }
+      else
+      {
+        IOT_SAMPLE_LOG_ERROR("Trust Bundle not received.");
+      }
+    }
+    else // Unsuccessful assignment (unassigned, failed or disabled states)
+    {
+      IOT_SAMPLE_LOG_ERROR("Device provisioning failed:");
+      IOT_SAMPLE_LOG("Registration state: %d", register_response->operation_status);
+      IOT_SAMPLE_LOG("Last operation status: %d", register_response->status);
+      IOT_SAMPLE_LOG_AZ_SPAN("Operation ID:", register_response->operation_id);
+      IOT_SAMPLE_LOG("Error code: %u", register_response->registration_state.extended_error_code);
+      IOT_SAMPLE_LOG_AZ_SPAN("Error message:", register_response->registration_state.error_message);
+      IOT_SAMPLE_LOG_AZ_SPAN(
+          "Error timestamp:", register_response->registration_state.error_timestamp);
+      IOT_SAMPLE_LOG_AZ_SPAN(
+          "Error tracking ID:", register_response->registration_state.error_tracking_id);
+      exit((int)register_response->registration_state.extended_error_code);
+    }
+  }
+}
+
+static void handle_trust_bundle(az_span trust_bundle)
+{
+  az_result ret;
+
+  az_json_reader jr;
+  ret = az_json_reader_init(&jr, trust_bundle, NULL);
+  if (az_result_failed(ret))
+  {
+    IOT_SAMPLE_LOG_ERROR("Failed to create JSON reader.");
+    return;
+  }
+
+  ret = az_json_reader_next_token(&jr);
+  if (az_result_failed(ret))
+  {
+    IOT_SAMPLE_LOG_ERROR("Failed to get next JSON Token.");
+    return;
+  }
+
+  if (jr.token.kind != AZ_JSON_TOKEN_BEGIN_OBJECT)
+  {
+    IOT_SAMPLE_LOG_ERROR("Unexpected JSON Token.");
+    return;
+  }
+
+  while (az_result_succeeded(az_json_reader_next_token(&jr)))
+  {
+    int32_t cert_idx = 0;
+
+    if (az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("certificate")))
+    {
+      ret = az_json_reader_next_token(&jr);
+      if (az_result_failed(ret))
+      {
+        IOT_SAMPLE_LOG_ERROR("Failed to get next JSON Token.");
+        return;
+      }
+
+      if (jr.token.kind != AZ_JSON_TOKEN_STRING)
+      {
+        IOT_SAMPLE_LOG_ERROR("Unexpected JSON Token.");
+        return;
+      }
+
+      cert_idx++;
+      IOT_SAMPLE_LOG("\t[%d] CA Certificate data:", cert_idx);
+
+      // Un-escape in-place. The original JSON buffer will be altered.
+      int32_t new_size = 0;
+      ret = az_json_token_get_string(
+          &jr.token, (char*)az_span_ptr(jr.token.slice), az_span_size(jr.token.slice), &new_size);
+      if (az_result_failed(ret))
+      {
+        IOT_SAMPLE_LOG_ERROR("Failed to unescape PEM certificate.");
+        return;
+      }
+
+      az_span pem = az_span_slice(jr.token.slice, 0, new_size);
+
+      IOT_SAMPLE_LOG_AZ_SPAN("RAW PEM:", pem);
+    }
+    else if (az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("subjectName")))
+    {
+      ret = az_json_reader_next_token(&jr);
+      if (az_result_failed(ret))
+      {
+        IOT_SAMPLE_LOG_ERROR("Failed to get next JSON Token.");
+        return;
+      }
+
+      if (jr.token.kind != AZ_JSON_TOKEN_STRING)
+      {
+        IOT_SAMPLE_LOG_ERROR("Unexpected JSON Token.");
+        return;
+      }
+
+      IOT_SAMPLE_LOG_AZ_SPAN("\tSubject:", jr.token.slice);
+    }
+    else if (az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("issuerName")))
+    {
+      ret = az_json_reader_next_token(&jr);
+      if (az_result_failed(ret))
+      {
+        IOT_SAMPLE_LOG_ERROR("Failed to get next JSON Token.");
+        return;
+      }
+
+      if (jr.token.kind != AZ_JSON_TOKEN_STRING)
+      {
+        IOT_SAMPLE_LOG_ERROR("Unexpected JSON Token.");
+        return;
+      }
+
+      IOT_SAMPLE_LOG_AZ_SPAN("\tIssuer:", jr.token.slice);
+    }
+    else if (az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("sha1Thumbprint")))
+    {
+      ret = az_json_reader_next_token(&jr);
+      if (az_result_failed(ret))
+      {
+        IOT_SAMPLE_LOG_ERROR("Failed to get next JSON Token.");
+        return;
+      }
+
+      if (jr.token.kind != AZ_JSON_TOKEN_STRING)
+      {
+        IOT_SAMPLE_LOG_ERROR("Unexpected JSON Token.");
+        return;
+      }
+
+      IOT_SAMPLE_LOG_AZ_SPAN("\tThumbprint:", jr.token.slice);
+    }
+    else if (az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("id")))
+    {
+      ret = az_json_reader_next_token(&jr);
+      if (az_result_failed(ret))
+      {
+        IOT_SAMPLE_LOG_ERROR("Failed to get next JSON Token.");
+        return;
+      }
+
+      if (jr.token.kind != AZ_JSON_TOKEN_STRING)
+      {
+        IOT_SAMPLE_LOG_ERROR("Unexpected JSON Token.");
+        return;
+      }
+
+      IOT_SAMPLE_LOG_AZ_SPAN("TrustBundle ID:", jr.token.slice);
+    }
+    else if (az_json_token_is_text_equal(&jr.token, AZ_SPAN_FROM_STR("etag")))
+    {
+      ret = az_json_reader_next_token(&jr);
+      if (az_result_failed(ret))
+      {
+        IOT_SAMPLE_LOG_ERROR("Failed to get next JSON Token.");
+        return;
+      }
+
+      if (jr.token.kind != AZ_JSON_TOKEN_STRING)
+      {
+        IOT_SAMPLE_LOG_ERROR("Unexpected JSON Token.");
+        return;
+      }
+
+      IOT_SAMPLE_LOG_AZ_SPAN("TrustBundle eTag:", jr.token.slice);
+    }
+  }
+}

--- a/sdk/src/azure/iot/az_iot_provisioning_client.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client.c
@@ -641,10 +641,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(
     size_t mqtt_payload_size,
     size_t* out_mqtt_payload_length)
 {
-  (void)options;
-
   _az_PRECONDITION_NOT_NULL(client);
-  _az_PRECONDITION_NOT_NULL(options);
   _az_PRECONDITION_NOT_NULL(mqtt_payload);
   _az_PRECONDITION(mqtt_payload_size > 0);
   _az_PRECONDITION_NOT_NULL(out_mqtt_payload_length);
@@ -665,7 +662,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(
     _az_RETURN_IF_FAILED(az_json_writer_append_json_text(&json_writer, custom_payload_property));
   }
 
-  if (az_span_size(options->certificate_signing_request) > 0)
+  if (options != NULL && az_span_size(options->certificate_signing_request) > 0)
   {
     _az_RETURN_IF_FAILED(az_json_writer_append_property_name(&json_writer, prov_csr_request_label));
     _az_RETURN_IF_FAILED(

--- a/sdk/tests/iot/provisioning/CMakeLists.txt
+++ b/sdk/tests/iot/provisioning/CMakeLists.txt
@@ -14,7 +14,7 @@ add_cmocka_test(az_iot_provisioning_test SOURCES
                 test_az_iot_provisioning_client.c
                 test_az_iot_provisioning_client_sas.c
                 test_az_iot_provisioning_client_parser.c
-                test_az_iot_proviosining_client_payload.c
+                test_az_iot_provisioning_client_register_get_request_payload.c
                 COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS} ${NO_CLOBBERED_WARNING}
                 LINK_LIBRARIES ${CMOCKA_LIBRARIES}
                     az_iot_common

--- a/sdk/tests/iot/provisioning/CMakeLists.txt
+++ b/sdk/tests/iot/provisioning/CMakeLists.txt
@@ -15,7 +15,9 @@ add_cmocka_test(az_iot_provisioning_test SOURCES
                 test_az_iot_provisioning_client_sas.c
                 test_az_iot_provisioning_client_parser.c
                 test_az_iot_provisioning_client_register_get_request_payload.c
-                COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS} ${NO_CLOBBERED_WARNING}
+                COMPILE_OPTIONS 
+                    ${DEFAULT_C_COMPILE_FLAGS} 
+                    ${NO_CLOBBERED_WARNING} 
                 LINK_LIBRARIES ${CMOCKA_LIBRARIES}
                     az_iot_common
                     az_iot_provisioning

--- a/sdk/tests/iot/provisioning/main.c
+++ b/sdk/tests/iot/provisioning/main.c
@@ -18,7 +18,7 @@ int main()
   result += test_az_iot_provisioning_client();
   result += test_az_iot_provisioning_client_sas_token();
   result += test_az_iot_provisioning_client_parser();
-  result += test_az_iot_provisioning_client_payload();
+  result += test_az_iot_provisioning_client_register_get_request_payload();
 
   return result;
 }

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client.h
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client.h
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-// Placeholder for int test_iot_provisioning_(); declarations
-
 int test_az_iot_provisioning_client();
 int test_az_iot_provisioning_client_sas_token();
 int test_az_iot_provisioning_client_parser();
-int test_az_iot_provisioning_client_payload();
+int test_az_iot_provisioning_client_register_get_request_payload();

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
@@ -22,6 +22,50 @@
 #define TEST_HUB_HOSTNAME "contoso.azure-devices.net"
 #define TEST_DEVICE_ID "my-device-id1"
 #define TEST_OPERATION_ID "4.d0a671905ea5b2c8.42d78160-4c78-479e-8be7-61d5e55dac0d"
+#define TEST_EMPTY_JSON "{}"
+
+#define TEST_JSON_PAYLOAD                             \
+  "{\"hello\":\"world\",\"o1\":{\"v1\":123, \"o2\": " \
+  "{\"v2\":321}}, \"arr\":[1,2,3,4,5,6],\"num\":123}"
+
+#define TEST_JSON_TRUSTBUNDLE_ESCAPED                                                              \
+  "{"                                                                                              \
+  "    \"certificates\": ["                                                                        \
+  "        {"                                                                                      \
+  "            \"certificate\": \"-----BEGIN "                                                     \
+  "CERTIFICATE-----"                                                                               \
+  "\\r\\nMIIB6zCCAZKgAwIBAgIIZiChmKQYrUUwCgYIKoZIzj0EAwIwcDEyMDAGA1UEAwwpcm9vdC02YTQ2\\r\\nOWMxYS" \
+  "04MzlmLTQ2NjgtOGU4Yy04NjhlOGI0MGRkNGMxETAPBgNVBAsMCG1hcm9oZXJhMRcwFQYD\\r\\nVQQKDA5tYXJvaGVyYW" \
+  "xvYW5lcjEOMAwGA1UEBhMFMTYxNDgwHhcNMjEwOTA1MDcxOTQ4WhcNMjEw\\r\\nOTExMDcxOTQ4WjBwMTIwMAYDVQQDDC" \
+  "lyb290LTZhNDY5YzFhLTgzOWYtNDY2OC04ZThjLTg2OGU4\\r\\nYjQwZGQ0YzERMA8GA1UECwwIbWFyb2hlcmExFzAVBg" \
+  "NVBAoMDm1hcm9oZXJhbG9hbmVyMQ4wDAYD\\r\\nVQQGEwUxNjE0ODBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABOPnvx" \
+  "g7TfTGkfIDyJZgdkAWrhZ4\\r\\nkNCzZoBdujF9BdIe9yQKrM3sskfKBMJTAp0Mx7Hr6PM4qU0UNxispFW6uRyjFjAUMB" \
+  "IGA1UdEwEB\\r\\n/"                                                                              \
+  "wQIMAYBAf8CAQEwCgYIKoZIzj0EAwIDRwAwRAIgFlF0vGuAIWOVEhZ0jYmA4IO0agbFbq1KOTfN\\r\\nq4AVzwgCIAgxA" \
+  "psBGYwslDboPToMR8zTkG8mTdd3I/MNf8qQBKfm\\r\\n-----END CERTIFICATE-----\\r\\n\","                \
+  "            \"metadata\": {"                                                                    \
+  "                \"subjectName\": \"CN=root-6a469c1a-839f-4668-8e8c-868e8b40dd4c, OU=test, "     \
+  "O=testloaner, C=16148\","                                                                       \
+  "                \"sha1Thumbprint\": \"5C57EB7EED8E278B1EAE278AAE1C6083EC2861B0\","              \
+  "                \"sha256Thumbprint\": "                                                         \
+  "\"1EA3870D991E432B5895FD9C8845D859AFDA933569B7FA5855050CC1C2DFD1E5\","                          \
+  "                \"issuerName\": \"CN=root-6a469c1a-839f-4668-8e8c-868e8b40dd4c, OU=test, "      \
+  "O=testloaner, C=16148\","                                                                       \
+  "                \"notBeforeUtc\": \"2019-08-24T14:15:22Z\","                                    \
+  "                \"notAfterUtc\": \"2019-08-24T14:15:22Z\","                                     \
+  "                \"serialNumber\": \"6620A198A418AD45\","                                        \
+  "                \"version\": 3"                                                                 \
+  "            }"                                                                                  \
+  "        }"                                                                                      \
+  "    ],"                                                                                         \
+  "    \"id\": \"TestTrustBundle-4e697b1f-1b59-4587-bdc7-e8645eef0a13\","                          \
+  "    \"createdDateTime\": \"2019-08-24T14:15:22Z\","                                             \
+  "    \"lastModifiedDateTime\": \"2019-08-24T14:15:22Z\","                                        \
+  "     \"etag\": \"\\\"5301e830-0000-0300-0000-613864190000\\\"\""                                \
+  "}"
+
+#define TEST_ISSUED_CERTIFICATE_ESCAPED "--BEGIN_CERT 12345\\r\\n END_CERT--"
+#define TEST_ISSUED_CERTIFICATE_UNESCAPED "--BEGIN_CERT 12345\r\n END_CERT--"
 
 static const az_span test_global_device_hostname
     = AZ_SPAN_LITERAL_FROM_STR("global.azure-devices-provisioning.net");
@@ -144,8 +188,7 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_assigned_state_
                          "\"status\":\"" TEST_STATUS_ASSIGNED "\","
                          "\"substatus\":\"initialAssignment\","
                          "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
-                         "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
-                         "\"payload\":{\"hello\":\"world\",\"arr\":[1,2,3,4,5,6],\"num\":123}}}");
+                         "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\"}}");
 
   az_iot_provisioning_client_register_response response;
   ret = az_iot_provisioning_client_parse_received_topic_and_payload(
@@ -166,6 +209,10 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_assigned_state_
       strlen(TEST_HUB_HOSTNAME));
   assert_memory_equal(
       az_span_ptr(response.registration_state.device_id), TEST_DEVICE_ID, strlen(TEST_DEVICE_ID));
+
+  assert_int_equal(0, az_span_size(response.registration_state.payload));
+  assert_int_equal(0, az_span_size(response.registration_state.trust_bundle));
+  assert_int_equal(0, az_span_size(response.registration_state.issued_client_certificate));
 
   assert_int_equal(0, response.registration_state.error_code);
   assert_int_equal(0, response.registration_state.extended_error_code);
@@ -219,7 +266,8 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_invalid_certifi
       strlen(TEST_ERROR_TRACKING_ID));
 }
 
-static void test_az_iot_provisioning_client_parse_received_topic_payload_disabled_state_succeed()
+static void
+test_az_iot_provisioning_client_parse_received_topic_and_payload_disabled_state_succeed()
 {
   az_iot_provisioning_client client = { 0 };
   az_result ret = az_iot_provisioning_client_init(
@@ -444,8 +492,7 @@ static void test_az_iot_provisioning_client_received_topic_and_payload_parse_hub
                          "\"status\":\"" TEST_STATUS_ASSIGNED "\","
                          "\"substatus\":\"initialAssignment\","
                          "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
-                         "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
-                         "\"payload\":{\"hello\":\"world\",\"arr\":[1,2,3,4,5,6],\"num\":123}}}");
+                         "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\"}}");
 
   az_iot_provisioning_client_register_response response;
   ret = az_iot_provisioning_client_parse_received_topic_and_payload(
@@ -472,8 +519,7 @@ test_az_iot_provisioning_client_received_topic_and_payload_parse_device_not_foun
                          "\"status\":\"" TEST_STATUS_ASSIGNED "\","
                          "\"substatus\":\"initialAssignment\","
                          "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
-                         "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
-                         "\"payload\":{\"hello\":\"world\",\"arr\":[1,2,3,4,5,6],\"num\":123}}}");
+                         "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\"}}");
 
   az_iot_provisioning_client_register_response response;
   ret = az_iot_provisioning_client_parse_received_topic_and_payload(
@@ -640,6 +686,374 @@ static void test_az_iot_provisioning_client_no_logging_succeed()
   az_log_set_classification_filter_callback(NULL);
 }
 
+static void
+test_az_iot_provisioning_client_parse_received_topic_and_payload_json_custom_payload_succeed()
+{
+  az_iot_provisioning_client client = { 0 };
+  az_result ret = az_iot_provisioning_client_init(
+      &client, test_global_device_hostname, test_id_scope, test_registration_id, NULL);
+  assert_int_equal(AZ_OK, ret);
+
+  az_span received_topic = AZ_SPAN_FROM_STR("$dps/registrations/res/200/?$rid=1");
+  char received_payload[] = "{\"operationId\":\"" TEST_OPERATION_ID
+                            "\",\"status\":\"" TEST_STATUS_ASSIGNED "\",\"registrationState\":{"
+                            "\"x509\":{},"
+                            "\"registrationId\":\"" TEST_REGISTRATION_ID "\","
+                            "\"createdDateTimeUtc\":\"2020-04-10T03:11:13.0276997Z\","
+                            "\"assignedHub\":\"" TEST_HUB_HOSTNAME "\","
+                            "\"deviceId\":\"" TEST_DEVICE_ID "\","
+                            "\"status\":\"" TEST_STATUS_ASSIGNED "\","
+                            "\"substatus\":\"initialAssignment\","
+                            "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
+                            "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
+                            "\"payload\":" TEST_JSON_PAYLOAD "}}";
+
+  az_span received_payload_span = az_span_create_from_str(received_payload);
+
+  az_iot_provisioning_client_register_response response;
+  ret = az_iot_provisioning_client_parse_received_topic_and_payload(
+      &client, received_topic, received_payload_span, &response);
+  assert_int_equal(AZ_OK, ret);
+
+  // From topic
+  assert_int_equal(AZ_IOT_STATUS_OK, response.status); // 200
+  assert_int_equal(0, response.retry_after_seconds);
+
+  // From payload
+  assert_memory_equal(
+      az_span_ptr(response.operation_id), TEST_OPERATION_ID, strlen(TEST_OPERATION_ID));
+  assert_int_equal(AZ_IOT_PROVISIONING_STATUS_ASSIGNED, response.operation_status);
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.assigned_hub_hostname),
+      TEST_HUB_HOSTNAME,
+      strlen(TEST_HUB_HOSTNAME));
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.device_id), TEST_DEVICE_ID, strlen(TEST_DEVICE_ID));
+
+  assert_int_equal(strlen(TEST_JSON_PAYLOAD), az_span_size(response.registration_state.payload));
+
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.payload),
+      TEST_JSON_PAYLOAD,
+      strlen(TEST_JSON_PAYLOAD));
+
+  assert_int_equal(0, az_span_size(response.registration_state.trust_bundle));
+  assert_int_equal(0, az_span_size(response.registration_state.issued_client_certificate));
+
+  assert_int_equal(0, response.registration_state.error_code);
+  assert_int_equal(0, response.registration_state.extended_error_code);
+  assert_int_equal(0, az_span_size(response.registration_state.error_message));
+}
+
+static void
+test_az_iot_provisioning_client_parse_received_topic_and_payload_json_custom_payload_empty_succeed()
+{
+  az_iot_provisioning_client client = { 0 };
+  az_result ret = az_iot_provisioning_client_init(
+      &client, test_global_device_hostname, test_id_scope, test_registration_id, NULL);
+  assert_int_equal(AZ_OK, ret);
+
+  az_span received_topic = AZ_SPAN_FROM_STR("$dps/registrations/res/200/?$rid=1");
+  char received_payload[] = "{\"operationId\":\"" TEST_OPERATION_ID
+                            "\",\"status\":\"" TEST_STATUS_ASSIGNED "\",\"registrationState\":{"
+                            "\"x509\":{},"
+                            "\"registrationId\":\"" TEST_REGISTRATION_ID "\","
+                            "\"createdDateTimeUtc\":\"2020-04-10T03:11:13.0276997Z\","
+                            "\"assignedHub\":\"" TEST_HUB_HOSTNAME "\","
+                            "\"deviceId\":\"" TEST_DEVICE_ID "\","
+                            "\"status\":\"" TEST_STATUS_ASSIGNED "\","
+                            "\"substatus\":\"initialAssignment\","
+                            "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
+                            "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
+                            "\"payload\":" TEST_EMPTY_JSON "}}";
+
+  az_span received_payload_span = az_span_create_from_str(received_payload);
+
+  az_iot_provisioning_client_register_response response;
+  ret = az_iot_provisioning_client_parse_received_topic_and_payload(
+      &client, received_topic, received_payload_span, &response);
+  assert_int_equal(AZ_OK, ret);
+
+  // From topic
+  assert_int_equal(AZ_IOT_STATUS_OK, response.status); // 200
+  assert_int_equal(0, response.retry_after_seconds);
+
+  // From payload
+  assert_memory_equal(
+      az_span_ptr(response.operation_id), TEST_OPERATION_ID, strlen(TEST_OPERATION_ID));
+  assert_int_equal(AZ_IOT_PROVISIONING_STATUS_ASSIGNED, response.operation_status);
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.assigned_hub_hostname),
+      TEST_HUB_HOSTNAME,
+      strlen(TEST_HUB_HOSTNAME));
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.device_id), TEST_DEVICE_ID, strlen(TEST_DEVICE_ID));
+
+  assert_int_equal(strlen(TEST_EMPTY_JSON), az_span_size(response.registration_state.payload));
+
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.payload), TEST_EMPTY_JSON, strlen(TEST_EMPTY_JSON));
+
+  assert_int_equal(0, az_span_size(response.registration_state.trust_bundle));
+  assert_int_equal(0, az_span_size(response.registration_state.issued_client_certificate));
+
+  assert_int_equal(0, response.registration_state.error_code);
+  assert_int_equal(0, response.registration_state.extended_error_code);
+  assert_int_equal(0, az_span_size(response.registration_state.error_message));
+}
+
+static void
+test_az_iot_provisioning_client_parse_received_topic_and_payload_json_custom_payload_null_succeed()
+{
+  az_iot_provisioning_client client = { 0 };
+  az_result ret = az_iot_provisioning_client_init(
+      &client, test_global_device_hostname, test_id_scope, test_registration_id, NULL);
+  assert_int_equal(AZ_OK, ret);
+
+  az_span received_topic = AZ_SPAN_FROM_STR("$dps/registrations/res/200/?$rid=1");
+  char received_payload[] = "{\"operationId\":\"" TEST_OPERATION_ID
+                            "\",\"status\":\"" TEST_STATUS_ASSIGNED "\",\"registrationState\":{"
+                            "\"x509\":{},"
+                            "\"registrationId\":\"" TEST_REGISTRATION_ID "\","
+                            "\"createdDateTimeUtc\":\"2020-04-10T03:11:13.0276997Z\","
+                            "\"assignedHub\":\"" TEST_HUB_HOSTNAME "\","
+                            "\"deviceId\":\"" TEST_DEVICE_ID "\","
+                            "\"status\":\"" TEST_STATUS_ASSIGNED "\","
+                            "\"substatus\":\"initialAssignment\","
+                            "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
+                            "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
+                            "\"payload\": null }}";
+
+  az_span received_payload_span = az_span_create_from_str(received_payload);
+
+  az_iot_provisioning_client_register_response response;
+  ret = az_iot_provisioning_client_parse_received_topic_and_payload(
+      &client, received_topic, received_payload_span, &response);
+  assert_int_equal(AZ_OK, ret);
+
+  // From topic
+  assert_int_equal(AZ_IOT_STATUS_OK, response.status); // 200
+  assert_int_equal(0, response.retry_after_seconds);
+
+  // From payload
+  assert_memory_equal(
+      az_span_ptr(response.operation_id), TEST_OPERATION_ID, strlen(TEST_OPERATION_ID));
+  assert_int_equal(AZ_IOT_PROVISIONING_STATUS_ASSIGNED, response.operation_status);
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.assigned_hub_hostname),
+      TEST_HUB_HOSTNAME,
+      strlen(TEST_HUB_HOSTNAME));
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.device_id), TEST_DEVICE_ID, strlen(TEST_DEVICE_ID));
+
+  assert_int_equal(0, az_span_size(response.registration_state.payload));
+
+  assert_int_equal(0, az_span_size(response.registration_state.trust_bundle));
+  assert_int_equal(0, az_span_size(response.registration_state.issued_client_certificate));
+
+  assert_int_equal(0, response.registration_state.error_code);
+  assert_int_equal(0, response.registration_state.extended_error_code);
+  assert_int_equal(0, az_span_size(response.registration_state.error_message));
+}
+
+static void
+test_az_iot_provisioning_client_parse_received_topic_and_payload_json_trust_bundle_succeed()
+{
+  az_iot_provisioning_client client = { 0 };
+  az_result ret = az_iot_provisioning_client_init(
+      &client, test_global_device_hostname, test_id_scope, test_registration_id, NULL);
+  assert_int_equal(AZ_OK, ret);
+
+  az_span received_topic = AZ_SPAN_FROM_STR("$dps/registrations/res/200/?$rid=1");
+  char received_payload[] = "{\"operationId\":\"" TEST_OPERATION_ID
+                            "\",\"status\":\"" TEST_STATUS_ASSIGNED "\",\"registrationState\":{"
+                            "\"x509\":{},"
+                            "\"registrationId\":\"" TEST_REGISTRATION_ID "\","
+                            "\"createdDateTimeUtc\":\"2020-04-10T03:11:13.0276997Z\","
+                            "\"assignedHub\":\"" TEST_HUB_HOSTNAME "\","
+                            "\"deviceId\":\"" TEST_DEVICE_ID "\","
+                            "\"status\":\"" TEST_STATUS_ASSIGNED "\","
+                            "\"substatus\":\"initialAssignment\","
+                            "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
+                            "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
+                            "\"trustBundle\":" TEST_JSON_TRUSTBUNDLE_ESCAPED "}}";
+
+  az_span received_payload_span = az_span_create_from_str(received_payload);
+
+  az_iot_provisioning_client_register_response response;
+  ret = az_iot_provisioning_client_parse_received_topic_and_payload(
+      &client, received_topic, received_payload_span, &response);
+  assert_int_equal(AZ_OK, ret);
+
+  // From topic
+  assert_int_equal(AZ_IOT_STATUS_OK, response.status); // 200
+  assert_int_equal(0, response.retry_after_seconds);
+
+  // From payload
+  assert_memory_equal(
+      az_span_ptr(response.operation_id), TEST_OPERATION_ID, strlen(TEST_OPERATION_ID));
+  assert_int_equal(AZ_IOT_PROVISIONING_STATUS_ASSIGNED, response.operation_status);
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.assigned_hub_hostname),
+      TEST_HUB_HOSTNAME,
+      strlen(TEST_HUB_HOSTNAME));
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.device_id), TEST_DEVICE_ID, strlen(TEST_DEVICE_ID));
+
+  assert_int_equal(0, az_span_size(response.registration_state.payload));
+
+  assert_int_equal(
+      strlen(TEST_JSON_TRUSTBUNDLE_ESCAPED),
+      az_span_size(response.registration_state.trust_bundle));
+
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.trust_bundle),
+      TEST_JSON_TRUSTBUNDLE_ESCAPED,
+      strlen(TEST_JSON_TRUSTBUNDLE_ESCAPED));
+
+  assert_int_equal(0, az_span_size(response.registration_state.issued_client_certificate));
+
+  assert_int_equal(0, response.registration_state.error_code);
+  assert_int_equal(0, response.registration_state.extended_error_code);
+  assert_int_equal(0, az_span_size(response.registration_state.error_message));
+}
+
+static void test_az_iot_provisioning_client_parse_received_topic_and_payload_json_csr_succeed()
+{
+  az_iot_provisioning_client client = { 0 };
+  az_result ret = az_iot_provisioning_client_init(
+      &client, test_global_device_hostname, test_id_scope, test_registration_id, NULL);
+  assert_int_equal(AZ_OK, ret);
+
+  az_span received_topic = AZ_SPAN_FROM_STR("$dps/registrations/res/200/?$rid=1");
+  char received_payload[] = "{\"operationId\":\"" TEST_OPERATION_ID
+                            "\",\"status\":\"" TEST_STATUS_ASSIGNED "\",\"registrationState\":{"
+                            "\"x509\":{},"
+                            "\"registrationId\":\"" TEST_REGISTRATION_ID "\","
+                            "\"createdDateTimeUtc\":\"2020-04-10T03:11:13.0276997Z\","
+                            "\"assignedHub\":\"" TEST_HUB_HOSTNAME "\","
+                            "\"deviceId\":\"" TEST_DEVICE_ID "\","
+                            "\"status\":\"" TEST_STATUS_ASSIGNED "\","
+                            "\"substatus\":\"initialAssignment\","
+                            "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
+                            "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
+                            "\"issuedClientCertificate\":\"" TEST_ISSUED_CERTIFICATE_ESCAPED "\"}}";
+
+  az_span received_payload_span = az_span_create_from_str(received_payload);
+
+  az_iot_provisioning_client_register_response response;
+  ret = az_iot_provisioning_client_parse_received_topic_and_payload(
+      &client, received_topic, received_payload_span, &response);
+  assert_int_equal(AZ_OK, ret);
+
+  // From topic
+  assert_int_equal(AZ_IOT_STATUS_OK, response.status); // 200
+  assert_int_equal(0, response.retry_after_seconds);
+
+  // From payload
+  assert_memory_equal(
+      az_span_ptr(response.operation_id), TEST_OPERATION_ID, strlen(TEST_OPERATION_ID));
+  assert_int_equal(AZ_IOT_PROVISIONING_STATUS_ASSIGNED, response.operation_status);
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.assigned_hub_hostname),
+      TEST_HUB_HOSTNAME,
+      strlen(TEST_HUB_HOSTNAME));
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.device_id), TEST_DEVICE_ID, strlen(TEST_DEVICE_ID));
+
+  assert_int_equal(0, az_span_size(response.registration_state.payload));
+  assert_int_equal(0, az_span_size(response.registration_state.trust_bundle));
+
+  assert_int_equal(
+      strlen(TEST_ISSUED_CERTIFICATE_UNESCAPED),
+      az_span_size(response.registration_state.issued_client_certificate));
+
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.issued_client_certificate),
+      TEST_ISSUED_CERTIFICATE_UNESCAPED,
+      strlen(TEST_ISSUED_CERTIFICATE_UNESCAPED));
+
+  assert_int_equal(0, response.registration_state.error_code);
+  assert_int_equal(0, response.registration_state.extended_error_code);
+  assert_int_equal(0, az_span_size(response.registration_state.error_message));
+}
+
+static void
+test_az_iot_provisioning_client_parse_received_topic_and_payload_json_all_options_succeed()
+{
+  az_iot_provisioning_client client = { 0 };
+  az_result ret = az_iot_provisioning_client_init(
+      &client, test_global_device_hostname, test_id_scope, test_registration_id, NULL);
+  assert_int_equal(AZ_OK, ret);
+
+  az_span received_topic = AZ_SPAN_FROM_STR("$dps/registrations/res/200/?$rid=1");
+  char received_payload[] = "{\"operationId\":\"" TEST_OPERATION_ID
+                            "\",\"status\":\"" TEST_STATUS_ASSIGNED "\",\"registrationState\":{"
+                            "\"x509\":{},"
+                            "\"registrationId\":\"" TEST_REGISTRATION_ID "\","
+                            "\"createdDateTimeUtc\":\"2020-04-10T03:11:13.0276997Z\","
+                            "\"assignedHub\":\"" TEST_HUB_HOSTNAME "\","
+                            "\"deviceId\":\"" TEST_DEVICE_ID "\","
+                            "\"status\":\"" TEST_STATUS_ASSIGNED "\","
+                            "\"substatus\":\"initialAssignment\","
+                            "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
+                            "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
+                            "\"payload\":" TEST_JSON_PAYLOAD ",        "
+                            "\"trustBundle\":" TEST_JSON_TRUSTBUNDLE_ESCAPED ","
+                            "\"issuedClientCertificate\":\"" TEST_ISSUED_CERTIFICATE_ESCAPED "\"}}";
+
+  az_span received_payload_span = az_span_create_from_str(received_payload);
+
+  az_iot_provisioning_client_register_response response;
+  ret = az_iot_provisioning_client_parse_received_topic_and_payload(
+      &client, received_topic, received_payload_span, &response);
+  assert_int_equal(AZ_OK, ret);
+
+  // From topic
+  assert_int_equal(AZ_IOT_STATUS_OK, response.status); // 200
+  assert_int_equal(0, response.retry_after_seconds);
+
+  // From payload
+  assert_memory_equal(
+      az_span_ptr(response.operation_id), TEST_OPERATION_ID, strlen(TEST_OPERATION_ID));
+  assert_int_equal(AZ_IOT_PROVISIONING_STATUS_ASSIGNED, response.operation_status);
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.assigned_hub_hostname),
+      TEST_HUB_HOSTNAME,
+      strlen(TEST_HUB_HOSTNAME));
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.device_id), TEST_DEVICE_ID, strlen(TEST_DEVICE_ID));
+
+  assert_int_equal(strlen(TEST_JSON_PAYLOAD), az_span_size(response.registration_state.payload));
+
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.payload),
+      TEST_JSON_PAYLOAD,
+      strlen(TEST_JSON_PAYLOAD));
+
+  assert_int_equal(
+      strlen(TEST_JSON_TRUSTBUNDLE_ESCAPED),
+      az_span_size(response.registration_state.trust_bundle));
+
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.trust_bundle),
+      TEST_JSON_TRUSTBUNDLE_ESCAPED,
+      strlen(TEST_JSON_TRUSTBUNDLE_ESCAPED));
+
+  assert_int_equal(
+      strlen(TEST_ISSUED_CERTIFICATE_UNESCAPED),
+      az_span_size(response.registration_state.issued_client_certificate));
+
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.issued_client_certificate),
+      TEST_ISSUED_CERTIFICATE_UNESCAPED,
+      strlen(TEST_ISSUED_CERTIFICATE_UNESCAPED));
+
+  assert_int_equal(0, response.registration_state.error_code);
+  assert_int_equal(0, response.registration_state.extended_error_code);
+  assert_int_equal(0, az_span_size(response.registration_state.error_message));
+}
+
 #ifdef _MSC_VER
 // warning C4113: 'void (__cdecl *)()' differs in parameter lists from 'CMUnitTestFunction'
 #pragma warning(disable : 4113)
@@ -659,7 +1073,7 @@ int test_az_iot_provisioning_client_parser()
     cmocka_unit_test(
         test_az_iot_provisioning_client_parse_received_topic_and_payload_invalid_certificate_error_succeed),
     cmocka_unit_test(
-        test_az_iot_provisioning_client_parse_received_topic_payload_disabled_state_succeed),
+        test_az_iot_provisioning_client_parse_received_topic_and_payload_disabled_state_succeed),
     cmocka_unit_test(
         test_az_iot_provisioning_client_parse_received_topic_and_payload_allocation_error_state_succeed),
     cmocka_unit_test(
@@ -682,6 +1096,18 @@ int test_az_iot_provisioning_client_parser()
     cmocka_unit_test(test_az_iot_provisioning_client_operation_complete_translate_succeed),
     cmocka_unit_test(test_az_iot_provisioning_client_logging_succeed),
     cmocka_unit_test(test_az_iot_provisioning_client_no_logging_succeed),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_parse_received_topic_and_payload_json_custom_payload_succeed),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_parse_received_topic_and_payload_json_custom_payload_empty_succeed),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_parse_received_topic_and_payload_json_custom_payload_null_succeed),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_parse_received_topic_and_payload_json_trust_bundle_succeed),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_parse_received_topic_and_payload_json_csr_succeed),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_parse_received_topic_and_payload_json_all_options_succeed),
   };
 
   return cmocka_run_group_tests_name("az_iot_provisioning_client_parser", tests, NULL, NULL);

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
@@ -155,27 +155,9 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_payload_len
   AZ_POP_WARNINGS
 }
 
-static void test_az_iot_provisioning_client_register_get_request_payload_NULL_options_fails()
-{
-  az_iot_provisioning_client client;
-  az_result ret = az_iot_provisioning_client_init(
-      &client,
-      test_global_device_hostname,
-      AZ_SPAN_FROM_STR(TEST_ID_SCOPE),
-      AZ_SPAN_FROM_STR(TEST_REGISTRATION_ID),
-      NULL);
-  assert_int_equal(AZ_OK, ret);
-
-  uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
-  size_t payload_len;
-
-  ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_register_get_request_payload(
-      &client, AZ_SPAN_EMPTY, NULL, payload, 1, &payload_len));
-}
-
 #endif // AZ_NO_PRECONDITION_CHECKING
 
-static void test_az_iot_provisioning_client_get_request_payload_no_custom_payload()
+static void test_az_iot_provisioning_client_get_request_payload_no_custom_payload_succeed()
 {
   az_iot_provisioning_client client = { 0 };
   az_result ret = az_iot_provisioning_client_init(
@@ -203,7 +185,7 @@ static void test_az_iot_provisioning_client_get_request_payload_no_custom_payloa
   assert_int_equal((uint8_t)0xCC, payload[expected_payload_len]);
 }
 
-static void test_az_iot_provisioning_client_get_request_payload_custom_payload()
+static void test_az_iot_provisioning_client_get_request_payload_custom_payload_succeed()
 {
   az_iot_provisioning_client client = { 0 };
   az_result ret = az_iot_provisioning_client_init(
@@ -232,7 +214,7 @@ static void test_az_iot_provisioning_client_get_request_payload_custom_payload()
   AZ_POP_WARNINGS
 }
 
-static void test_az_iot_provisioning_client_register_get_request_payload_with_csr()
+static void test_az_iot_provisioning_client_register_get_request_payload_with_csr_succeed()
 {
   az_iot_provisioning_client client = { 0 };
   az_result ret = az_iot_provisioning_client_init(
@@ -267,6 +249,34 @@ static void test_az_iot_provisioning_client_register_get_request_payload_with_cs
   assert_int_equal((uint8_t)0xCC, payload[expected_payload_len]);
 }
 
+static void test_az_iot_provisioning_client_register_get_request_payload_NULL_options_succeed()
+{
+  az_iot_provisioning_client client = { 0 };
+  az_result ret = az_iot_provisioning_client_init(
+      &client,
+      test_global_device_hostname,
+      AZ_SPAN_FROM_STR(TEST_ID_SCOPE),
+      AZ_SPAN_FROM_STR(TEST_REGISTRATION_ID),
+      NULL);
+  assert_int_equal(AZ_OK, ret);
+
+  char expected_payload[]
+      = "{\"registrationId\":\"" TEST_REGISTRATION_ID "\",\"payload\":" TEST_CUSTOM_PAYLOAD "}";
+  size_t expected_payload_len = sizeof(expected_payload) - 1;
+
+  uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
+  memset(payload, 0xCC, sizeof(payload));
+  size_t payload_len = 0xBAADC0DE;
+
+  ret = az_iot_provisioning_client_register_get_request_payload(
+      &client, test_custom_payload, NULL, payload, sizeof(payload), &payload_len);
+
+  assert_int_equal(AZ_OK, ret);
+  assert_int_equal(payload_len, expected_payload_len);
+  assert_memory_equal(expected_payload, payload, expected_payload_len);
+  assert_int_equal((uint8_t)0xCC, payload[expected_payload_len]);
+}
+
 int test_az_iot_provisioning_client_register_get_request_payload()
 {
 #ifndef AZ_NO_PRECONDITION_CHECKING
@@ -280,13 +290,13 @@ int test_az_iot_provisioning_client_register_get_request_payload()
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_NULL_mqtt_payload_fails),
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_zero_payload_size_fails),
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_NULL_payload_length_fails),
-    cmocka_unit_test(
-        test_az_iot_provisioning_client_register_get_request_payload_NULL_options_fails),
 #endif // AZ_NO_PRECONDITION_CHECKING
 
-    cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_no_custom_payload),
-    cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_custom_payload),
-    cmocka_unit_test(test_az_iot_provisioning_client_register_get_request_payload_with_csr),
+    cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_no_custom_payload_succeed),
+    cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_custom_payload_succeed),
+    cmocka_unit_test(test_az_iot_provisioning_client_register_get_request_payload_with_csr_succeed),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_register_get_request_payload_NULL_options_succeed),
   };
 
   return cmocka_run_group_tests_name("az_iot_provisioning_client_payload", tests, NULL, NULL);

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
@@ -66,7 +66,7 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_client_fail
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
-  AZ_IGNORE_DEPRECATIONS
+  AZ_PUSH_IGNORE_DEPRECATIONS 
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       NULL, AZ_SPAN_EMPTY, NULL, payload, sizeof(payload), &payload_len));
   AZ_POP_WARNINGS
@@ -86,7 +86,7 @@ static void test_az_iot_provisioning_client_get_request_payload_non_NULL_reserve
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
-  AZ_IGNORE_DEPRECATIONS
+  AZ_PUSH_IGNORE_DEPRECATIONS 
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client,
       AZ_SPAN_EMPTY,
@@ -110,7 +110,7 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_mqtt_payloa
 
   size_t payload_len;
 
-  AZ_IGNORE_DEPRECATIONS
+  AZ_PUSH_IGNORE_DEPRECATIONS 
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, NULL, 1, &payload_len));
   AZ_POP_WARNINGS
@@ -130,7 +130,7 @@ static void test_az_iot_provisioning_client_get_request_payload_zero_payload_siz
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
-  AZ_IGNORE_DEPRECATIONS
+  AZ_PUSH_IGNORE_DEPRECATIONS 
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, 0, &payload_len));
   AZ_POP_WARNINGS
@@ -149,7 +149,7 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_payload_len
 
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
 
-  AZ_IGNORE_DEPRECATIONS
+  AZ_PUSH_IGNORE_DEPRECATIONS 
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, 1, NULL));
   AZ_POP_WARNINGS
@@ -193,7 +193,7 @@ static void test_az_iot_provisioning_client_get_request_payload_no_custom_payloa
   memset(payload, 0xCC, sizeof(payload));
   size_t payload_len = 0xBAADC0DE;
 
-  AZ_IGNORE_DEPRECATIONS
+  AZ_PUSH_IGNORE_DEPRECATIONS 
   ret = az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, sizeof(payload), &payload_len);
   AZ_POP_WARNINGS
@@ -222,7 +222,7 @@ static void test_az_iot_provisioning_client_get_request_payload_custom_payload()
   memset(payload, 0xCC, sizeof(payload));
   size_t payload_len = 0xBAADC0DE;
 
-  AZ_IGNORE_DEPRECATIONS
+  AZ_PUSH_IGNORE_DEPRECATIONS 
   ret = az_iot_provisioning_client_get_request_payload(
       &client, test_custom_payload, NULL, payload, sizeof(payload), &payload_len);
   assert_int_equal(AZ_OK, ret);

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
@@ -66,8 +66,10 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_client_fail
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
+  AZ_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       NULL, AZ_SPAN_EMPTY, NULL, payload, sizeof(payload), &payload_len));
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_non_NULL_reserved_fails()
@@ -84,6 +86,7 @@ static void test_az_iot_provisioning_client_get_request_payload_non_NULL_reserve
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
+  AZ_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client,
       AZ_SPAN_EMPTY,
@@ -91,6 +94,7 @@ static void test_az_iot_provisioning_client_get_request_payload_non_NULL_reserve
       payload,
       sizeof(payload),
       &payload_len));
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_NULL_mqtt_payload_fails()
@@ -106,8 +110,10 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_mqtt_payloa
 
   size_t payload_len;
 
+  AZ_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, NULL, 1, &payload_len));
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_zero_payload_size_fails()
@@ -124,8 +130,10 @@ static void test_az_iot_provisioning_client_get_request_payload_zero_payload_siz
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
+  AZ_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, 0, &payload_len));
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_NULL_payload_length_fails()
@@ -141,8 +149,10 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_payload_len
 
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
 
+  AZ_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, 1, NULL));
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_register_get_request_payload_NULL_options_fails()
@@ -183,8 +193,10 @@ static void test_az_iot_provisioning_client_get_request_payload_no_custom_payloa
   memset(payload, 0xCC, sizeof(payload));
   size_t payload_len = 0xBAADC0DE;
 
+  AZ_IGNORE_DEPRECATIONS
   ret = az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, sizeof(payload), &payload_len);
+  AZ_POP_WARNINGS
   assert_int_equal(AZ_OK, ret);
   assert_int_equal(payload_len, expected_payload_len);
   assert_memory_equal(expected_payload, payload, expected_payload_len);
@@ -210,12 +222,14 @@ static void test_az_iot_provisioning_client_get_request_payload_custom_payload()
   memset(payload, 0xCC, sizeof(payload));
   size_t payload_len = 0xBAADC0DE;
 
+  AZ_IGNORE_DEPRECATIONS
   ret = az_iot_provisioning_client_get_request_payload(
       &client, test_custom_payload, NULL, payload, sizeof(payload), &payload_len);
   assert_int_equal(AZ_OK, ret);
   assert_int_equal(payload_len, expected_payload_len);
   assert_memory_equal(expected_payload, payload, expected_payload_len);
   assert_int_equal((uint8_t)0xCC, payload[expected_payload_len]);
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_register_get_request_payload_with_csr()

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
@@ -22,12 +22,31 @@
 // the absolute minimum number of bytes.  (See _az_MINIMUM_STRING_CHUNK_SIZE e.g.)
 // Since we use az_json_writer in the implementation, we need to reserve additional bytes
 // for tests.
-#define TEST_PAYLOAD_RESERVE_SIZE 192
+#define TEST_PAYLOAD_RESERVE_SIZE 1024
 
 #define TEST_REGISTRATION_ID "myRegistrationId"
 #define TEST_CUSTOM_PAYLOAD "{\"testData\":1, \"testData2\":{\"a\":\"b\"}}"
 #define TEST_ID_SCOPE "0neFEEDC0DE"
 #define TEST_OPERATION_ID "4.d0a671905ea5b2c8.42d78160-4c78-479e-8be7-61d5e55dac0d"
+#define TEST_CSR                                                       \
+  "-----BEGIN CERTIFICATE REQUEST-----\n"                              \
+  "MIHxMIGYAgEAMDYxNDAyBgNVBAMMK2RldmljZS1hOTBkNDMzYi02ZDUyLTRkNzMt\n" \
+  "OGY5OS1lMWM3OWQ4Zjg0NDQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATPa5lj\n" \
+  "HzjjUtUvke8vZ0ATXujUoYpPPlUQKXaZu5qxyP7iCwJNal6z5niXy8ZDqmbO6coh\n" \
+  "DTFeRqW/WcvFzu3RoAAwCgYIKoZIzj0EAwIDSAAwRQIhAPe+tJNc4qDpoc+p/38J\n" \
+  "YjOpoGmAU/Fs7Xa77Nq9cEkQAiBhDVtxbAPk6xDkFZRTMY1eMnIvLFDXw+rbJcSG\n" \
+  "D4jwfg==\n"                                                         \
+  "-----END CERTIFICATE REQUEST-----\n"
+
+#define TEST_CSR_ESCAPED                                                \
+  "-----BEGIN CERTIFICATE REQUEST-----\\n"                              \
+  "MIHxMIGYAgEAMDYxNDAyBgNVBAMMK2RldmljZS1hOTBkNDMzYi02ZDUyLTRkNzMt\\n" \
+  "OGY5OS1lMWM3OWQ4Zjg0NDQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATPa5lj\\n" \
+  "HzjjUtUvke8vZ0ATXujUoYpPPlUQKXaZu5qxyP7iCwJNal6z5niXy8ZDqmbO6coh\\n" \
+  "DTFeRqW/WcvFzu3RoAAwCgYIKoZIzj0EAwIDSAAwRQIhAPe+tJNc4qDpoc+p/38J\\n" \
+  "YjOpoGmAU/Fs7Xa77Nq9cEkQAiBhDVtxbAPk6xDkFZRTMY1eMnIvLFDXw+rbJcSG\\n" \
+  "D4jwfg==\\n"                                                         \
+  "-----END CERTIFICATE REQUEST-----\\n"
 
 static const az_span test_global_device_hostname
     = AZ_SPAN_LITERAL_FROM_STR("global.azure-devices-provisioning.net");
@@ -126,7 +145,25 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_payload_len
       &client, AZ_SPAN_EMPTY, NULL, payload, 1, NULL));
 }
 
-#endif
+static void test_az_iot_provisioning_client_register_get_request_payload_NULL_options_fails()
+{
+  az_iot_provisioning_client client;
+  az_result ret = az_iot_provisioning_client_init(
+      &client,
+      test_global_device_hostname,
+      AZ_SPAN_FROM_STR(TEST_ID_SCOPE),
+      AZ_SPAN_FROM_STR(TEST_REGISTRATION_ID),
+      NULL);
+  assert_int_equal(AZ_OK, ret);
+
+  uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
+  size_t payload_len;
+
+  ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_register_get_request_payload(
+      &client, AZ_SPAN_EMPTY, NULL, payload, 1, &payload_len));
+}
+
+#endif // AZ_NO_PRECONDITION_CHECKING
 
 static void test_az_iot_provisioning_client_get_request_payload_no_custom_payload()
 {
@@ -181,7 +218,42 @@ static void test_az_iot_provisioning_client_get_request_payload_custom_payload()
   assert_int_equal((uint8_t)0xCC, payload[expected_payload_len]);
 }
 
-int test_az_iot_provisioning_client_payload()
+static void test_az_iot_provisioning_client_register_get_request_payload_with_csr()
+{
+  az_iot_provisioning_client client = { 0 };
+  az_result ret = az_iot_provisioning_client_init(
+      &client,
+      test_global_device_hostname,
+      AZ_SPAN_FROM_STR(TEST_ID_SCOPE),
+      AZ_SPAN_FROM_STR(TEST_REGISTRATION_ID),
+      NULL);
+  assert_int_equal(AZ_OK, ret);
+
+  char* test_csr = TEST_CSR;
+
+  char expected_payload[]
+      = "{\"registrationId\":\"" TEST_REGISTRATION_ID "\",\"payload\":" TEST_CUSTOM_PAYLOAD
+        ",\"clientCertificateCsr\":\"" TEST_CSR_ESCAPED "\"}";
+  size_t expected_payload_len = sizeof(expected_payload) - 1;
+
+  uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
+  memset(payload, 0xCC, sizeof(payload));
+  size_t payload_len = 0xBAADC0DE;
+
+  az_iot_provisioning_client_payload_options options
+      = az_iot_provisioning_client_payload_options_default();
+  options.certificate_signing_request = az_span_create_from_str(test_csr);
+
+  ret = az_iot_provisioning_client_register_get_request_payload(
+      &client, test_custom_payload, &options, payload, sizeof(payload), &payload_len);
+
+  assert_int_equal(AZ_OK, ret);
+  assert_int_equal(payload_len, expected_payload_len);
+  assert_memory_equal(expected_payload, payload, expected_payload_len);
+  assert_int_equal((uint8_t)0xCC, payload[expected_payload_len]);
+}
+
+int test_az_iot_provisioning_client_register_get_request_payload()
 {
 #ifndef AZ_NO_PRECONDITION_CHECKING
   SETUP_PRECONDITION_CHECK_TESTS();
@@ -194,10 +266,13 @@ int test_az_iot_provisioning_client_payload()
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_NULL_mqtt_payload_fails),
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_zero_payload_size_fails),
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_NULL_payload_length_fails),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_register_get_request_payload_NULL_options_fails),
 #endif // AZ_NO_PRECONDITION_CHECKING
 
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_no_custom_payload),
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_custom_payload),
+    cmocka_unit_test(test_az_iot_provisioning_client_register_get_request_payload_with_csr),
   };
 
   return cmocka_run_group_tests_name("az_iot_provisioning_client_payload", tests, NULL, NULL);


### PR DESCRIPTION
1. Changing `az_iot_provisioning_client_register_get_request_payload` to accept `options == NULL`. 
2. Addressing PR comments from #2184.