### PR TITLE
Azure IoT Provisioning Client Receiving Custom Allocation Payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@
 
 ### Features Added
 
+- Adding IoT Device Provisioning support for [Custom Allocation Payload](https://docs.microsoft.com/azure/iot-dps/how-to-send-additional-data).
+  - New APIs: `az_iot_provisioning_client_register_get_request_payload()` and  `az_iot_provisioning_client_registration_state.payload`.
+
 ### Breaking Changes
 
 ### Bugs Fixed
 
+- Azure IoT Samples now display errors following the _source file:line number_ format, allowing Visual Studio Code to automatically create links from the output log.
+
 ### Other Changes
+
+- Azure IoT Device Provisioning Client API __deprecation__: `az_iot_provisioning_client_get_request_payload()` is deprecated in favor of `az_iot_provisioning_client_register_get_request_payload()`. The new API _requires_ an initialized `az_iot_provisioning_client_payload_options` structure (using `az_iot_provisioning_client_payload_options_default()`).
 
 ## 1.4.0 (2022-11-11)
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -391,16 +391,16 @@ jobs:
 
   # Validate all the files are formatted correctly according to the .clang-format file.
   - bash: |
-      # Run clang-format recursively on each source and header file within the repo.
-      clang-format --version
-      find . \( -iname '*.h' -o -iname '*.c' \) -exec clang-format -i {} \;
+      # Run clang-format-9 recursively on each source and header file within the repo.
+      clang-format-9 --version
+      find . \( -iname '*.h' -o -iname '*.c' \) -exec clang-format-9 -i {} \;
 
       git status --untracked-files=no --porcelain
 
       if [[ `git status --untracked-files=no --porcelain` ]]; then
         echo Some files were not formatted correctly according to the .clang-format file.
-        echo Please run clang-format to fix the issue by using this bash command at the root of the repo:
-        echo "find . \( -iname '*.h' -o -iname '*.c' \) -exec clang-format -i {} \;"
+        echo Please run clang-format-9 to fix the issue by using this bash command at the root of the repo:
+        echo "find . \( -iname '*.h' -o -iname '*.c' \) -exec clang-format-9 -i {} \;"
         exit 1
       fi
 

--- a/sdk/inc/azure/core/_az_cfg.h
+++ b/sdk/inc/azure/core/_az_cfg.h
@@ -88,4 +88,31 @@
 // Get the number of elements in an array
 #define _az_COUNTOF(array) (sizeof(array) / sizeof((array)[0]))
 
+/**
+ * @brief Deprecate functions.
+ *
+ */
+#ifdef __has_c_attribute
+#if __has_c_attribute(deprecated)
+#define AZ_DEPRECATED [[deprecated]]
+#endif
+#endif
+
+#ifndef AZ_DEPRECATED
+#if defined(_MSC_VER)
+#define AZ_DEPRECATED __declspec(deprecated)
+#elif defined(__GNUC__)
+#define AZ_DEPRECATED __attribute__((deprecated))
+#endif
+#endif
+
+#ifdef _MSC_VER
+#define AZ_PUSH_IGNORE_DEPRECATIONS _Pragma("warning(push)") _Pragma("warning(disable:4996)")
+#define AZ_POP_WARNINGS _Pragma("warning(pop)")
+#else
+#define AZ_PUSH_IGNORE_DEPRECATIONS \
+  _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define AZ_POP_WARNINGS _Pragma("GCC diagnostic pop")
+#endif
+
 #endif // _az_CFG_H

--- a/sdk/inc/azure/core/_az_cfg.h
+++ b/sdk/inc/azure/core/_az_cfg.h
@@ -95,24 +95,24 @@
 #ifdef __has_c_attribute
 #if __has_c_attribute(deprecated)
 #define AZ_DEPRECATED [[deprecated]]
-#endif
-#endif
+#endif // __has_c_attribute(deprecated)
+#endif // __has_c_attribute
 
 #ifndef AZ_DEPRECATED
 #if defined(_MSC_VER)
 #define AZ_DEPRECATED __declspec(deprecated)
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) // !defined(_MSC_VER)
 #define AZ_DEPRECATED __attribute__((deprecated))
-#endif
-#endif
+#endif // defined(_MSC_VER)
+#endif // AZ_DEPRECATED
 
 #ifdef _MSC_VER
 #define AZ_PUSH_IGNORE_DEPRECATIONS _Pragma("warning(push)") _Pragma("warning(disable:4996)")
 #define AZ_POP_WARNINGS _Pragma("warning(pop)")
-#else
+#else // !_MSC_VER
 #define AZ_PUSH_IGNORE_DEPRECATIONS \
   _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
 #define AZ_POP_WARNINGS _Pragma("GCC diagnostic pop")
-#endif
+#endif // _MSC_VER
 
 #endif // _az_CFG_H

--- a/sdk/inc/azure/iot/az_iot_hub_client.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client.h
@@ -102,10 +102,10 @@ AZ_NODISCARD az_iot_hub_client_options az_iot_hub_client_options_default();
  * topic names (listed below) and of the IoT Hub (listed below)
  * http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718106
  * https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-identity-registry#device-identity-properties
- * @param[in] options A reference to an #az_iot_hub_client_options structure. If `NULL` is passed,
- * the hub client will use the default options. If using custom options, please initialize first by
- * calling az_iot_hub_client_options_default() and then populating relevant options with your own
- * values.
+ * @param[in] options __[nullable]__ A reference to an #az_iot_hub_client_options structure. If
+ * `NULL` is passed, the hub client will use the default options. If using custom options, please
+ * initialize first by calling az_iot_hub_client_options_default() and then populating relevant
+ * options with your own values.
  * @pre \p client must not be `NULL`.
  * @pre \p iot_hub_hostname must be a valid span of size greater than 0.
  * @pre \p device_id must be a valid span of size greater than 0.

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -78,8 +78,9 @@ AZ_NODISCARD az_iot_provisioning_client_options az_iot_provisioning_client_optio
  * part of the certificate subject). Must conform to the limitations listed in the link below:
  * https://docs.microsoft.com/azure/iot-dps/concepts-service#registration-id
  * @param[in] options __[nullable]__ A reference to an #az_iot_provisioning_client_options
- * structure. Can be `NULL` for default options.
- * @pre \p client must not be `NULL`.
+ * structure. If `NULL` is passed, the provisioning client will use the default options. If using
+ * custom options, please initialize first by calling az_iot_provisioning_client_options_default()
+ * and then populating relevant options with your own values.* @pre \p client must not be `NULL`.
  * @pre \p global_device_hostname must be a valid span of size greater than 0.
  * @pre \p id_scope must be a valid span of size greater than 0.
  * @pre \p registration_id must be a valid span of size greater than 0.
@@ -271,6 +272,12 @@ typedef struct
    * Submit this timestamp when asking for Azure IoT service-desk help.
    */
   az_span error_timestamp;
+
+  /**
+   * An optional custom payload received from the service.
+   */
+  az_span payload;
+
 } az_iot_provisioning_client_registration_state;
 
 /**
@@ -341,6 +348,7 @@ typedef struct
    * and device id in case of success.
    */
   az_iot_provisioning_client_registration_state registration_state;
