### PR TITLE
ADU request keeps span slice instead of copying string

### DIFF
--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -792,6 +792,33 @@ AZ_NODISCARD az_result az_json_reader_next_token(az_json_reader* ref_json_reader
  */
 AZ_NODISCARD az_result az_json_reader_skip_children(az_json_reader* ref_json_reader);
 
+/**
+ * @brief Unescapes the JSON string within the provided #az_span.
+ *
+ * @param[in] json_string The #az_span that contains the string to be unescaped.
+ * @param destination Pointer to the buffer that will contain the output.
+ * @param[in] destination_max_size The maximum available space within the buffer referred to by
+ * \p destination.
+ * @param[out] out_string_length __[nullable]__ Contains the number of bytes written to the
+ * \p destination which denote the length of the unescaped string. If `NULL` is passed, the
+ * \p parameter is ignored.
+ *
+ * @return An #az_result value indicating the result of the operation.
+ * @retval #AZ_OK The string is returned.
+ * @retval #AZ_ERROR_NOT_ENOUGH_SPACE \p destination does not have enough size.
+ *
+ * @remarks The buffer referred to by \p destination must have a size that is at least 1 byte bigger
+ * than the \p json_string #az_span for the \p destination string to be zero-terminated.
+ * Content is copied from the source buffer, while unescaping and then `\0` is added at the end.
+ *
+ * @remarks This API can also be used to perform in place unescaping.
+ */
+AZ_NODISCARD az_result az_json_string_unescape(
+    az_span json_string,
+    char* destination,
+    int32_t destination_max_size,
+    int32_t* out_string_length);
+
 #include <azure/core/_az_cfg_suffix.h>
 
 #endif // _az_JSON_H

--- a/sdk/inc/azure/iot/az_iot_adu_client.h
+++ b/sdk/inc/azure/iot/az_iot_adu_client.h
@@ -556,24 +556,18 @@ AZ_NODISCARD az_result az_iot_adu_client_get_agent_state_payload(
  *                                 service writable properties json, set to the
  *                                 beginning of the json object that is the value
  *                                 of the ADU component.
- * @param[in] buffer               An #az_span buffer where to write the parsed
- *                                 values read from the json content.
  * @param[out] update_request      A pointer to the #az_iot_adu_client_update_request
  *                                 structure where to store the parsed contents
  *                                 read from the `ref_json_reader` json reader.
  *                                 In summary, this structure holds #az_span
  *                                 instances that point to the actual data
  *                                 parsed from `ref_json_reader` and copied to `buffer`.
- * @param[out] buffer_remainder    A pointer to an #az_span where to store the
- *                                 remaining available space of `buffer`.
  * @return An #az_result value indicating the result of the operation.
  */
 AZ_NODISCARD az_result az_iot_adu_client_parse_service_properties(
     az_iot_adu_client* client,
     az_json_reader* ref_json_reader,
-    az_span buffer,
-    az_iot_adu_client_update_request* update_request,
-    az_span* buffer_remainder);
+    az_iot_adu_client_update_request* update_request);
 
 /**
  * @brief    Generates the payload necessary to respond to the service

--- a/sdk/inc/azure/iot/az_iot_adu_client.h
+++ b/sdk/inc/azure/iot/az_iot_adu_client.h
@@ -309,6 +309,9 @@ typedef struct
   az_iot_adu_client_workflow workflow;
   /**
    * Description of the content of an update.
+   * @note This will come as an escaped string. The user must unescape it using
+   * an API such as az_json_string_unescape() before subsequently calling
+   * az_iot_adu_client_parse_update_manifest() with it.
    */
   az_span update_manifest;
   /**

--- a/sdk/src/azure/core/az_json_private.h
+++ b/sdk/src/azure/core/az_json_private.h
@@ -120,6 +120,24 @@ AZ_NODISCARD AZ_INLINE _az_json_stack_item _az_json_stack_peek(_az_json_bit_stac
                                                          : _az_JSON_STACK_ARRAY;
 }
 
+AZ_NODISCARD AZ_INLINE bool _az_is_valid_escaped_character(uint8_t byte)
+{
+  switch (byte)
+  {
+    case '\\':
+    case '"':
+    case '/':
+    case 'b':
+    case 'f':
+    case 'n':
+    case 'r':
+    case 't':
+      return true;
+    default:
+      return false;
+  }
+}
+
 #include <azure/core/_az_cfg_suffix.h>
 
 #endif // _az_SPAN_PRIVATE_H

--- a/sdk/src/azure/core/az_json_reader.c
+++ b/sdk/src/azure/core/az_json_reader.c
@@ -237,24 +237,6 @@ AZ_NODISCARD static az_result _az_json_reader_process_container_start(
   return AZ_OK;
 }
 
-AZ_NODISCARD static bool _az_is_valid_escaped_character(uint8_t byte)
-{
-  switch (byte)
-  {
-    case '\\':
-    case '"':
-    case '/':
-    case 'b':
-    case 'f':
-    case 'n':
-    case 'r':
-    case 't':
-      return true;
-    default:
-      return false;
-  }
-}
-
 AZ_NODISCARD static az_result _az_json_reader_process_string(az_json_reader* ref_json_reader)
 {
   // Move past the first '"' character

--- a/sdk/src/azure/iot/az_iot_adu_client.c
+++ b/sdk/src/azure/iot/az_iot_adu_client.c
@@ -844,23 +844,3 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_update_manifest(
 
   return AZ_OK;
 }
-
-/* --- az_core extensions --- */
-// static az_span split_az_span(az_span span, int32_t size, az_span* remainder)
-// {
-//   az_span result = az_span_slice(span, 0, size);
-
-//   if (remainder != NULL)
-//   {
-//     if (az_span_is_content_equal(AZ_SPAN_EMPTY, result))
-//     {
-//       *remainder = AZ_SPAN_EMPTY;
-//     }
-//     else
-//     {
-//       *remainder = az_span_slice(span, size, az_span_size(span));
-//     }
-//   }
-
-//   return result;
-// }

--- a/sdk/src/azure/iot/az_iot_adu_client.c
+++ b/sdk/src/azure/iot/az_iot_adu_client.c
@@ -382,8 +382,6 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_service_properties(
 
   (void)client;
 
-  az_json_token property_name_token_holder;
-
   RETURN_IF_JSON_TOKEN_NOT_TYPE(ref_json_reader, AZ_JSON_TOKEN_PROPERTY_NAME);
   RETURN_IF_JSON_TOKEN_NOT_TEXT(ref_json_reader, AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_SERVICE);
 
@@ -476,7 +474,7 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_service_properties(
           RETURN_IF_JSON_TOKEN_NOT_TYPE(ref_json_reader, AZ_JSON_TOKEN_PROPERTY_NAME);
 
           update_request->file_urls[update_request->file_urls_count].id
-                = ref_json_reader->token.slice;
+              = ref_json_reader->token.slice;
 
           _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
           if (ref_json_reader->token.kind != AZ_JSON_TOKEN_NULL)

--- a/sdk/src/azure/iot/az_iot_adu_client.c
+++ b/sdk/src/azure/iot/az_iot_adu_client.c
@@ -119,8 +119,6 @@ const uint8_t azure_iot_adu_root_key_n[385]
         0x77, 0x3e, 0x40, 0x87, 0x18, 0xc9, 0xab, 0xd9, 0xf7, 0x79 };
 const uint8_t azure_iot_adu_root_key_e[3] = { 0x01, 0x00, 0x01 };
 
-static az_span split_az_span(az_span span, int32_t size, az_span* remainder);
-
 const az_span default_compatibility_properties
     = AZ_SPAN_LITERAL_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_DEFAULT_COMPATIBILITY_PROPERTIES);
 
@@ -376,20 +374,15 @@ AZ_NODISCARD az_result az_iot_adu_client_get_agent_state_payload(
 AZ_NODISCARD az_result az_iot_adu_client_parse_service_properties(
     az_iot_adu_client* client,
     az_json_reader* ref_json_reader,
-    az_span buffer,
-    az_iot_adu_client_update_request* update_request,
-    az_span* buffer_remainder)
+    az_iot_adu_client_update_request* update_request)
 {
   _az_PRECONDITION_NOT_NULL(client);
   _az_PRECONDITION_NOT_NULL(ref_json_reader);
-  _az_PRECONDITION_VALID_SPAN(buffer, 1, false);
   _az_PRECONDITION_NOT_NULL(update_request);
 
   (void)client;
 
   az_json_token property_name_token_holder;
-  int32_t required_size;
-  int32_t out_length;
 
   RETURN_IF_JSON_TOKEN_NOT_TYPE(ref_json_reader, AZ_JSON_TOKEN_PROPERTY_NAME);
   RETURN_IF_JSON_TOKEN_NOT_TEXT(ref_json_reader, AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_SERVICE);
@@ -435,22 +428,7 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_service_properties(
         {
           _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
 
-          required_size = ref_json_reader->token.size + NULL_TERM_CHAR_SIZE;
-
-          _az_RETURN_IF_NOT_ENOUGH_SIZE(buffer, required_size);
-
-          update_request->workflow.id = split_az_span(buffer, required_size, &buffer);
-
-          _az_RETURN_IF_FAILED(az_json_token_get_string(
-              &ref_json_reader->token,
-              (char*)az_span_ptr(update_request->workflow.id),
-              az_span_size(update_request->workflow.id),
-              &out_length));
-
-          // TODO: find a way to get rid of az_json_token_get_string (which adds a \0 at the
-          // end!!!!!!)
-          //       Preferably have a function that does not copy anything.
-          update_request->workflow.id = az_span_slice(update_request->workflow.id, 0, out_length);
+          update_request->workflow.id = ref_json_reader->token.slice;
         }
         else
         {
@@ -465,36 +443,11 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_service_properties(
                  &ref_json_reader->token,
                  AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_UPDATE_MANIFEST)))
     {
-      int32_t update_manifest_length;
-
       _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
 
       if (ref_json_reader->token.kind != AZ_JSON_TOKEN_NULL)
       {
-
-        _az_RETURN_IF_FAILED(az_json_token_get_string(
-            &ref_json_reader->token,
-            (char*)az_span_ptr(buffer),
-            az_span_size(buffer),
-            &update_manifest_length));
-
-        // TODO: find a way to get rid of az_json_token_get_string (which adds a \0 at the
-        // end!!!!!!)
-        //       Preferably have a function that does not copy anything.
-        // TODO: optmize the memory usage for update_manifest:
-        //       Here we are copying the entire update manifest [originally escaped] json into
-        //       update_request->update_manifest. Later az_iot_adu_client_parse_update_manifest
-        //       parses that json into a az_iot_adu_client_update_manifest structure, by simply
-        //       mapping the values of update_request->update_manifest. Option 1: there seems to be
-        //       no workaround for update_request->update_manifest for copying with
-        //                 az_json_token_get_string, since the original update manifest comes as an
-        //                 escaped json. What can be done is to make it temporary, and parse the
-        //                 update manifest within az_iot_adu_client_parse_service_request, saving
-        //                 only the update manifest values in the (then) provided buffer.
-        //       Option 2: Have a function in azure SDK core that can parse an escaped json,
-        //       allowing us to
-        //                 avoid copying the update manifest at all.
-        update_request->update_manifest = split_az_span(buffer, update_manifest_length, &buffer);
+        update_request->update_manifest = ref_json_reader->token.slice;
       }
     }
     else if (az_json_token_is_text_equal(
@@ -505,24 +458,7 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_service_properties(
 
       if (ref_json_reader->token.kind != AZ_JSON_TOKEN_NULL)
       {
-
-        required_size = ref_json_reader->token.size + NULL_TERM_CHAR_SIZE;
-
-        _az_RETURN_IF_NOT_ENOUGH_SIZE(buffer, required_size);
-
-        update_request->update_manifest_signature = split_az_span(buffer, required_size, &buffer);
-
-        _az_RETURN_IF_FAILED(az_json_token_get_string(
-            &ref_json_reader->token,
-            (char*)az_span_ptr(update_request->update_manifest_signature),
-            az_span_size(update_request->update_manifest_signature),
-            &out_length));
-
-        // TODO: find a way to get rid of az_json_token_get_string (which adds a \0 at the
-        // end!!!!!!)
-        //       Preferably have a function that does not copy anything.
-        update_request->update_manifest_signature
-            = az_span_slice(update_request->update_manifest_signature, 0, out_length);
+        update_request->update_manifest_signature = ref_json_reader->token.slice;
       }
     }
     else if (az_json_token_is_text_equal(
@@ -539,50 +475,14 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_service_properties(
         {
           RETURN_IF_JSON_TOKEN_NOT_TYPE(ref_json_reader, AZ_JSON_TOKEN_PROPERTY_NAME);
 
-          // Hold the url id temporarily and advance.
-          // If the value is null, we are going to skip over it.
-          property_name_token_holder = ref_json_reader->token;
+          update_request->file_urls[update_request->file_urls_count].id
+                = ref_json_reader->token.slice;
 
           _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
           if (ref_json_reader->token.kind != AZ_JSON_TOKEN_NULL)
           {
-            required_size = property_name_token_holder.size + NULL_TERM_CHAR_SIZE;
-
-            _az_RETURN_IF_NOT_ENOUGH_SIZE(buffer, required_size);
-
-            update_request->file_urls[update_request->file_urls_count].id
-                = split_az_span(buffer, required_size, &buffer);
-
-            _az_RETURN_IF_FAILED(az_json_token_get_string(
-                &property_name_token_holder,
-                (char*)az_span_ptr(update_request->file_urls[update_request->file_urls_count].id),
-                az_span_size(update_request->file_urls[update_request->file_urls_count].id),
-                &out_length));
-
-            // TODO: find a way to get rid of az_json_token_get_string (which adds a \0 at the
-            // end!!!!!!)
-            //       Preferably have a function that does not copy anything.
-            update_request->file_urls[update_request->file_urls_count].id = az_span_slice(
-                update_request->file_urls[update_request->file_urls_count].id, 0, out_length);
-
-            required_size = ref_json_reader->token.size + NULL_TERM_CHAR_SIZE;
-
-            _az_RETURN_IF_NOT_ENOUGH_SIZE(buffer, required_size);
-
             update_request->file_urls[update_request->file_urls_count].url
-                = split_az_span(buffer, required_size, &buffer);
-
-            _az_RETURN_IF_FAILED(az_json_token_get_string(
-                &ref_json_reader->token,
-                (char*)az_span_ptr(update_request->file_urls[update_request->file_urls_count].url),
-                az_span_size(update_request->file_urls[update_request->file_urls_count].url),
-                &out_length));
-
-            // TODO: find a way to get rid of az_json_token_get_string (which adds a \0 at the
-            // end!!!!!!)
-            //       Preferably have a function that does not copy anything.
-            update_request->file_urls[update_request->file_urls_count].url = az_span_slice(
-                update_request->file_urls[update_request->file_urls_count].url, 0, out_length);
+                = ref_json_reader->token.slice;
 
             update_request->file_urls_count++;
           }
@@ -593,11 +493,6 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_service_properties(
     }
 
     _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
-  }
-
-  if (buffer_remainder != NULL)
-  {
-    *buffer_remainder = buffer;
   }
 
   return AZ_OK;
@@ -953,21 +848,21 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_update_manifest(
 }
 
 /* --- az_core extensions --- */
-static az_span split_az_span(az_span span, int32_t size, az_span* remainder)
-{
-  az_span result = az_span_slice(span, 0, size);
+// static az_span split_az_span(az_span span, int32_t size, az_span* remainder)
+// {
+//   az_span result = az_span_slice(span, 0, size);
 
-  if (remainder != NULL)
-  {
-    if (az_span_is_content_equal(AZ_SPAN_EMPTY, result))
-    {
-      *remainder = AZ_SPAN_EMPTY;
-    }
-    else
-    {
-      *remainder = az_span_slice(span, size, az_span_size(span));
-    }
-  }
+//   if (remainder != NULL)
+//   {
+//     if (az_span_is_content_equal(AZ_SPAN_EMPTY, result))
+//     {
+//       *remainder = AZ_SPAN_EMPTY;
+//     }
+//     else
+//     {
+//       *remainder = az_span_slice(span, size, az_span_size(span));
+//     }
+//   }
 
-  return result;
-}
+//   return result;
+// }

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -2978,6 +2978,378 @@ static void test_az_json_reader_chunked(void** state)
   assert_true(az_span_is_content_equal(expected, az_span_create_from_str(m.name_string)));
 }
 
+static void _az_span_free(az_span* p)
+{
+  if (p == NULL)
+  {
+    return;
+  }
+  free(az_span_ptr(*p));
+  *p = AZ_SPAN_EMPTY;
+}
+
+static void test_az_json_string_unescape(void** state)
+{
+  (void)state;
+
+  // no escapes
+  {
+    az_span json = AZ_SPAN_FROM_STR(" { \"name\": \"some value string\" , \"code\" : 123456 } ");
+    az_span expected
+        = AZ_SPAN_FROM_STR(" { \"name\": \"some value string\" , \"code\" : 123456 } ");
+
+    char destination[59] = { 0 };
+    az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
+
+    int final_size;
+    az_result result = az_json_string_unescape(json, destination, 59, &final_size);
+
+    destination_span = az_span_slice(destination_span, 0, final_size);
+
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, destination_span));
+  }
+
+  // unexpected end
+  {
+    uint8_t buffer[3];
+    az_span test_span = AZ_SPAN_FROM_BUFFER(buffer);
+    test_span._internal.ptr[0] = 'a';
+    test_span._internal.ptr[1] = 'b';
+    test_span._internal.ptr[2] = '\\';
+
+    char destination[59] = { 0 };
+
+    int final_size;
+    az_result result = az_json_string_unescape(test_span, destination, 59, &final_size);
+
+    assert_int_equal(AZ_ERROR_UNEXPECTED_END, result);
+  }
+
+  // null terminator
+  {
+    uint8_t buffer[3];
+    az_span test_span = AZ_SPAN_FROM_BUFFER(buffer);
+    test_span._internal.ptr[0] = 'a';
+    test_span._internal.ptr[1] = 'b';
+    test_span._internal.ptr[2] = 'c';
+
+    az_span expected = AZ_SPAN_FROM_STR("ab");
+
+    char destination[59] = { 0 };
+    destination[2] = 'd'; // verify that 'd' is overwritten with 0
+    az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
+
+    int final_size;
+    az_result result
+        = az_json_string_unescape(az_span_slice(test_span, 0, 2), destination, 59, &final_size);
+
+    destination_span = az_span_slice(destination_span, 0, final_size);
+
+    assert_int_equal(0, (int)destination[2]);
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, destination_span));
+  }
+
+  // only escapes
+  {
+    az_span original = AZ_SPAN_FROM_STR("\\b\\f\\n\\r\\t\\\\");
+    az_span expected = AZ_SPAN_FROM_STR("\b\f\n\r\t\\");
+
+    char destination[59] = { 0 };
+    az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
+
+    int final_size;
+    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+
+    destination_span = az_span_slice(destination_span, 0, final_size);
+
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, destination_span));
+  }
+
+  // mix and match
+  {
+    az_span original
+        = AZ_SPAN_FROM_STR("Hello \\b My \\f Name \\n Is \\r Doctor \\t Green \\\\ Thumb");
+    az_span expected = AZ_SPAN_FROM_STR("Hello \b My \f Name \n Is \r Doctor \t Green \\ Thumb");
+
+    char destination[59] = { 0 };
+    az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
+
+    int final_size;
+    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+
+    destination_span = az_span_slice(destination_span, 0, final_size);
+
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, destination_span));
+  }
+
+  // fake escapes
+  {
+    az_span original = AZ_SPAN_FROM_STR("\\9");
+
+    char destination[59] = { 0 };
+
+    int final_size;
+    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+
+    assert_int_equal(AZ_ERROR_UNEXPECTED_CHAR, result);
+  }
+
+  // malformed escapes
+  {
+    az_span original = AZ_SPAN_FROM_STR("abcd\\");
+
+    char destination[59] = { 0 };
+
+    int final_size;
+    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+
+    assert_int_equal(AZ_ERROR_UNEXPECTED_END, result);
+  }
+
+  // single char
+  {
+    az_span original = AZ_SPAN_FROM_STR("a");
+    az_span expected = AZ_SPAN_FROM_STR("a");
+
+    char destination[59] = { 0 };
+    az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
+
+    int final_size;
+    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+
+    destination_span = az_span_slice(destination_span, 0, final_size);
+
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, destination_span));
+  }
+
+  // magic test
+  {
+    az_span original = AZ_SPAN_FROM_STR("A\\\"\"Z");
+    az_span expected = AZ_SPAN_FROM_STR("A\"\"Z");
+    char destination[59] = { 0 };
+    az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
+
+    int final_size;
+    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+
+    destination_span = az_span_slice(destination_span, 0, final_size);
+
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, destination_span));
+  }
+
+  // magic test2
+  {
+    az_span original = AZ_SPAN_FROM_STR("A\\\\\\\\\\\"\\\"Z");
+    az_span expected = AZ_SPAN_FROM_STR("A\\\\\"\"Z");
+    char destination[59] = { 0 };
+    az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
+
+    int final_size;
+    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+
+    destination_span = az_span_slice(destination_span, 0, final_size);
+
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, destination_span));
+  }
+
+  // magic test 2
+  {
+    az_span original = AZ_SPAN_FROM_STR("\\\"\\\"");
+    az_span expected = AZ_SPAN_FROM_STR("\"\"");
+
+    char destination[59] = { 0 };
+    az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
+
+    int final_size;
+    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+
+    destination_span = az_span_slice(destination_span, 0, final_size);
+
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, destination_span));
+  }
+
+  // magic test 3
+  {
+    az_span original = AZ_SPAN_FROM_STR("\" \" \\\" \\\"");
+    az_span expected = AZ_SPAN_FROM_STR("\" \" \" \"");
+
+    char destination[59] = { 0 };
+    az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
+
+    int final_size;
+    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+
+    destination_span = az_span_slice(destination_span, 0, final_size);
+
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, destination_span));
+  }
+
+  // magic test 4
+  {
+    az_span original = AZ_SPAN_FROM_STR("My name is \\\\\\\"Ahson\\\"!");
+    az_span expected = AZ_SPAN_FROM_STR("My name is \\\"Ahson\"!");
+
+    char destination[59] = { 0 };
+    az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
+
+    int final_size;
+    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+
+    destination_span = az_span_slice(destination_span, 0, final_size);
+
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, destination_span));
+  }
+
+  // magic test 5
+  {
+    az_span original = AZ_SPAN_FROM_STR("My name is \\\\\\\"Ahson\\\"!");
+    az_span expected = AZ_SPAN_FROM_STR("My name is \\\"Ahson\"!");
+
+    char destination[59] = { 0 };
+    az_result result = az_json_string_unescape(original, destination, 59, NULL);
+
+    assert_int_equal(AZ_OK, result);
+    assert_string_equal((char*)az_span_ptr(expected), destination);
+  }
+
+  // glorious test
+  {
+    az_span original = AZ_SPAN_FROM_STR("\\/\\/\\\"");
+    az_span expected = AZ_SPAN_FROM_STR("//\"");
+
+    char destination[59] = { 0 };
+    az_result result = az_json_string_unescape(original, destination, 59, NULL);
+
+    assert_int_equal(AZ_OK, result);
+    assert_string_equal((char*)az_span_ptr(expected), destination);
+  }
+}
+
+static void test_az_json_string_unescape_same_buffer(void** state)
+{
+  (void)state;
+
+  // no escapes
+  {
+    az_span json = az_span_create_from_str(
+        strdup(" { \"name\": \"some value string\" , \"code\" : 123456 } "));
+
+    az_span expected
+        = AZ_SPAN_FROM_STR(" { \"name\": \"some value string\" , \"code\" : 123456 } ");
+
+    int final_size;
+    az_result result = az_json_string_unescape(json, (char*)az_span_ptr(json), 59, &final_size);
+
+    json = az_span_slice(json, 0, final_size);
+
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, json));
+    _az_span_free(&json);
+  }
+
+  // null terminator
+  {
+    uint8_t buffer[3];
+    az_span test_span = AZ_SPAN_FROM_BUFFER(buffer);
+    test_span._internal.ptr[0] = 'a';
+    test_span._internal.ptr[1] = 'b';
+    test_span._internal.ptr[2] = 'c'; // verify that 'c' is overwritten with 0
+
+    az_span expected = AZ_SPAN_FROM_STR("ab");
+
+    int final_size;
+    az_result result = az_json_string_unescape(
+        az_span_slice(test_span, 0, 2), (char*)az_span_ptr(test_span), 59, &final_size);
+
+    assert_int_equal(0, test_span._internal.ptr[2]);
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, az_span_slice(test_span, 0, final_size)));
+  }
+
+  // only escapes
+  {
+    az_span original = az_span_create_from_str(strdup("\\b\\f\\n\\r\\t\\\\"));
+    az_span expected = AZ_SPAN_FROM_STR("\b\f\n\r\t\\");
+
+    int final_size;
+    az_result result
+        = az_json_string_unescape(original, (char*)az_span_ptr(original), 59, &final_size);
+
+    original = az_span_slice(original, 0, final_size);
+
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, original));
+    _az_span_free(&original);
+  }
+
+  // some other escapes
+  {
+    az_span original = az_span_create_from_str(strdup("\\/\\/\\\""));
+    az_span expected = AZ_SPAN_FROM_STR("//\"");
+
+    int final_size;
+    az_result result
+        = az_json_string_unescape(original, (char*)az_span_ptr(original), 59, &final_size);
+
+    original = az_span_slice(original, 0, final_size);
+
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, original));
+    _az_span_free(&original);
+  }
+
+  // mix and match
+  {
+    az_span original = az_span_create_from_str(
+        strdup("Hello \\b My \\f Name \\n Is \\r Doctor \\t Green \\\\ Thumb"));
+    az_span expected = AZ_SPAN_FROM_STR("Hello \b My \f Name \n Is \r Doctor \t Green \\ Thumb");
+
+    int final_size;
+    az_result result
+        = az_json_string_unescape(original, (char*)az_span_ptr(original), 59, &final_size);
+
+    original = az_span_slice(original, 0, final_size);
+
+    assert_int_equal(AZ_OK, result);
+    assert_true(az_span_is_content_equal(expected, original));
+    _az_span_free(&original);
+  }
+
+  // fake escapes
+  {
+    az_span original = az_span_create_from_str(strdup("\\9"));
+
+    int final_size;
+    az_result result
+        = az_json_string_unescape(original, (char*)az_span_ptr(original), 59, &final_size);
+
+    assert_int_equal(AZ_ERROR_UNEXPECTED_CHAR, result);
+    _az_span_free(&original);
+  }
+
+  // malformed escapes
+  {
+    az_span original = az_span_create_from_str(strdup("abcd\\"));
+
+    int final_size;
+    az_result result
+        = az_json_string_unescape(original, (char*)az_span_ptr(original), 59, &final_size);
+
+    assert_int_equal(AZ_ERROR_UNEXPECTED_END, result);
+    _az_span_free(&original);
+  }
+}
+
 int test_az_json()
 {
   const struct CMUnitTest tests[]

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+#define strdup _strdup
+#endif
 
 #include "az_test_definitions.h"
 #include <azure/core/az_json.h>
@@ -13,7 +16,7 @@
 #include <cmocka.h>
 
 #include <azure/core/_az_cfg.h>
-
+#include <stdlib.h>
 #define TEST_EXPECT_SUCCESS(exp) assert_true(az_result_succeeded(exp))
 
 az_result test_allocator(
@@ -3373,6 +3376,8 @@ int test_az_json()
           cmocka_unit_test(test_az_json_token_number_too_large),
           cmocka_unit_test(test_az_json_token_literal),
           cmocka_unit_test(test_az_json_token_copy),
-          cmocka_unit_test(test_az_json_reader_chunked) };
+          cmocka_unit_test(test_az_json_reader_chunked),
+          cmocka_unit_test(test_az_json_string_unescape),
+          cmocka_unit_test(test_az_json_string_unescape_same_buffer) };
   return cmocka_run_group_tests_name("az_core_json", tests, NULL, NULL);
 }

