### PR TITLE
Move dtmi to public header

### DIFF
--- a/sdk/inc/azure/iot/az_iot_adu_client.h
+++ b/sdk/inc/azure/iot/az_iot_adu_client.h
@@ -30,6 +30,11 @@
 #include <azure/core/_az_cfg_prefix.h>
 
 /**
+ * @brief  Define the ADU agent interface ID.
+ */
+#define AZ_IOT_ADU_CLIENT_AGENT_INTERFACE_ID "dtmi:azure:iot:deviceUpdate;1"
+
+/**
  * @brief ADU Agent Version
  */
 #define AZ_IOT_ADU_CLIENT_AGENT_VERSION "DU;agent/0.8.0-rc1-public-preview"

--- a/sdk/src/azure/iot/az_iot_adu_client.c
+++ b/sdk/src/azure/iot/az_iot_adu_client.c
@@ -11,9 +11,6 @@
 /* Define the ADU agent component name.  */
 #define AZ_IOT_ADU_CLIENT_AGENT_COMPONENT_NAME "deviceUpdate"
 
-/* Define the ADU agent interface ID.  */
-#define AZ_IOT_ADU_CLIENT_AGENT_INTERFACE_ID "dtmi:azure:iot:deviceUpdate;1"
-
 /* Define the ADU agent property name "agent" and sub property names.  */
 #define AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_AGENT "agent"
 


### PR DESCRIPTION
The parsing APIs are developed to be hardcoded for a specific version of the DTMI. If the DTMI were to change, our underlying parsing would also have to change. I see no reason why we shouldn't make this public, since users can then reference it in their own published DTMI (and not have to create this string themselves).

For example, in the middleware sample, I don't see a reason why the user should have to provide this string. We should make this available to them to use.

https://github.com/Azure-Samples/iot-middleware-freertos-samples/blob/aa3d65a6e930062319bc4802d7cc1a00d0169570/demos/sample_azure_iot_adu/sample_azure_iot_adu.c#L216-L219