+
 } az_iot_provisioning_client_register_response;
 
 /**
@@ -439,8 +447,8 @@ AZ_NODISCARD az_result az_iot_provisioning_client_query_status_get_publish_topic
     size_t* out_mqtt_topic_length);
 
 /**
- * @brief Azure IoT Provisioning Client options for
- * az_iot_provisioning_client_get_request_payload(). Not currently used.  Reserved for future use.
+ * @brief Azure IoT Provisioning Client options for 
+ * az_iot_provisioning_client_get_request_payload().
  *
  */
 typedef struct
@@ -453,6 +461,57 @@ typedef struct
 } az_iot_provisioning_client_payload_options;
 
 /**
+ * @brief Gets the default az_iot_provisioning_client_payload_options.
+ * @details Call this to obtain an initialized #az_iot_provisioning_client_payload_options structure
+ * that can be afterwards modified and passed to
+ * #az_iot_provisioning_client_register_get_request_payload.
+ *
+ * @return #az_iot_provisioning_client_payload_options.
+ */
+AZ_NODISCARD az_iot_provisioning_client_payload_options
+az_iot_provisioning_client_payload_options_default();
+
+/**
+ * @brief Builds the optional payload for a provisioning request.
+ * @remark Use this API to build an MQTT payload during registration.
+ *         This call is optional for most scenarios. Some service
+ *         applications may require `custom_payload_property` specified during
+ *         registration to take additional decisions during provisioning time.
+ *         For example, if you need to register an IoT Plug and Play device you must
+ *         specify its model_id with this API via the `custom_payload_property`
+ *         `{"modelId":"your_model_id"}`.
+ *
+ * @param[in] client The #az_iot_provisioning_client to use for this call.
+ * @param[in] custom_payload_property __[nullable]__ Custom JSON to be added to this payload.
+ * Can be `NULL`.
+ * @param[in] options __[nullable]__ A reference to an #az_iot_provisioning_client_payload_options
+ * structure. If `NULL` is passed, the provisioning client will use the default options. If using
+ * custom options, please initialize first by calling
+ * az_iot_provisioning_client_payload_options_default() and then populating relevant options with
+ * your own values.
+ * @param[out] mqtt_payload A buffer with sufficient capacity to hold the MQTT payload.
+ * @param[in] mqtt_payload_size The size, in bytes of \p mqtt_payload.
+ * @param[out] out_mqtt_payload_length Contains the length, in bytes, written to \p mqtt_payload on
+ * success.
+ * @pre \p client must not be `NULL`.
+ * @pre \p mqtt_payload must not be `NULL`.
+ * @pre \p mqtt_payload_size must be greater than 0.
+ * @pre \p out_mqtt_payload_length must not be `NULL`.
+ * @return An #az_result value indicating the result of the operation.
+ * @retval #AZ_OK The payload was created successfully.
+ * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small.
+ */
+AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(
+    az_iot_provisioning_client const* client,
+    az_span custom_payload_property,
+    az_iot_provisioning_client_payload_options const* options,
+    uint8_t* mqtt_payload,
+    size_t mqtt_payload_size,
+    size_t* out_mqtt_payload_length);
+
+/**
+ * @deprecated since 1.5.0-beta.1.
+ * @see az_iot_provisioning_client_register_get_request_payload 
  * @brief Builds the optional payload for a provisioning request.
  * @remark Use this API to build an MQTT payload during registration.
  *         This call is optional for most scenarios. Some service
@@ -480,7 +539,7 @@ typedef struct
  * @retval #AZ_OK The payload was created successfully.
  * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small.
  */