--- a/sdk/tests/iot/adu/test_az_iot_adu.c
+++ b/sdk/tests/iot/adu/test_az_iot_adu.c
@@ -608,11 +608,11 @@ static void test_az_iot_adu_client_parse_service_properties_succeed(void** state
   assert_int_equal(
       az_json_string_unescape(
           request.update_manifest,
-          (char*)az_span_ptr(request.update_manifest),
-          az_span_size(request.update_manifest) + 1,
+          (char*)scratch_buffer,
+          sizeof(scratch_buffer),
           &out_size),
       AZ_OK);
-  request.update_manifest = az_span_slice(request.update_manifest, 0, out_size);
+  request.update_manifest = az_span_create(scratch_buffer, out_size);
   assert_memory_equal(
       az_span_ptr(request.update_manifest), adu_request_manifest, sizeof(adu_request_manifest) - 1);
   assert_int_equal(az_span_size(request.update_manifest), sizeof(adu_request_manifest) - 1);
@@ -666,11 +666,11 @@ static void test_az_iot_adu_client_parse_service_properties_with_null_file_url_v
   assert_int_equal(
       az_json_string_unescape(
           request.update_manifest,
-          (char*)az_span_ptr(request.update_manifest),
-          az_span_size(request.update_manifest) + 1,
+          (char*)scratch_buffer,
+          sizeof(scratch_buffer),
           &out_size),
       AZ_OK);
-  request.update_manifest = az_span_slice(request.update_manifest, 0, out_size);
+  request.update_manifest = az_span_create(scratch_buffer, out_size);
   assert_memory_equal(
       az_span_ptr(request.update_manifest), adu_request_manifest, sizeof(adu_request_manifest) - 1);
   assert_int_equal(az_span_size(request.update_manifest), sizeof(adu_request_manifest) - 1);
@@ -724,11 +724,11 @@ static void test_az_iot_adu_client_parse_service_properties_multiple_file_url_va
   assert_int_equal(
       az_json_string_unescape(
           request.update_manifest,
-          (char*)az_span_ptr(request.update_manifest),
-          az_span_size(request.update_manifest) + 1,
+          (char*)scratch_buffer,
+          sizeof(scratch_buffer),
           &out_size),
       AZ_OK);
-  request.update_manifest = az_span_slice(request.update_manifest, 0, out_size);
+  request.update_manifest = az_span_create(scratch_buffer, out_size);
   assert_memory_equal(
       az_span_ptr(request.update_manifest), adu_request_manifest, sizeof(adu_request_manifest) - 1);
   assert_int_equal(az_span_size(request.update_manifest), sizeof(adu_request_manifest) - 1);
@@ -787,11 +787,11 @@ static void test_az_iot_adu_client_parse_service_properties_payload_reverse_orde
   assert_int_equal(
       az_json_string_unescape(
           request.update_manifest,
-          (char*)az_span_ptr(request.update_manifest),
-          az_span_size(request.update_manifest) + 1,
+          (char*)scratch_buffer,
+          sizeof(scratch_buffer),
           &out_size),
       AZ_OK);
-  request.update_manifest = az_span_slice(request.update_manifest, 0, out_size);
+  request.update_manifest = az_span_create(scratch_buffer, out_size);
   assert_memory_equal(
       az_span_ptr(request.update_manifest), adu_request_manifest, sizeof(adu_request_manifest) - 1);
   assert_int_equal(az_span_size(request.update_manifest), sizeof(adu_request_manifest) - 1);

--- a/sdk/tests/iot/adu/test_az_iot_adu.c
+++ b/sdk/tests/iot/adu/test_az_iot_adu.c
@@ -607,10 +607,7 @@ static void test_az_iot_adu_client_parse_service_properties_succeed(void** state
   int32_t out_size;
   assert_int_equal(
       az_json_string_unescape(
-          request.update_manifest,
-          (char*)scratch_buffer,
-          sizeof(scratch_buffer),
-          &out_size),
+          request.update_manifest, (char*)scratch_buffer, sizeof(scratch_buffer), &out_size),
       AZ_OK);
   request.update_manifest = az_span_create(scratch_buffer, out_size);
   assert_memory_equal(
@@ -665,10 +662,7 @@ static void test_az_iot_adu_client_parse_service_properties_with_null_file_url_v
   int32_t out_size;
   assert_int_equal(
       az_json_string_unescape(
-          request.update_manifest,
-          (char*)scratch_buffer,
-          sizeof(scratch_buffer),
-          &out_size),
+          request.update_manifest, (char*)scratch_buffer, sizeof(scratch_buffer), &out_size),
       AZ_OK);
   request.update_manifest = az_span_create(scratch_buffer, out_size);
   assert_memory_equal(
@@ -723,10 +717,7 @@ static void test_az_iot_adu_client_parse_service_properties_multiple_file_url_va
   int32_t out_size;
   assert_int_equal(
       az_json_string_unescape(
-          request.update_manifest,
-          (char*)scratch_buffer,
-          sizeof(scratch_buffer),
-          &out_size),
+          request.update_manifest, (char*)scratch_buffer, sizeof(scratch_buffer), &out_size),
       AZ_OK);
   request.update_manifest = az_span_create(scratch_buffer, out_size);
   assert_memory_equal(
@@ -786,10 +777,7 @@ static void test_az_iot_adu_client_parse_service_properties_payload_reverse_orde
   int32_t out_size;
   assert_int_equal(
       az_json_string_unescape(
-          request.update_manifest,
-          (char*)scratch_buffer,
-          sizeof(scratch_buffer),
-          &out_size),
+          request.update_manifest, (char*)scratch_buffer, sizeof(scratch_buffer), &out_size),
       AZ_OK);
   request.update_manifest = az_span_create(scratch_buffer, out_size);
   assert_memory_equal(

--- a/sdk/tests/iot/adu/test_az_iot_adu.c
+++ b/sdk/tests/iot/adu/test_az_iot_adu.c
@@ -638,7 +638,6 @@ static void test_az_iot_adu_client_parse_service_properties_with_null_file_url_v
   az_iot_adu_client adu_client;
   az_json_reader reader;
   az_iot_adu_client_update_request request;
-  az_span remainder;
 
   assert_int_equal(az_iot_adu_client_init(&adu_client, NULL), AZ_OK);
 
@@ -656,19 +655,22 @@ static void test_az_iot_adu_client_parse_service_properties_with_null_file_url_v
   assert_int_equal(az_json_reader_next_token(&reader), AZ_OK);
 
   assert_int_equal(
-      az_iot_adu_client_parse_service_properties(
-          &adu_client,
-          &reader,
-          az_span_create(scratch_buffer, sizeof(scratch_buffer)),
-          &request,
-          &remainder),
-      AZ_OK);
+      az_iot_adu_client_parse_service_properties(&adu_client, &reader, &request), AZ_OK);
 
   // Workflow
   assert_int_equal(request.workflow.action, workflow_action);
   assert_memory_equal(az_span_ptr(request.workflow.id), workflow_id, sizeof(workflow_id) - 1);
 
   // Update Manifest
+  int32_t out_size;
+  assert_int_equal(
+      az_json_string_unescape(
+          request.update_manifest,
+          (char*)az_span_ptr(request.update_manifest),
+          az_span_size(request.update_manifest) + 1,
+          &out_size),
+      AZ_OK);
+  request.update_manifest = az_span_slice(request.update_manifest, 0, out_size);
   assert_memory_equal(
       az_span_ptr(request.update_manifest), adu_request_manifest, sizeof(adu_request_manifest) - 1);
   assert_int_equal(az_span_size(request.update_manifest), sizeof(adu_request_manifest) - 1);
@@ -694,7 +696,6 @@ static void test_az_iot_adu_client_parse_service_properties_multiple_file_url_va
   az_iot_adu_client adu_client;
   az_json_reader reader;
   az_iot_adu_client_update_request request;
-  az_span remainder;
 
   assert_int_equal(az_iot_adu_client_init(&adu_client, NULL), AZ_OK);
 
@@ -712,19 +713,22 @@ static void test_az_iot_adu_client_parse_service_properties_multiple_file_url_va
   assert_int_equal(az_json_reader_next_token(&reader), AZ_OK);
 
   assert_int_equal(
-      az_iot_adu_client_parse_service_properties(
-          &adu_client,
-          &reader,
-          az_span_create(scratch_buffer, sizeof(scratch_buffer)),
-          &request,
-          &remainder),
-      AZ_OK);
+      az_iot_adu_client_parse_service_properties(&adu_client, &reader, &request), AZ_OK);
 
   // Workflow
   assert_int_equal(request.workflow.action, workflow_action);
   assert_memory_equal(az_span_ptr(request.workflow.id), workflow_id, sizeof(workflow_id) - 1);
 
   // Update Manifest
