### PR TITLE
Adding MQTT implementation specific client handle to MQTT initializer

### DIFF
--- a/sdk/inc/azure/core/az_mqtt5.h
+++ b/sdk/inc/azure/core/az_mqtt5.h
@@ -44,15 +44,21 @@
  * - #az_mqtt5_property_stringpair
  * - #az_mqtt5_property_binarydata
  *
- * The following function must be created:
- * - #az_mqtt5_property_bag_init with the last argument being specific to the implementation.
+ * The following functions must be created:
+ * - #az_mqtt5_init with the following arguments:
+ *  - An #az_mqtt5 pointer to the MQTT 5 instance.
+ *  - A pointer to the implementation specific MQTT 5 handle.
+ *  - #az_mqtt5_options pointer to the MQTT 5 options.
+ * - #az_mqtt5_property_bag_init with the following arguments:
+ *  - An #az_mqtt5_property_bag pointer to the MQTT 5 property bag instance.
+ *  - An #az_mqtt5 pointer to the MQTT 5 instance.
+ *  - A pointer to the implementation specific property structure.
  *
  * @section section2 Functions that must be implemented:
  * The following functions must be implemented and will be called by the SDK to send data:
  *
  * In az_mqtt5.h:
  * - #az_mqtt5_options_default
- * - #az_mqtt5_init
  * - #az_mqtt5_outbound_connect
  * - #az_mqtt5_outbound_sub
  * - #az_mqtt5_outbound_pub

--- a/sdk/inc/azure/core/az_mqtt5.h
+++ b/sdk/inc/azure/core/az_mqtt5.h
@@ -491,16 +491,6 @@ az_mqtt5_inbound_disconnect(az_mqtt5* mqtt5, az_mqtt5_disconnect_data* disconnec
 AZ_NODISCARD az_mqtt5_options az_mqtt5_options_default();
 
 /**
- * @brief Initializes the MQTT 5 instance.
- *
- * @param mqtt5 The MQTT 5 instance.
- * @param options The MQTT 5 options.
- *
- * @return An #az_result value indicating the result of the operation.
- */
-AZ_NODISCARD az_result az_mqtt5_init(az_mqtt5* mqtt5, az_mqtt5_options const* options);
-
-/**
  * @brief Sends a MQTT 5 connect data packet to broker.
  *
  * @param mqtt5 The MQTT 5 instance.

--- a/sdk/inc/azure/platform/az_mqtt5_mosquitto.h
+++ b/sdk/inc/azure/platform/az_mqtt5_mosquitto.h
@@ -45,11 +45,6 @@ typedef struct
   az_span openssl_engine;
 
   /**
-   * @brief Handle to the underlying MQTT 5 implementation (Mosquitto).
-   */
-  struct mosquitto* mosquitto_handle;
-
-  /**
    * @brief Whether to use TLS for the underlying MQTT 5 implementation.
    */
   bool disable_tls;
@@ -134,6 +129,18 @@ typedef struct
    */
   az_span bindata;
 } az_mqtt5_property_binarydata;
+
+/**
+ * @brief Initializes the MQTT 5 instance specific to Mosquitto.
+ *
+ * @param mqtt5 The MQTT 5 instance.
+ * @param options The MQTT 5 options.
+ * @param mosquitto_handle The Mosquitto handle.
+ *
+ * @return An #az_result value indicating the result of the operation.
+ */
+AZ_NODISCARD az_result
+az_mqtt5_init(az_mqtt5* mqtt5, struct mosquitto* mosquitto_handle, az_mqtt5_options const* options);
 
 /**
  * @brief Initializes an MQTT 5 property bag instance specific to Mosquitto.

--- a/sdk/inc/azure/platform/az_mqtt5_mosquitto.h
+++ b/sdk/inc/azure/platform/az_mqtt5_mosquitto.h
@@ -134,13 +134,15 @@ typedef struct
  * @brief Initializes the MQTT 5 instance specific to Eclipse Mosquitto.
  *
  * @param mqtt5 The MQTT 5 instance.
- * @param mosquitto_handle The Mosquitto handle, can't be NULL.
+ * @param mosquitto_handle The Mosquitto handle, can't be NULL but the value pointed to can be.
  * @param options The MQTT 5 options.
  *
  * @return An #az_result value indicating the result of the operation.
  */