-AZ_NODISCARD az_result az_iot_provisioning_client_get_request_payload(
+AZ_DEPRECATED az_result az_iot_provisioning_client_get_request_payload(
     az_iot_provisioning_client const* client,
     az_span custom_payload_property,
     az_iot_provisioning_client_payload_options const* options,

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -473,7 +473,7 @@ az_iot_provisioning_client_payload_options_default();
 
 /**
  * @brief Builds the optional payload for a provisioning request.
- * @remark Use this API to build an MQTT payload during registration.
+ * @remark Use this API to build an MQTT payload during device registration.
  *         This call is optional for most scenarios. Some service
  *         applications may require `custom_payload_property` specified during
  *         registration to take additional decisions during provisioning time.

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -80,7 +80,8 @@ AZ_NODISCARD az_iot_provisioning_client_options az_iot_provisioning_client_optio
  * @param[in] options __[nullable]__ A reference to an #az_iot_provisioning_client_options
  * structure. If `NULL` is passed, the provisioning client will use the default options. If using
  * custom options, please initialize first by calling az_iot_provisioning_client_options_default()
- * and then populating relevant options with your own values.* @pre \p client must not be `NULL`.
+ * and then populating relevant options with your own values.
+ * @pre \p client must not be `NULL`.
  * @pre \p global_device_hostname must be a valid span of size greater than 0.
  * @pre \p id_scope must be a valid span of size greater than 0.
  * @pre \p registration_id must be a valid span of size greater than 0.
@@ -348,7 +349,6 @@ typedef struct
    * and device id in case of success.
    */
   az_iot_provisioning_client_registration_state registration_state;
-
 } az_iot_provisioning_client_register_response;
 
 /**
@@ -448,7 +448,8 @@ AZ_NODISCARD az_result az_iot_provisioning_client_query_status_get_publish_topic
 
 /**
  * @brief Azure IoT Provisioning Client options for
- * az_iot_provisioning_client_get_request_payload().
+ * az_iot_provisioning_client_get_request_payload() and
+ * az_iot_provisioning_client_register_get_request_payload().
  *
  */
 typedef struct
@@ -476,7 +477,7 @@ az_iot_provisioning_client_payload_options_default();
  * @remark Use this API to build an MQTT payload during device registration.
  *         This call is optional for most scenarios. Some service
  *         applications may require `custom_payload_property` specified during
- *         registration to take additional decisions during provisioning time.
+ *         registration to make additional decisions during provisioning time.
  *         For example, if you need to register an IoT Plug and Play device you must
  *         specify its model_id with this API via the `custom_payload_property`
  *         `{"modelId":"your_model_id"}`.
@@ -484,9 +485,8 @@ az_iot_provisioning_client_payload_options_default();
  * @param[in] client The #az_iot_provisioning_client to use for this call.
  * @param[in] custom_payload_property __[nullable]__ Custom JSON to be added to this payload.
  * Can be `NULL`.
- * @param[in] options __[nullable]__ A reference to an #az_iot_provisioning_client_payload_options
- * structure. If `NULL` is passed, the provisioning client will use the default options. If using
- * custom options, please initialize first by calling
+ * @param[in] options A reference to an #az_iot_provisioning_client_payload_options
+ * structure. Must be initialized first by calling
  * az_iot_provisioning_client_payload_options_default() and then populating relevant options with
  * your own values.
  * @param[out] mqtt_payload A buffer with sufficient capacity to hold the MQTT payload.
@@ -516,7 +516,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(
  * @remark Use this API to build an MQTT payload during registration.
  *         This call is optional for most scenarios. Some service
  *         applications may require `custom_payload_property` specified during
- *         registration to take additional decisions during provisioning time.
+ *         registration to make additional decisions during provisioning time.
  *         For example, if you need to register an IoT Plug and Play device you must
  *         specify its model_id with this API via the `custom_payload_property`
  *         `{"modelId":"your_model_id"}`.

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -447,7 +447,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_query_status_get_publish_topic
     size_t* out_mqtt_topic_length);
 
 /**
- * @brief Azure IoT Provisioning Client options for 
+ * @brief Azure IoT Provisioning Client options for
  * az_iot_provisioning_client_get_request_payload().
  *
  */
@@ -511,7 +511,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(
 
 /**
  * @deprecated since 1.5.0-beta.1.
- * @see az_iot_provisioning_client_register_get_request_payload 
+ * @see az_iot_provisioning_client_register_get_request_payload
  * @brief Builds the optional payload for a provisioning request.
  * @remark Use this API to build an MQTT payload during registration.
  *         This call is optional for most scenarios. Some service

--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -539,7 +539,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(
  * @retval #AZ_OK The payload was created successfully.
  * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small.
  */
-AZ_DEPRECATED az_result az_iot_provisioning_client_get_request_payload(
+AZ_DEPRECATED AZ_NODISCARD az_result az_iot_provisioning_client_get_request_payload(
     az_iot_provisioning_client const* client,
     az_span custom_payload_property,
     az_iot_provisioning_client_payload_options const* options,

--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -349,7 +349,7 @@ Set the following environment variables if running any of these samples: `paho_i
     Access your Azure IoT Hub from either your Azure Portal or Azure IoT Explorer.
 
     - `AZ_IOT_HUB_DEVICE_ID`: From the IoT devices tab, select your device. Copy its Device Id.
-    - `AZ_IOT_HUB_HOSTNAME`: From the Overiview tab, copy your Azure IoT hub Hostname.
+    - `AZ_IOT_HUB_HOSTNAME`: From the Overview tab, copy your Azure IoT hub Hostname.
 
 2. Set the variables:
 
@@ -416,7 +416,7 @@ Set the following environment variables if running the sample:  `paho_iot_hub_sa
 
     - `AZ_IOT_HUB_SAS_DEVICE_ID`: From the IoT devices tab, select your device. Copy its Device Id.
     - `AZ_IOT_HUB_SAS_KEY`: From the same page, copy its Primary Key.
-    - `AZ_IOT_HUB_HOSTNAME`: From the Overiview tab, copy your Azure IoT hub Hostname.
+    - `AZ_IOT_HUB_HOSTNAME`: From the Overview tab, copy your Azure IoT hub Hostname.
 
 2. Set the variables:
 
@@ -655,6 +655,7 @@ This section provides an overview of the different samples available to run and 
   This [sample](https://github.com/Azure/azure-sdk-for-c/blob/main/sdk/samples/iot/paho_iot_provisioning_sas_sample.c) registers a device with the Azure IoT Device Provisioning Service. It will wait to receive the registration status before disconnecting. SAS authentication is used.
 
 ## Using IoT Hub with an ECC Server Certificate Chain
+
 To work with the new Azure Cloud ECC server certificate chain, the TLS stack must be configured to prevent RSA cipher-suites from being advertised, as described [here](https://docs.microsoft.com/azure/iot-hub/iot-hub-tls-support#elliptic-curve-cryptography-ecc-server-tls-certificate-preview).
 
 When using Paho MQTT for C, modify the samples by adding the following TLS option:

--- a/sdk/samples/iot/iot_sample_common.h
+++ b/sdk/samples/iot/iot_sample_common.h
@@ -22,7 +22,7 @@
 #define IOT_SAMPLE_LOG_ERROR(...)                                                  \
   do                                                                               \
   {                                                                                \
-    (void)fprintf(stderr, "ERROR:\t\t%s:%s():%d: ", __FILE__, __func__, __LINE__); \
+    (void)fprintf(stderr, "ERROR:\t\t%s:%d %s(): ", __FILE__, __LINE__, __func__); \
     (void)fprintf(stderr, __VA_ARGS__);                                            \
     (void)fprintf(stderr, "\n");                                                   \
     fflush(stdout);                                                                \

--- a/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
@@ -250,6 +250,7 @@ static void register_device_with_provisioning_service(void)
   uint8_t mqtt_payload[MQTT_PAYLOAD_BUFFER_LENGTH];
   size_t mqtt_payload_length;
 
+  AZ_PUSH_IGNORE_DEPRECATIONS
   rc = az_iot_provisioning_client_get_request_payload(
       &provisioning_client,
       custom_registration_payload_property,
@@ -257,6 +258,7 @@ static void register_device_with_provisioning_service(void)
       mqtt_payload,
       sizeof(mqtt_payload),
       &mqtt_payload_length);
+  AZ_POP_WARNINGS
   if (az_result_failed(rc))
   {
     IOT_SAMPLE_LOG_ERROR(

--- a/sdk/samples/iot/paho_iot_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_provisioning_sample.c
@@ -323,6 +323,16 @@ static void handle_device_registration_status_message(
           "Hub Hostname:", register_response->registration_state.assigned_hub_hostname);
       IOT_SAMPLE_LOG_AZ_SPAN("Device Id:", register_response->registration_state.device_id);
       IOT_SAMPLE_LOG(" "); // Formatting
+
+      if (az_span_size(register_response->registration_state.payload) > 0)
+      {
+        IOT_SAMPLE_LOG_SUCCESS("Optional payload (Custom Allocation Policy) received:");
+        IOT_SAMPLE_LOG_AZ_SPAN("\t", register_response->registration_state.payload);
+      }
+      else
+      {
+        IOT_SAMPLE_LOG_SUCCESS("Optional payload (Custom Allocation Policy) not received.");
+      }
     }
     else // Unsuccessful assignment (unassigned, failed or disabled states)
     {

--- a/sdk/samples/iot/paho_iot_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_provisioning_sample.c
@@ -326,12 +326,8 @@ static void handle_device_registration_status_message(
 
       if (az_span_size(register_response->registration_state.payload) > 0)
       {
-        IOT_SAMPLE_LOG_SUCCESS("Optional payload (Custom Allocation Policy) received:");
+        IOT_SAMPLE_LOG_SUCCESS("Payload received:");
         IOT_SAMPLE_LOG_AZ_SPAN("\t", register_response->registration_state.payload);
-      }
-      else
-      {
-        IOT_SAMPLE_LOG_SUCCESS("Optional payload (Custom Allocation Policy) not received.");
       }
     }
     else // Unsuccessful assignment (unassigned, failed or disabled states)

--- a/sdk/src/azure/iot/az_iot_provisioning_client.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client.c
@@ -237,7 +237,8 @@ _az_iot_provisioning_registration_state_default()
                                                           .extended_error_code = 0,
                                                           .error_message = AZ_SPAN_EMPTY,
                                                           .error_tracking_id = AZ_SPAN_EMPTY,
-                                                          .error_timestamp = AZ_SPAN_EMPTY };
+                                                          .error_timestamp = AZ_SPAN_EMPTY,
+                                                          .payload = { 0 } };
 }
 
 AZ_INLINE az_iot_status _az_iot_status_from_extended_status(uint32_t extended_status)
@@ -276,6 +277,35 @@ AZ_INLINE az_result _az_iot_provisioning_client_parse_payload_error_code(
   return AZ_ERROR_ITEM_NOT_FOUND;
 }
 
+AZ_INLINE az_result
+_az_iot_provisioning_client_get_json_object_span(az_json_reader* jr, az_span* out_span)
+{
+  *out_span = jr->token.slice;
+
+  if (jr->token.kind == AZ_JSON_TOKEN_NULL)
+  {
+    *out_span = AZ_SPAN_EMPTY;
+    return AZ_OK;
+  }
+
+  if (jr->token.kind != AZ_JSON_TOKEN_BEGIN_OBJECT)
+  {
+    return AZ_ERROR_UNEXPECTED_CHAR;
+  }
+
+  _az_RETURN_IF_FAILED(az_json_reader_skip_children(jr));
+
+  if (jr->token.kind != AZ_JSON_TOKEN_END_OBJECT)
+  {
+    return AZ_ERROR_UNEXPECTED_CHAR;
+  }
+
+  int32_t payload_len = (int32_t)(az_span_ptr(jr->token.slice) - az_span_ptr(*out_span)) + 1;
+  *out_span = az_span_create(az_span_ptr(*out_span), payload_len);
+
+  return AZ_OK;
+}
+
 AZ_INLINE az_result _az_iot_provisioning_client_payload_registration_state_parse(
     az_json_reader* jr,
     az_iot_provisioning_client_registration_state* out_state)
@@ -288,8 +318,7 @@ AZ_INLINE az_result _az_iot_provisioning_client_payload_registration_state_parse
   bool found_assigned_hub = false;
   bool found_device_id = false;
 
-  while ((!(found_device_id && found_assigned_hub))
-         && az_result_succeeded(az_json_reader_next_token(jr))
+  while (az_result_succeeded(az_json_reader_next_token(jr))
          && jr->token.kind != AZ_JSON_TOKEN_END_OBJECT)
   {
     if (az_json_token_is_text_equal(&jr->token, AZ_SPAN_FROM_STR("assignedHub")))
@@ -311,6 +340,12 @@ AZ_INLINE az_result _az_iot_provisioning_client_payload_registration_state_parse
       }
       out_state->device_id = jr->token.slice;
       found_device_id = true;
+    }
+    else if (az_json_token_is_text_equal(&jr->token, AZ_SPAN_FROM_STR("payload")))
+    {
+      _az_RETURN_IF_FAILED(az_json_reader_next_token(jr));
+      _az_RETURN_IF_FAILED(
+          _az_iot_provisioning_client_get_json_object_span(jr, &out_state->payload));
     }
     else if (az_json_token_is_text_equal(&jr->token, AZ_SPAN_FROM_STR("errorMessage")))
     {
@@ -564,6 +599,13 @@ AZ_NODISCARD az_result az_iot_provisioning_client_parse_received_topic_and_paylo
   return AZ_OK;
 }
 
+AZ_NODISCARD az_iot_provisioning_client_payload_options
+az_iot_provisioning_client_payload_options_default()
+{
+  return (az_iot_provisioning_client_payload_options){ 0 };
+}
+
+
 AZ_NODISCARD az_result az_iot_provisioning_client_get_request_payload(
     az_iot_provisioning_client const* client,
     az_span custom_payload_property,
@@ -572,10 +614,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_get_request_payload(
     size_t mqtt_payload_size,
     size_t* out_mqtt_payload_length)
 {
-  (void)options;
-
   _az_PRECONDITION_NOT_NULL(client);
-  _az_PRECONDITION_IS_NULL(options);
   _az_PRECONDITION_NOT_NULL(mqtt_payload);
   _az_PRECONDITION(mqtt_payload_size > 0);
   _az_PRECONDITION_NOT_NULL(out_mqtt_payload_length);
@@ -602,4 +641,34 @@ AZ_NODISCARD az_result az_iot_provisioning_client_get_request_payload(
   ;
 
   return AZ_OK;
+}
+
+// DEPRECATED:
+AZ_NODISCARD az_result az_iot_provisioning_client_get_request_payload(
+    az_iot_provisioning_client const* client,
+    az_span custom_payload_property,
+    az_iot_provisioning_client_payload_options const* options,
+    uint8_t* mqtt_payload,
+    size_t mqtt_payload_size,
+    size_t* out_mqtt_payload_length)
+{
+  (void)options; // Ignored to avoid breaking compatibility with existing apps.
+
+  _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_IS_NULL(options);
+  _az_PRECONDITION_NOT_NULL(mqtt_payload);
+  _az_PRECONDITION(mqtt_payload_size > 0);
+  _az_PRECONDITION_NOT_NULL(out_mqtt_payload_length);
+
+  // Building a default options to maintain compatibility with existing apps.
+  az_iot_provisioning_client_payload_options default_options
+      = az_iot_provisioning_client_payload_options_default();
+
+  return az_iot_provisioning_client_register_get_request_payload(
+      client,
+      custom_payload_property,
+      &default_options,
+      mqtt_payload,
+      mqtt_payload_size,
+      out_mqtt_payload_length);
 }

--- a/sdk/src/azure/iot/az_iot_provisioning_client.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client.c
@@ -294,11 +294,7 @@ _az_iot_provisioning_client_get_json_object_span(az_json_reader* jr, az_span* ou
   }
 
   _az_RETURN_IF_FAILED(az_json_reader_skip_children(jr));
-
-  if (jr->token.kind != AZ_JSON_TOKEN_END_OBJECT)
-  {
-    return AZ_ERROR_UNEXPECTED_CHAR;
-  }
+  _az_PRECONDITION(jr->token.kind == AZ_JSON_TOKEN_END_OBJECT);
 
   int32_t payload_len = (int32_t)(az_span_ptr(jr->token.slice) - az_span_ptr(*out_span)) + 1;
   *out_span = az_span_create(az_span_ptr(*out_span), payload_len);

--- a/sdk/src/azure/iot/az_iot_provisioning_client.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client.c
@@ -606,7 +606,7 @@ az_iot_provisioning_client_payload_options_default()
 }
 
 
-AZ_NODISCARD az_result az_iot_provisioning_client_get_request_payload(
+AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(
     az_iot_provisioning_client const* client,
     az_span custom_payload_property,
     az_iot_provisioning_client_payload_options const* options,
@@ -615,10 +615,12 @@ AZ_NODISCARD az_result az_iot_provisioning_client_get_request_payload(
     size_t* out_mqtt_payload_length)
 {
   _az_PRECONDITION_NOT_NULL(client);
+  _az_PRECONDITION_NOT_NULL(options);
   _az_PRECONDITION_NOT_NULL(mqtt_payload);
   _az_PRECONDITION(mqtt_payload_size > 0);
   _az_PRECONDITION_NOT_NULL(out_mqtt_payload_length);
 
+  (void)options;
   az_json_writer json_writer;
   az_span payload_buffer = az_span_create(mqtt_payload, (int32_t)mqtt_payload_size);
 

--- a/sdk/src/azure/iot/az_iot_provisioning_client.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client.c
@@ -601,7 +601,6 @@ az_iot_provisioning_client_payload_options_default()
   return (az_iot_provisioning_client_payload_options){ 0 };
 }
 
-
 AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(
     az_iot_provisioning_client const* client,
     az_span custom_payload_property,

--- a/sdk/src/azure/iot/az_iot_provisioning_client.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client.c
@@ -598,7 +598,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_parse_received_topic_and_paylo
 AZ_NODISCARD az_iot_provisioning_client_payload_options
 az_iot_provisioning_client_payload_options_default()
 {
-  return (az_iot_provisioning_client_payload_options){ ._internal.unused =  false };
+  return (az_iot_provisioning_client_payload_options){ ._internal.unused = false };
 }
 
 AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(

--- a/sdk/src/azure/iot/az_iot_provisioning_client.c
+++ b/sdk/src/azure/iot/az_iot_provisioning_client.c
@@ -598,7 +598,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_parse_received_topic_and_paylo
 AZ_NODISCARD az_iot_provisioning_client_payload_options
 az_iot_provisioning_client_payload_options_default()
 {
-  return (az_iot_provisioning_client_payload_options){ 0 };
+  return (az_iot_provisioning_client_payload_options){ ._internal.unused =  false };
 }
 
 AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(

--- a/sdk/tests/iot/provisioning/CMakeLists.txt
+++ b/sdk/tests/iot/provisioning/CMakeLists.txt
@@ -14,8 +14,10 @@ add_cmocka_test(az_iot_provisioning_test SOURCES
                 test_az_iot_provisioning_client.c
                 test_az_iot_provisioning_client_sas.c
                 test_az_iot_provisioning_client_parser.c
-                test_az_iot_proviosining_client_payload.c
-                COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS} ${NO_CLOBBERED_WARNING}
+                test_az_iot_provisioning_client_register_get_request_payload.c
+                COMPILE_OPTIONS 
+                    ${DEFAULT_C_COMPILE_FLAGS} 
+                    ${NO_CLOBBERED_WARNING} 
                 LINK_LIBRARIES ${CMOCKA_LIB}
                     az_iot_common
                     az_iot_provisioning

--- a/sdk/tests/iot/provisioning/main.c
+++ b/sdk/tests/iot/provisioning/main.c
@@ -18,7 +18,7 @@ int main()
   result += test_az_iot_provisioning_client();
   result += test_az_iot_provisioning_client_sas_token();
   result += test_az_iot_provisioning_client_parser();
-  result += test_az_iot_provisioning_client_payload();
-
+  result += test_az_iot_provisioning_client_register_get_request_payload();
+  
   return result;
 }

--- a/sdk/tests/iot/provisioning/main.c
+++ b/sdk/tests/iot/provisioning/main.c
@@ -19,6 +19,6 @@ int main()
   result += test_az_iot_provisioning_client_sas_token();
   result += test_az_iot_provisioning_client_parser();
   result += test_az_iot_provisioning_client_register_get_request_payload();
-  
+
   return result;
 }

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client.h
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client.h
@@ -6,4 +6,4 @@
 int test_az_iot_provisioning_client();
 int test_az_iot_provisioning_client_sas_token();
 int test_az_iot_provisioning_client_parser();
-int test_az_iot_provisioning_client_payload();
+int test_az_iot_provisioning_client_register_get_request_payload();

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
@@ -22,6 +22,11 @@
 #define TEST_HUB_HOSTNAME "contoso.azure-devices.net"
 #define TEST_DEVICE_ID "my-device-id1"
 #define TEST_OPERATION_ID "4.d0a671905ea5b2c8.42d78160-4c78-479e-8be7-61d5e55dac0d"
+#define TEST_EMPTY_JSON "{}"
+
+#define TEST_JSON_PAYLOAD                             \
+  "{\"hello\":\"world\",\"o1\":{\"v1\":123, \"o2\": " \
+  "{\"v2\":321}}, \"arr\":[1,2,3,4,5,6],\"num\":123}"
 
 static const az_span test_global_device_hostname
     = AZ_SPAN_LITERAL_FROM_STR("global.azure-devices-provisioning.net");
@@ -144,8 +149,7 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_assigned_state_
                          "\"status\":\"" TEST_STATUS_ASSIGNED "\","
                          "\"substatus\":\"initialAssignment\","
                          "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
-                         "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
-                         "\"payload\":{\"hello\":\"world\",\"arr\":[1,2,3,4,5,6],\"num\":123}}}");
+                         "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\"}}");
 
   az_iot_provisioning_client_register_response response;
   ret = az_iot_provisioning_client_parse_received_topic_and_payload(
@@ -166,6 +170,8 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_assigned_state_
       strlen(TEST_HUB_HOSTNAME));
   assert_memory_equal(
       az_span_ptr(response.registration_state.device_id), TEST_DEVICE_ID, strlen(TEST_DEVICE_ID));
+
+  assert_int_equal(0, az_span_size(response.registration_state.payload));
 
   assert_int_equal(0, response.registration_state.error_code);
   assert_int_equal(0, response.registration_state.extended_error_code);
@@ -219,7 +225,8 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_invalid_certifi
       strlen(TEST_ERROR_TRACKING_ID));
 }
 
-static void test_az_iot_provisioning_client_parse_received_topic_payload_disabled_state_succeed()
+static void 
+test_az_iot_provisioning_client_parse_received_topic_and_payload_disabled_state_succeed()          
 {
   az_iot_provisioning_client client = { 0 };
   az_result ret = az_iot_provisioning_client_init(
@@ -444,8 +451,7 @@ static void test_az_iot_provisioning_client_received_topic_and_payload_parse_hub
                          "\"status\":\"" TEST_STATUS_ASSIGNED "\","
                          "\"substatus\":\"initialAssignment\","
                          "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
-                         "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
-                         "\"payload\":{\"hello\":\"world\",\"arr\":[1,2,3,4,5,6],\"num\":123}}}");
+                         "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\"}}");
 
   az_iot_provisioning_client_register_response response;
   ret = az_iot_provisioning_client_parse_received_topic_and_payload(
@@ -472,8 +478,7 @@ test_az_iot_provisioning_client_received_topic_and_payload_parse_device_not_foun
                          "\"status\":\"" TEST_STATUS_ASSIGNED "\","
                          "\"substatus\":\"initialAssignment\","
                          "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
-                         "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
-                         "\"payload\":{\"hello\":\"world\",\"arr\":[1,2,3,4,5,6],\"num\":123}}}");
+                         "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\"}}");
 
   az_iot_provisioning_client_register_response response;
   ret = az_iot_provisioning_client_parse_received_topic_and_payload(
@@ -640,6 +645,168 @@ static void test_az_iot_provisioning_client_no_logging_succeed()
   az_log_set_classification_filter_callback(NULL);
 }
 
+static void
+test_az_iot_provisioning_client_parse_received_topic_and_payload_json_custom_payload_succeed()
+{
+  az_iot_provisioning_client client = { 0 };
+  az_result ret = az_iot_provisioning_client_init(
+      &client, test_global_device_hostname, test_id_scope, test_registration_id, NULL);
+  assert_int_equal(AZ_OK, ret);
+
+  az_span received_topic = AZ_SPAN_FROM_STR("$dps/registrations/res/200/?$rid=1");
+  char received_payload[] = "{\"operationId\":\"" TEST_OPERATION_ID
+                            "\",\"status\":\"" TEST_STATUS_ASSIGNED "\",\"registrationState\":{"
+                            "\"x509\":{},"
+                            "\"registrationId\":\"" TEST_REGISTRATION_ID "\","
+                            "\"createdDateTimeUtc\":\"2020-04-10T03:11:13.0276997Z\","
+                            "\"assignedHub\":\"" TEST_HUB_HOSTNAME "\","
+                            "\"deviceId\":\"" TEST_DEVICE_ID "\","
+                            "\"status\":\"" TEST_STATUS_ASSIGNED "\","
+                            "\"substatus\":\"initialAssignment\","
+                            "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
+                            "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
+                            "\"payload\":" TEST_JSON_PAYLOAD "}}";
+
+  az_span received_payload_span = az_span_create_from_str(received_payload);
+
+  az_iot_provisioning_client_register_response response;
+  ret = az_iot_provisioning_client_parse_received_topic_and_payload(
+      &client, received_topic, received_payload_span, &response);
+  assert_int_equal(AZ_OK, ret);
+
+  // From topic
+  assert_int_equal(AZ_IOT_STATUS_OK, response.status); // 200
+  assert_int_equal(0, response.retry_after_seconds);
+
+  // From payload
+  assert_memory_equal(
+      az_span_ptr(response.operation_id), TEST_OPERATION_ID, strlen(TEST_OPERATION_ID));
+  assert_int_equal(AZ_IOT_PROVISIONING_STATUS_ASSIGNED, response.operation_status);
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.assigned_hub_hostname),
+      TEST_HUB_HOSTNAME,
+      strlen(TEST_HUB_HOSTNAME));
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.device_id), TEST_DEVICE_ID, strlen(TEST_DEVICE_ID));
+
+  assert_int_equal(strlen(TEST_JSON_PAYLOAD), az_span_size(response.registration_state.payload));
+
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.payload),
+      TEST_JSON_PAYLOAD,
+      strlen(TEST_JSON_PAYLOAD));
+
+  assert_int_equal(0, response.registration_state.error_code);
+  assert_int_equal(0, response.registration_state.extended_error_code);
+  assert_int_equal(0, az_span_size(response.registration_state.error_message));
+}
+
+static void
+test_az_iot_provisioning_client_parse_received_topic_and_payload_json_custom_payload_empty_succeed()
+{
+  az_iot_provisioning_client client = { 0 };
+  az_result ret = az_iot_provisioning_client_init(
+      &client, test_global_device_hostname, test_id_scope, test_registration_id, NULL);
+  assert_int_equal(AZ_OK, ret);
+
+  az_span received_topic = AZ_SPAN_FROM_STR("$dps/registrations/res/200/?$rid=1");
+  char received_payload[] = "{\"operationId\":\"" TEST_OPERATION_ID
+                            "\",\"status\":\"" TEST_STATUS_ASSIGNED "\",\"registrationState\":{"
+                            "\"x509\":{},"
+                            "\"registrationId\":\"" TEST_REGISTRATION_ID "\","
+                            "\"createdDateTimeUtc\":\"2020-04-10T03:11:13.0276997Z\","
+                            "\"assignedHub\":\"" TEST_HUB_HOSTNAME "\","
+                            "\"deviceId\":\"" TEST_DEVICE_ID "\","
+                            "\"status\":\"" TEST_STATUS_ASSIGNED "\","
+                            "\"substatus\":\"initialAssignment\","
+                            "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
+                            "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
+                            "\"payload\":" TEST_EMPTY_JSON "}}";
+
+  az_span received_payload_span = az_span_create_from_str(received_payload);
+
+  az_iot_provisioning_client_register_response response;
+  ret = az_iot_provisioning_client_parse_received_topic_and_payload(
+      &client, received_topic, received_payload_span, &response);
+  assert_int_equal(AZ_OK, ret);
+
+  // From topic
+  assert_int_equal(AZ_IOT_STATUS_OK, response.status); // 200
+  assert_int_equal(0, response.retry_after_seconds);
+
+  // From payload
+  assert_memory_equal(
+      az_span_ptr(response.operation_id), TEST_OPERATION_ID, strlen(TEST_OPERATION_ID));
+  assert_int_equal(AZ_IOT_PROVISIONING_STATUS_ASSIGNED, response.operation_status);
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.assigned_hub_hostname),
+      TEST_HUB_HOSTNAME,
+      strlen(TEST_HUB_HOSTNAME));
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.device_id), TEST_DEVICE_ID, strlen(TEST_DEVICE_ID));
+
+  assert_int_equal(strlen(TEST_EMPTY_JSON), az_span_size(response.registration_state.payload));
+
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.payload), TEST_EMPTY_JSON, strlen(TEST_EMPTY_JSON));
+
+  assert_int_equal(0, response.registration_state.error_code);
+  assert_int_equal(0, response.registration_state.extended_error_code);
+  assert_int_equal(0, az_span_size(response.registration_state.error_message));
+}
+
+static void
+test_az_iot_provisioning_client_parse_received_topic_and_payload_json_custom_payload_null_succeed()
+{
+  az_iot_provisioning_client client = { 0 };
+  az_result ret = az_iot_provisioning_client_init(
+      &client, test_global_device_hostname, test_id_scope, test_registration_id, NULL);
+  assert_int_equal(AZ_OK, ret);
+
+  az_span received_topic = AZ_SPAN_FROM_STR("$dps/registrations/res/200/?$rid=1");
+  char received_payload[] = "{\"operationId\":\"" TEST_OPERATION_ID
+                            "\",\"status\":\"" TEST_STATUS_ASSIGNED "\",\"registrationState\":{"
+                            "\"x509\":{},"
+                            "\"registrationId\":\"" TEST_REGISTRATION_ID "\","
+                            "\"createdDateTimeUtc\":\"2020-04-10T03:11:13.0276997Z\","
+                            "\"assignedHub\":\"" TEST_HUB_HOSTNAME "\","
+                            "\"deviceId\":\"" TEST_DEVICE_ID "\","
+                            "\"status\":\"" TEST_STATUS_ASSIGNED "\","
+                            "\"substatus\":\"initialAssignment\","
+                            "\"lastUpdatedDateTimeUtc\":\"2020-04-10T03:11:13.2096201Z\","
+                            "\"etag\":\"IjYxMDA4ZDQ2LTAwMDAtMDEwMC0wMDAwLTVlOGZlM2QxMDAwMCI=\","
+                            "\"payload\": null }}";
+
+  az_span received_payload_span = az_span_create_from_str(received_payload);
+
+  az_iot_provisioning_client_register_response response;
+  ret = az_iot_provisioning_client_parse_received_topic_and_payload(
+      &client, received_topic, received_payload_span, &response);
+  assert_int_equal(AZ_OK, ret);
+
+  // From topic
+  assert_int_equal(AZ_IOT_STATUS_OK, response.status); // 200
+  assert_int_equal(0, response.retry_after_seconds);
+
+  // From payload
+  assert_memory_equal(
+      az_span_ptr(response.operation_id), TEST_OPERATION_ID, strlen(TEST_OPERATION_ID));
+  assert_int_equal(AZ_IOT_PROVISIONING_STATUS_ASSIGNED, response.operation_status);
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.assigned_hub_hostname),
+      TEST_HUB_HOSTNAME,
+      strlen(TEST_HUB_HOSTNAME));
+  assert_memory_equal(
+      az_span_ptr(response.registration_state.device_id), TEST_DEVICE_ID, strlen(TEST_DEVICE_ID));
+
+  assert_int_equal(0, az_span_size(response.registration_state.payload));
+
+  assert_int_equal(0, response.registration_state.error_code);
+  assert_int_equal(0, response.registration_state.extended_error_code);
+  assert_int_equal(0, az_span_size(response.registration_state.error_message));
+}
+
+
 #ifdef _MSC_VER
 // warning C4113: 'void (__cdecl *)()' differs in parameter lists from 'CMUnitTestFunction'
 #pragma warning(disable : 4113)
