### PR TITLE
Change ADU client update id to match service specification

### DIFF
--- a/sdk/inc/azure/iot/az_iot_adu_client.h
+++ b/sdk/inc/azure/iot/az_iot_adu_client.h
@@ -119,7 +119,7 @@ typedef struct
    * The version for the update.
    */
   az_span version;
-} az_iot_adu_client_update_id;
+} az_iot_adu_update_id;
 
 /**
  * @brief Holds any user-defined custom properties of the device.
@@ -179,7 +179,7 @@ typedef struct
   /**
    * An ID of the update that is currently installed.
    */
-  az_iot_adu_client_update_id update_id;
+  az_span update_id;
 } az_iot_adu_client_device_properties;
 
 /**
@@ -417,7 +417,7 @@ typedef struct
   /**
    * User-defined identity of the update manifest.
    */
-  az_iot_adu_client_update_id update_id;
+  az_iot_adu_update_id update_id;
   /**
    * Instructions of the update manifest.
    */

--- a/sdk/samples/iot/paho_iot_adu_sample_common.c
+++ b/sdk/samples/iot/paho_iot_adu_sample_common.c
@@ -76,7 +76,9 @@ static bool did_parse_update = false;
 static bool did_update = false;
 static char adu_scratch_buffer[10000];
 
-#define ADU_DEVICE_UPDATE_ID "{ \"provider\": \"" ADU_DEVICE_MANUFACTURER "\", \"name\": \"" ADU_DEVICE_MODEL "\", \"version\": \"" ADU_DEVICE_VERSION "\" }"
+#define ADU_DEVICE_UPDATE_ID                                                       \
+  "{ \"provider\": \"" ADU_DEVICE_MANUFACTURER "\", \"name\": \"" ADU_DEVICE_MODEL \
+  "\", \"version\": \"" ADU_DEVICE_VERSION "\" }"
 
 az_iot_adu_device_properties adu_device_properties
     = { .manufacturer = AZ_SPAN_LITERAL_FROM_STR(ADU_DEVICE_MANUFACTURER),

--- a/sdk/samples/iot/paho_iot_adu_sample_common.c
+++ b/sdk/samples/iot/paho_iot_adu_sample_common.c
@@ -76,14 +76,14 @@ static bool did_parse_update = false;
 static bool did_update = false;
 static char adu_scratch_buffer[10000];
 
+#define ADU_DEVICE_UPDATE_ID "{ \"provider\": \"" ADU_DEVICE_MANUFACTURER "\", \"name\": \"" ADU_DEVICE_MODEL "\", \"version\": \"" ADU_DEVICE_VERSION "\" }"
+
 az_iot_adu_device_properties adu_device_properties
     = { .manufacturer = AZ_SPAN_LITERAL_FROM_STR(ADU_DEVICE_MANUFACTURER),
         .model = AZ_SPAN_LITERAL_FROM_STR(ADU_DEVICE_MODEL),
         .adu_version = AZ_SPAN_LITERAL_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_VERSION),
         .delivery_optimization_agent_version = AZ_SPAN_EMPTY,
-        .update_id = { .name = AZ_SPAN_LITERAL_FROM_STR(ADU_DEVICE_MODEL),
-                       .provider = AZ_SPAN_LITERAL_FROM_STR(ADU_DEVICE_MANUFACTURER),
-                       .version = AZ_SPAN_LITERAL_FROM_STR(ADU_DEVICE_VERSION) } };
+        .update_id = AZ_SPAN_LITERAL_FROM_STR(ADU_DEVICE_UPDATE_ID) };
 
 //
 // Functions

--- a/sdk/src/azure/iot/az_iot_adu_client.c
+++ b/sdk/src/azure/iot/az_iot_adu_client.c
@@ -329,7 +329,7 @@ AZ_NODISCARD az_result az_iot_adu_client_get_agent_state_payload(
     _az_RETURN_IF_FAILED(az_json_writer_append_end_object(ref_json_writer));
   }
 
-  /* Fill installed update id.  */
+  /* Fill installed update id. */
   _az_RETURN_IF_FAILED(az_json_writer_append_property_name(
       ref_json_writer,
       AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_INSTALLED_UPDATE_ID)));

--- a/sdk/src/azure/iot/az_iot_adu_client.c
+++ b/sdk/src/azure/iot/az_iot_adu_client.c
@@ -333,8 +333,7 @@ AZ_NODISCARD az_result az_iot_adu_client_get_agent_state_payload(
   _az_RETURN_IF_FAILED(az_json_writer_append_property_name(
       ref_json_writer,
       AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_INSTALLED_UPDATE_ID)));
-  _az_RETURN_IF_FAILED(az_json_writer_append_string(
-      ref_json_writer, device_properties->update_id));
+  _az_RETURN_IF_FAILED(az_json_writer_append_string(ref_json_writer, device_properties->update_id));
 
   _az_RETURN_IF_FAILED(az_json_writer_append_end_object(ref_json_writer));
 

--- a/sdk/src/azure/iot/az_iot_adu_client.c
+++ b/sdk/src/azure/iot/az_iot_adu_client.c
@@ -75,7 +75,7 @@
 
 #define RESULT_STEP_ID_PREFIX "step_"
 #define MAX_UINT32_NUMBER_OF_DIGITS 10
