### PR TITLE
Update az_json_string_unescape to accept az_span as destination to improve usability of API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@
 
 ### Features Added
 
-[[#2329](https://github.com/Azure/azure-sdk-for-c/pull/2329)] Add Base64 URL decoder.
+- [[#2329](https://github.com/Azure/azure-sdk-for-c/pull/2329)] Add Base64 URL decoder.
 
 ### Breaking Changes
 
+- Modified the `az_json_string_unescape()` function signature to accept `az_span` as the destination.
+
 ### Bugs Fixed
 
-[[#2372](https://github.com/Azure/azure-sdk-for-c/pull/2372)] Incorrect minimum buffer size calculation when logging an HTTP request.
+- [[#2372](https://github.com/Azure/azure-sdk-for-c/pull/2372)] Incorrect minimum buffer size calculation when logging an HTTP request.
 
 ### Other Changes
 

--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -796,28 +796,23 @@ AZ_NODISCARD az_result az_json_reader_skip_children(az_json_reader* ref_json_rea
  * @brief Unescapes the JSON string within the provided #az_span.
  *
  * @param[in] json_string The #az_span that contains the string to be unescaped.
- * @param destination Pointer to the buffer that will contain the output.
- * @param[in] destination_max_size The maximum available space within the buffer referred to by
- * \p destination.
- * @param[out] out_string_length __[nullable]__ Contains the number of bytes written to the
- * \p destination which denote the length of the unescaped string. If `NULL` is passed, the
- * \p parameter is ignored.
+ * @param destination The destination buffer used to write the unescaped output into.
+ * 
+ * @return An #az_span that is a slice of the \p destination #az_span containing the unescaped JSON string, which denotes the length of the unescaped string.
+ * 
+ * @remarks For user-defined or unknown input, the buffer referred to by \p destination must be at least as large as the \p json_string #az_span.
+ * Content is copied from the source buffer, while unescaping.
+ * 
+ * @remarks This function assumes that the \p json_string input is well-formed JSON.
+ * 
+ * @remarks This function assumes that the \p destination has a large enough size to hold the unescaped \p
+ * json_string.
  *
- * @return An #az_result value indicating the result of the operation.
- * @retval #AZ_OK The string is returned.
- * @retval #AZ_ERROR_NOT_ENOUGH_SPACE \p destination does not have enough size.
- *
- * @remarks The buffer referred to by \p destination must have a size that is at least 1 byte bigger
- * than the \p json_string #az_span for the \p destination string to be zero-terminated.
- * Content is copied from the source buffer, while unescaping and then `\0` is added at the end.
- *
- * @remarks This API can also be used to perform in place unescaping.
+ * @remarks This API can also be used to perform in place unescaping. However, doing so, is destructive and the input JSON may no longer be valid or parsable.
  */
-AZ_NODISCARD az_result az_json_string_unescape(
+AZ_NODISCARD az_span az_json_string_unescape(
     az_span json_string,
-    char* destination,
-    int32_t destination_max_size,
-    int32_t* out_string_length);
+    az_span destination);
 
 #include <azure/core/_az_cfg_suffix.h>
 

--- a/sdk/inc/azure/core/az_json.h
+++ b/sdk/inc/azure/core/az_json.h
@@ -797,22 +797,23 @@ AZ_NODISCARD az_result az_json_reader_skip_children(az_json_reader* ref_json_rea
  *
  * @param[in] json_string The #az_span that contains the string to be unescaped.
  * @param destination The destination buffer used to write the unescaped output into.
- * 
- * @return An #az_span that is a slice of the \p destination #az_span containing the unescaped JSON string, which denotes the length of the unescaped string.
- * 
- * @remarks For user-defined or unknown input, the buffer referred to by \p destination must be at least as large as the \p json_string #az_span.
- * Content is copied from the source buffer, while unescaping.
- * 
- * @remarks This function assumes that the \p json_string input is well-formed JSON.
- * 
- * @remarks This function assumes that the \p destination has a large enough size to hold the unescaped \p
- * json_string.
  *
- * @remarks This API can also be used to perform in place unescaping. However, doing so, is destructive and the input JSON may no longer be valid or parsable.
+ * @return An #az_span that is a slice of the \p destination #az_span containing the unescaped JSON
+ * string, which denotes the length of the unescaped string.
+ *
+ * @remarks For user-defined or unknown input, the buffer referred to by \p destination must be at
+ * least as large as the \p json_string #az_span. Content is copied from the source buffer, while
+ * unescaping.
+ *
+ * @remarks This function assumes that the \p json_string input is well-formed JSON.
+ *
+ * @remarks This function assumes that the \p destination has a large enough size to hold the
+ * unescaped \p json_string.
+ *
+ * @remarks This API can also be used to perform in place unescaping. However, doing so, is
+ * destructive and the input JSON may no longer be valid or parsable.
  */
-AZ_NODISCARD az_span az_json_string_unescape(
-    az_span json_string,
-    az_span destination);
+AZ_NODISCARD az_span az_json_string_unescape(az_span json_string, az_span destination);
 
 #include <azure/core/_az_cfg_suffix.h>
 

--- a/sdk/src/azure/core/az_json_token.c
+++ b/sdk/src/azure/core/az_json_token.c
@@ -325,9 +325,7 @@ AZ_NODISCARD static az_result _az_json_token_get_string_helper(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_span az_json_string_unescape(
-    az_span json_string,
-    az_span destination)
+AZ_NODISCARD az_span az_json_string_unescape(az_span json_string, az_span destination)
 {
   _az_PRECONDITION_VALID_SPAN(json_string, 1, false);
 
@@ -367,7 +365,8 @@ AZ_NODISCARD az_span az_json_string_unescape(
 
     if (position > destination_size)
     {
-      // We assume that the destination buffer is large enough, but stop processing, in-case it isn't.
+      // We assume that the destination buffer is large enough, but stop processing, in-case it
+      // isn't.
       return az_span_slice(destination, 0, position);
     }
 

--- a/sdk/src/azure/core/az_json_token.c
+++ b/sdk/src/azure/core/az_json_token.c
@@ -325,20 +325,21 @@ AZ_NODISCARD static az_result _az_json_token_get_string_helper(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_json_string_unescape(
+AZ_NODISCARD az_span az_json_string_unescape(
     az_span json_string,
-    char* destination,
-    int32_t destination_max_size,
-    int32_t* out_string_length)
+    az_span destination)
 {
   _az_PRECONDITION_VALID_SPAN(json_string, 1, false);
-  _az_PRECONDITION_NOT_NULL(destination);
-  // The destination needs to be larger than the input, for null terminator.
-  _az_PRECONDITION(destination_max_size > az_span_size(json_string));
+
+  int32_t span_size = az_span_size(json_string);
+
+  // The destination needs to be at least as large as the input, in the worst case.
+  _az_PRECONDITION_VALID_SPAN(destination, span_size, false);
 
   int32_t position = 0;
-  int32_t span_size = az_span_size(json_string);
   uint8_t* span_ptr = az_span_ptr(json_string);
+  uint8_t* destination_ptr = az_span_ptr(destination);
+  int32_t destination_size = az_span_size(destination);
   for (int32_t i = 0; i < span_size; i++)
   {
     uint8_t current_char = span_ptr[i];
@@ -353,32 +354,28 @@ AZ_NODISCARD az_result az_json_string_unescape(
       }
       else
       {
-        return AZ_ERROR_UNEXPECTED_CHAR;
+        // We assume that the input json is well-formed, but stop processing, in-case it isn't.
+        return az_span_slice(destination, 0, position);
       }
     }
     else if (current_char == '\\')
     {
       // At this point, we are at the last character, i == span_size - 1
-      return AZ_ERROR_UNEXPECTED_END;
+      // We assume that the input json is well-formed, but stop processing, in-case it isn't.
+      return az_span_slice(destination, 0, position);
     }
 
-    if (position > destination_max_size)
+    if (position > destination_size)
     {
-      return AZ_ERROR_NOT_ENOUGH_SPACE;
+      // We assume that the destination buffer is large enough, but stop processing, in-case it isn't.
+      return az_span_slice(destination, 0, position);
     }
 
-    destination[position] = (char)current_char;
+    destination_ptr[position] = current_char;
     position++;
   }
 
-  destination[position] = 0;
-
-  if (out_string_length != NULL)
-  {
-    *out_string_length = position;
-  }
-
-  return AZ_OK;
+  return az_span_slice(destination, 0, position);
 }
 
 AZ_NODISCARD az_result az_json_token_get_string(

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -3185,8 +3185,7 @@ static void test_az_json_string_unescape_same_buffer(void** state)
 
     az_span expected = AZ_SPAN_FROM_STR("ab");
 
-    test_span = az_json_string_unescape(
-        az_span_slice(test_span, 0, 2), test_span);
+    test_span = az_json_string_unescape(az_span_slice(test_span, 0, 2), test_span);
 
     assert_int_equal((int)'c', buffer[2]);
     assert_true(az_span_is_content_equal(expected, az_span_slice(test_span, 0, 2)));
@@ -3197,8 +3196,7 @@ static void test_az_json_string_unescape_same_buffer(void** state)
     az_span original = az_span_create_from_str(strdup("\\b\\f\\n\\r\\t\\\\"));
     az_span expected = AZ_SPAN_FROM_STR("\b\f\n\r\t\\");
 
-    original
-        = az_json_string_unescape(original, original);
+    original = az_json_string_unescape(original, original);
 
     assert_true(az_span_is_content_equal(expected, original));
     _az_span_free(&original);
@@ -3209,9 +3207,8 @@ static void test_az_json_string_unescape_same_buffer(void** state)
     az_span original = az_span_create_from_str(strdup("\\/\\/\\\""));
     az_span expected = AZ_SPAN_FROM_STR("//\"");
 
-    original
-        = az_json_string_unescape(original, original);
-    
+    original = az_json_string_unescape(original, original);
+
     assert_true(az_span_is_content_equal(expected, original));
     _az_span_free(&original);
   }
@@ -3222,8 +3219,7 @@ static void test_az_json_string_unescape_same_buffer(void** state)
         strdup("Hello \\b My \\f Name \\n Is \\r Doctor \\t Green \\\\ Thumb"));
     az_span expected = AZ_SPAN_FROM_STR("Hello \b My \f Name \n Is \r Doctor \t Green \\ Thumb");
 
-    original
-        = az_json_string_unescape(original, original);
+    original = az_json_string_unescape(original, original);
 
     assert_true(az_span_is_content_equal(expected, original));
     _az_span_free(&original);

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -3004,32 +3004,12 @@ static void test_az_json_string_unescape(void** state)
     char destination[59] = { 0 };
     az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
 
-    int final_size;
-    az_result result = az_json_string_unescape(json, destination, 59, &final_size);
+    destination_span = az_json_string_unescape(json, destination_span);
 
-    destination_span = az_span_slice(destination_span, 0, final_size);
-
-    assert_int_equal(AZ_OK, result);
     assert_true(az_span_is_content_equal(expected, destination_span));
   }
 
-  // unexpected end
-  {
-    uint8_t buffer[3];
-    az_span test_span = AZ_SPAN_FROM_BUFFER(buffer);
-    test_span._internal.ptr[0] = 'a';
-    test_span._internal.ptr[1] = 'b';
-    test_span._internal.ptr[2] = '\\';
-
-    char destination[59] = { 0 };
-
-    int final_size;
-    az_result result = az_json_string_unescape(test_span, destination, 59, &final_size);
-
-    assert_int_equal(AZ_ERROR_UNEXPECTED_END, result);
-  }
-
-  // null terminator
+  // nothing is written past the end (including null terminator)
   {
     uint8_t buffer[3];
     az_span test_span = AZ_SPAN_FROM_BUFFER(buffer);
@@ -3040,17 +3020,12 @@ static void test_az_json_string_unescape(void** state)
     az_span expected = AZ_SPAN_FROM_STR("ab");
 
     char destination[59] = { 0 };
-    destination[2] = 'd'; // verify that 'd' is overwritten with 0
+    destination[2] = 'd'; // verify that 'd' is not overwritten with 0
     az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
 
-    int final_size;
-    az_result result
-        = az_json_string_unescape(az_span_slice(test_span, 0, 2), destination, 59, &final_size);
+    destination_span = az_json_string_unescape(az_span_slice(test_span, 0, 2), destination_span);
 
-    destination_span = az_span_slice(destination_span, 0, final_size);
-
-    assert_int_equal(0, (int)destination[2]);
-    assert_int_equal(AZ_OK, result);
+    assert_int_equal((int)'d', (int)destination[2]);
     assert_true(az_span_is_content_equal(expected, destination_span));
   }
 
@@ -3062,12 +3037,8 @@ static void test_az_json_string_unescape(void** state)
     char destination[59] = { 0 };
     az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
 
-    int final_size;
-    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+    destination_span = az_json_string_unescape(original, destination_span);
 
-    destination_span = az_span_slice(destination_span, 0, final_size);
-
-    assert_int_equal(AZ_OK, result);
     assert_true(az_span_is_content_equal(expected, destination_span));
   }
 
@@ -3080,37 +3051,9 @@ static void test_az_json_string_unescape(void** state)
     char destination[59] = { 0 };
     az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
 
-    int final_size;
-    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+    destination_span = az_json_string_unescape(original, destination_span);
 
-    destination_span = az_span_slice(destination_span, 0, final_size);
-
-    assert_int_equal(AZ_OK, result);
     assert_true(az_span_is_content_equal(expected, destination_span));
-  }
-
-  // fake escapes
-  {
-    az_span original = AZ_SPAN_FROM_STR("\\9");
-
-    char destination[59] = { 0 };
-
-    int final_size;
-    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
-
-    assert_int_equal(AZ_ERROR_UNEXPECTED_CHAR, result);
-  }
-
-  // malformed escapes
-  {
-    az_span original = AZ_SPAN_FROM_STR("abcd\\");
-
-    char destination[59] = { 0 };
-
-    int final_size;
-    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
-
-    assert_int_equal(AZ_ERROR_UNEXPECTED_END, result);
   }
 
   // single char
@@ -3121,12 +3064,8 @@ static void test_az_json_string_unescape(void** state)
     char destination[59] = { 0 };
     az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
 
-    int final_size;
-    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+    destination_span = az_json_string_unescape(original, destination_span);
 
-    destination_span = az_span_slice(destination_span, 0, final_size);
-
-    assert_int_equal(AZ_OK, result);
     assert_true(az_span_is_content_equal(expected, destination_span));
   }
 
@@ -3137,12 +3076,8 @@ static void test_az_json_string_unescape(void** state)
     char destination[59] = { 0 };
     az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
 
-    int final_size;
-    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+    destination_span = az_json_string_unescape(original, destination_span);
 
-    destination_span = az_span_slice(destination_span, 0, final_size);
-
-    assert_int_equal(AZ_OK, result);
     assert_true(az_span_is_content_equal(expected, destination_span));
   }
 
@@ -3153,12 +3088,8 @@ static void test_az_json_string_unescape(void** state)
     char destination[59] = { 0 };
     az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
 
-    int final_size;
-    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+    destination_span = az_json_string_unescape(original, destination_span);
 
-    destination_span = az_span_slice(destination_span, 0, final_size);
-
-    assert_int_equal(AZ_OK, result);
     assert_true(az_span_is_content_equal(expected, destination_span));
   }
 
@@ -3170,12 +3101,8 @@ static void test_az_json_string_unescape(void** state)
     char destination[59] = { 0 };
     az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
 
-    int final_size;
-    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+    destination_span = az_json_string_unescape(original, destination_span);
 
-    destination_span = az_span_slice(destination_span, 0, final_size);
-
-    assert_int_equal(AZ_OK, result);
     assert_true(az_span_is_content_equal(expected, destination_span));
   }
 
@@ -3187,12 +3114,8 @@ static void test_az_json_string_unescape(void** state)
     char destination[59] = { 0 };
     az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
 
-    int final_size;
-    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+    destination_span = az_json_string_unescape(original, destination_span);
 
-    destination_span = az_span_slice(destination_span, 0, final_size);
-
-    assert_int_equal(AZ_OK, result);
     assert_true(az_span_is_content_equal(expected, destination_span));
   }
 
@@ -3204,12 +3127,8 @@ static void test_az_json_string_unescape(void** state)
     char destination[59] = { 0 };
     az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
 
-    int final_size;
-    az_result result = az_json_string_unescape(original, destination, 59, &final_size);
+    destination_span = az_json_string_unescape(original, destination_span);
 
-    destination_span = az_span_slice(destination_span, 0, final_size);
-
-    assert_int_equal(AZ_OK, result);
     assert_true(az_span_is_content_equal(expected, destination_span));
   }
 
@@ -3219,9 +3138,9 @@ static void test_az_json_string_unescape(void** state)
     az_span expected = AZ_SPAN_FROM_STR("My name is \\\"Ahson\"!");
 
     char destination[59] = { 0 };
-    az_result result = az_json_string_unescape(original, destination, 59, NULL);
+    az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
+    destination_span = az_json_string_unescape(original, destination_span);
 
-    assert_int_equal(AZ_OK, result);
     assert_string_equal((char*)az_span_ptr(expected), destination);
   }
 
@@ -3231,9 +3150,9 @@ static void test_az_json_string_unescape(void** state)
     az_span expected = AZ_SPAN_FROM_STR("//\"");
 
     char destination[59] = { 0 };
-    az_result result = az_json_string_unescape(original, destination, 59, NULL);
+    az_span destination_span = AZ_SPAN_FROM_BUFFER(destination);
+    destination_span = az_json_string_unescape(original, destination_span);
 
-    assert_int_equal(AZ_OK, result);
     assert_string_equal((char*)az_span_ptr(expected), destination);
   }
 }
