### PR TITLE
Adding MQTT container to test pipeline

### DIFF
--- a/eng/config/mosquitto.conf
+++ b/eng/config/mosquitto.conf
@@ -1,5 +1,5 @@
 allow_anonymous true
-listener 1883 127.0.0.1
+listener 2883
 persistence true
 persistence_location /mosquitto/data/
 log_dest stdout

--- a/eng/config/mosquitto.conf
+++ b/eng/config/mosquitto.conf
@@ -1,0 +1,11 @@
+allow_anonymous true
+listener 1883
+persistence true
+persistence_location /mosquitto/data/
+log_dest stdout
+
+log_type error
+log_type warning
+log_type notice
+log_type information
+log_type all

--- a/eng/config/mosquitto.conf
+++ b/eng/config/mosquitto.conf
@@ -1,5 +1,5 @@
 allow_anonymous true
-listener 1883
+listener 1883 127.0.0.1
 persistence true
 persistence_location /mosquitto/data/
 log_dest stdout

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -279,7 +279,7 @@ jobs:
       filePath: eng/scripts/Setup-MQTTContainer.ps1
       arguments: >
         -AgentImage "$(OSVmImage)"
-        -ConfigFile "/eng/config/mosquitto.conf"
+        -ConfigFile "eng/config/mosquitto.conf"
     condition: contains(variables['vcpkg.deps'], 'mosquitto')
 
   # Run unit tests

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -63,9 +63,10 @@ jobs:
       Linux_Release_MapFiles_Logging_UnitTests_Mocks_Samples:
         Pool: azsdk-pool-mms-ubuntu-2004-general
         OSVmImage: ubuntu-20.04
-        vcpkg.deps: 'cmocka paho-mqtt'
+        vcpkg.deps: 'cmocka paho-mqtt mosquitto'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON -DTRANSPORT_PAHO=ON -DADDRESS_SANITIZER=ON'
+        AptDependencies: 'ca-certificates curl gnupg'
+        build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON -DTRANSPORT_PAHO=ON -DADDRESS_SANITIZER=ON -DAZ_PLATFORM_IMPL=POSIX -DAZ_MQTT_TRANSPORT_IMPL=MOSQUITTO'
         PublishMapFiles: 'true'
         MapFileArtifactSuffix: 'lnx-x64-rel-noprc-log-samples'
         BuildType: Release
@@ -73,9 +74,10 @@ jobs:
       Linux_Logging_UnitTests_Mocks_Samples:
         Pool: azsdk-pool-mms-ubuntu-2004-general
         OSVmImage: ubuntu-20.04
-        vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
+        vcpkg.deps: 'curl[ssl] paho-mqtt cmocka mosquitto'
+        AptDependencies: 'ca-certificates curl gnupg'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DADDRESS_SANITIZER=ON -DUNIT_TESTING_MOCKS=ON'
+        build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DADDRESS_SANITIZER=ON -DUNIT_TESTING_MOCKS=ON -DAZ_MQTT_TRANSPORT_IMPL=MOSQUITTO'
         PublishMapFiles: 'false'
         BuildType: Debug
 
@@ -135,19 +137,20 @@ jobs:
       Linux_Release_Preconditions_Logging_UnitTests_Mocks_Samples:
         Pool: azsdk-pool-mms-ubuntu-2004-general
         OSVmImage: ubuntu-20.04
-        vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
+        vcpkg.deps: 'curl[ssl] paho-mqtt cmocka mosquitto'
+        AptDependencies: 'ca-certificates curl gnupg'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON'
+        build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON -DAZ_MQTT_TRANSPORT_IMPL=MOSQUITTO'
         PublishMapFiles: 'false'
         BuildType: Release
 
       Linux_Preconditions_Logging_UnitTests_Mocks_CodeCov_Linter:
         Pool: azsdk-pool-mms-ubuntu-2004-general
         OSVmImage: ubuntu-20.04