@@ -659,7 +826,7 @@ int test_az_iot_provisioning_client_parser()
     cmocka_unit_test(
         test_az_iot_provisioning_client_parse_received_topic_and_payload_invalid_certificate_error_succeed),
     cmocka_unit_test(
-        test_az_iot_provisioning_client_parse_received_topic_payload_disabled_state_succeed),
+        test_az_iot_provisioning_client_parse_received_topic_and_payload_disabled_state_succeed),
     cmocka_unit_test(
         test_az_iot_provisioning_client_parse_received_topic_and_payload_allocation_error_state_succeed),
     cmocka_unit_test(
@@ -682,6 +849,12 @@ int test_az_iot_provisioning_client_parser()
     cmocka_unit_test(test_az_iot_provisioning_client_operation_complete_translate_succeed),
     cmocka_unit_test(test_az_iot_provisioning_client_logging_succeed),
     cmocka_unit_test(test_az_iot_provisioning_client_no_logging_succeed),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_parse_received_topic_and_payload_json_custom_payload_succeed),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_parse_received_topic_and_payload_json_custom_payload_empty_succeed),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_parse_received_topic_and_payload_json_custom_payload_null_succeed),
   };
 
   return cmocka_run_group_tests_name("az_iot_provisioning_client_parser", tests, NULL, NULL);

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_parser.c
@@ -225,8 +225,8 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_invalid_certifi
       strlen(TEST_ERROR_TRACKING_ID));
 }
 