+  int32_t out_size;
+  assert_int_equal(
+      az_json_string_unescape(
+          request.update_manifest,
+          (char*)az_span_ptr(request.update_manifest),
+          az_span_size(request.update_manifest) + 1,
+          &out_size),
+      AZ_OK);
+  request.update_manifest = az_span_slice(request.update_manifest, 0, out_size);
   assert_memory_equal(
       az_span_ptr(request.update_manifest), adu_request_manifest, sizeof(adu_request_manifest) - 1);
   assert_int_equal(az_span_size(request.update_manifest), sizeof(adu_request_manifest) - 1);
@@ -860,7 +864,6 @@ test_az_iot_adu_client_parse_service_properties_payload_no_deployment_null_file_
   az_iot_adu_client adu_client;
   az_json_reader reader;
   az_iot_adu_client_update_request request;
-  az_span remainder;
 
   assert_int_equal(az_iot_adu_client_init(&adu_client, NULL), AZ_OK);
 
@@ -878,13 +881,7 @@ test_az_iot_adu_client_parse_service_properties_payload_no_deployment_null_file_
   assert_int_equal(az_json_reader_next_token(&reader), AZ_OK);
 
   assert_int_equal(
-      az_iot_adu_client_parse_service_properties(
-          &adu_client,
-          &reader,
-          az_span_create(scratch_buffer, sizeof(scratch_buffer)),
-          &request,
-          &remainder),
-      AZ_OK);
+      az_iot_adu_client_parse_service_properties(&adu_client, &reader, &request), AZ_OK);
 
   // Workflow
   assert_int_equal(request.workflow.action, workflow_action_failed);


### PR DESCRIPTION
This change doesn't require the user to pass a buffer to the ADU properties parsing. The values in the JSON are passed by value, with the ability for the user to then unescape them as needed (possibly in place to further save memory).

Ultimately, we require less from the user and they get more control.