### PR TITLE
Workaround for gcc 11.3 on Ubuntu 22

### DIFF
--- a/sdk/inc/azure/core/_az_cfg.h
+++ b/sdk/inc/azure/core/_az_cfg.h
@@ -94,7 +94,7 @@
  */
 #ifdef __has_c_attribute
 #if __has_c_attribute(deprecated)
-#define AZ_DEPRECATED [[deprecated]]
+#define AZ_DEPRECATED __attribute__((__deprecated__))
 #endif // __has_c_attribute(deprecated)
 #endif // __has_c_attribute
 


### PR DESCRIPTION
Fixes #2447

