### PR TITLE
Rename push ignore deprecations and pop warnings macro from AZ_ to _az_ to indicate they are for internal use only.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,4 +15,5 @@ Cpp11BracedListStyle: false
 IndentCaseLabels: true
 PenaltyReturnTypeOnItsOwnLine: 300
 PointerAlignment: Left
+StatementMacros: ['_az_PUSH_IGNORE_DEPRECATIONS', '_az_POP_WARNINGS']
 ...

--- a/sdk/inc/azure/core/_az_cfg.h
+++ b/sdk/inc/azure/core/_az_cfg.h
@@ -107,12 +107,12 @@
 #endif // AZ_DEPRECATED
 
 #ifdef _MSC_VER
-#define AZ_PUSH_IGNORE_DEPRECATIONS _Pragma("warning(push)") _Pragma("warning(disable:4996)")
-#define AZ_POP_WARNINGS _Pragma("warning(pop)")
+#define _az_PUSH_IGNORE_DEPRECATIONS _Pragma("warning(push)") _Pragma("warning(disable:4996)")
+#define _az_POP_WARNINGS _Pragma("warning(pop)")
 #else // !_MSC_VER
-#define AZ_PUSH_IGNORE_DEPRECATIONS \
+#define _az_PUSH_IGNORE_DEPRECATIONS \
   _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#define AZ_POP_WARNINGS _Pragma("GCC diagnostic pop")
+#define _az_POP_WARNINGS _Pragma("GCC diagnostic pop")
 #endif // _MSC_VER
 
 #endif // _az_CFG_H

--- a/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
+++ b/sdk/samples/iot/paho_iot_pnp_with_provisioning_sample.c
@@ -250,7 +250,7 @@ static void register_device_with_provisioning_service(void)
   uint8_t mqtt_payload[MQTT_PAYLOAD_BUFFER_LENGTH];
   size_t mqtt_payload_length;
 
-  AZ_PUSH_IGNORE_DEPRECATIONS
+  _az_PUSH_IGNORE_DEPRECATIONS
   rc = az_iot_provisioning_client_get_request_payload(
       &provisioning_client,
       custom_registration_payload_property,
@@ -258,7 +258,7 @@ static void register_device_with_provisioning_service(void)
       mqtt_payload,
       sizeof(mqtt_payload),
       &mqtt_payload_length);
-  AZ_POP_WARNINGS
+  _az_POP_WARNINGS
   if (az_result_failed(rc))
   {
     IOT_SAMPLE_LOG_ERROR(

--- a/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
+++ b/sdk/tests/iot/provisioning/test_az_iot_provisioning_client_register_get_request_payload.c
@@ -47,10 +47,10 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_client_fail
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
-  AZ_PUSH_IGNORE_DEPRECATIONS
+  _az_PUSH_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       NULL, AZ_SPAN_EMPTY, NULL, payload, sizeof(payload), &payload_len));
-  AZ_POP_WARNINGS
+  _az_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_non_NULL_reserved_fails()
@@ -67,7 +67,7 @@ static void test_az_iot_provisioning_client_get_request_payload_non_NULL_reserve
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
-  AZ_PUSH_IGNORE_DEPRECATIONS
+  _az_PUSH_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client,
       AZ_SPAN_EMPTY,
@@ -75,7 +75,7 @@ static void test_az_iot_provisioning_client_get_request_payload_non_NULL_reserve
       payload,
       sizeof(payload),
       &payload_len));
-  AZ_POP_WARNINGS
+  _az_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_NULL_mqtt_payload_fails()
@@ -91,10 +91,10 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_mqtt_payloa
 
   size_t payload_len;
 
-  AZ_PUSH_IGNORE_DEPRECATIONS
+  _az_PUSH_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, NULL, 1, &payload_len));
-  AZ_POP_WARNINGS
+  _az_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_zero_payload_size_fails()
@@ -111,10 +111,10 @@ static void test_az_iot_provisioning_client_get_request_payload_zero_payload_siz
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
   size_t payload_len;
 
-  AZ_PUSH_IGNORE_DEPRECATIONS
+  _az_PUSH_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, 0, &payload_len));
-  AZ_POP_WARNINGS
+  _az_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_get_request_payload_NULL_payload_length_fails()
@@ -130,10 +130,10 @@ static void test_az_iot_provisioning_client_get_request_payload_NULL_payload_len
 
   uint8_t payload[TEST_PAYLOAD_RESERVE_SIZE];
 
-  AZ_PUSH_IGNORE_DEPRECATIONS
+  _az_PUSH_IGNORE_DEPRECATIONS
   ASSERT_PRECONDITION_CHECKED(az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, 1, NULL));
-  AZ_POP_WARNINGS
+  _az_POP_WARNINGS
 }
 
 static void test_az_iot_provisioning_client_register_get_request_payload_NULL_options_fails()
@@ -174,10 +174,10 @@ static void test_az_iot_provisioning_client_get_request_payload_no_custom_payloa
   memset(payload, 0xCC, sizeof(payload));
   size_t payload_len = 0xBAADC0DE;
 
-  AZ_PUSH_IGNORE_DEPRECATIONS
+  _az_PUSH_IGNORE_DEPRECATIONS
   ret = az_iot_provisioning_client_get_request_payload(
       &client, AZ_SPAN_EMPTY, NULL, payload, sizeof(payload), &payload_len);
-  AZ_POP_WARNINGS
+  _az_POP_WARNINGS
   assert_int_equal(AZ_OK, ret);
   assert_int_equal(payload_len, expected_payload_len);
   assert_memory_equal(expected_payload, payload, expected_payload_len);
@@ -203,14 +203,14 @@ static void test_az_iot_provisioning_client_get_request_payload_custom_payload_s
   memset(payload, 0xCC, sizeof(payload));
   size_t payload_len = 0xBAADC0DE;
 
-  AZ_PUSH_IGNORE_DEPRECATIONS
+  _az_PUSH_IGNORE_DEPRECATIONS
   ret = az_iot_provisioning_client_get_request_payload(
       &client, test_custom_payload, NULL, payload, sizeof(payload), &payload_len);
   assert_int_equal(AZ_OK, ret);
   assert_int_equal(payload_len, expected_payload_len);
   assert_memory_equal(expected_payload, payload, expected_payload_len);
   assert_int_equal((uint8_t)0xCC, payload[expected_payload_len]);
-  AZ_POP_WARNINGS
+  _az_POP_WARNINGS
 }
 
 int test_az_iot_provisioning_client_register_get_request_payload()


### PR DESCRIPTION
Follow-up from https://github.com/Azure/azure-sdk-for-c/pull/2443#discussion_r1066391277