-AZ_NODISCARD az_result
-az_mqtt5_init(az_mqtt5* mqtt5, struct mosquitto** mosquitto_handle, az_mqtt5_options const* options);
+AZ_NODISCARD az_result az_mqtt5_init(
+    az_mqtt5* mqtt5,
+    struct mosquitto** mosquitto_handle,
+    az_mqtt5_options const* options);
 
 /**
  * @brief Initializes an MQTT 5 property bag instance specific to Mosquitto.

--- a/sdk/inc/azure/platform/az_mqtt5_mosquitto.h
+++ b/sdk/inc/azure/platform/az_mqtt5_mosquitto.h
@@ -60,7 +60,7 @@ struct az_mqtt5
     /**
      * @brief Handle to the underlying MQTT 5 implementation (Mosquitto).
      */
-    struct mosquitto* mosquitto_handle;
+    struct mosquitto** mosquitto_handle;
 
     /**
      * @brief Platform MQTT 5 client that is common across all MQTT 5 implementations.
@@ -131,16 +131,16 @@ typedef struct
 } az_mqtt5_property_binarydata;
 
 /**
- * @brief Initializes the MQTT 5 instance specific to Mosquitto.
+ * @brief Initializes the MQTT 5 instance specific to Eclipse Mosquitto.
  *
  * @param mqtt5 The MQTT 5 instance.
+ * @param mosquitto_handle The Mosquitto handle, can't be NULL.
  * @param options The MQTT 5 options.
- * @param mosquitto_handle The Mosquitto handle.
  *
  * @return An #az_result value indicating the result of the operation.
  */
 AZ_NODISCARD az_result
