### PR TITLE
allow assumption of two padding chars with base64

### DIFF
--- a/sdk/tests/core/test_az_base64.c
+++ b/sdk/tests/core/test_az_base64.c
@@ -165,11 +165,19 @@ static void az_base64_decode_test(void** state)
 
   uint8_t expected_buffer1[1] = { 1 };
   _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQ=="), AZ_SPAN_FROM_BUFFER(expected_buffer1));
+  uint8_t expected_buffer0[1] = { 1 };
+  _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQ"), AZ_SPAN_FROM_BUFFER(expected_buffer0));
   uint8_t expected_buffer2[2] = { 1, 2 };
   _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQI="), AZ_SPAN_FROM_BUFFER(expected_buffer2));
   uint8_t expected_buffer3[3] = { 1, 2, 3 };
   _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQID"), AZ_SPAN_FROM_BUFFER(expected_buffer3));
   uint8_t expected_buffer4[4] = { 1, 2, 3, 4 };
+  // Can't have three short padding characters, so test later for "AQIDB" returns AZ_ERROR_UNEXPECTED_END
+  // Assume 2 padding
+  _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQIDBA"), AZ_SPAN_FROM_BUFFER(expected_buffer4));
+  // Assume 1 padding
+  _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQIDBA="), AZ_SPAN_FROM_BUFFER(expected_buffer4));
+  // Assume 0 padding
   _az_base64_decode_test_helper(
       AZ_SPAN_FROM_STR("AQIDBA=="), AZ_SPAN_FROM_BUFFER(expected_buffer4));
   uint8_t expected_buffer5[5] = { 1, 2, 3, 4, 5 };
@@ -244,21 +252,6 @@ static void az_base64_decode_source_small_test(void** state)
 
   assert_int_equal(
       az_base64_decode(destination, AZ_SPAN_FROM_STR("AQIDB"), &bytes_written),
-      AZ_ERROR_UNEXPECTED_END);
-  assert_int_equal(bytes_written, 0);
-
-  assert_int_equal(
-      az_base64_decode(destination, AZ_SPAN_FROM_STR("AQIDBA"), &bytes_written),
-      AZ_ERROR_UNEXPECTED_END);
-  assert_int_equal(bytes_written, 0);
-
-  assert_int_equal(
-      az_base64_decode(destination, AZ_SPAN_FROM_STR("AQIDBA="), &bytes_written),
-      AZ_ERROR_UNEXPECTED_END);
-  assert_int_equal(bytes_written, 0);
-
-  assert_int_equal(
-      az_base64_decode(destination, AZ_SPAN_FROM_STR("AQIDBAU"), &bytes_written),
       AZ_ERROR_UNEXPECTED_END);
   assert_int_equal(bytes_written, 0);
 }


### PR DESCRIPTION
With JWS or JWK's, padding characters are explicitly not allowed. We need to allow for the assumption of padding characters should the text be `length % 4 != 0`.