### PR TITLE
Adding missing header for websocket usage

### DIFF
--- a/sdk/samples/iot/iot_sample_common.c
+++ b/sdk/samples/iot/iot_sample_common.c
@@ -30,6 +30,7 @@
 #include <openssl/hmac.h>
 
 #include <azure/az_core.h>
+#include <azure/az_iot.h>
 
 #include "iot_sample_common.h"
 


### PR DESCRIPTION
When websockets is enabled through uncommenting `#define USE_WEB_SOCKET` build failed due to missing header. Added it.