### PR TITLE
Adding MQTT5 property initializers

### DIFF
--- a/sdk/inc/azure/core/az_mqtt5_property_bag.h
+++ b/sdk/inc/azure/core/az_mqtt5_property_bag.h
@@ -127,6 +127,84 @@ typedef enum
 } az_mqtt5_property_type;
 
 /**
+ * @brief Creates a property string with the given string value.
+ *
+ * @param[in] str
+ * @return An #az_mqtt5_property_string.
+ */
+AZ_NODISCARD AZ_INLINE az_mqtt5_property_string az_mqtt5_property_string_create(az_span str)
+{
+  return (az_mqtt5_property_string){ .str = str };
+}
+
+/**
+ * @brief An empty #az_mqtt5_property_string literal.
+ *
+ */
+#define AZ_MQTT5_PROPERTY_STRING_LITERAL_EMPTY \
+  {                                            \
+    .str = AZ_SPAN_EMPTY                       \
+  }
+
+/**
+ * @brief An empty #az_mqtt5_property_string.
+ *
+ */
+#define AZ_MQTT5_PROPERTY_STRING_EMPTY \
+  (az_mqtt5_property_string) AZ_MQTT5_PROPERTY_STRING_LITERAL_EMPTY
+
+/**
+ * @brief Creates a property string pair with the given key and value.
+ *
+ * @param[in] key
+ * @param[in] value
+ * @return An #az_mqtt5_property_stringpair.
+ */
+AZ_NODISCARD AZ_INLINE az_mqtt5_property_stringpair
+az_mqtt5_property_stringpair_create(az_span key, az_span value)
+{
+  return (az_mqtt5_property_stringpair){ .key = key, .value = value };
+}
+
+/**
+ * @brief An empty #az_mqtt5_property_stringpair literal.
+ *
+ */
+#define AZ_MQTT5_PROPERTY_STRINGPAIR_LITERAL_EMPTY \
+  {                                                \
+    .key = AZ_SPAN_EMPTY, .value = AZ_SPAN_EMPTY   \
+  }
+
+/**
+ * @brief An empty #az_mqtt5_property_stringpair.
+ *
+ */
+#define AZ_MQTT5_PROPERTY_STRINGPAIR_EMPTY \
+  (az_mqtt5_property_stringpair) AZ_MQTT5_PROPERTY_STRINGPAIR_LITERAL_EMPTY
+
+AZ_NODISCARD AZ_INLINE az_mqtt5_property_binarydata
+az_mqtt5_property_binarydata_create(az_span bindata)
+{
+  return (az_mqtt5_property_binarydata){ .bindata = bindata };
+}
+
+/**
+ * @brief An empty #az_mqtt5_property_binarydata literal.
+ *
+ */
+#define AZ_MQTT5_PROPERTY_BINARYDATA_LITERAL_EMPTY \
+  {                                                \
+    .bindata = AZ_SPAN_EMPTY                       \
+  }
+
+/**
+ * @brief An empty #az_mqtt5_property_binarydata.
+ *
+ */
+#define AZ_MQTT5_PROPERTY_BINARYDATA_EMPTY \
+  (az_mqtt5_property_binarydata) AZ_MQTT5_PROPERTY_BINARYDATA_LITERAL_EMPTY
+
+/**
  * @brief Resets the MQTT 5 property bag to its initial state.
  *
  * @param[in] property_bag A pointer to an #az_mqtt5_property_bag instance to reset.

--- a/sdk/inc/azure/core/az_mqtt5_property_bag.h
+++ b/sdk/inc/azure/core/az_mqtt5_property_bag.h
@@ -129,7 +129,7 @@ typedef enum
 /**
  * @brief Creates a property string with the given string value.
  *
- * @param[in] str
+ * @param[in] str The #az_span that defines the property string value.
  * @return An #az_mqtt5_property_string.
  */
 AZ_NODISCARD AZ_INLINE az_mqtt5_property_string az_mqtt5_property_string_create(az_span str)