@@ -3250,33 +3169,27 @@ static void test_az_json_string_unescape_same_buffer(void** state)
     az_span expected
         = AZ_SPAN_FROM_STR(" { \"name\": \"some value string\" , \"code\" : 123456 } ");
 
-    int final_size;
-    az_result result = az_json_string_unescape(json, (char*)az_span_ptr(json), 59, &final_size);
+    json = az_json_string_unescape(json, json);
 
-    json = az_span_slice(json, 0, final_size);
-
-    assert_int_equal(AZ_OK, result);
     assert_true(az_span_is_content_equal(expected, json));
     _az_span_free(&json);
   }
 
-  // null terminator
+  // nothing is written past the end (including null terminator)
   {
     uint8_t buffer[3];
     az_span test_span = AZ_SPAN_FROM_BUFFER(buffer);
     test_span._internal.ptr[0] = 'a';
     test_span._internal.ptr[1] = 'b';
-    test_span._internal.ptr[2] = 'c'; // verify that 'c' is overwritten with 0
+    test_span._internal.ptr[2] = 'c'; // verify that 'c' is not overwritten with 0
 
     az_span expected = AZ_SPAN_FROM_STR("ab");
 
-    int final_size;
-    az_result result = az_json_string_unescape(
-        az_span_slice(test_span, 0, 2), (char*)az_span_ptr(test_span), 59, &final_size);
+    test_span = az_json_string_unescape(
+        az_span_slice(test_span, 0, 2), test_span);
 
-    assert_int_equal(0, test_span._internal.ptr[2]);
-    assert_int_equal(AZ_OK, result);
-    assert_true(az_span_is_content_equal(expected, az_span_slice(test_span, 0, final_size)));
+    assert_int_equal((int)'c', buffer[2]);
+    assert_true(az_span_is_content_equal(expected, az_span_slice(test_span, 0, 2)));
   }
 
   // only escapes