-        vcpkg.deps: 'cmocka'
+        vcpkg.deps: 'cmocka mosquitto'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        AptDependencies: 'gcovr lcov'
-        build.args: '-DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON'
+        AptDependencies: 'gcovr lcov ca-certificates curl gnupg'
+        build.args: '-DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON -DAZ_PLATFORM_IMPL=POSIX -DAZ_MQTT_TRANSPORT_IMPL=MOSQUITTO'
         AZ_SDK_CODE_COV: 1
         AZ_SDK_C_NO_SAMPLES: 'true'
         PublishMapFiles: 'false'
@@ -210,8 +213,9 @@ jobs:
         Pool: azsdk-pool-mms-ubuntu-2204-general
         OSVmImage: ubuntu-22.04
         vcpkg.deps: 'cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux mosquitto'
+        AptDependencies: 'ca-certificates curl gnupg'
+        build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF -DAZ_PLATFORM_IMPL=POSIX -DAZ_MQTT_TRANSPORT_IMPL=MOSQUITTO'
         AZ_SDK_C_NO_SAMPLES: 'true'
         PublishMapFiles: 'true'
         MapFileArtifactSuffix: 'lnx-gcc11-rel-noprc-nolog'
@@ -269,6 +273,18 @@ jobs:
     parameters:
       BuildArgs: $(build.args)
       BuildType: $(BuildType)
+
+  # Create MQTT broker container
+  - task: PowerShell@2
+    displayName: Create MQTT Broker Container
+    inputs:
+      pwsh: true
+      workingDirectory: $(System.DefaultWorkingDirectory)
+      filePath: eng/scripts/Setup-MQTTContainer.ps1
+      arguments: >
+        -AgentImage "$(OSVmImage)"
+        -ConfigFile "/eng/config/mosquitto.conf"
+    condition: contains(variables['vcpkg.deps'], 'mosquitto')
 
   # Run unit tests
   - script: |

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -209,8 +209,8 @@ jobs:
       LinuxGCC11_Release_MapFiles_UnitTests:
         Pool: azsdk-pool-mms-ubuntu-2204-general
         OSVmImage: ubuntu-22.04
-        vcpkg.deps: 'cmocka'
-        VCPKG_DEFAULT_TRIPLET: 'x64-linux mosquitto'
+        vcpkg.deps: 'cmocka mosquitto'
+        VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF -DAZ_PLATFORM_IMPL=POSIX -DAZ_MQTT_TRANSPORT_IMPL=MOSQUITTO'
         AZ_SDK_C_NO_SAMPLES: 'true'
         PublishMapFiles: 'true'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -65,7 +65,6 @@ jobs:
         OSVmImage: ubuntu-20.04
         vcpkg.deps: 'cmocka paho-mqtt mosquitto'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        AptDependencies: 'ca-certificates curl gnupg'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON -DTRANSPORT_PAHO=ON -DADDRESS_SANITIZER=ON -DAZ_PLATFORM_IMPL=POSIX -DAZ_MQTT_TRANSPORT_IMPL=MOSQUITTO'
         PublishMapFiles: 'true'
         MapFileArtifactSuffix: 'lnx-x64-rel-noprc-log-samples'
@@ -75,7 +74,6 @@ jobs:
         Pool: azsdk-pool-mms-ubuntu-2004-general
         OSVmImage: ubuntu-20.04
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka mosquitto'
-        AptDependencies: 'ca-certificates curl gnupg'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DADDRESS_SANITIZER=ON -DUNIT_TESTING_MOCKS=ON -DAZ_MQTT_TRANSPORT_IMPL=MOSQUITTO'
         PublishMapFiles: 'false'
@@ -138,7 +136,6 @@ jobs:
         Pool: azsdk-pool-mms-ubuntu-2004-general
         OSVmImage: ubuntu-20.04
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka mosquitto'
-        AptDependencies: 'ca-certificates curl gnupg'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON -DAZ_MQTT_TRANSPORT_IMPL=MOSQUITTO'
         PublishMapFiles: 'false'
@@ -149,7 +146,7 @@ jobs:
         OSVmImage: ubuntu-20.04
         vcpkg.deps: 'cmocka mosquitto'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        AptDependencies: 'gcovr lcov ca-certificates curl gnupg'