-static void 
-test_az_iot_provisioning_client_parse_received_topic_and_payload_disabled_state_succeed()          
+static void
+test_az_iot_provisioning_client_parse_received_topic_and_payload_disabled_state_succeed()
 {
   az_iot_provisioning_client client = { 0 };
   az_result ret = az_iot_provisioning_client_init(
@@ -805,7 +805,6 @@ test_az_iot_provisioning_client_parse_received_topic_and_payload_json_custom_pay
   assert_int_equal(0, response.registration_state.extended_error_code);
   assert_int_equal(0, az_span_size(response.registration_state.error_message));
 }
-
 
 #ifdef _MSC_VER
 // warning C4113: 'void (__cdecl *)()' differs in parameter lists from 'CMUnitTestFunction'

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
@@ -22,7 +22,7 @@
 // the absolute minimum number of bytes.  (See _az_MINIMUM_STRING_CHUNK_SIZE e.g.)
 // Since we use az_json_writer in the implementation, we need to reserve additional bytes
 // for tests.
-#define TEST_PAYLOAD_RESERVE_SIZE 192
+#define TEST_PAYLOAD_RESERVE_SIZE 1024
 
 #define TEST_REGISTRATION_ID "myRegistrationId"
 #define TEST_CUSTOM_PAYLOAD "{\"testData\":1, \"testData2\":{\"a\":\"b\"}}"
@@ -47,8 +47,10 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_client_fail
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
+  AZ_PUSH_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       NULL, AZ_SPAN_EMPTY, NULL, payload, sizeof(payload), &payload_len));
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_non_NULL_reserved_fails()
@@ -65,6 +67,7 @@ static void test_az_iot_provisioning_client_get_request_payload_non_NULL_reserve
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
+  AZ_PUSH_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client,
       AZ_SPAN_EMPTY,
