### PR TITLE
fix todos

### DIFF
--- a/sdk/inc/azure/iot/az_iot_common.h
+++ b/sdk/inc/azure/iot/az_iot_common.h
@@ -57,6 +57,9 @@ enum az_log_classification_iot
 
   AZ_LOG_IOT_AZURERTOS
   = _az_LOG_MAKE_CLASSIFICATION(_az_FACILITY_IOT, 3), ///< Azure IoT classification for Azure RTOS.
+
+  AZ_LOG_IOT_ADU
+  = _az_LOG_MAKE_CLASSIFICATION(_az_FACILITY_IOT, 4), ///< Azure IoT classification for ADU APIs.
 };
 
 enum

--- a/sdk/src/azure/iot/az_iot_adu_client.c
+++ b/sdk/src/azure/iot/az_iot_adu_client.c
@@ -117,8 +117,6 @@ const uint8_t azure_iot_adu_root_key_n[385]
         0x77, 0x3e, 0x40, 0x87, 0x18, 0xc9, 0xab, 0xd9, 0xf7, 0x79 };
 const uint8_t azure_iot_adu_root_key_e[3] = { 0x01, 0x00, 0x01 };
 
-uint8_t azure_iot_step_id_scratch_buffer[7];
-
 const az_span default_compatibility_properties
     = AZ_SPAN_LITERAL_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_DEFAULT_COMPATIBILITY_PROPERTIES);
 
@@ -179,6 +177,8 @@ AZ_NODISCARD az_result az_iot_adu_client_get_agent_state_payload(
   _az_PRECONDITION_VALID_SPAN(device_properties->update_id, 1, false);
   _az_PRECONDITION_VALID_SPAN(device_properties->adu_version, 1, false);
   _az_PRECONDITION_NOT_NULL(ref_json_writer);
+
+  uint8_t step_id_scratch_buffer[7];
 
   /* Update reported property */
   _az_RETURN_IF_FAILED(az_json_writer_append_begin_object(ref_json_writer));
@@ -276,7 +276,7 @@ AZ_NODISCARD az_result az_iot_adu_client_get_agent_state_payload(
 
     for (int32_t i = 0; i < last_install_result->step_results_count; i++)
     {
-      az_span step_id = AZ_SPAN_FROM_BUFFER(azure_iot_step_id_scratch_buffer);
+      az_span step_id = AZ_SPAN_FROM_BUFFER(step_id_scratch_buffer);
       _az_RETURN_IF_FAILED(generate_step_id(step_id, (uint32_t)i, &step_id));
 
       _az_RETURN_IF_FAILED(az_json_writer_append_property_name(ref_json_writer, step_id));

--- a/sdk/src/azure/iot/az_iot_adu_client.c
+++ b/sdk/src/azure/iot/az_iot_adu_client.c
@@ -4,6 +4,7 @@
 #include <azure/iot/az_iot_adu_client.h>
 #include <azure/iot/az_iot_hub_client_properties.h>
 
+#include <azure/core/internal/az_log_internal.h>
 #include <azure/core/internal/az_precondition_internal.h>
 #include <azure/core/internal/az_result_internal.h>
 #include <stdio.h>
@@ -116,6 +117,8 @@ const uint8_t azure_iot_adu_root_key_n[385]
         0x77, 0x3e, 0x40, 0x87, 0x18, 0xc9, 0xab, 0xd9, 0xf7, 0x79 };
 const uint8_t azure_iot_adu_root_key_e[3] = { 0x01, 0x00, 0x01 };
 
+uint8_t azure_iot_step_id_scratch_buffer[7];
+
 const az_span default_compatibility_properties
     = AZ_SPAN_LITERAL_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_DEFAULT_COMPATIBILITY_PROPERTIES);
 
@@ -145,13 +148,6 @@ AZ_NODISCARD bool az_iot_adu_client_is_component_device_update(
 
   return az_span_is_content_equal(
       AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_COMPONENT_NAME), component_name);
-}
-
-static az_span get_json_writer_remaining_buffer(az_json_writer* jw)
-{
-  return az_span_slice_to_end(
-      jw->_internal.destination_buffer,
-      az_span_size(az_json_writer_get_bytes_used_in_destination(jw)));
 }
 
 static az_result generate_step_id(az_span buffer, uint32_t step_index, az_span* step_id)
@@ -223,7 +219,6 @@ AZ_NODISCARD az_result az_iot_adu_client_get_agent_state_payload(
     }
   }
 