-#define RESULT_STEP_ID_MAX_SIZE (sizeof(RESULT_STEP_ID_PREFIX) + MAX_UINT32_NUMBER_OF_DIGITS)
+#define RESULT_STEP_ID_MAX_SIZE (sizeof(RESULT_STEP_ID_PREFIX) - 1 + MAX_UINT32_NUMBER_OF_DIGITS)
 
 #define RETURN_IF_JSON_TOKEN_NOT_TYPE(jr_ptr, json_token_type) \
   if (jr_ptr->token.kind != json_token_type)                   \

--- a/sdk/tests/iot/adu/test_az_iot_adu.c
+++ b/sdk/tests/iot/adu/test_az_iot_adu.c
@@ -23,7 +23,9 @@
 #define TEST_ADU_DEVICE_MODEL "Foobar"
 #define TEST_AZ_IOT_ADU_CLIENT_AGENT_VERSION AZ_IOT_ADU_CLIENT_AGENT_VERSION
 #define TEST_ADU_DEVICE_VERSION "1.0"
-#define TEST_ADU_DEVICE_UPDATE_ID "{\"provider\":\"" TEST_ADU_DEVICE_MANUFACTURER "\",\"name\":\"" TEST_ADU_DEVICE_MODEL "\",\"version\":\"" TEST_ADU_DEVICE_VERSION "\"}"
+#define TEST_ADU_DEVICE_UPDATE_ID                                                        \
+  "{\"provider\":\"" TEST_ADU_DEVICE_MANUFACTURER "\",\"name\":\"" TEST_ADU_DEVICE_MODEL \
+  "\",\"version\":\"" TEST_ADU_DEVICE_VERSION "\"}"
 
 static uint8_t expected_agent_state_payload[]
     = "{\"deviceUpdate\":{\"__t\":\"c\",\"agent\":{\"deviceProperties\":{\"manufacturer\":"

--- a/sdk/tests/iot/adu/test_az_iot_adu.c
+++ b/sdk/tests/iot/adu/test_az_iot_adu.c
@@ -426,9 +426,6 @@ static void test_az_iot_adu_client_get_agent_state_payload_succeed(void** state)
           &client, &adu_device_properties, AZ_IOT_ADU_CLIENT_AGENT_STATE_IDLE, NULL, NULL, &jw),
       AZ_OK);
 
-  printf("expected: %s\r\n", expected_agent_state_payload);
-  printf("actual: %s\r\n", payload_buffer);
-
   assert_memory_equal(
       payload_buffer, expected_agent_state_payload, sizeof(expected_agent_state_payload) - 1);
 }

--- a/sdk/tests/iot/adu/test_az_iot_adu.c
+++ b/sdk/tests/iot/adu/test_az_iot_adu.c
@@ -23,6 +23,7 @@
 #define TEST_ADU_DEVICE_MODEL "Foobar"
 #define TEST_AZ_IOT_ADU_CLIENT_AGENT_VERSION AZ_IOT_ADU_CLIENT_AGENT_VERSION
 #define TEST_ADU_DEVICE_VERSION "1.0"
+#define TEST_ADU_DEVICE_UPDATE_ID "{\"provider\":\"" TEST_ADU_DEVICE_MANUFACTURER "\",\"name\":\"" TEST_ADU_DEVICE_MODEL "\",\"version\":\"" TEST_ADU_DEVICE_VERSION "\"}"
 
 static uint8_t expected_agent_state_payload[]
     = "{\"deviceUpdate\":{\"__t\":\"c\",\"agent\":{\"deviceProperties\":{\"manufacturer\":"
@@ -47,9 +48,7 @@ az_iot_adu_client_device_properties adu_device_properties
         .model = AZ_SPAN_LITERAL_FROM_STR(TEST_ADU_DEVICE_MODEL),
         .adu_version = AZ_SPAN_LITERAL_FROM_STR(TEST_AZ_IOT_ADU_CLIENT_AGENT_VERSION),
         .delivery_optimization_agent_version = AZ_SPAN_LITERAL_EMPTY,
-        .update_id = { .provider = AZ_SPAN_LITERAL_FROM_STR(TEST_ADU_DEVICE_MANUFACTURER),
-                       .name = AZ_SPAN_LITERAL_FROM_STR(TEST_ADU_DEVICE_MODEL),
-                       .version = AZ_SPAN_LITERAL_FROM_STR(TEST_ADU_DEVICE_VERSION) } };
+        .update_id = AZ_SPAN_LITERAL_FROM_STR(TEST_ADU_DEVICE_UPDATE_ID) };
 
 static uint8_t send_response_valid_payload[]
     = "{\"deviceUpdate\":{\"__t\":\"c\",\"service\":{\"ac\":200,\"av\":1,\"value\":{}}}}";
@@ -424,6 +423,9 @@ static void test_az_iot_adu_client_get_agent_state_payload_succeed(void** state)
       az_iot_adu_client_get_agent_state_payload(
           &client, &adu_device_properties, AZ_IOT_ADU_CLIENT_AGENT_STATE_IDLE, NULL, NULL, &jw),
       AZ_OK);
+
+  printf("expected: %s\r\n", expected_agent_state_payload);
+  printf("actual: %s\r\n", payload_buffer);
 
   assert_memory_equal(
       payload_buffer, expected_agent_state_payload, sizeof(expected_agent_state_payload) - 1);


### PR DESCRIPTION
The update-id reported by the ADU agent, as defined by the ADU service, is an escaped string, and has no need to be split into a separate struct with the individual components (provider, name, version). This change simplifies the ADU agent state generation by following this specification, as well as removes a bug-prone buffer manipulation from az_iot_adu_client.c.