@@ -72,6 +75,7 @@ static void test_az_iot_provisioning_client_get_request_payload_non_NULL_reserve
       payload,
       sizeof(payload),
       &payload_len));
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_NULL_mqtt_payload_fails()
@@ -87,8 +91,10 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_mqtt_payloa
 
   size_t payload_len;
 
+  AZ_PUSH_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, NULL, 1, &payload_len));
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_zero_payload_size_fails()
@@ -105,8 +111,10 @@ static void test_az_iot_provisioning_client_get_request_payload_zero_payload_siz
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
+  AZ_PUSH_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, 0, &payload_len));
+  AZ_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_NULL_payload_length_fails()
@@ -122,13 +130,15 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_payload_len
 
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
 
+  AZ_PUSH_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, 1, NULL));
+  AZ_POP_WARNINGS
 }
 
-#endif
+#endif // AZ_NO_PRECONDITION_CHECKING
 
-static void test_az_iot_provisioning_client_get_request_payload_no_custom_payload()
+static void test_az_iot_provisioning_client_get_request_payload_no_custom_payload_succeed()
 {
   az_iot_provisioning_client client = { 0 };
   az_result ret = az_iot_provisioning_client_init(
@@ -146,15 +156,17 @@ static void test_az_iot_provisioning_client_get_request_payload_no_custom_payloa
   memset(payload, 0xCC, sizeof(payload));
   size_t payload_len = 0xBAADC0DE;
 
+  AZ_PUSH_IGNORE_DEPRECATIONS
   ret = az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, sizeof(payload), &payload_len);
+  AZ_POP_WARNINGS
   assert_int_equal(AZ_OK, ret);
   assert_int_equal(payload_len, expected_payload_len);
   assert_memory_equal(expected_payload, payload, expected_payload_len);
   assert_int_equal((uint8_t)0xCC, payload[expected_payload_len]);
 }
 
