### PR TITLE
[ADU] Update request manifest parsing to ignore Delta Updates

### DIFF
--- a/sdk/src/azure/iot/az_iot_adu_client.c
+++ b/sdk/src/azure/iot/az_iot_adu_client.c
@@ -808,24 +808,24 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_update_manifest(
             }
           }
           /*
-          * C SDK will not support delta updates at this time, so relatedFiles,
-          * downloadHandler, and mimeType are not exposed or processed.
-          */
+           * C SDK will not support delta updates at this time, so relatedFiles,
+           * downloadHandler, and mimeType are not exposed or processed.
+           */
           else if (az_json_token_is_text_equal(
-                  &ref_json_reader->token,
-                  AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_RELATED_FILES)))
+                       &ref_json_reader->token,
+                       AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_RELATED_FILES)))
           {
             _az_RETURN_IF_FAILED(az_json_reader_skip_children(ref_json_reader));
           }
           else if (az_json_token_is_text_equal(
-                  &ref_json_reader->token,
-                  AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_DOWNLOAD_HANDLER)))
+                       &ref_json_reader->token,
+                       AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_DOWNLOAD_HANDLER)))
           {
             _az_RETURN_IF_FAILED(az_json_reader_skip_children(ref_json_reader));
           }
           else if (az_json_token_is_text_equal(
-                  &ref_json_reader->token,
-                  AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_MIME_TYPE)))
+                       &ref_json_reader->token,
+                       AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_MIME_TYPE)))
           {
             _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
           }

--- a/sdk/src/azure/iot/az_iot_adu_client.c
+++ b/sdk/src/azure/iot/az_iot_adu_client.c
@@ -67,6 +67,9 @@
 #define AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_HASHES "hashes"
 #define AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_SHA256 "sha256"
 #define AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_CREATED_DATE_TIME "createdDateTime"
+#define AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_DOWNLOAD_HANDLER "downloadHandler"
+#define AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_RELATED_FILES "relatedFiles"
+#define AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_MIME_TYPE "mimeType"
 
 #define NULL_TERM_CHAR_SIZE 1
 
@@ -803,6 +806,28 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_update_manifest(
 
               _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
             }
+          }
+          /*
+          * C SDK will not support delta updates at this time, so relatedFiles,
+          * downloadHandler, and mimeType are not exposed or processed.
+          */
+          else if (az_json_token_is_text_equal(
+                  &ref_json_reader->token,
+                  AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_RELATED_FILES)))
+          {
+            _az_RETURN_IF_FAILED(az_json_reader_skip_children(ref_json_reader));
+          }
+          else if (az_json_token_is_text_equal(
+                  &ref_json_reader->token,
+                  AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_DOWNLOAD_HANDLER)))
+          {
+            _az_RETURN_IF_FAILED(az_json_reader_skip_children(ref_json_reader));
+          }
+          else if (az_json_token_is_text_equal(
+                  &ref_json_reader->token,
+                  AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_MIME_TYPE)))
+          {
+            _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
           }
           else
           {

--- a/sdk/tests/iot/adu/test_az_iot_adu.c
+++ b/sdk/tests/iot/adu/test_az_iot_adu.c
@@ -902,13 +902,8 @@ test_az_iot_adu_client_parse_service_properties_payload_no_deployment_null_file_
   assert_int_equal(request.file_urls_count, 0);
 }
 
-static void parse_update_manifest_succeed(
-    void** state,
-    uint8_t request_manifest[],
-    int32_t request_manifest_size)
+static void parse_update_manifest_succeed(uint8_t* request_manifest, int32_t request_manifest_size)
 {
-  (void)state;
-
   az_iot_adu_client adu_client;
   az_json_reader reader;
   az_iot_adu_client_update_manifest update_manifest;
@@ -990,19 +985,22 @@ static void parse_update_manifest_succeed(
 
 static void test_az_iot_adu_client_parse_update_manifest_succeed(void** state)
 {
-  parse_update_manifest_succeed(state, adu_request_manifest, sizeof(adu_request_manifest));
+  (void)state;
+  parse_update_manifest_succeed(adu_request_manifest, sizeof(adu_request_manifest));
 }
 
 static void test_az_iot_adu_client_parse_update_manifest_unused_fields_succeed(void** state)
 {
+  (void)state;
   parse_update_manifest_succeed(
-      state, adu_request_manifest_unused_fields, sizeof(adu_request_manifest_unused_fields));
+      adu_request_manifest_unused_fields, sizeof(adu_request_manifest_unused_fields));
 }
 
 static void test_az_iot_adu_client_parse_update_manifest_payload_reverse_order_succeed(void** state)
 {
+  (void)state;
   parse_update_manifest_succeed(
-      state, adu_request_manifest_reverse_order, sizeof(adu_request_manifest_reverse_order));
+      adu_request_manifest_reverse_order, sizeof(adu_request_manifest_reverse_order));
 }
 
 #ifdef _MSC_VER