@@ -3284,13 +3197,9 @@ static void test_az_json_string_unescape_same_buffer(void** state)
     az_span original = az_span_create_from_str(strdup("\\b\\f\\n\\r\\t\\\\"));
     az_span expected = AZ_SPAN_FROM_STR("\b\f\n\r\t\\");
 
-    int final_size;
-    az_result result
-        = az_json_string_unescape(original, (char*)az_span_ptr(original), 59, &final_size);
+    original
+        = az_json_string_unescape(original, original);
 
-    original = az_span_slice(original, 0, final_size);
-
-    assert_int_equal(AZ_OK, result);
     assert_true(az_span_is_content_equal(expected, original));
     _az_span_free(&original);
   }
@@ -3300,13 +3209,9 @@ static void test_az_json_string_unescape_same_buffer(void** state)
     az_span original = az_span_create_from_str(strdup("\\/\\/\\\""));
     az_span expected = AZ_SPAN_FROM_STR("//\"");
 
-    int final_size;
-    az_result result
-        = az_json_string_unescape(original, (char*)az_span_ptr(original), 59, &final_size);
-
-    original = az_span_slice(original, 0, final_size);
-
-    assert_int_equal(AZ_OK, result);
+    original
+        = az_json_string_unescape(original, original);
+    
     assert_true(az_span_is_content_equal(expected, original));
     _az_span_free(&original);
   }
