### PR TITLE
Make repository a Zephyr module

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,3 @@
+build:
+  cmake-ext: True
+  kconfig-ext: True


### PR DESCRIPTION
Add module.yml that enables Zephyr RTOS based projects to include
the repository as module.

For more information, see:
https://docs.zephyrproject.org/latest/develop/modules.html