-static void test_az_iot_provisioning_client_get_request_payload_custom_payload()
+static void test_az_iot_provisioning_client_get_request_payload_custom_payload_succeed()
 {
   az_iot_provisioning_client client = { 0 };
   az_result ret = az_iot_provisioning_client_init(
@@ -173,15 +185,45 @@ static void test_az_iot_provisioning_client_get_request_payload_custom_payload()
   memset(payload, 0xCC, sizeof(payload));
   size_t payload_len = 0xBAADC0DE;
 
+  AZ_PUSH_IGNORE_DEPRECATIONS
   ret = az_iot_provisioning_client_get_request_payload(
       &client, test_custom_payload, NULL, payload, sizeof(payload), &payload_len);
   assert_int_equal(AZ_OK, ret);
   assert_int_equal(payload_len, expected_payload_len);
   assert_memory_equal(expected_payload, payload, expected_payload_len);
   assert_int_equal((uint8_t)0xCC, payload[expected_payload_len]);
+  AZ_POP_WARNINGS
 }
 
-int test_az_iot_provisioning_client_payload()
+static void test_az_iot_provisioning_client_register_get_request_payload_NULL_options_succeed()
+{
+  az_iot_provisioning_client client = { 0 };
+  az_result ret = az_iot_provisioning_client_init(
+      &client,
+      test_global_device_hostname,
+      AZ_SPAN_FROM_STR(TEST_ID_SCOPE),
+      AZ_SPAN_FROM_STR(TEST_REGISTRATION_ID),
+      NULL);
+  assert_int_equal(AZ_OK, ret);
+
+  char expected_payload[]
+      = "{\"registrationId\":\"" TEST_REGISTRATION_ID "\",\"payload\":" TEST_CUSTOM_PAYLOAD "}";
+  size_t expected_payload_len = sizeof(expected_payload) - 1;
+
+  uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
+  memset(payload, 0xCC, sizeof(payload));
+  size_t payload_len = 0xBAADC0DE;
+
+  ret = az_iot_provisioning_client_register_get_request_payload(
+      &client, test_custom_payload, NULL, payload, sizeof(payload), &payload_len);
+
+  assert_int_equal(AZ_OK, ret);
+  assert_int_equal(payload_len, expected_payload_len);
+  assert_memory_equal(expected_payload, payload, expected_payload_len);
+  assert_int_equal((uint8_t)0xCC, payload[expected_payload_len]);
+}
+
+int test_az_iot_provisioning_client_register_get_request_payload()
 {
 #ifndef AZ_NO_PRECONDITION_CHECKING
   SETUP_PRECONDITION_CHECK_TESTS();
@@ -196,8 +238,10 @@ int test_az_iot_provisioning_client_payload()
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_NULL_payload_length_fails),
 #endif // AZ_NO_PRECONDITION_CHECKING
 
-    cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_no_custom_payload),
-    cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_custom_payload),
+    cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_no_custom_payload_succeed),
+    cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_custom_payload_succeed),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_register_get_request_payload_NULL_options_succeed),
   };
 
   return cmocka_run_group_tests_name("az_iot_provisioning_client_payload", tests, NULL, NULL);

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
@@ -227,7 +227,7 @@ int test_az_iot_provisioning_client_register_get_request_payload()
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_zero_payload_size_fails),
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_NULL_payload_length_fails),
     cmocka_unit_test(
-        test_az_iot_provisioning_client_register_get_request_payload_NULL_options_fails),    
+        test_az_iot_provisioning_client_register_get_request_payload_NULL_options_fails),
 #endif // AZ_NO_PRECONDITION_CHECKING
 
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_no_custom_payload_succeed),

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
@@ -136,6 +136,24 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_payload_len
   AZ_POP_WARNINGS
 }
 
