### PR TITLE
Fix the release version in docs where `az_iot_provisioning_client_register_get_request_payload` got deprecated

### DIFF
--- a/sdk/inc/azure/iot/az_iot_provisioning_client.h
+++ b/sdk/inc/azure/iot/az_iot_provisioning_client.h
@@ -510,7 +510,7 @@ AZ_NODISCARD az_result az_iot_provisioning_client_register_get_request_payload(
     size_t* out_mqtt_payload_length);
 
 /**
- * @deprecated since 1.5.0-beta.1.
+ * @deprecated since 1.5.0.
  * @see az_iot_provisioning_client_register_get_request_payload
  * @brief Builds the optional payload for a provisioning request.
  * @remark Use this API to build an MQTT payload during registration.


### PR DESCRIPTION
Follow-up from https://github.com/Azure/azure-sdk-for-c/pull/2443#discussion_r1067407268

We don't have a `1.5.0-beta.1` release, as we went directly to `1.5.0` GA:
https://github.com/Azure/azure-sdk-for-c/blob/1.5.0/CHANGELOG.md#150-2023-01-10