+        AptDependencies: 'gcovr lcov'
         build.args: '-DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON -DAZ_PLATFORM_IMPL=POSIX -DAZ_MQTT_TRANSPORT_IMPL=MOSQUITTO'
         AZ_SDK_CODE_COV: 1
         AZ_SDK_C_NO_SAMPLES: 'true'
@@ -214,7 +211,6 @@ jobs:
         OSVmImage: ubuntu-22.04
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux mosquitto'
-        AptDependencies: 'ca-certificates curl gnupg'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF -DAZ_PLATFORM_IMPL=POSIX -DAZ_MQTT_TRANSPORT_IMPL=MOSQUITTO'
         AZ_SDK_C_NO_SAMPLES: 'true'
         PublishMapFiles: 'true'

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -6,19 +6,32 @@ param (
 )
 
 if ($IsLinux -and $AgentImage -match "ubuntu") {
-    docker pull eclipse-mosquitto
+    docker pull azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
 
-    sudo docker run -d -p 1883:1883 -p 9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf eclipse-mosquitto
+    sudo docker run -d -p 1883:1883 -p 9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
+    
+    $count = 0
 
-    # Testing
+    sudo docker ps -a
 
-    sudo apt install net-tools
+    Start-Sleep -Milliseconds 2000
 
-    echo "Checking connections"
+    while ($count -lt 3) {
+        $container = sudo docker ps -a --filter "ancestor=eclipse-mosquitto" --format "{{.Names}}"
+    
+        if ($container) {
+            Write-Host "Container is running"
+            break
+        }
+        else {
+            Write-Host "Container is not running"
+            Start-Sleep -Milliseconds 2000
+            $count++
+        }
+    }
 
-    sudo netstat -p
-
-    sudo netstat -apn | grep 1883
-
-    docker ps
+    if ($count -eq 3) {
+        Write-Error "Container is not running"
+        exit 1
+    }
 }

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -6,23 +6,6 @@ param (
 )
 
 if ($IsLinux -and $AgentImage -match "ubuntu") {
-    $dockerGpgDir = "/etc/apt/keyrings"
-    $dockerGpgPath = "/etc/apt/keyrings/docker.gpg"
-    $dockerGpgUrl = "https://download.docker.com/linux/ubuntu/gpg"
-    $dockerListPath = "/etc/apt/sources.list.d/docker.list"
-
-    sudo install -m 0755 -d $dockerGpgDir
-
-    sudo curl -fsSL $dockerGpgUrl | sudo gpg --dearmor -o $dockerGpgPath
-
-    sudo chmod a+r /etc/apt/keyrings/docker.gpg
-    
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=$($dockerGpgPath)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee $dockerListPath > /dev/null
-
-    sudo apt-get update
-
-    sudo apt-get -y install docker-ce
-
     docker pull eclipse-mosquitto
 
     sudo docker run -d -p 1883:1883 -p 9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf eclipse-mosquitto
@@ -36,4 +19,6 @@ if ($IsLinux -and $AgentImage -match "ubuntu") {
     sudo netstat -p
 
     sudo netstat -apn | grep 1883
+
+    docker ps
 }

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -8,6 +8,14 @@ param (
 if ($IsLinux -and $AgentImage -match "ubuntu") {
     docker pull azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
 
+    Write-Host "Following is the config file path:"
+    $ConfigFile
+
+    Write-Host "Following is the working directory:"
+    Get-Location
+
+    Write-Host "Run the docker run command to start the container"
+
     sudo docker run -d -p 127.0.0.1:2883:2883 -p 127.0.0.1:9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
     
     $count = 0

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -21,6 +21,12 @@ if ($IsLinux -and $AgentImage -match "ubuntu") {
     
         if ($container) {
             Write-Host "Container is running"
+
+            # Debugging
+            sudo docker container inspect $container
+            Write-Host "<<<<<<<<<<< Printing out logs >>>>>>>>>>>>>"
+            sudo docker logs $container
+
             break
         }
         else {

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -27,7 +27,11 @@ if ($IsLinux -and $AgentImage -match "ubuntu") {
 
     Write-Host "Run the docker run command to start the container"
 
-    sudo docker run -d -p 127.0.0.1:2883:2883 -p 127.0.0.1:9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
+    $fullPathConfigFile = "$currentPath/$ConfigFile"
+
+    Write-Host "Full path of the config file: $fullPathConfigFile"
+
+    sudo docker run -d -p 127.0.0.1:2883:2883 -p 127.0.0.1:9001:9001 -v ${$fullPathConfigFile}:/mosquitto/config/mosquitto.conf azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
     
     $count = 0
 

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -1,0 +1,29 @@
+param (
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string] $AgentImage,
+    [string] $ConfigFile
+)
+
+if ($IsLinux -and $AgentImage -match "ubuntu") {
+    $dockerGpgDir = "/etc/apt/keyrings"
+    $dockerGpgPath = "/etc/apt/keyrings/docker.gpg"
+    $dockerGpgUrl = "https://download.docker.com/linux/ubuntu/gpg"
+    $dockerListPath = "/etc/apt/sources.list.d/docker.list"
+
+    sudo install -m 0755 -d $dockerGpgDir
+
+    sudo curl -fsSL $dockerGpgUrl | sudo gpg --dearmor -o $dockerGpgPath
+
+    sudo chmod a+r /etc/apt/keyrings/docker.gpg
+    
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=$($dockerGpgPath)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee $dockerListPath > /dev/null
+
+    sudo apt-get update
+
+    sudo apt-get -y install docker-ce
+
+    docker pull eclipse-mosquitto
+
+    sudo docker run -it -p 1883:1883 -p 9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf eclipse-mosquitto
+}

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -25,5 +25,15 @@ if ($IsLinux -and $AgentImage -match "ubuntu") {
 
     docker pull eclipse-mosquitto
 
-    sudo docker run -d -p 1883:1883 -p 9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf eclipse-mosquitto
+    # Testing
+
+    sudo apt install net-tools
+
+    echo "Checking connections"
+
+    sudo netstat -p
+
+    # End of testing
+
+    sudo docker run -d -p 50000:50000 -p 9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf eclipse-mosquitto
 }

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -8,11 +8,22 @@ param (
 if ($IsLinux -and $AgentImage -match "ubuntu") {
     docker pull azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
 
-    Write-Host "Following is the config file path:"
-    $ConfigFile
+    Write-Host "Following is the config file path: $ConfigFile"
 
-    Write-Host "Following is the working directory:"
-    Get-Location
+    # Get the current path
+    $currentPath = Get-Location
+
+    # Print the current path
+    Write-Host "Current path: $currentPath"
+
+    # Get the files and folders in the current directory
+    $filesAndFolders = Get-ChildItem -Path $currentPath
+
+    # Print the files and folders
+    Write-Host "Files and folders in current directory:"
+    foreach ($item in $filesAndFolders) {
+        Write-Host $item.Name
+    }
 
     Write-Host "Run the docker run command to start the container"
 

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -25,5 +25,5 @@ if ($IsLinux -and $AgentImage -match "ubuntu") {
 
     docker pull eclipse-mosquitto
 
-    sudo docker run -it -p 1883:1883 -p 9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf eclipse-mosquitto
+    sudo docker run -p 1883:1883 -p 9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf eclipse-mosquitto
 }

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -34,4 +34,6 @@ if ($IsLinux -and $AgentImage -match "ubuntu") {
     echo "Checking connections"
 
     sudo netstat -p
+
+    sudo netstat -apn | grep 1883
 }

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -17,7 +17,7 @@ if ($IsLinux -and $AgentImage -match "ubuntu") {
     Start-Sleep -Milliseconds 2000
 
     while ($count -lt 3) {
-        $container = sudo docker ps -a --filter "ancestor=eclipse-mosquitto" --format "{{.Names}}"
+        $container = sudo docker ps -a --filter "ancestor=azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1" --format "{{.Names}}"
     
         if ($container) {
             Write-Host "Container is running"

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -31,9 +31,8 @@ if ($IsLinux -and $AgentImage -match "ubuntu") {
 
     Write-Host "Full path of the config file: $fullPathConfigFile"
 
-    sudo docker run -d -p 127.0.0.1:2883:2883 -p 127.0.0.1:9001:9001 -v ${$fullPathConfigFile}:/mosquitto/config/mosquitto.conf azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
-    
-    $count = 0
+    #sudo docker run -d -p 127.0.0.1:2883:2883 -p 127.0.0.1:9001:9001 -v ${$fullPathConfigFile}:/mosquitto/config/mosquitto.conf azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
+    sudo docker run -d -p 127.0.0.1:2883:2883 -p 127.0.0.1:9001:9001 --mount type=bind,src=$fullPathConfigFile,dst=/mosquitto/config/mosquitto.conf azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
 
     sudo docker ps -a
 

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -8,7 +8,7 @@ param (
 if ($IsLinux -and $AgentImage -match "ubuntu") {
     docker pull azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
 
-    sudo docker run -d -p 1883:1883 -p 9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
+    sudo docker run -d -p 127.0.0.1:2883:2883 -p 127.0.0.1:9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
     
     $count = 0
 

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -25,5 +25,5 @@ if ($IsLinux -and $AgentImage -match "ubuntu") {
 
     docker pull eclipse-mosquitto
 
-    sudo docker run -p 1883:1883 -p 9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf eclipse-mosquitto
+    sudo docker run -d -p 1883:1883 -p 9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf eclipse-mosquitto
 }

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -8,33 +8,11 @@ param (
 if ($IsLinux -and $AgentImage -match "ubuntu") {
     docker pull azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
 
-    Write-Host "Following is the config file path: $ConfigFile"
+    $CurrentPath = Get-Location
 
-    # Get the current path
-    $currentPath = Get-Location
+    $FullPathConfigFile = Resolve-Path (Join-Path $CurrentPath $ConfigFile)
 
-    # Print the current path
-    Write-Host "Current path: $currentPath"
-
-    # Get the files and folders in the current directory
-    $filesAndFolders = Get-ChildItem -Path $currentPath
-
-    # Print the files and folders
-    Write-Host "Files and folders in current directory:"
-    foreach ($item in $filesAndFolders) {
-        Write-Host $item.Name
-    }
-
-    Write-Host "Run the docker run command to start the container"
-
-    $fullPathConfigFile = "$currentPath/$ConfigFile"
-
-    Write-Host "Full path of the config file: $fullPathConfigFile"
-
-    #sudo docker run -d -p 127.0.0.1:2883:2883 -p 127.0.0.1:9001:9001 -v ${$fullPathConfigFile}:/mosquitto/config/mosquitto.conf azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
-    sudo docker run -d -p 127.0.0.1:2883:2883 -p 127.0.0.1:9001:9001 --mount type=bind,src=$fullPathConfigFile,dst=/mosquitto/config/mosquitto.conf azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
-
-    sudo docker ps -a
+    sudo docker run -d -p 127.0.0.1:2883:2883 -p 127.0.0.1:9001:9001 --mount type=bind,src=$FullPathConfigFile,dst=/mosquitto/config/mosquitto.conf azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1
 
     Start-Sleep -Milliseconds 2000
 
@@ -42,24 +20,22 @@ if ($IsLinux -and $AgentImage -match "ubuntu") {
         $container = sudo docker ps -a --filter "ancestor=azsdkengsys.azurecr.io/eclipse-mosquitto:2.0.1" --format "{{.Names}}"
     
         if ($container) {
-            Write-Host "Container is running"
+            Write-Host "Container started."
 
-            # Debugging
-            sudo docker container inspect $container
-            Write-Host "<<<<<<<<<<< Printing out logs >>>>>>>>>>>>>"
+            Write-Host "Container initialization logs:"
             sudo docker logs $container
 
             break
         }
         else {
-            Write-Host "Container is not running"
+            Write-Host "Container starting..."
             Start-Sleep -Milliseconds 2000
             $count++
         }
     }
 
     if ($count -eq 3) {
-        Write-Error "Container is not running"
+        Write-Error "Container failed to start."
         exit 1
     }
 }

--- a/eng/scripts/Setup-MQTTContainer.ps1
+++ b/eng/scripts/Setup-MQTTContainer.ps1
@@ -25,6 +25,8 @@ if ($IsLinux -and $AgentImage -match "ubuntu") {
 
     docker pull eclipse-mosquitto
 
+    sudo docker run -d -p 1883:1883 -p 9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf eclipse-mosquitto
+
     # Testing
 
     sudo apt install net-tools
@@ -32,8 +34,4 @@ if ($IsLinux -and $AgentImage -match "ubuntu") {
     echo "Checking connections"
 
     sudo netstat -p
-
-    # End of testing
-
-    sudo docker run -d -p 50000:50000 -p 9001:9001 -v ${$ConfigFile}:/mosquitto/config/mosquitto.conf eclipse-mosquitto
 }

--- a/sdk/inc/azure/platform/az_mqtt_mosquitto.h
+++ b/sdk/inc/azure/platform/az_mqtt_mosquitto.h
@@ -48,6 +48,11 @@ typedef struct
    * @brief Handle to the underlying MQTT implementation (Mosquitto).
    */
   struct mosquitto* mosquitto_handle;
+
+  /**
+   * @brief Whether to use TLS for the underlying MQTT implementation.
+   */
+  bool use_tls;
 } az_mqtt_options;
 
 /**

--- a/sdk/src/azure/platform/az_mosquitto.c
+++ b/sdk/src/azure/platform/az_mosquitto.c
@@ -180,11 +180,12 @@ static void _az_mosquitto_on_log(struct mosquitto* mosq, void* obj, int level, c
 
 AZ_NODISCARD az_mqtt_options az_mqtt_options_default()
 {
-  return (az_mqtt_options){ .certificate_authority_trusted_roots = AZ_SPAN_EMPTY,
-                            .openssl_engine = NULL,
-                            .mosquitto_handle = NULL,
-                            .use_tls = true,
-                            };
+  return (az_mqtt_options){
+    .certificate_authority_trusted_roots = AZ_SPAN_EMPTY,
+    .openssl_engine = NULL,
+    .mosquitto_handle = NULL,
+    .use_tls = true,
+  };
 }
 
 AZ_NODISCARD az_result az_mqtt_init(az_mqtt* mqtt, az_mqtt_options const* options)

--- a/sdk/src/azure/platform/az_mosquitto.c
+++ b/sdk/src/azure/platform/az_mosquitto.c
@@ -49,6 +49,9 @@ AZ_INLINE az_result _az_result_from_mosq(int mosquitto_ret)
 
 static void _az_mosquitto_on_connect(struct mosquitto* mosq, void* obj, int reason_code)
 {
+#ifdef AZ_NO_PRECONDITION_CHECKING
+  (void)mosq;
+#endif // AZ_NO_PRECONDITION_CHECKING
   az_result ret;
   az_mqtt* me = (az_mqtt*)obj;
 
@@ -79,6 +82,9 @@ static void _az_mosquitto_on_connect(struct mosquitto* mosq, void* obj, int reas
 
 static void _az_mosquitto_on_disconnect(struct mosquitto* mosq, void* obj, int rc)
 {
+  #ifdef AZ_NO_PRECONDITION_CHECKING
+  (void)mosq;
+  #endif // AZ_NO_PRECONDITION_CHECKING
   az_mqtt* me = (az_mqtt*)obj;
 
   _az_PRECONDITION(mosq == me->_internal.mosquitto_handle);
@@ -101,6 +107,9 @@ static void _az_mosquitto_on_disconnect(struct mosquitto* mosq, void* obj, int r
  * received a PUBCOMP from the broker. */
 static void _az_mosquitto_on_publish(struct mosquitto* mosq, void* obj, int mid)
 {
+#ifdef AZ_NO_PRECONDITION_CHECKING
+  (void)mosq;
+#endif // AZ_NO_PRECONDITION_CHECKING
   az_mqtt* me = (az_mqtt*)obj;
 
   _az_PRECONDITION(mosq == me->_internal.mosquitto_handle);
@@ -120,6 +129,9 @@ static void _az_mosquitto_on_subscribe(
     int qos_count,
     const int* granted_qos)
 {
+#ifdef AZ_NO_PRECONDITION_CHECKING
+  (void)mosq;
+#endif // AZ_NO_PRECONDITION_CHECKING
   (void)qos_count;
   (void)granted_qos;
 
@@ -150,6 +162,9 @@ static void _az_mosquitto_on_message(
     void* obj,
     const struct mosquitto_message* message)
 {
+#ifdef AZ_NO_PRECONDITION_CHECKING
+  (void)mosq;
+#endif // AZ_NO_PRECONDITION_CHECKING
   az_mqtt* me = (az_mqtt*)obj;
 
   _az_PRECONDITION(mosq == me->_internal.mosquitto_handle);

--- a/sdk/src/azure/platform/az_mosquitto.c
+++ b/sdk/src/azure/platform/az_mosquitto.c
@@ -187,6 +187,9 @@ static void _az_mosquitto_on_log(struct mosquitto* mosq, void* obj, int level, c
   (void)mosq;
   (void)obj;
   (void)level;
+#ifdef AZ_NO_LOGGING
+  (void)str;
+#endif // AZ_NO_LOGGING
   if (_az_LOG_SHOULD_WRITE(AZ_LOG_MQTT_STACK))
   {
     _az_LOG_WRITE(AZ_LOG_MQTT_STACK, az_span_create_from_str((char*)(uintptr_t)str));

--- a/sdk/tests/platform/test_az_mqtt_policy.c
+++ b/sdk/tests/platform/test_az_mqtt_policy.c
@@ -24,7 +24,7 @@ void az_platform_critical_error(void) { assert_true(false); }
 
 // MQTT information for testing
 #define TEST_MQTT_ENDPOINT "0.0.0.0"
-#define TEST_MQTT_PORT 1883
+#define TEST_MQTT_PORT 50000
 #define TEST_MQTT_USERNAME ""
 #define TEST_MQTT_PASSWORD ""
 #define TEST_MQTT_CLIENT_ID "test_client_id"

--- a/sdk/tests/platform/test_az_mqtt_policy.c
+++ b/sdk/tests/platform/test_az_mqtt_policy.c
@@ -23,7 +23,7 @@
 void az_platform_critical_error(void) { assert_true(false); }
 
 // MQTT information for testing
-#define TEST_MQTT_ENDPOINT "0.0.0.0"
+#define TEST_MQTT_ENDPOINT "localhost"
 #define TEST_MQTT_PORT 1883
 #define TEST_MQTT_USERNAME ""
 #define TEST_MQTT_PASSWORD ""

--- a/sdk/tests/platform/test_az_mqtt_policy.c
+++ b/sdk/tests/platform/test_az_mqtt_policy.c
@@ -23,7 +23,7 @@
 void az_platform_critical_error(void) { assert_true(false); }
 
 // MQTT information for testing
-#define TEST_MQTT_ENDPOINT "localhost"
+#define TEST_MQTT_ENDPOINT "127.0.0.1"
 #define TEST_MQTT_PORT 1883
 #define TEST_MQTT_USERNAME ""
 #define TEST_MQTT_PASSWORD ""

--- a/sdk/tests/platform/test_az_mqtt_policy.c
+++ b/sdk/tests/platform/test_az_mqtt_policy.c
@@ -24,7 +24,7 @@ void az_platform_critical_error(void) { assert_true(false); }
 
 // MQTT information for testing
 #define TEST_MQTT_ENDPOINT "127.0.0.1"
-#define TEST_MQTT_PORT 1883
+#define TEST_MQTT_PORT 2883
 #define TEST_MQTT_USERNAME ""
 #define TEST_MQTT_PASSWORD ""
 #define TEST_MQTT_CLIENT_ID "test_client_id"

--- a/sdk/tests/platform/test_az_mqtt_policy.c
+++ b/sdk/tests/platform/test_az_mqtt_policy.c
@@ -24,7 +24,7 @@ void az_platform_critical_error(void) { assert_true(false); }
 
 // MQTT information for testing
 #define TEST_MQTT_ENDPOINT "0.0.0.0"
-#define TEST_MQTT_PORT 50000
+#define TEST_MQTT_PORT 1883
 #define TEST_MQTT_USERNAME ""
 #define TEST_MQTT_PASSWORD ""
 #define TEST_MQTT_CLIENT_ID "test_client_id"


### PR DESCRIPTION
Adding MQTT container to the testing pipeline. Powershell script will create a **non-tls** container exposing a local MQTT endpoint which `test_az_mqtt_policy.c` will use.

Tested scripts in local setup. 