--- a/sdk/tests/iot/adu/test_az_iot_adu.c
+++ b/sdk/tests/iot/adu/test_az_iot_adu.c
@@ -258,10 +258,10 @@ static uint8_t adu_request_manifest_unused_fields[]
       "\"1.0\"}}]},\"files\":{\"f2f4a804ca17afbae\":{\"fileName\":\"iot-middleware-sample-adu-v1."
       "1\",\"sizeInBytes\":844976,\"hashes\":{\"sha256\":\"xsoCnYAMkZZ7m9RL9Vyg9jKfFehCNxyuPFaJVM/"
       "WBi0=\"},\"mimeType\":\"application/octet-stream\",\"relatedFiles\":[{\"filename\":\"in1_in"
-      "2_deltaupdate.dat\",\"sizeInBytes\":\"102910752\",\"hashes\":{\"sha256\":\"2MIl...\"},\"properties\":"
-      "{\"microsoft.sourceFileAlgorithm\":\"sha256\",\"microsoft.sourceFileHash\":\"YmFY...\"}}],"
-      "\"downloadHandler\":{\"id\":\"microsoft/delta:1\"}}},\"createdDateTime\":\"2022-07-07T03:02"
-      ":48.8449038Z\"}";
+      "2_deltaupdate.dat\",\"sizeInBytes\":\"102910752\",\"hashes\":{\"sha256\":\"2MIl...\"},"
+      "\"properties\":{\"microsoft.sourceFileAlgorithm\":\"sha256\",\"microsoft.sourceFileHash\":"
+      "\"YmFY...\"}}],\"downloadHandler\":{\"id\":\"microsoft/"
+      "delta:1\"}}},\"createdDateTime\":\"2022-07-07T03:02:48.8449038Z\"}";
 static uint8_t adu_request_manifest_reverse_order[]
     = "{\"createdDateTime\":\"2022-07-07T03:02:48.8449038Z\",\"files\":{\"f2f4a804ca17afbae\":{"
       "\"fileName\":\"iot-middleware-sample-adu-v1.1\",\"sizeInBytes\":844976,\"hashes\":{"
@@ -902,7 +902,10 @@ test_az_iot_adu_client_parse_service_properties_payload_no_deployment_null_file_
   assert_int_equal(request.file_urls_count, 0);
 }
 
-static void parse_update_manifest_succeed(void** state, uint8_t request_manifest[], int32_t request_manifest_size)
+static void parse_update_manifest_succeed(
+    void** state,
+    uint8_t request_manifest[],
+    int32_t request_manifest_size)
 {
   (void)state;
 
@@ -992,12 +995,14 @@ static void test_az_iot_adu_client_parse_update_manifest_succeed(void** state)
 
 static void test_az_iot_adu_client_parse_update_manifest_unused_fields_succeed(void** state)
 {
-  parse_update_manifest_succeed(state, adu_request_manifest_unused_fields, sizeof(adu_request_manifest_unused_fields));
+  parse_update_manifest_succeed(
+      state, adu_request_manifest_unused_fields, sizeof(adu_request_manifest_unused_fields));
 }
 
 static void test_az_iot_adu_client_parse_update_manifest_payload_reverse_order_succeed(void** state)
 {
-  parse_update_manifest_succeed(state, adu_request_manifest_reverse_order, sizeof(adu_request_manifest_reverse_order));
+  parse_update_manifest_succeed(
+      state, adu_request_manifest_reverse_order, sizeof(adu_request_manifest_reverse_order));
 }
 
 #ifdef _MSC_VER


### PR DESCRIPTION
- ignore delta update fields when parsing an adu request manifest.
- add test for a request manifest that has these fields (keeping tests with manifests that _don't_ have these fields).
- combine shared code to test request manifests (since this change explicitly _doesn't_ expose or process these fields, there are no additional fields to check against, we just want to ensure that everything still works as expected).

Note: I did modify all of the tests to use request manifests that have delta update fields to verify that they all pass (they did), but the other tests don't explicitly test the code changes, so I only duplicated the relevant test.