-  // TODO: verify if this needs to be exposed as an option.
   _az_RETURN_IF_FAILED(az_json_writer_append_property_name(
       ref_json_writer, AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_INTERFACE_ID)));
   _az_RETURN_IF_FAILED(az_json_writer_append_string(
@@ -273,7 +268,6 @@ AZ_NODISCARD az_result az_iot_adu_client_get_agent_state_payload(
 
     if (!az_span_is_content_equal(last_install_result->result_details, AZ_SPAN_EMPTY))
     {
-      // TODO: Add quotes if result_details is not enclosed by quotes.
       _az_RETURN_IF_FAILED(az_json_writer_append_property_name(
           ref_json_writer, AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_RESULT_DETAILS)));
       _az_RETURN_IF_FAILED(
@@ -282,13 +276,7 @@ AZ_NODISCARD az_result az_iot_adu_client_get_agent_state_payload(
 
     for (int32_t i = 0; i < last_install_result->step_results_count; i++)
     {
-      // TODO: investigate better way to grab remaining buffer space
-      az_span remaining_buffer = get_json_writer_remaining_buffer(ref_json_writer);
-      // Taking from the end of the remaining buffer to avoid az_json_writer overlapping
-      // with the data we will generate in that buffer.
-      az_span step_id = az_span_slice_to_end(
-          remaining_buffer, az_span_size(remaining_buffer) - (int32_t)RESULT_STEP_ID_MAX_SIZE);
-
+      az_span step_id = AZ_SPAN_FROM_BUFFER(azure_iot_step_id_scratch_buffer);
       _az_RETURN_IF_FAILED(generate_step_id(step_id, (uint32_t)i, &step_id));
 
       _az_RETURN_IF_FAILED(az_json_writer_append_property_name(ref_json_writer, step_id));
@@ -308,7 +296,6 @@ AZ_NODISCARD az_result az_iot_adu_client_get_agent_state_payload(
       if (!az_span_is_content_equal(
               last_install_result->step_results[i].result_details, AZ_SPAN_EMPTY))
       {
-        // TODO: Add quotes if result_details is not enclosed by quotes.
         _az_RETURN_IF_FAILED(az_json_writer_append_property_name(
             ref_json_writer,
             AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_RESULT_DETAILS)));
@@ -427,7 +414,9 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_service_properties(
         }
         else
         {
-          // TODO: log unexpected property.
+          _az_LOG_WRITE(
+              AZ_LOG_IOT_ADU,
+              AZ_SPAN_FROM_STR("Unexpected property found in ADU manifest workflow"));
           return AZ_ERROR_JSON_INVALID_STATE;
         }
 
@@ -675,7 +664,8 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_update_manifest(
       }
       else
       {
-        // TODO: log unexpected property.
+        _az_LOG_WRITE(
+            AZ_LOG_IOT_ADU, AZ_SPAN_FROM_STR("Unexpected property found in ADU manifest steps"));
         return AZ_ERROR_JSON_INVALID_STATE;
       }
     }
@@ -717,7 +707,9 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_update_manifest(
         }
         else
         {
-          // TODO: log unexpected property.
+          _az_LOG_WRITE(
+              AZ_LOG_IOT_ADU,
+              AZ_SPAN_FROM_STR("Unexpected property found in ADU update id object"));
           return AZ_ERROR_JSON_INVALID_STATE;
         }
 

--- a/sdk/src/azure/iot/az_iot_adu_client.c
+++ b/sdk/src/azure/iot/az_iot_adu_client.c
@@ -416,7 +416,8 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_service_properties(
         {
           _az_LOG_WRITE(
               AZ_LOG_IOT_ADU,
-              AZ_SPAN_FROM_STR("Unexpected property found in ADU manifest workflow"));
+              AZ_SPAN_FROM_STR("Unexpected property found in ADU manifest workflow:"));
+          _az_LOG_WRITE(AZ_LOG_IOT_ADU, ref_json_reader->token.slice);
           return AZ_ERROR_JSON_INVALID_STATE;
         }
 
@@ -665,7 +666,8 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_update_manifest(
       else
       {
         _az_LOG_WRITE(
-            AZ_LOG_IOT_ADU, AZ_SPAN_FROM_STR("Unexpected property found in ADU manifest steps"));
+            AZ_LOG_IOT_ADU, AZ_SPAN_FROM_STR("Unexpected property found in ADU manifest steps:"));
+        _az_LOG_WRITE(AZ_LOG_IOT_ADU, ref_json_reader->token.slice);
         return AZ_ERROR_JSON_INVALID_STATE;
       }
     }
@@ -709,7 +711,8 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_update_manifest(
         {
           _az_LOG_WRITE(
               AZ_LOG_IOT_ADU,
-              AZ_SPAN_FROM_STR("Unexpected property found in ADU update id object"));
+              AZ_SPAN_FROM_STR("Unexpected property found in ADU update id object:"));
+          _az_LOG_WRITE(AZ_LOG_IOT_ADU, ref_json_reader->token.slice);
           return AZ_ERROR_JSON_INVALID_STATE;
         }
 


### PR DESCRIPTION
For items not explicitly fixed:

>  // TODO: verify if this needs to be exposed as an option.

  - No we do not since this is tied to the ADU parsing. Worst case scenario, if this is ever an issue, we can add an option in the ADU client options field.
  
>  // TODO: Add quotes if result_details is not enclosed by quotes.
  - append_string adds the quotes already