### PR TITLE
Update `archetype-sdk-client.yml`: Update Ubuntu 18 to Ubuntu 20

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -111,8 +111,8 @@ jobs:
         BuildType: Debug
 
       LinuxARM_Release_Preconditions:
-        Pool: azsdk-pool-mms-ubuntu-1804-general
-        OSVmImage: ubuntu-18.04
+        Pool: azsdk-pool-mms-ubuntu-2004-general
+        OSVmImage: ubuntu-20.04
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'


### PR DESCRIPTION
A follow-up to:
- https://github.com/Azure/azure-sdk-for-c/pull/2546

Apparently I forgot to update this one place.

Related work:
- https://github.com/Azure/azure-sdk-tools/issues/5472