-az_mqtt5_init(az_mqtt5* mqtt5, struct mosquitto* mosquitto_handle, az_mqtt5_options const* options);
+az_mqtt5_init(az_mqtt5* mqtt5, struct mosquitto** mosquitto_handle, az_mqtt5_options const* options);
 
 /**
  * @brief Initializes an MQTT 5 property bag instance specific to Mosquitto.

--- a/sdk/inc/azure/platform/az_mqtt5_notransport.h
+++ b/sdk/inc/azure/platform/az_mqtt5_notransport.h
@@ -30,6 +30,9 @@ typedef void az_mqtt5_property_stringpair;
 typedef void az_mqtt5_property_binarydata;
 
 AZ_NODISCARD az_result
+az_mqtt5_init(az_mqtt5* mqtt5, void* notransport_handle, az_mqtt5_options const* options);
+
+AZ_NODISCARD az_result
 az_mqtt5_property_bag_init(az_mqtt5_property_bag* property_bag, az_mqtt5* mqtt5, void* options);
 
 #include <azure/core/_az_cfg_suffix.h>

--- a/sdk/samples/core/mosquitto_rpc_server_sample.c
+++ b/sdk/samples/core/mosquitto_rpc_server_sample.c
@@ -424,10 +424,10 @@ int main(int argc, char* argv[])
   // clean-up functions shown for completeness
   LOG_AND_EXIT_IF_FAILED(az_mqtt5_connection_close(&mqtt_connection));
 
-  if (*mqtt5._internal.mosquitto_handle != NULL)
+  if (mosq != NULL)
   {
-    mosquitto_loop_stop(*mqtt5._internal.mosquitto_handle, false);
-    mosquitto_destroy(*mqtt5._internal.mosquitto_handle);
+    mosquitto_loop_stop(mosq, false);
+    mosquitto_destroy(mosq);
   }
 
   // mosquitto allocates the property bag for us, but we're responsible for free'ing it

--- a/sdk/samples/core/mosquitto_rpc_server_sample.c
+++ b/sdk/samples/core/mosquitto_rpc_server_sample.c
@@ -367,8 +367,9 @@ int main(int argc, char* argv[])
       &az_context_application, az_context_get_expiration(&az_context_application));
 
   az_mqtt5 mqtt5;
+  struct mosquitto* mosq = NULL;
 
-  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, NULL, NULL));
+  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, &mosq, NULL));
 
   az_mqtt5_x509_client_certificate primary_credential = (az_mqtt5_x509_client_certificate){
     .cert = cert_path1,
@@ -423,10 +424,10 @@ int main(int argc, char* argv[])
   // clean-up functions shown for completeness
   LOG_AND_EXIT_IF_FAILED(az_mqtt5_connection_close(&mqtt_connection));
 
-  if (mqtt5._internal.mosquitto_handle != NULL)
+  if (*mqtt5._internal.mosquitto_handle != NULL)
   {
-    mosquitto_loop_stop(mqtt5._internal.mosquitto_handle, false);
-    mosquitto_destroy(mqtt5._internal.mosquitto_handle);
+    mosquitto_loop_stop(*mqtt5._internal.mosquitto_handle, false);
+    mosquitto_destroy(*mqtt5._internal.mosquitto_handle);
   }
 
   // mosquitto allocates the property bag for us, but we're responsible for free'ing it

--- a/sdk/samples/core/mosquitto_rpc_server_sample.c
+++ b/sdk/samples/core/mosquitto_rpc_server_sample.c
@@ -368,7 +368,7 @@ int main(int argc, char* argv[])
 
   az_mqtt5 mqtt5;
 
-  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, NULL));
+  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, NULL, NULL));
 
   az_mqtt5_x509_client_certificate primary_credential = (az_mqtt5_x509_client_certificate){
     .cert = cert_path1,

--- a/sdk/src/azure/platform/az_mosquitto5.c
+++ b/sdk/src/azure/platform/az_mosquitto5.c
@@ -241,7 +241,6 @@ AZ_NODISCARD az_mqtt5_options az_mqtt5_options_default()
   };
 }
 
-// TODO_L: Should we have az_mosquitto5_init(..., mosquitto_handle h)
 AZ_NODISCARD az_result
 az_mqtt5_init(az_mqtt5* mqtt5, struct mosquitto** mosquitto_handle, az_mqtt5_options const* options)
 {
@@ -323,7 +322,8 @@ az_mqtt5_outbound_connect(az_mqtt5* mqtt5, az_mqtt5_connect_data* connect_data)
       connect_data->port,
       AZ_MQTT5_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS)));
 
-  _az_RETURN_IF_FAILED(_az_result_from_mosq5(mosquitto_loop_start(*me->_internal.mosquitto_handle)));
+  _az_RETURN_IF_FAILED(
+      _az_result_from_mosq5(mosquitto_loop_start(*me->_internal.mosquitto_handle)));
 
   return ret;
 }
@@ -342,7 +342,7 @@ AZ_NODISCARD az_result az_mqtt5_outbound_sub(az_mqtt5* mqtt5, az_mqtt5_sub_data*
 AZ_NODISCARD az_result az_mqtt5_outbound_pub(az_mqtt5* mqtt5, az_mqtt5_pub_data* pub_data)
 {
   return _az_result_from_mosq5(mosquitto_publish_v5(
-     *mqtt5->_internal.mosquitto_handle,
+      *mqtt5->_internal.mosquitto_handle,
       &pub_data->out_id,
       (char*)az_span_ptr(pub_data->topic), // Assumes properly formed NULL terminated string.
       az_span_size(pub_data->payload),
@@ -354,7 +354,8 @@ AZ_NODISCARD az_result az_mqtt5_outbound_pub(az_mqtt5* mqtt5, az_mqtt5_pub_data*
 
 AZ_NODISCARD az_result az_mqtt5_outbound_disconnect(az_mqtt5* mqtt5)
 {
-  return _az_result_from_mosq5(mosquitto_disconnect_v5(*mqtt5->_internal.mosquitto_handle, 0, NULL));
+  return _az_result_from_mosq5(
+      mosquitto_disconnect_v5(*mqtt5->_internal.mosquitto_handle, 0, NULL));
 }
 
 AZ_NODISCARD az_result az_mqtt5_property_bag_init(

--- a/sdk/src/azure/platform/az_mosquitto5.c
+++ b/sdk/src/azure/platform/az_mosquitto5.c
@@ -62,14 +62,14 @@ static void _az_mosquitto5_on_connect(
   az_result ret;
   az_mqtt5* me = (az_mqtt5*)obj;
 
-  _az_PRECONDITION(mosq == me->_internal.mosquitto_handle);
+  _az_PRECONDITION(mosq == *me->_internal.mosquitto_handle);
 
   if (rc != 0)
   {
     /* If the connection fails for any reason, we don't want to keep on
      * retrying in this example, so disconnect. Without this, the client
      * will attempt to reconnect. */
