### PR TITLE
Add default .assets directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -325,3 +325,6 @@ fingerprint.txt
 
 # Cert
 /cert
+
+# Default Assets restore directory
+.assets


### PR DESCRIPTION
The default assets restore is a `.assets` directory in the repository root. This directory needs to be ignored by each individual langue.