@@ -3317,38 +3222,10 @@ static void test_az_json_string_unescape_same_buffer(void** state)
         strdup("Hello \\b My \\f Name \\n Is \\r Doctor \\t Green \\\\ Thumb"));
     az_span expected = AZ_SPAN_FROM_STR("Hello \b My \f Name \n Is \r Doctor \t Green \\ Thumb");
 
-    int final_size;
-    az_result result
-        = az_json_string_unescape(original, (char*)az_span_ptr(original), 59, &final_size);
+    original
+        = az_json_string_unescape(original, original);
 
-    original = az_span_slice(original, 0, final_size);
-
-    assert_int_equal(AZ_OK, result);
     assert_true(az_span_is_content_equal(expected, original));
-    _az_span_free(&original);
-  }
-
-  // fake escapes
-  {
-    az_span original = az_span_create_from_str(strdup("\\9"));
-
-    int final_size;
-    az_result result
-        = az_json_string_unescape(original, (char*)az_span_ptr(original), 59, &final_size);
-
-    assert_int_equal(AZ_ERROR_UNEXPECTED_CHAR, result);
-    _az_span_free(&original);
-  }
-
-  // malformed escapes
-  {
-    az_span original = az_span_create_from_str(strdup("abcd\\"));
-
-    int final_size;
-    az_result result
-        = az_json_string_unescape(original, (char*)az_span_ptr(original), 59, &final_size);
-
-    assert_int_equal(AZ_ERROR_UNEXPECTED_END, result);
     _az_span_free(&original);
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-c/issues/2302

Addressing usability feedback from IoT and simplifying the API signature.

This gives flexibility to the caller and allows the user, if they really choose to, to unescape in-place. Because we are returning spans, the destination doesn't need to be null terminated, and hence extra buffer space isn't required. Added remarks within the docs so the user is aware of the implications of doing in-place unescape.

I decided to stick with the verb "unescape" instead of "decode" in the function name since the RFC uses that term and cursory searches on the web show folks seem to refer to the act of transforming the JSON string as "unescape" more so than decode (which seems to be overloaded with deserialize sometimes).