-    ret = mosquitto_disconnect(me->_internal.mosquitto_handle);
+    ret = mosquitto_disconnect(*me->_internal.mosquitto_handle);
 
     if (ret != MOSQ_ERR_SUCCESS && ret != MOSQ_ERR_NO_CONN)
     {
@@ -98,7 +98,7 @@ static void _az_mosquitto5_on_disconnect(
   (void)props;
   az_mqtt5* me = (az_mqtt5*)obj;
 
-  _az_PRECONDITION(mosq == me->_internal.mosquitto_handle);
+  _az_PRECONDITION(mosq == *me->_internal.mosquitto_handle);
 
   az_result ret = az_mqtt5_inbound_disconnect(
       me,
@@ -130,7 +130,7 @@ static void _az_mosquitto5_on_publish(
   (void)props;
   az_mqtt5* me = (az_mqtt5*)obj;
 
-  _az_PRECONDITION(mosq == me->_internal.mosquitto_handle);
+  _az_PRECONDITION(mosq == *me->_internal.mosquitto_handle);
 
   az_result ret = az_mqtt5_inbound_puback(me, &(az_mqtt5_puback_data){ .id = mid });
 
@@ -157,7 +157,7 @@ static void _az_mosquitto5_on_subscribe(
 
   az_mqtt5* me = (az_mqtt5*)obj;
 
-  _az_PRECONDITION(mosq == me->_internal.mosquitto_handle);
+  _az_PRECONDITION(mosq == *me->_internal.mosquitto_handle);
 
   az_result ret = az_mqtt5_inbound_suback(me, &(az_mqtt5_suback_data){ .id = mid });
 
@@ -195,7 +195,7 @@ static void _az_mosquitto5_on_message(
   az_mqtt5* me = (az_mqtt5*)obj;
   az_mqtt5_property_bag property_bag;
 
-  _az_PRECONDITION(mosq == me->_internal.mosquitto_handle);
+  _az_PRECONDITION(mosq == *me->_internal.mosquitto_handle);
 
   ret = az_mqtt5_property_bag_init(&property_bag, me, (mosquitto_property**)(uintptr_t)&props);
 
@@ -243,7 +243,7 @@ AZ_NODISCARD az_mqtt5_options az_mqtt5_options_default()
 
 // TODO_L: Should we have az_mosquitto5_init(..., mosquitto_handle h)
 AZ_NODISCARD az_result
-az_mqtt5_init(az_mqtt5* mqtt5, struct mosquitto* mosquitto_handle, az_mqtt5_options const* options)
+az_mqtt5_init(az_mqtt5* mqtt5, struct mosquitto** mosquitto_handle, az_mqtt5_options const* options)
 {
   _az_PRECONDITION_NOT_NULL(mqtt5);
   mqtt5->_internal.options = options == NULL ? az_mqtt5_options_default() : *options;
@@ -261,33 +261,33 @@ az_mqtt5_outbound_connect(az_mqtt5* mqtt5, az_mqtt5_connect_data* connect_data)
 
   // IMPORTANT: application must call mosquitto_lib_init() before any Mosquitto clients are created.
 
-  if (me->_internal.mosquitto_handle == NULL)
+  if (*me->_internal.mosquitto_handle == NULL)
   {
-    me->_internal.mosquitto_handle = mosquitto_new(
+    *me->_internal.mosquitto_handle = mosquitto_new(
         (char*)az_span_ptr(connect_data->client_id),
         false, // clean-session
         me); // callback context - i.e. user data.
   }
 
-  if (me->_internal.mosquitto_handle == NULL)
+  if (*me->_internal.mosquitto_handle == NULL)
   {
     ret = AZ_ERROR_OUT_OF_MEMORY;
     return ret;
   }
 
   _az_RETURN_IF_FAILED(_az_result_from_mosq5(mosquitto_int_option(
-      me->_internal.mosquitto_handle, MOSQ_OPT_PROTOCOL_VERSION, MQTT_PROTOCOL_V5)));
+      *me->_internal.mosquitto_handle, MOSQ_OPT_PROTOCOL_VERSION, MQTT_PROTOCOL_V5)));
 
   // Configure callbacks. This should be done before connecting ideally.
-  mosquitto_log_callback_set(me->_internal.mosquitto_handle, _az_mosquitto_on_log);
-  mosquitto_connect_v5_callback_set(me->_internal.mosquitto_handle, _az_mosquitto5_on_connect);
+  mosquitto_log_callback_set(*me->_internal.mosquitto_handle, _az_mosquitto_on_log);
+  mosquitto_connect_v5_callback_set(*me->_internal.mosquitto_handle, _az_mosquitto5_on_connect);
   mosquitto_disconnect_v5_callback_set(
-      me->_internal.mosquitto_handle, _az_mosquitto5_on_disconnect);
-  mosquitto_publish_v5_callback_set(me->_internal.mosquitto_handle, _az_mosquitto5_on_publish);
-  mosquitto_subscribe_v5_callback_set(me->_internal.mosquitto_handle, _az_mosquitto5_on_subscribe);
+      *me->_internal.mosquitto_handle, _az_mosquitto5_on_disconnect);
+  mosquitto_publish_v5_callback_set(*me->_internal.mosquitto_handle, _az_mosquitto5_on_publish);
+  mosquitto_subscribe_v5_callback_set(*me->_internal.mosquitto_handle, _az_mosquitto5_on_subscribe);
   mosquitto_unsubscribe_v5_callback_set(
-      me->_internal.mosquitto_handle, _az_mosquitto5_on_unsubscribe);
-  mosquitto_message_v5_callback_set(me->_internal.mosquitto_handle, _az_mosquitto5_on_message);
+      *me->_internal.mosquitto_handle, _az_mosquitto5_on_unsubscribe);
+  mosquitto_message_v5_callback_set(*me->_internal.mosquitto_handle, _az_mosquitto5_on_message);
 
   if (me->_internal.options.disable_tls == 0)
   {
@@ -297,11 +297,11 @@ az_mqtt5_outbound_connect(az_mqtt5* mqtt5, az_mqtt5_connect_data* connect_data)
     if (use_os_certs)
     {
       _az_RETURN_IF_FAILED(_az_result_from_mosq5(
-          mosquitto_int_option(me->_internal.mosquitto_handle, MOSQ_OPT_TLS_USE_OS_CERTS, 1)));
+          mosquitto_int_option(*me->_internal.mosquitto_handle, MOSQ_OPT_TLS_USE_OS_CERTS, 1)));
     }
 
     _az_RETURN_IF_FAILED(_az_result_from_mosq5(mosquitto_tls_set(
-        me->_internal.mosquitto_handle,
+        *me->_internal.mosquitto_handle,
         (const char*)az_span_ptr(me->_internal.options.certificate_authority_trusted_roots),
         use_os_certs ? REQUIRED_TLS_SET_CERT_PATH : NULL,
         (const char*)az_span_ptr(connect_data->certificate.cert),
@@ -312,18 +312,18 @@ az_mqtt5_outbound_connect(az_mqtt5* mqtt5, az_mqtt5_connect_data* connect_data)
   if (az_span_ptr(connect_data->username) != NULL)
   {
     _az_RETURN_IF_FAILED(_az_result_from_mosq5(mosquitto_username_pw_set(
-        me->_internal.mosquitto_handle,
+        *me->_internal.mosquitto_handle,
         (const char*)az_span_ptr(connect_data->username),
         (const char*)az_span_ptr(connect_data->password))));
   }
 
   _az_RETURN_IF_FAILED(_az_result_from_mosq5(mosquitto_connect_async(
-      (struct mosquitto*)me->_internal.mosquitto_handle,
+      *me->_internal.mosquitto_handle,
       (char*)az_span_ptr(connect_data->host),
       connect_data->port,
       AZ_MQTT5_DEFAULT_MQTT_CONNECT_KEEPALIVE_SECONDS)));
 
-  _az_RETURN_IF_FAILED(_az_result_from_mosq5(mosquitto_loop_start(me->_internal.mosquitto_handle)));
+  _az_RETURN_IF_FAILED(_az_result_from_mosq5(mosquitto_loop_start(*me->_internal.mosquitto_handle)));
 
   return ret;
 }
@@ -331,7 +331,7 @@ az_mqtt5_outbound_connect(az_mqtt5* mqtt5, az_mqtt5_connect_data* connect_data)
 AZ_NODISCARD az_result az_mqtt5_outbound_sub(az_mqtt5* mqtt5, az_mqtt5_sub_data* sub_data)
 {
   return _az_result_from_mosq5(mosquitto_subscribe_v5(
-      mqtt5->_internal.mosquitto_handle,
+      *mqtt5->_internal.mosquitto_handle,
       &sub_data->out_id,
       (char*)az_span_ptr(sub_data->topic_filter),
       sub_data->qos,
@@ -342,7 +342,7 @@ AZ_NODISCARD az_result az_mqtt5_outbound_sub(az_mqtt5* mqtt5, az_mqtt5_sub_data*
 AZ_NODISCARD az_result az_mqtt5_outbound_pub(az_mqtt5* mqtt5, az_mqtt5_pub_data* pub_data)
 {
   return _az_result_from_mosq5(mosquitto_publish_v5(
-      mqtt5->_internal.mosquitto_handle,
+     *mqtt5->_internal.mosquitto_handle,
       &pub_data->out_id,
       (char*)az_span_ptr(pub_data->topic), // Assumes properly formed NULL terminated string.
       az_span_size(pub_data->payload),
@@ -354,7 +354,7 @@ AZ_NODISCARD az_result az_mqtt5_outbound_pub(az_mqtt5* mqtt5, az_mqtt5_pub_data*
 
 AZ_NODISCARD az_result az_mqtt5_outbound_disconnect(az_mqtt5* mqtt5)
 {
-  return _az_result_from_mosq5(mosquitto_disconnect_v5(mqtt5->_internal.mosquitto_handle, 0, NULL));
+  return _az_result_from_mosq5(mosquitto_disconnect_v5(*mqtt5->_internal.mosquitto_handle, 0, NULL));
 }
 
 AZ_NODISCARD az_result az_mqtt5_property_bag_init(

--- a/sdk/src/azure/platform/az_mosquitto5.c
+++ b/sdk/src/azure/platform/az_mosquitto5.c
@@ -237,17 +237,17 @@ AZ_NODISCARD az_mqtt5_options az_mqtt5_options_default()
   return (az_mqtt5_options){
     .certificate_authority_trusted_roots = AZ_SPAN_EMPTY,
     .openssl_engine = NULL,
-    .mosquitto_handle = NULL,
     .disable_tls = false,
   };
 }
 
 // TODO_L: Should we have az_mosquitto5_init(..., mosquitto_handle h)
-AZ_NODISCARD az_result az_mqtt5_init(az_mqtt5* mqtt5, az_mqtt5_options const* options)
+AZ_NODISCARD az_result
+az_mqtt5_init(az_mqtt5* mqtt5, struct mosquitto* mosquitto_handle, az_mqtt5_options const* options)
 {
   _az_PRECONDITION_NOT_NULL(mqtt5);
   mqtt5->_internal.options = options == NULL ? az_mqtt5_options_default() : *options;
-  mqtt5->_internal.mosquitto_handle = mqtt5->_internal.options.mosquitto_handle;
+  mqtt5->_internal.mosquitto_handle = mosquitto_handle;
   mqtt5->_internal.platform_mqtt5.pipeline = NULL;
 
   return AZ_OK;

--- a/sdk/tests/core/mock_az_mqtt5.c
+++ b/sdk/tests/core/mock_az_mqtt5.c
@@ -19,20 +19,44 @@
 #include <azure/core/internal/az_result_internal.h>
 #include <azure/core/internal/az_span_internal.h>
 
+#if defined(TRANSPORT_MOSQUITTO)
 #include <mosquitto.h>
+#endif
+
 #include <pthread.h>
 #include <stdlib.h>
 
 #include <azure/core/_az_cfg.h>
 
-AZ_NODISCARD az_result __wrap_az_mqtt5_init(az_mqtt5* mqtt5, az_mqtt5_options const* options);
-AZ_NODISCARD az_result __wrap_az_mqtt5_init(az_mqtt5* mqtt5, az_mqtt5_options const* options)
+#if defined(TRANSPORT_MOSQUITTO)
+AZ_NODISCARD az_result __wrap_az_mqtt5_init(
+    az_mqtt5* mqtt5,
+    struct mosquitto* mosquitto_handle,
+    az_mqtt5_options const* options);
+AZ_NODISCARD az_result __wrap_az_mqtt5_init(
+    az_mqtt5* mqtt5,
+    struct mosquitto* mosquitto_handle,
+    az_mqtt5_options const* options)
 {
   (void)mqtt5;
+  (void)mosquitto_handle;
   (void)options;
 
   return AZ_OK;
 }
+#else
+AZ_NODISCARD az_result
+__wrap_az_mqtt5_init(az_mqtt5* mqtt5, void* notransport_handle, az_mqtt5_options const* options);
+AZ_NODISCARD az_result
+__wrap_az_mqtt5_init(az_mqtt5* mqtt5, void* notransport_handle, az_mqtt5_options const* options)
+{
+  (void)mqtt5;
+  (void)notransport_handle;
+  (void)options;
+
+  return AZ_OK;
+}
+#endif
 
 AZ_NODISCARD az_result
 __wrap_az_mqtt5_outbound_connect(az_mqtt5* mqtt5, az_mqtt5_connect_data* connect_data);

--- a/sdk/tests/core/mock_az_mqtt5.c
+++ b/sdk/tests/core/mock_az_mqtt5.c
@@ -31,11 +31,11 @@
 #if defined(TRANSPORT_MOSQUITTO)
 AZ_NODISCARD az_result __wrap_az_mqtt5_init(
     az_mqtt5* mqtt5,
-    struct mosquitto* mosquitto_handle,
+    struct mosquitto** mosquitto_handle,
     az_mqtt5_options const* options);
 AZ_NODISCARD az_result __wrap_az_mqtt5_init(
     az_mqtt5* mqtt5,
-    struct mosquitto* mosquitto_handle,
+    struct mosquitto** mosquitto_handle,
     az_mqtt5_options const* options)
 {
   (void)mqtt5;

--- a/sdk/tests/core/test_az_mqtt5_connection.c
+++ b/sdk/tests/core/test_az_mqtt5_connection.c
@@ -148,6 +148,7 @@ static void test_az_mqtt5_connection_disabled_init_success(void** state)
   };
   test_disabled_connection_options.client_certificates[0] = test_cert;
 
+  // Implementation handle is NULL because test does not use an underlying MQTT stack.
   assert_int_equal(az_mqtt5_init(&mock_mqtt_disabled, NULL, &mock_mqtt_options_disabled), AZ_OK);
 
   assert_int_equal(

--- a/sdk/tests/core/test_az_mqtt5_connection.c
+++ b/sdk/tests/core/test_az_mqtt5_connection.c
@@ -148,7 +148,7 @@ static void test_az_mqtt5_connection_disabled_init_success(void** state)
   };
   test_disabled_connection_options.client_certificates[0] = test_cert;
 
-  assert_int_equal(az_mqtt5_init(&mock_mqtt_disabled, &mock_mqtt_options_disabled), AZ_OK);
+  assert_int_equal(az_mqtt5_init(&mock_mqtt_disabled, NULL, &mock_mqtt_options_disabled), AZ_OK);
 
   assert_int_equal(
       az_mqtt5_connection_init(
@@ -177,7 +177,7 @@ static void test_az_mqtt5_connection_enabled_init_success(void** state)
   };
   test_connection_options.client_certificates[0] = test_cert;
 
-  assert_int_equal(az_mqtt5_init(&mock_mqtt5, &mock_mqtt5_options), AZ_OK);
+  assert_int_equal(az_mqtt5_init(&mock_mqtt5, NULL, &mock_mqtt5_options), AZ_OK);
 
   assert_int_equal(
       az_mqtt5_connection_init(

--- a/sdk/tests/core/test_az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_server_hfsm.c
@@ -54,7 +54,7 @@ static void test_az_rpc_server_init_success(void** state)
 {
   (void)state;
 
-  assert_int_equal(az_mqtt5_init(&mock_mqtt5, &mock_mqtt5_options), AZ_OK);
+  assert_int_equal(az_mqtt5_init(&mock_mqtt5, NULL, &mock_mqtt5_options), AZ_OK);
 
   assert_int_equal(
       az_mqtt5_connection_init(

--- a/sdk/tests/platform/test_az_mqtt5_policy.c
+++ b/sdk/tests/platform/test_az_mqtt5_policy.c
@@ -42,6 +42,12 @@ void az_platform_critical_error(void) { assert_true(false); }
 #define TEST_MAX_RESPONSE_CHECKS 3
 #define TEST_RESPONSE_DELAY_MS 100 // Response from endpoint is slow.
 
+#ifdef TRANSPORT_MOSQUITTO
+static struct mosquitto* test_mosquitto_handle = NULL;
+#else
+static void* test_mosquitto_handle = NULL;
+#endif // TRANSPORT_MOSQUITTO
+
 static az_mqtt5 test_mqtt5_client;
 static _az_mqtt5_policy test_mqtt5_policy;
 static _az_hfsm test_inbound_hfsm;
@@ -69,7 +75,6 @@ static az_mqtt5_connect_data test_mqtt5_connect_data = {
 static az_mqtt5_options options = {
   .certificate_authority_trusted_roots = AZ_SPAN_LITERAL_EMPTY,
   .openssl_engine = AZ_SPAN_LITERAL_EMPTY,
-  .mosquitto_handle = NULL,
   .disable_tls = true,
 };
 
@@ -261,7 +266,7 @@ static void test_az_mqtt5_policy_init_null_failure(void** state)
   SETUP_PRECONDITION_CHECK_TESTS();
   (void)state;
 
-  ASSERT_PRECONDITION_CHECKED(az_mqtt5_init(NULL, NULL));
+  ASSERT_PRECONDITION_CHECKED(az_mqtt5_init(NULL, NULL, NULL));
 }
 
 #endif // AZ_NO_PRECONDITION_CHECKING
@@ -303,7 +308,7 @@ static void test_az_mqtt5_policy_init_valid_success(void** state)
 {
   (void)state;
 
-  assert_int_equal(az_mqtt5_init(&test_mqtt5_client, &options), AZ_OK);
+  assert_int_equal(az_mqtt5_init(&test_mqtt5_client, test_mosquitto_handle, &options), AZ_OK);
 
   test_mqtt5_client._internal.platform_mqtt5.pipeline = &test_event_pipeline;
 }

--- a/sdk/tests/platform/test_az_mqtt5_policy.c
+++ b/sdk/tests/platform/test_az_mqtt5_policy.c
@@ -308,7 +308,7 @@ static void test_az_mqtt5_policy_init_valid_success(void** state)
 {
   (void)state;
 
-  assert_int_equal(az_mqtt5_init(&test_mqtt5_client, test_mosquitto_handle, &options), AZ_OK);
+  assert_int_equal(az_mqtt5_init(&test_mqtt5_client, &test_mosquitto_handle, &options), AZ_OK);
 
   test_mqtt5_client._internal.platform_mqtt5.pipeline = &test_event_pipeline;
 }
@@ -328,6 +328,8 @@ static void test_az_mqtt5_policy_outbound_connect_success(void** state)
   }
 
   assert_int_equal(ref_connack, 1);
+
+  assert_ptr_equal(*test_mqtt5_client._internal.mosquitto_handle, test_mosquitto_handle);
 }
 
 static void test_az_mqtt5_policy_outbound_sub_success(void** state)


### PR DESCRIPTION
Moving `az_mqtt5_init` from `az_mqtt` to `az_mqtt_[implementation]` and adding client handle argument. 

The reasoning is that other MQTT implementations (ex. Paho) require allocation of the MQTT handle by the application (ex. Paho).