+static void test_az_iot_provisioning_client_register_get_request_payload_NULL_options_fails()
+{
+  az_iot_provisioning_client client;
+  az_result ret = az_iot_provisioning_client_init(
+      &client,
+      test_global_device_hostname,
+      AZ_SPAN_FROM_STR(TEST_ID_SCOPE),
+      AZ_SPAN_FROM_STR(TEST_REGISTRATION_ID),
+      NULL);
+  assert_int_equal(AZ_OK, ret);
+
+  uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
+  size_t payload_len;
+
+  ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_register_get_request_payload(
+      &client, AZ_SPAN_EMPTY, NULL, payload, 1, &payload_len));
+}
+
 #endif // AZ_NO_PRECONDITION_CHECKING
 
 static void test_az_iot_provisioning_client_get_request_payload_no_custom_payload_succeed()
@@ -195,34 +213,6 @@ static void test_az_iot_provisioning_client_get_request_payload_custom_payload_s
   AZ_POP_WARNINGS
 }
 
-static void test_az_iot_provisioning_client_register_get_request_payload_NULL_options_succeed()
-{
-  az_iot_provisioning_client client = { 0 };
-  az_result ret = az_iot_provisioning_client_init(
-      &client,
-      test_global_device_hostname,
-      AZ_SPAN_FROM_STR(TEST_ID_SCOPE),
-      AZ_SPAN_FROM_STR(TEST_REGISTRATION_ID),
-      NULL);
-  assert_int_equal(AZ_OK, ret);
-
-  char expected_payload[]
-      = "{\"registrationId\":\"" TEST_REGISTRATION_ID "\",\"payload\":" TEST_CUSTOM_PAYLOAD "}";
-  size_t expected_payload_len = sizeof(expected_payload) - 1;
-
-  uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
-  memset(payload, 0xCC, sizeof(payload));
-  size_t payload_len = 0xBAADC0DE;
-
-  ret = az_iot_provisioning_client_register_get_request_payload(
-      &client, test_custom_payload, NULL, payload, sizeof(payload), &payload_len);
-
-  assert_int_equal(AZ_OK, ret);
-  assert_int_equal(payload_len, expected_payload_len);
-  assert_memory_equal(expected_payload, payload, expected_payload_len);
-  assert_int_equal((uint8_t)0xCC, payload[expected_payload_len]);
-}
-
 int test_az_iot_provisioning_client_register_get_request_payload()
 {
 #ifndef AZ_NO_PRECONDITION_CHECKING
@@ -236,12 +226,12 @@ int test_az_iot_provisioning_client_register_get_request_payload()
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_NULL_mqtt_payload_fails),
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_zero_payload_size_fails),
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_NULL_payload_length_fails),
+    cmocka_unit_test(
+        test_az_iot_provisioning_client_register_get_request_payload_NULL_options_fails),    
 #endif // AZ_NO_PRECONDITION_CHECKING
 
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_no_custom_payload_succeed),
     cmocka_unit_test(test_az_iot_provisioning_client_get_request_payload_custom_payload_succeed),
-    cmocka_unit_test(
-        test_az_iot_provisioning_client_register_get_request_payload_NULL_options_succeed),
   };
 
   return cmocka_run_group_tests_name("az_iot_provisioning_client_payload", tests, NULL, NULL);


### PR DESCRIPTION
Port from https://github.com/Azure/azure-sdk-for-c/tree/feature/iot-certificate-management.

- Feature: Azure IoT Provisioning Client Receiving Custom Allocation Payloads
- Includes unit tests, sample and documentation.
- Adding standardized API deprecation.
- Forcing clang v9 for verification.
- Roll-back from feature branch: member function `options` parameter cannot be `NULL`. (https://github.com/Azure/azure-sdk-for-c/pull/2188#discussion_r860141070)

**Deprecation notice:** `az_iot_provisioning_client_get_request_payload()` is deprecated in favor of `az_iot_provisioning_client_register_get_request_payload()`. The new API _requires_ an initialized `az_iot_provisioning_client_payload_options` structure (using `az_iot_provisioning_client_payload_options_default()`).