@@ -156,8 +156,8 @@ AZ_NODISCARD AZ_INLINE az_mqtt5_property_string az_mqtt5_property_string_create(
 /**
  * @brief Creates a property string pair with the given key and value.
  *
- * @param[in] key
- * @param[in] value
+ * @param[in] key The #az_span that defines the property name.
+ * @param[in] value The #az_span that defines the property value.
  * @return An #az_mqtt5_property_stringpair.
  */
 AZ_NODISCARD AZ_INLINE az_mqtt5_property_stringpair
@@ -185,7 +185,7 @@ az_mqtt5_property_stringpair_create(az_span key, az_span value)
 /**
  * @brief Creates a property binary data with the given binary data value.
  *
- * @param[in] bindata
+ * @param[in] bindata The #az_span that defines the property binary value.
  * @return An #az_mqtt5_property_binarydata.
  */
 AZ_NODISCARD AZ_INLINE az_mqtt5_property_binarydata

--- a/sdk/inc/azure/core/az_mqtt5_property_bag.h
+++ b/sdk/inc/azure/core/az_mqtt5_property_bag.h
@@ -182,6 +182,12 @@ az_mqtt5_property_stringpair_create(az_span key, az_span value)
 #define AZ_MQTT5_PROPERTY_STRINGPAIR_EMPTY \
   (az_mqtt5_property_stringpair) AZ_MQTT5_PROPERTY_STRINGPAIR_LITERAL_EMPTY
 
+/**
+ * @brief Creates a property binary data with the given binary data value.
+ *
+ * @param[in] bindata
+ * @return An #az_mqtt5_property_binarydata.
+ */
 AZ_NODISCARD AZ_INLINE az_mqtt5_property_binarydata
 az_mqtt5_property_binarydata_create(az_span bindata)
 {

--- a/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
@@ -157,8 +157,8 @@ AZ_INLINE az_result _build_response(
   {
     // TODO: is an error message required on failure?
     _az_PRECONDITION_VALID_SPAN(event_data->error_message, 0, true);
-    az_mqtt5_property_stringpair status_message_property
-        = { .key = AZ_SPAN_FROM_STR("statusMessage"), .value = event_data->error_message };
+    az_mqtt5_property_stringpair status_message_property = az_mqtt5_property_stringpair_create(
+        AZ_SPAN_FROM_STR("statusMessage"), event_data->error_message);
 
     _az_RETURN_IF_FAILED(az_mqtt5_property_bag_append_stringpair(
         &this_policy->_internal.property_bag,
@@ -172,7 +172,8 @@ AZ_INLINE az_result _build_response(
   {
     // TODO: is a payload required?
     _az_PRECONDITION_VALID_SPAN(event_data->response, 0, true);
-    az_mqtt5_property_string content_type = { .str = event_data->content_type };
+    az_mqtt5_property_string content_type
+        = az_mqtt5_property_string_create(event_data->content_type);
 
     _az_RETURN_IF_FAILED(az_mqtt5_property_bag_append_string(
         &this_policy->_internal.property_bag, AZ_MQTT5_PROPERTY_TYPE_CONTENT_TYPE, &content_type));
@@ -183,8 +184,8 @@ AZ_INLINE az_result _build_response(
   // Set the status user property
   char status_str[5];
   sprintf(status_str, "%d", event_data->status);
-  az_mqtt5_property_stringpair status_property
-      = { .key = AZ_SPAN_FROM_STR("status"), .value = az_span_create_from_str(status_str) };
+  az_mqtt5_property_stringpair status_property = az_mqtt5_property_stringpair_create(
+      AZ_SPAN_FROM_STR("status"), az_span_create_from_str(status_str));
 
   _az_RETURN_IF_FAILED(az_mqtt5_property_bag_append_stringpair(
       &this_policy->_internal.property_bag,
@@ -193,7 +194,8 @@ AZ_INLINE az_result _build_response(
 
   // Set the correlation data property
   _az_PRECONDITION_VALID_SPAN(event_data->correlation_id, 0, true);
-  az_mqtt5_property_binarydata correlation_data = { .bindata = event_data->correlation_id };
+  az_mqtt5_property_binarydata correlation_data
+      = az_mqtt5_property_binarydata_create(event_data->correlation_id);
   _az_RETURN_IF_FAILED(az_mqtt5_property_bag_append_binary(
       &this_policy->_internal.property_bag,
       AZ_MQTT5_PROPERTY_TYPE_CORRELATION_DATA,
@@ -221,19 +223,19 @@ AZ_INLINE az_result _handle_request(az_mqtt5_rpc_server* this_policy, az_mqtt5_r
   _az_PRECONDITION_NOT_NULL(this_policy);
 
   // save the response topic
-  az_mqtt5_property_string response_topic;
+  az_mqtt5_property_string response_topic = AZ_MQTT5_PROPERTY_STRING_EMPTY;
   _az_RETURN_IF_FAILED(az_mqtt5_property_bag_read_string(
       data->properties, AZ_MQTT5_PROPERTY_TYPE_RESPONSE_TOPIC, &response_topic));
 
   // save the correlation data to send back with the response
-  az_mqtt5_property_binarydata correlation_data;
+  az_mqtt5_property_binarydata correlation_data = AZ_MQTT5_PROPERTY_BINARYDATA_EMPTY;
   _az_RETURN_IF_FAILED(az_mqtt5_property_bag_read_binarydata(
       data->properties, AZ_MQTT5_PROPERTY_TYPE_CORRELATION_DATA, &correlation_data));
 
   // validate request isn't expired?
 
   // read the content type so the application can properly deserialize the request
-  az_mqtt5_property_string content_type;
+  az_mqtt5_property_string content_type = AZ_MQTT5_PROPERTY_STRING_EMPTY;
   _az_RETURN_IF_FAILED(az_mqtt5_property_bag_read_string(
       data->properties, AZ_MQTT5_PROPERTY_TYPE_CONTENT_TYPE, &content_type));
 

--- a/sdk/src/azure/platform/az_mosquitto5.c
+++ b/sdk/src/azure/platform/az_mosquitto5.c
@@ -596,24 +596,37 @@ void az_mqtt5_property_free_string(az_mqtt5_property_string* prop_str)
 {
   _az_PRECONDITION_NOT_NULL(prop_str);
 
-  free((void*)az_span_ptr(prop_str->str));
-  prop_str->str = AZ_SPAN_EMPTY;
+  if (az_span_size(prop_str->str) != 0)
+  {
+    free((void*)az_span_ptr(prop_str->str));
+    prop_str->str = AZ_SPAN_EMPTY;
+  }
 }
 
 void az_mqtt5_property_free_stringpair(az_mqtt5_property_stringpair* prop_strpair)
 {
   _az_PRECONDITION_NOT_NULL(prop_strpair);
 
-  free((void*)az_span_ptr(prop_strpair->key));
-  free((void*)az_span_ptr(prop_strpair->value));
-  prop_strpair->key = AZ_SPAN_EMPTY;
-  prop_strpair->value = AZ_SPAN_EMPTY;
+  if (az_span_size(prop_strpair->key) != 0)
+  {
+    free((void*)az_span_ptr(prop_strpair->key));
+    prop_strpair->key = AZ_SPAN_EMPTY;
+  }
+
+  if (az_span_size(prop_strpair->value) != 0)
+  {
+    free((void*)az_span_ptr(prop_strpair->value));
+    prop_strpair->value = AZ_SPAN_EMPTY;
+  }
 }
 
 void az_mqtt5_property_free_binarydata(az_mqtt5_property_binarydata* prop_bindata)
 {
   _az_PRECONDITION_NOT_NULL(prop_bindata);
 
-  free((void*)az_span_ptr(prop_bindata->bindata));
-  prop_bindata->bindata = AZ_SPAN_EMPTY;
+  if (az_span_size(prop_bindata->bindata) != 0)
+  {
+    free((void*)az_span_ptr(prop_bindata->bindata));
+    prop_bindata->bindata = AZ_SPAN_EMPTY;
+  }
 }

--- a/sdk/src/azure/platform/az_mosquitto5.c
+++ b/sdk/src/azure/platform/az_mosquitto5.c
@@ -596,7 +596,7 @@ void az_mqtt5_property_free_string(az_mqtt5_property_string* prop_str)
 {
   _az_PRECONDITION_NOT_NULL(prop_str);
 
-  if (az_span_size(prop_str->str) != 0)
+  if (az_span_ptr(prop_str->str) != NULL)
   {
     free((void*)az_span_ptr(prop_str->str));
     prop_str->str = AZ_SPAN_EMPTY;
@@ -607,13 +607,13 @@ void az_mqtt5_property_free_stringpair(az_mqtt5_property_stringpair* prop_strpai
 {
   _az_PRECONDITION_NOT_NULL(prop_strpair);
 
-  if (az_span_size(prop_strpair->key) != 0)
+  if (az_span_ptr(prop_strpair->key) != NULL)
   {
     free((void*)az_span_ptr(prop_strpair->key));
     prop_strpair->key = AZ_SPAN_EMPTY;
   }
 
-  if (az_span_size(prop_strpair->value) != 0)
+  if (az_span_ptr(prop_strpair->value) != NULL)
   {
     free((void*)az_span_ptr(prop_strpair->value));
     prop_strpair->value = AZ_SPAN_EMPTY;
@@ -624,7 +624,7 @@ void az_mqtt5_property_free_binarydata(az_mqtt5_property_binarydata* prop_bindat
 {
   _az_PRECONDITION_NOT_NULL(prop_bindata);
 
-  if (az_span_size(prop_bindata->bindata) != 0)
+  if (az_span_ptr(prop_bindata->bindata) != NULL)
   {
     free((void*)az_span_ptr(prop_bindata->bindata));
     prop_bindata->bindata = AZ_SPAN_EMPTY;

--- a/sdk/tests/platform/test_az_mqtt5_policy.c
+++ b/sdk/tests/platform/test_az_mqtt5_policy.c
@@ -109,7 +109,7 @@ static az_result test_inbound_hfsm_root(az_event_policy* me, az_event event)
 
       if (expect_msg_properties != 0)
       {
-        az_mqtt5_property_string test_mqtt5_property_string;
+        az_mqtt5_property_string test_mqtt5_property_string = AZ_MQTT5_PROPERTY_STRING_EMPTY;
         assert_int_equal(
             az_mqtt5_property_bag_read_string(
                 test_recv_data->properties,
@@ -121,7 +121,8 @@ static az_result test_inbound_hfsm_root(az_event_policy* me, az_event event)
             AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_CONTENT_TYPE)));
         az_mqtt5_property_free_string(&test_mqtt5_property_string);
 
-        az_mqtt5_property_stringpair test_mqtt5_property_string_pair1;
+        az_mqtt5_property_stringpair test_mqtt5_property_string_pair1
+            = AZ_MQTT5_PROPERTY_STRINGPAIR_EMPTY;
         assert_int_equal(
             az_mqtt5_property_bag_find_stringpair(
                 test_recv_data->properties,
@@ -137,7 +138,8 @@ static az_result test_inbound_hfsm_root(az_event_policy* me, az_event event)
             AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_VALUE1)));
         az_mqtt5_property_free_stringpair(&test_mqtt5_property_string_pair1);
 
-        az_mqtt5_property_stringpair test_mqtt5_property_string_pair2;
+        az_mqtt5_property_stringpair test_mqtt5_property_string_pair2
+            = AZ_MQTT5_PROPERTY_STRINGPAIR_EMPTY;
         assert_int_equal(
             az_mqtt5_property_bag_find_stringpair(
                 test_recv_data->properties,
@@ -171,7 +173,8 @@ static az_result test_inbound_hfsm_root(az_event_policy* me, az_event event)
             AZ_OK);
         assert_int_equal(test_mqtt5_property_int_8, TEST_MQTT_PROPERTY_PAYLOAD_FORMAT_INDICATOR);
 
-        az_mqtt5_property_binarydata test_mqtt5_property_binary_data;
+        az_mqtt5_property_binarydata test_mqtt5_property_binary_data
+            = AZ_MQTT5_PROPERTY_BINARYDATA_EMPTY;
         assert_int_equal(
             az_mqtt5_property_bag_read_binarydata(
                 test_recv_data->properties,
@@ -185,7 +188,7 @@ static az_result test_inbound_hfsm_root(az_event_policy* me, az_event event)
       }
       else
       {
-        az_mqtt5_property_string test_mqtt5_property_string;
+        az_mqtt5_property_string test_mqtt5_property_string = AZ_MQTT5_PROPERTY_STRING_EMPTY;
         assert_int_equal(
             az_mqtt5_property_bag_read_string(
                 test_recv_data->properties,
@@ -193,7 +196,8 @@ static az_result test_inbound_hfsm_root(az_event_policy* me, az_event event)
                 &test_mqtt5_property_string),
             AZ_ERROR_ITEM_NOT_FOUND);
 
-        az_mqtt5_property_stringpair test_mqtt5_property_string_pair1;
+        az_mqtt5_property_stringpair test_mqtt5_property_string_pair1
+            = AZ_MQTT5_PROPERTY_STRINGPAIR_EMPTY;
         assert_int_equal(
             az_mqtt5_property_bag_find_stringpair(
                 test_recv_data->properties,
@@ -202,7 +206,8 @@ static az_result test_inbound_hfsm_root(az_event_policy* me, az_event event)
                 &test_mqtt5_property_string_pair1),
             AZ_ERROR_ITEM_NOT_FOUND);
 
-        az_mqtt5_property_stringpair test_mqtt5_property_string_pair2;
+        az_mqtt5_property_stringpair test_mqtt5_property_string_pair2
+            = AZ_MQTT5_PROPERTY_STRINGPAIR_EMPTY;
         assert_int_equal(
             az_mqtt5_property_bag_find_stringpair(
                 test_recv_data->properties,
@@ -227,7 +232,8 @@ static az_result test_inbound_hfsm_root(az_event_policy* me, az_event event)
                 &test_mqtt5_property_int_8),
             AZ_ERROR_ITEM_NOT_FOUND);
 
-        az_mqtt5_property_binarydata test_mqtt5_property_binary_data;
+        az_mqtt5_property_binarydata test_mqtt5_property_binary_data
+            = AZ_MQTT5_PROPERTY_BINARYDATA_EMPTY;
         assert_int_equal(
             az_mqtt5_property_bag_read_binarydata(
                 test_recv_data->properties,
@@ -386,13 +392,15 @@ static void test_az_mqtt5_policy_outbound_pub_properties_success(void** state)
 
   az_mqtt5_property_bag test_mqtt5_property_bag;
   az_mqtt5_property_string test_mqtt5_property_string
-      = { .str = AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_CONTENT_TYPE) };
+      = az_mqtt5_property_string_create(AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_CONTENT_TYPE));
   az_mqtt5_property_stringpair test_mqtt5_property_string_pair1
-      = { .key = AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY1),
-          .value = AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_VALUE1) };
+      = az_mqtt5_property_stringpair_create(
+          AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY1),
+          AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_VALUE1));
   az_mqtt5_property_stringpair test_mqtt5_property_string_pair2
-      = { .key = AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY2),
-          .value = AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_VALUE2) };
+      = az_mqtt5_property_stringpair_create(
+          AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY2),
+          AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_VALUE2));
   az_mqtt5_property_binarydata test_mqtt5_property_binary_data
       = { .bindata = AZ_SPAN_FROM_BUFFER(TEST_MQTT_PROPERTY_CORRELATION_DATA) };
 


### PR DESCRIPTION
We need to add initializers for MQTT5 properties because there is currently no way to tell if a property has been read into (i.e. we've passed a `az_mqtt5_property_string` to a `az_mqtt5_property_bag_read_string`).