### PR TITLE
Fix zlib 1.2.12 vcpkg failure

### DIFF
--- a/cmake-modules/AzureVcpkg.cmake
+++ b/cmake-modules/AzureVcpkg.cmake
@@ -21,7 +21,7 @@ macro(az_vcpkg_integrate)
       if(NOT DEFINED ENV{AZURE_SDK_DISABLE_AUTO_VCPKG})
         # GET VCPKG FROM SOURCE
         #  User can set env var AZURE_SDK_VCPKG_COMMIT to pick the VCPKG commit to fetch
-        set(VCPKG_COMMIT_STRING f0aa678b7471497f1adedcc99f40e1599ad22f69) # default SDK tested commit
+        set(VCPKG_COMMIT_STRING 6ca56aeb457f033d344a7106cb3f9f1abf8f4e98) # default SDK tested commit
         if(DEFINED ENV{AZURE_SDK_VCPKG_COMMIT})
           set(VCPKG_COMMIT_STRING "$ENV{AZURE_SDK_VCPKG_COMMIT}") # default SDK tested commit
         endif()

--- a/cmake-modules/AzureVcpkg.cmake
+++ b/cmake-modules/AzureVcpkg.cmake
@@ -21,7 +21,7 @@ macro(az_vcpkg_integrate)
       if(NOT DEFINED ENV{AZURE_SDK_DISABLE_AUTO_VCPKG})
         # GET VCPKG FROM SOURCE
         #  User can set env var AZURE_SDK_VCPKG_COMMIT to pick the VCPKG commit to fetch
-        set(VCPKG_COMMIT_STRING 6ca56aeb457f033d344a7106cb3f9f1abf8f4e98) # default SDK tested commit
+        set(VCPKG_COMMIT_STRING f0aa678b7471497f1adedcc99f40e1599ad22f69) # default SDK tested commit
         if(DEFINED ENV{AZURE_SDK_VCPKG_COMMIT})
           set(VCPKG_COMMIT_STRING "$ENV{AZURE_SDK_VCPKG_COMMIT}") # default SDK tested commit
         endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-sdk-for-c",
   "version": "1.0.0",
-  "builtin-baseline": "f0aa678b7471497f1adedcc99f40e1599ad22f69",
+  "builtin-baseline": "6ca56aeb457f033d344a7106cb3f9f1abf8f4e98",
   "dependencies": [
     {
       "name": "curl"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-sdk-for-c",
   "version": "1.0.0",
-  "builtin-baseline": "6ca56aeb457f033d344a7106cb3f9f1abf8f4e98",
+  "builtin-baseline": "f0aa678b7471497f1adedcc99f40e1599ad22f69",
   "dependencies": [
     {
       "name": "curl"
@@ -11,6 +11,12 @@
     },
     {
       "name": "cmocka"
+    }
+  ],
+  "overrides": [
+    {
+      "name": "zlib",
+      "version": "1.2.12#2"
     }
   ]
 }


### PR DESCRIPTION
Unfortunately, we can't easily pick same SHA that we picked for updating the C++ SDK (https://github.com/Azure/azure-sdk-for-cpp/pull/4036), because `paho-mqtt` has a breaking change at that commit SHA (`fatal error C1083: Cannot open include file: 'paho-mqtt/MQTTClient.h': No such file or directory`).

So, `overrides` if not the final step, is definitely the first fix.