### PR TITLE
Add null terminator for char* based json string unescape, and precondition on input length

### DIFF
--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -807,6 +807,10 @@ AZ_NODISCARD az_result az_json_reader_skip_children(az_json_reader* ref_json_rea
  * @retval #AZ_OK The string is returned.
  * @retval #AZ_ERROR_NOT_ENOUGH_SPACE \p destination does not have enough size.
  *
+ * @remarks The buffer referred to by \p destination must have a size that is at least 1 byte bigger
+ * than the \p json_string #az_span for the \p destination string to be zero-terminated.
+ * Content is copied from the \p source buffer, while unescaping and then `\0` is added at the end.
+ *
  * @remarks This API can also be used to perform in place unescaping.
  */
 AZ_NODISCARD az_result az_json_string_unescape(

--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -809,7 +809,7 @@ AZ_NODISCARD az_result az_json_reader_skip_children(az_json_reader* ref_json_rea
  *
  * @remarks The buffer referred to by \p destination must have a size that is at least 1 byte bigger
  * than the \p json_string #az_span for the \p destination string to be zero-terminated.
- * Content is copied from the \p source buffer, while unescaping and then `\0` is added at the end.
+ * Content is copied from the source buffer, while unescaping and then `\0` is added at the end.
  *
  * @remarks This API can also be used to perform in place unescaping.
  */

--- a/sdk/src/azure/core/az_json_token.c
+++ b/sdk/src/azure/core/az_json_token.c
@@ -333,7 +333,8 @@ AZ_NODISCARD az_result az_json_string_unescape(
 {
   _az_PRECONDITION_VALID_SPAN(json_string, 1, false);
   _az_PRECONDITION_NOT_NULL(destination);
-  _az_PRECONDITION(destination_max_size > 0);
+  // The destination needs to be larger than the input, for null terminator.
+  _az_PRECONDITION(destination_max_size > az_span_size(json_string));
 
   int32_t position = 0;
   int32_t span_size = az_span_size(json_string);
@@ -369,6 +370,8 @@ AZ_NODISCARD az_result az_json_string_unescape(
     destination[position] = (char)current_char;
     position++;
   }
+    
+  destination[position] = 0;
 
   if (out_string_length != NULL)
   {

--- a/sdk/src/azure/core/az_json_token.c
+++ b/sdk/src/azure/core/az_json_token.c
@@ -370,7 +370,7 @@ AZ_NODISCARD az_result az_json_string_unescape(
     destination[position] = (char)current_char;
     position++;
   }
-    
+
   destination[position] = 0;
 
   if (out_string_length != NULL)

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -3105,17 +3105,6 @@ static void test_az_json_string_unescape(void** state)
     assert_true(az_span_is_content_equal(expected, destination_span));
   }
 
-  // insufficient space
-  {
-    az_span json = AZ_SPAN_FROM_STR(" { \"name\": \"some value string\" , \"code\" : 123456 } ");
-    char destination[5] = { 0 };
-    int final_size;
-
-    az_result result = az_json_string_unescape(json, destination, 4, &final_size);
-
-    assert_int_equal(AZ_ERROR_NOT_ENOUGH_SPACE, result);
-  }
-
   // magic test
   {
     az_span original = AZ_SPAN_FROM_STR("A\\\"\"Z");
@@ -3317,18 +3306,6 @@ static void test_az_json_string_unescape_same_buffer(void** state)
 
     assert_int_equal(AZ_ERROR_UNEXPECTED_END, result);
     _az_span_free(&original);
-  }
-
-  // insufficient space
-  {
-    az_span json = az_span_create_from_str(
-        strdup(" { \"name\": \"some value string\" , \"code\" : 123456 } "));
-    int final_size;
-
-    az_result result = az_json_string_unescape(json, (char*)az_span_ptr(json), 5, &final_size);
-
-    assert_int_equal(AZ_ERROR_NOT_ENOUGH_SPACE, result);
-    _az_span_free(&json);
   }
 }
 

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -3272,13 +3272,11 @@ static void test_az_json_string_unescape_same_buffer(void** state)
 
     int final_size;
     az_result result = az_json_string_unescape(
-        az_span_slice(test_span, 0, 2), (char*)az_span_ptr(json), 59, &final_size);
-
-    test_span = az_span_slice(test_span, 0, final_size);
+        az_span_slice(test_span, 0, 2), (char*)az_span_ptr(test_span), 59, &final_size);
 
     assert_int_equal(0, test_span._internal.ptr[2]);
     assert_int_equal(AZ_OK, result);
-    assert_true(az_span_is_content_equal(expected, destination_span));
+    assert_true(az_span_is_content_equal(expected, az_span_slice(test_span, 0, final_size)));
   }
 
   // only escapes

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -3035,11 +3035,12 @@ static void test_az_json_string_unescape(void** state)
     az_span test_span = AZ_SPAN_FROM_BUFFER(buffer);
     test_span._internal.ptr[0] = 'a';
     test_span._internal.ptr[1] = 'b';
-    test_span._internal.ptr[2] = 'c'; // verify that 'c' is overwritten with 0
+    test_span._internal.ptr[2] = 'c';
 
     az_span expected = AZ_SPAN_FROM_STR("ab");
 
     char destination[59] = { 0 };
+    destination[2] = 'd'; // verify that 'd' is overwritten with 0
     az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
 
     int final_size;
@@ -3048,6 +3049,7 @@ static void test_az_json_string_unescape(void** state)
 
     destination_span = az_span_slice(destination_span, 0, final_size);
 
+    assert_int_equal(0, (int)destination[2]);
     assert_int_equal(AZ_OK, result);
     assert_true(az_span_is_content_equal(expected, destination_span));
   }
@@ -3274,6 +3276,7 @@ static void test_az_json_string_unescape_same_buffer(void** state)
 
     test_span = az_span_slice(test_span, 0, final_size);
 
+    assert_int_equal(0, test_span._internal.ptr[2]);
     assert_int_equal(AZ_OK, result);
     assert_true(az_span_is_content_equal(expected, destination_span));
   }


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/2301