### PR TITLE
Add MQTTClient to the ignore list since cspell flags that as a false positive.

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -48,6 +48,7 @@
     "mkdir",
     "moxygen",
     "mqtt",
+    "MQTTCLIENT",
     "mspremier",
     "MSRC",
     "MSVC",


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-c/issues/2405