### PR TITLE
add zip to linux install

### DIFF
--- a/sdk/samples/iot/README.md
+++ b/sdk/samples/iot/README.md
@@ -99,7 +99,7 @@ To run the samples, ensure you have the following programs and tools installed o
 
     ```bash
     sudo apt-get update
-    sudo apt-get install build-essential curl unzip tar pkg-config
+    sudo apt-get install build-essential curl zip unzip tar pkg-config
     ```
 
     Windows (PowerShell):


### PR DESCRIPTION
Thanks to @preethi826 for helping find this. VCPKG bootstrap fails with zip not being installed.