### PR TITLE
Update `CODEOWNERS` paths: fix invalid paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,19 +1,12 @@
 # Instructions for CODEOWNERS file format and automatic build failure notifications:
 # https://github.com/Azure/azure-sdk/blob/main/docs/policies/opensource.md#codeowners
 
-################
-# Automation
-################
-
-# Git Hub integration and bot rules
-/.github/                     @jsquire @ronniegeraghty
-
 ###########
 # SDK
 ###########
 
 # Catch all for non-code project files
-* @rickwinter
+/** @rickwinter
 
 # SDK team
 /sdk/ @rickwinter
@@ -23,24 +16,30 @@
 
 # Service teams
 # Core
-sdk/docs/core/                @ahsonkhan @antkmsft @rickwinter @vhvb1989 @gearama
-sdk/inc/azure/core/           @ahsonkhan @antkmsft @rickwinter @vhvb1989 @gearama
-sdk/samples/core/             @ahsonkhan @antkmsft @rickwinter @vhvb1989 @gearama
-sdk/src/azure/core/           @ahsonkhan @antkmsft @rickwinter @vhvb1989 @gearama
-sdk/tests/core/               @ahsonkhan @antkmsft @rickwinter @vhvb1989 @gearama
+/sdk/docs/core/                @ahsonkhan @antkmsft @rickwinter @vhvb1989 @gearama
+/sdk/inc/azure/core/           @ahsonkhan @antkmsft @rickwinter @vhvb1989 @gearama
+/sdk/samples/core/             @ahsonkhan @antkmsft @rickwinter @vhvb1989 @gearama
+/sdk/src/azure/core/           @ahsonkhan @antkmsft @rickwinter @vhvb1989 @gearama
+/sdk/tests/core/               @ahsonkhan @antkmsft @rickwinter @vhvb1989 @gearama
 
 # IoT
-sdk/docs/iot/                 @CIPop @danewalton @ericwol-msft @ewertons @josesanchez7 @jspaith @preethi826 @RLeclair @vaavva
-sdk/inc/azure/iot/            @CIPop @danewalton @ericwol-msft @ewertons @josesanchez7 @jspaith @preethi826 @RLeclair @vaavva
-sdk/samples/iot/              @CIPop @danewalton @ericwol-msft @ewertons @josesanchez7 @jspaith @preethi826 @RLeclair @vaavva
-sdk/src/azure/iot/            @CIPop @danewalton @ericwol-msft @ewertons @josesanchez7 @jspaith @preethi826 @RLeclair @vaavva
-sdk/tests/iot/                @CIPop @danewalton @ericwol-msft @ewertons @josesanchez7 @jspaith @preethi826 @RLeclair @vaavva
+/sdk/docs/iot/                 @CIPop @danewalton @ericwol-msft @ewertons @josesanchez7 @jspaith @preethi826 @RLeclair @vaavva
+/sdk/inc/azure/iot/            @CIPop @danewalton @ericwol-msft @ewertons @josesanchez7 @jspaith @preethi826 @RLeclair @vaavva
+/sdk/samples/iot/              @CIPop @danewalton @ericwol-msft @ewertons @josesanchez7 @jspaith @preethi826 @RLeclair @vaavva
+/sdk/src/azure/iot/            @CIPop @danewalton @ericwol-msft @ewertons @josesanchez7 @jspaith @preethi826 @RLeclair @vaavva
+/sdk/tests/iot/                @CIPop @danewalton @ericwol-msft @ewertons @josesanchez7 @jspaith @preethi826 @RLeclair @vaavva
 
 # Platform
-sdk/src/azure/platform/       @ahsonkhan @antkmsft @rickwinter @vhvb1989 @gearama
+/sdk/src/azure/platform/       @ahsonkhan @antkmsft @rickwinter @vhvb1989 @gearama
+
+################
+# Automation
+################
+
+# Git Hub integration and bot rules
+/.github/                     @jsquire @ronniegeraghty
 
 ###########
 # Eng Sys
 ###########
 /eng/       @danieljurek @weshaggard @benbp
-/**/ci.yml  @danieljurek


### PR DESCRIPTION
As part of ongoing work of enabling wildcard support for `CODEOWNERS`:
- https://github.com/Azure/azure-sdk-tools/issues/2770
- https://github.com/Azure/azure-sdk-tools/pull/5088

and enabling stricter validation:
- https://github.com/Azure/azure-sdk-tools/issues/4859

this PR:
- fixes invalid paths, to match rules explained [here](https://github.com/Azure/azure-sdk/blob/main/docs/policies/opensource.md#codeowners);
- removes `/**/tests.yml` and `/**/ci.yml`, to avoid all build failure notifications being routed to it once we enable the new regex-based, wildcard-supporting `CODEOWNERS` matcher, per: https://github.com/Azure/azure-sdk-tools/pull/5088#issuecomment-1397330147

Once this PR is merged, I will enable the new `CODEOWNERS` matcher, similar to how it was done for `net` repo by these two PRs:
- https://github.com/Azure/azure-sdk-tools/pull/5241
- https://github.com/Azure/azure-sdk-tools/pull/5240