### PR TITLE
Reworking MQTT 5 Properties and integrating paho to RPC samples and code

### DIFF
--- a/sdk/inc/azure/core/az_mqtt5.h
+++ b/sdk/inc/azure/core/az_mqtt5.h
@@ -83,9 +83,9 @@
  * - #az_mqtt5_property_stringpair_get_key
  * - #az_mqtt5_property_stringpair_get_value
  * - #az_mqtt5_property_get_binarydata
- * - #az_mqtt5_property_free_string
- * - #az_mqtt5_property_free_stringpair
- * - #az_mqtt5_property_free_binarydata
+ * - #az_mqtt5_property_read_free_string
+ * - #az_mqtt5_property_read_free_stringpair
+ * - #az_mqtt5_property_read_free_binarydata
  *
  */
 

--- a/sdk/inc/azure/core/az_mqtt5_connection.h
+++ b/sdk/inc/azure/core/az_mqtt5_connection.h
@@ -64,7 +64,7 @@ enum az_event_type_mqtt5_connection
  * @brief Callback for MQTT 5 connection events.
  *
  */
-typedef az_result (*az_mqtt5_connection_callback)(az_mqtt5_connection* client, az_event event, const void* event_callback_context);
+typedef az_result (*az_mqtt5_connection_callback)(az_mqtt5_connection* client, az_event event, void* event_callback_context);
 
 /**
  * @brief MQTT 5 connection options.
@@ -158,7 +158,7 @@ struct az_mqtt5_connection
      * @brief Context for MQTT 5 connection events callback.
      *
      */
-    const void* event_callback_context;
+    void* event_callback_context;
 
     /**
      * @brief Options for the MQTT 5 connection.
@@ -191,7 +191,7 @@ AZ_NODISCARD az_result az_mqtt5_connection_init(
     az_mqtt5* mqtt_client,
     az_mqtt5_connection_callback event_callback,
     az_mqtt5_connection_options* options,
-    const void* event_callback_context);
+    void* event_callback_context);
 
 /**
  * @brief Opens the connection to the broker.

--- a/sdk/inc/azure/core/az_mqtt5_property_bag.h
+++ b/sdk/inc/azure/core/az_mqtt5_property_bag.h
@@ -132,10 +132,8 @@ typedef enum
  * @brief Resets the MQTT 5 property bag to its initial state.
  *
  * @param[in] property_bag A pointer to an #az_mqtt5_property_bag instance to reset.
- *
- * @return An #az_result value indicating the result of the operation.
  */
-AZ_NODISCARD az_result az_mqtt5_property_bag_clear(az_mqtt5_property_bag* property_bag);
+void az_mqtt5_property_bag_clear(az_mqtt5_property_bag* property_bag);
 
 /**
  * @brief Appends an MQTT 5 string property to the property bag.

--- a/sdk/inc/azure/core/az_mqtt5_property_bag.h
+++ b/sdk/inc/azure/core/az_mqtt5_property_bag.h
@@ -129,90 +129,6 @@ typedef enum
 } az_mqtt5_property_type;
 
 /**
- * @brief Creates a property string with the given string value.
- *
- * @param[in] str The #az_span that defines the property string value.
- * @return An #az_mqtt5_property_string.
- */
-AZ_NODISCARD AZ_INLINE az_mqtt5_property_string az_mqtt5_property_create_string(az_span str)
-{
-  return (az_mqtt5_property_string){ .str = str };
-}
-
-/**
- * @brief An empty #az_mqtt5_property_string literal.
- *
- */
-#define AZ_MQTT5_PROPERTY_STRING_LITERAL_EMPTY \
-  {                                            \
-    .str = AZ_SPAN_EMPTY                       \
-  }
-
-/**
- * @brief An empty #az_mqtt5_property_string.
- *
- */
-#define AZ_MQTT5_PROPERTY_STRING_EMPTY \
-  (az_mqtt5_property_string) AZ_MQTT5_PROPERTY_STRING_LITERAL_EMPTY
-
-/**
- * @brief Creates a property string pair with the given key and value.
- *
- * @param[in] key The #az_span that defines the property name.
- * @param[in] value The #az_span that defines the property value.
- * @return An #az_mqtt5_property_stringpair.
- */
-AZ_NODISCARD AZ_INLINE az_mqtt5_property_stringpair
-az_mqtt5_property_create_stringpair(az_span key, az_span value)
-{
-  return (az_mqtt5_property_stringpair){ .key = key, .value = value };
-}
-
-/**
- * @brief An empty #az_mqtt5_property_stringpair literal.
- *
- */
-#define AZ_MQTT5_PROPERTY_STRINGPAIR_LITERAL_EMPTY \
-  {                                                \
-    .key = AZ_SPAN_EMPTY, .value = AZ_SPAN_EMPTY   \
-  }
-
-/**
- * @brief An empty #az_mqtt5_property_stringpair.
- *
- */
-#define AZ_MQTT5_PROPERTY_STRINGPAIR_EMPTY \
-  (az_mqtt5_property_stringpair) AZ_MQTT5_PROPERTY_STRINGPAIR_LITERAL_EMPTY
-
-/**
- * @brief Creates a property binary data with the given binary data value.
- *
- * @param[in] bindata The #az_span that defines the property binary value.
- * @return An #az_mqtt5_property_binarydata.
- */
-AZ_NODISCARD AZ_INLINE az_mqtt5_property_binarydata
-az_mqtt5_property_create_binarydata(az_span bindata)
-{
-  return (az_mqtt5_property_binarydata){ .bindata = bindata };
-}
-
-/**
- * @brief An empty #az_mqtt5_property_binarydata literal.
- *
- */
-#define AZ_MQTT5_PROPERTY_BINARYDATA_LITERAL_EMPTY \
-  {                                                \
-    .bindata = AZ_SPAN_EMPTY                       \
-  }
-
-/**
- * @brief An empty #az_mqtt5_property_binarydata.
- *
- */
-#define AZ_MQTT5_PROPERTY_BINARYDATA_EMPTY \
-  (az_mqtt5_property_binarydata) AZ_MQTT5_PROPERTY_BINARYDATA_LITERAL_EMPTY
-
-/**
  * @brief Resets the MQTT 5 property bag to its initial state.
  *
  * @param[in] property_bag A pointer to an #az_mqtt5_property_bag instance to reset.
@@ -226,28 +142,30 @@ AZ_NODISCARD az_result az_mqtt5_property_bag_clear(az_mqtt5_property_bag* proper
  *
  * @param property_bag The MQTT 5 property bag instance.
  * @param type The MQTT 5 property type.
- * @param prop_str The MQTT 5 string property.
+ * @param prop_str An #az_span containing the MQTT 5 string property.
  *
  * @return An #az_result value indicating the result of the operation.
  */
 AZ_NODISCARD az_result az_mqtt5_property_bag_append_string(
     az_mqtt5_property_bag* property_bag,
     az_mqtt5_property_type type,
-    az_mqtt5_property_string* prop_str);
+    az_span prop_str);
 
 /**
  * @brief Appends an MQTT 5 string pair property to the property bag.
  *
  * @param property_bag The MQTT 5 property bag instance.
  * @param type The MQTT 5 property type.
- * @param prop_strpair The MQTT 5 string pair property.
+ * @param prop_key An #az_span containing the MQTT 5 string pair property key.
+ * @param prop_value An #az_span containing the MQTT 5 string pair property value.
  *
  * @return An #az_result value indicating the result of the operation.
  */
 AZ_NODISCARD az_result az_mqtt5_property_bag_append_stringpair(
     az_mqtt5_property_bag* property_bag,
     az_mqtt5_property_type type,
-    az_mqtt5_property_stringpair* prop_strpair);
+    az_span prop_key,
+    az_span prop_value);
 
 /**
  * @brief Appends an MQTT 5 byte property to the property bag.
@@ -282,31 +200,28 @@ AZ_NODISCARD az_result az_mqtt5_property_bag_append_int(
  *
  * @param property_bag The MQTT 5 property bag instance.
  * @param type The MQTT 5 property type.
- * @param prop_bindata The MQTT 5 binary data property.
+ * @param prop_bindata An #az_span containing the MQTT 5 binary data property.
  *
  * @return An #az_result value indicating the result of the operation.
  */
 AZ_NODISCARD az_result az_mqtt5_property_bag_append_binary(
     az_mqtt5_property_bag* property_bag,
     az_mqtt5_property_type type,
-    az_mqtt5_property_binarydata* prop_bindata);
+    az_span prop_bindata);
 
 /**
  * @brief Reads an MQTT 5 string property from the property bag.
  *
  * @param property_bag The MQTT 5 property bag instance.
  * @param type The MQTT 5 property type.
- * @param out_prop_str The output MQTT 5 string property.
  *
- * @note After reading, the property string must be freed using #az_mqtt5_property_free_string when
- * it is no longer needed.
+ * @note After reading, the property string must be freed using #az_mqtt5_property_read_free_string
+ * when it is no longer needed.
  *
- * @return An #az_result value indicating the result of the operation.
+ * @return An #az_mqtt5_property_string containing the MQTT 5 string property or empty if not found.
  */
-AZ_NODISCARD az_result az_mqtt5_property_bag_read_string(
-    az_mqtt5_property_bag* property_bag,
-    az_mqtt5_property_type type,
-    az_mqtt5_property_string* out_prop_str);
+AZ_NODISCARD az_mqtt5_property_string
+az_mqtt5_property_bag_read_string(az_mqtt5_property_bag* property_bag, az_mqtt5_property_type type);
 
 /**
  * @brief Finds an MQTT 5 string pair property in the property bag.
@@ -314,21 +229,20 @@ AZ_NODISCARD az_result az_mqtt5_property_bag_read_string(
  * @param property_bag The MQTT 5 property bag instance.
  * @param type The MQTT 5 property type.
  * @param key The key of the MQTT 5 string pair property.
- * @param out_prop_strpair The output MQTT 5 string pair property.
  *
  * @note After reading, the property string pair must be freed using
- * #az_mqtt5_property_free_stringpair when it is no longer needed.
+ * #az_mqtt5_property_read_free_stringpair when it is no longer needed.
  *
- * @note User property is the only MQTT 5 property that uses string pairs. The type argument is kept
+ * @note User property is the only MQTT 5 property that uses string pairs. The return type is kept
  * in the function below to safeguard against future MQTT 5 properties that may use string pairs.
  *
- * @return An #az_result value indicating the result of the operation.
+ * @return An #az_mqtt5_property_stringpair containing the MQTT 5 string pair property or empty if
+ * not found.
  */
-AZ_NODISCARD az_result az_mqtt5_property_bag_find_stringpair(
+AZ_NODISCARD az_mqtt5_property_stringpair az_mqtt5_property_bag_find_stringpair(
     az_mqtt5_property_bag* property_bag,
     az_mqtt5_property_type type,
-    az_span key,
-    az_mqtt5_property_stringpair* out_prop_strpair);
+    az_span key);
 
 /**
  * @brief Reads an MQTT 5 byte property from the property bag.
@@ -363,24 +277,23 @@ AZ_NODISCARD az_result az_mqtt5_property_bag_read_int(
  *
  * @param property_bag The MQTT 5 property bag instance.
  * @param type The MQTT 5 property type.
- * @param out_prop_bindata The output MQTT 5 binary data property.
  *
  * @note After reading, the property binary data must be freed using
- * #az_mqtt5_property_free_binarydata when it is no longer needed.
+ * #az_mqtt5_property_read_free_binarydata when it is no longer needed.
  *
- * @return An #az_result value indicating the result of the operation.
+ * @return An #az_mqtt5_property_binarydata containing the MQTT 5 binary data property or empty if
+ * not found.
  */
-AZ_NODISCARD az_result az_mqtt5_property_bag_read_binarydata(
+AZ_NODISCARD az_mqtt5_property_binarydata az_mqtt5_property_bag_read_binarydata(
     az_mqtt5_property_bag* property_bag,
-    az_mqtt5_property_type type,
-    az_mqtt5_property_binarydata* out_prop_bindata);
+    az_mqtt5_property_type type);
 
 /**
  * @brief Gets the string value of an MQTT 5 property string.
  *
  * @param[in] prop_str The MQTT 5 property string.
  *
- * @return The string value of the property.
+ * @return An #az_span containing the string value of the property.
  */
 AZ_NODISCARD az_span az_mqtt5_property_get_string(az_mqtt5_property_string* prop_str);
 
@@ -389,7 +302,7 @@ AZ_NODISCARD az_span az_mqtt5_property_get_string(az_mqtt5_property_string* prop
  *
  * @param[in] prop_strpair The MQTT 5 property string pair.
  *
- * @return The key of the property.
+ * @return An #az_span containing the key of the property.
  */
 AZ_NODISCARD az_span
 az_mqtt5_property_stringpair_get_key(az_mqtt5_property_stringpair* prop_strpair);
@@ -399,7 +312,7 @@ az_mqtt5_property_stringpair_get_key(az_mqtt5_property_stringpair* prop_strpair)
  *
  * @param[in] prop_strpair The MQTT 5 property string pair.
  *
- * @return The value of the property.
+ * @return An #az_span containing the value of the property.
  */
 AZ_NODISCARD az_span
 az_mqtt5_property_stringpair_get_value(az_mqtt5_property_stringpair* prop_strpair);
@@ -409,7 +322,7 @@ az_mqtt5_property_stringpair_get_value(az_mqtt5_property_stringpair* prop_strpai
  *
  * @param[in] prop_bindata The MQTT 5 property binary data.
  *
- * @return The binary data value of the property.
+ * @return An #az_span containing the binary data value of the property.
  */
 AZ_NODISCARD az_span az_mqtt5_property_get_binarydata(az_mqtt5_property_binarydata* prop_bindata);
 
@@ -421,7 +334,7 @@ AZ_NODISCARD az_span az_mqtt5_property_get_binarydata(az_mqtt5_property_binaryda
  * @note This function is only required for MQTT stacks that require memory allocation for the
  * property. Otherwise, this function is a no-op.
  */
-void az_mqtt5_property_free_string(az_mqtt5_property_string* prop_str);
+void az_mqtt5_property_read_free_string(az_mqtt5_property_string* prop_str);
 
 /**
  * @brief Frees an MQTT 5 string pair property. Called after value is read from property bag.
@@ -431,7 +344,7 @@ void az_mqtt5_property_free_string(az_mqtt5_property_string* prop_str);
  * @note This function is only required for MQTT stacks that require memory allocation for the
  * property. Otherwise, this function is a no-op.
  */
-void az_mqtt5_property_free_stringpair(az_mqtt5_property_stringpair* prop_strpair);
+void az_mqtt5_property_read_free_stringpair(az_mqtt5_property_stringpair* prop_strpair);
 
 /**
  * @brief Frees an MQTT 5 binary data property. Called after value is read from property bag.
@@ -441,7 +354,7 @@ void az_mqtt5_property_free_stringpair(az_mqtt5_property_stringpair* prop_strpai
  * @note This function is only required for MQTT stacks that require memory allocation for the
  * property. Otherwise, this function is a no-op.
  */
-void az_mqtt5_property_free_binarydata(az_mqtt5_property_binarydata* prop_bindata);
+void az_mqtt5_property_read_free_binarydata(az_mqtt5_property_binarydata* prop_bindata);
 
 #include <azure/core/_az_cfg_suffix.h>
 

--- a/sdk/inc/azure/core/az_mqtt5_rpc.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc.h
@@ -76,15 +76,17 @@ typedef enum
 } az_mqtt5_rpc_status;
 
 /**
- * @brief Helper function to check if an az_span topic matches an #az_span subscription, even if the
- * subscription topic has wildcards.
+ * @brief Helper function to check if an #az_span topic matches an #az_span topic filter, even if
+ * the topic filter has wildcards.
  *
- * @param[in] sub the subscription topic to check against.
- * @param[in] topic the topic to check.
+ * @note Does not handle topics or topic levels with $.
  *
- * @return true if the topic is valid within the subscription, false otherwise.
+ * @param[in] topic_filter The topic filter to check against.
+ * @param[in] topic The topic to check.
+ *
+ * @return True if the topic matches the topic filter, false otherwise.
  */
-AZ_NODISCARD bool az_span_topic_matches_sub(az_span sub, az_span topic);
+AZ_NODISCARD bool _az_span_topic_matches_filter(az_span topic_filter, az_span topic);
 
 /**
  * @brief Helper function to check if an #az_mqtt5_rpc_status indicates failure.

--- a/sdk/inc/azure/core/az_mqtt5_rpc_client.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc_client.h
@@ -110,6 +110,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_subscription_topic(
  * command name provided during initialization of the client.
  * @param[out] out_response_topic The buffer to write the response topic to. Must be large enough to
  * hold the server_client_id and the subscription_topic.
+ * @param[out] out_topic_length The length of the response topic.
  *
  * @return An #az_result value indicating the result of the operation.
  */
@@ -117,7 +118,8 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_response_topic(
     az_mqtt5_rpc_client_codec* client,
     az_span server_client_id,
     az_span command_name,
-    az_span out_response_topic);
+    az_span out_response_topic,
+    int32_t* out_topic_length);
 
 /**
  * @brief Generates the request topic for this RPC Client Codec.

--- a/sdk/inc/azure/core/az_result.h
+++ b/sdk/inc/azure/core/az_result.h
@@ -156,6 +156,9 @@ enum az_result_core
    *
    */
   AZ_ERROR_HFSM_INVALID_STATE = _az_RESULT_MAKE_ERROR(_az_FACILITY_HFSM, 1),
+
+  /// Inidcates that the MQTT received topic does not match the subscription topic.
+  AZ_ERROR_MQTT_TOPIC_NO_MATCH = _az_RESULT_MAKE_ERROR(_az_FACILITY_CORE_MQTT5, 1),
 };
 
 /**

--- a/sdk/inc/azure/platform/az_mqtt5_mosquitto.h
+++ b/sdk/inc/azure/platform/az_mqtt5_mosquitto.h
@@ -91,47 +91,46 @@ typedef struct
  * @brief MQTT 5 property string.
  *
  * @note After reading using #az_mqtt5_property_bag_read_string, string should always be freed using
- * #az_mqtt5_property_free_string.
+ * #az_mqtt5_property_read_free_string.
  */
-typedef struct
-{
-  /**
-   * @brief The string value of the property.
-   */
-  az_span str;
-} az_mqtt5_property_string;
+typedef const char* az_mqtt5_property_string;
 
 /**
  * @brief MQTT 5 property string pair.
  *
  * @note After reading using #az_mqtt5_property_bag_find_stringpair, string pair should always be
- * freed using #az_mqtt5_property_free_stringpair.
+ * freed using #az_mqtt5_property_read_free_stringpair.
  */
 typedef struct
 {
   /**
    * @brief The key of the property.
    */
-  az_span key;
+  char* key;
 
   /**
    * @brief The value of the property.
    */
-  az_span value;
+  char* value;
 } az_mqtt5_property_stringpair;
 
 /**
  * @brief MQTT 5 property binary data.
  *
  * @note After reading using #az_mqtt5_property_bag_read_binarydata, binary data should always be
- * freed using #az_mqtt5_property_free_binarydata.
+ * freed using #az_mqtt5_property_read_free_binarydata.
  */
 typedef struct
 {
   /**
    * @brief The binary data value of the property.
    */
-  az_span bindata;
+  uint8_t* bindata;
+
+  /**
+   * @brief The length of the binary data value of the property.
+   */
+  uint16_t bindata_length;
 } az_mqtt5_property_binarydata;
 
 /**

--- a/sdk/inc/azure/platform/az_mqtt5_pahoasync.h
+++ b/sdk/inc/azure/platform/az_mqtt5_pahoasync.h
@@ -93,48 +93,25 @@ typedef struct
  * @brief MQTT 5 property string.
  *
  * @note After reading using #az_mqtt5_property_bag_read_string, string should always be freed using
- * #az_mqtt5_property_free_string.
+ * #az_mqtt5_property_read_free_string.
  */
-typedef struct
-{
-  /**
-   * @brief The string value of the property.
-   */
-  az_span str;
-} az_mqtt5_property_string;
+typedef MQTTProperty* az_mqtt5_property_string;
 
 /**
  * @brief MQTT 5 property string pair.
  *
  * @note After reading using #az_mqtt5_property_bag_find_stringpair, string pair should always be
- * freed using #az_mqtt5_property_free_stringpair.
+ * freed using #az_mqtt5_property_read_free_stringpair.
  */
-typedef struct
-{
-  /**
-   * @brief The key of the property.
-   */
-  az_span key;
-
-  /**
-   * @brief The value of the property.
-   */
-  az_span value;
-} az_mqtt5_property_stringpair;
+typedef MQTTProperty* az_mqtt5_property_stringpair;
 
 /**
  * @brief MQTT 5 property binary data.
  *
  * @note After reading using #az_mqtt5_property_bag_read_binarydata, binary data should always be
- * freed using #az_mqtt5_property_free_binarydata.
+ * freed using #az_mqtt5_property_read_free_binarydata.
  */
-typedef struct
-{
-  /**
-   * @brief The binary data value of the property.
-   */
-  az_span bindata;
-} az_mqtt5_property_binarydata;
+typedef MQTTProperty* az_mqtt5_property_binarydata;
 
 /**
  * @brief Initializes the MQTT 5 instance specific to Eclipse Paho Async.

--- a/sdk/samples/core/CMakeLists.txt
+++ b/sdk/samples/core/CMakeLists.txt
@@ -102,4 +102,23 @@ elseif (TRANSPORT_PAHO)
   )
 
   create_map_file(paho_rpc_client_sample paho_rpc_client_sample.map)
+
+  # Azure MQTT5 State Machine RPC Client & Server Sample
+  add_executable (paho_multiple_rpc_sample
+    ${CMAKE_CURRENT_LIST_DIR}/paho_multiple_rpc_sample.c
+  )
+
+  target_include_directories(paho_multiple_rpc_sample
+    PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}
+      ${CMAKE_SOURCE_DIR}/sdk/src/azure/core/
+  )
+
+  target_link_libraries(paho_multiple_rpc_sample
+    PRIVATE
+    uuid
+    az_core
+  )
+
+  create_map_file(paho_multiple_rpc_sample paho_multiple_rpc_sample.map)
 endif()

--- a/sdk/samples/core/CMakeLists.txt
+++ b/sdk/samples/core/CMakeLists.txt
@@ -1,69 +1,105 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-if (TRANSPORT_MOSQUITTO)
-
 cmake_minimum_required (VERSION 3.10)
 
 project (az_mqtt5_samples LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 
-# Azure MQTT5 State Machine RPC Server Sample
-add_executable (mosquitto_rpc_server_sample
-  ${CMAKE_CURRENT_LIST_DIR}/mosquitto_rpc_server_sample.c
-  ${CMAKE_CURRENT_LIST_DIR}/mosquitto_rpc_server_sample_json_parser.c
-)
+if (TRANSPORT_MOSQUITTO)
+  # Azure MQTT5 State Machine RPC Server Sample
+  add_executable (mosquitto_rpc_server_sample
+    ${CMAKE_CURRENT_LIST_DIR}/mosquitto_rpc_server_sample.c
+    ${CMAKE_CURRENT_LIST_DIR}/mosquitto_rpc_server_sample_json_parser.c
+  )
 
-target_include_directories(mosquitto_rpc_server_sample
-  PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}
-    ${CMAKE_SOURCE_DIR}/sdk/src/azure/core/
-)
+  target_include_directories(mosquitto_rpc_server_sample
+    PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}
+      ${CMAKE_SOURCE_DIR}/sdk/src/azure/core/
+  )
 
-target_link_libraries(mosquitto_rpc_server_sample
-  PRIVATE
-  az_core
-)
+  target_link_libraries(mosquitto_rpc_server_sample
+    PRIVATE
+    az_core
+  )
 
-create_map_file(mosquitto_rpc_server_sample mosquitto_rpc_server_sample.map)
+  create_map_file(mosquitto_rpc_server_sample mosquitto_rpc_server_sample.map)
 
-# Azure MQTT5 State Machine RPC Client Sample
-add_executable (mosquitto_rpc_client_sample
-  ${CMAKE_CURRENT_LIST_DIR}/mosquitto_rpc_client_sample.c
-)
+  # Azure MQTT5 State Machine RPC Client Sample
+  add_executable (mosquitto_rpc_client_sample
+    ${CMAKE_CURRENT_LIST_DIR}/mosquitto_rpc_client_sample.c
+  )
 
-target_include_directories(mosquitto_rpc_client_sample
-  PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}
-    ${CMAKE_SOURCE_DIR}/sdk/src/azure/core/
-)
+  target_include_directories(mosquitto_rpc_client_sample
+    PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}
+      ${CMAKE_SOURCE_DIR}/sdk/src/azure/core/
+  )
 
-target_link_libraries(mosquitto_rpc_client_sample
-  PRIVATE
-  uuid
-  az_core
-)
+  target_link_libraries(mosquitto_rpc_client_sample
+    PRIVATE
+    uuid
+    az_core
+  )
 
-create_map_file(mosquitto_rpc_client_sample mosquitto_rpc_client_sample.map)
+  create_map_file(mosquitto_rpc_client_sample mosquitto_rpc_client_sample.map)
 
-# Azure MQTT5 State Machine RPC Client & Server Sample
-add_executable (mosquitto_multiple_rpc_sample
-  ${CMAKE_CURRENT_LIST_DIR}/mosquitto_multiple_rpc_sample.c
-)
+  # Azure MQTT5 State Machine RPC Client & Server Sample
+  add_executable (mosquitto_multiple_rpc_sample
+    ${CMAKE_CURRENT_LIST_DIR}/mosquitto_multiple_rpc_sample.c
+  )
 
-target_include_directories(mosquitto_multiple_rpc_sample
-  PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}
-    ${CMAKE_SOURCE_DIR}/sdk/src/azure/core/
-)
+  target_include_directories(mosquitto_multiple_rpc_sample
+    PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}
+      ${CMAKE_SOURCE_DIR}/sdk/src/azure/core/
+  )
 
-target_link_libraries(mosquitto_multiple_rpc_sample
-  PRIVATE
-  uuid
-  az_core
-)
+  target_link_libraries(mosquitto_multiple_rpc_sample
+    PRIVATE
+    uuid
+    az_core
+  )
 
-create_map_file(mosquitto_multiple_rpc_sample mosquitto_multiple_rpc_sample.map)
+  create_map_file(mosquitto_multiple_rpc_sample mosquitto_multiple_rpc_sample.map)
+elseif (TRANSPORT_PAHO)
+  # Azure MQTT5 State Machine RPC Server Sample
+  add_executable (paho_rpc_server_sample
+    ${CMAKE_CURRENT_LIST_DIR}/paho_rpc_server_sample.c
+    ${CMAKE_CURRENT_LIST_DIR}/mosquitto_rpc_server_sample_json_parser.c
+  )
 
-endif() # TRANSPORT_MOSQUITTO
+  target_include_directories(paho_rpc_server_sample
+    PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}
+      ${CMAKE_SOURCE_DIR}/sdk/src/azure/core/
+  )
+
+  target_link_libraries(paho_rpc_server_sample
+    PRIVATE
+    az_core
+  )
+
+  create_map_file(paho_rpc_server_sample paho_rpc_server_sample.map)
+
+  # Azure MQTT5 State Machine RPC Client Sample
+  add_executable (paho_rpc_client_sample
+    ${CMAKE_CURRENT_LIST_DIR}/paho_rpc_client_sample.c
+  )
+
+  target_include_directories(paho_rpc_client_sample
+    PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}
+      ${CMAKE_SOURCE_DIR}/sdk/src/azure/core/
+  )
+
+  target_link_libraries(paho_rpc_client_sample
+    PRIVATE
+    uuid
+    az_core
+  )
+
+  create_map_file(paho_rpc_client_sample paho_rpc_client_sample.map)
+endif()

--- a/sdk/samples/core/mosquitto_multiple_rpc_sample.c
+++ b/sdk/samples/core/mosquitto_multiple_rpc_sample.c
@@ -78,7 +78,7 @@ az_result check_for_commands_to_execute();
 az_result copy_execution_event_data(
     az_mqtt5_rpc_server_execution_req_event_data* destination,
     az_mqtt5_rpc_server_execution_req_event_data source);
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event, const void* callback_context);
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, void* callback_context);
 void handle_response(az_span response_payload);
 az_result invoke_stop_module();
 az_result invoke_start_module();
@@ -252,7 +252,7 @@ void handle_response(az_span response_payload)
  * @brief MQTT client callback function for all clients
  * @note If you add other clients, you can add handling for their events here
  */
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event, const void* callback_context)
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, void* callback_context)
 {
   (void)client;
   (void)callback_context;

--- a/sdk/samples/core/mosquitto_multiple_rpc_sample.c
+++ b/sdk/samples/core/mosquitto_multiple_rpc_sample.c
@@ -39,11 +39,6 @@ static const az_span client_subscription_topic_format
 static const az_span client_request_topic_format
     = AZ_SPAN_LITERAL_FROM_STR("device/{executorId}/command/{name}");
 
-static az_mqtt5_options options = {
-  .certificate_authority_trusted_roots = AZ_SPAN_LITERAL_EMPTY,
-  .disable_tls_validation = true,
-};
-
 // Static memory allocation
 static char client_response_topic_buffer[256];
 static char client_request_topic_buffer[256];
@@ -492,7 +487,7 @@ int main(int argc, char* argv[])
   az_mqtt5 mqtt5;
   struct mosquitto* mosq = NULL;
 
-  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, &mosq, &options));
+  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, &mosq, NULL));
 
   az_mqtt5_x509_client_certificate primary_credential = (az_mqtt5_x509_client_certificate){
     .cert = cert_path1,

--- a/sdk/samples/core/mosquitto_rpc_client_sample.c
+++ b/sdk/samples/core/mosquitto_rpc_client_sample.c
@@ -45,11 +45,6 @@ static uint8_t correlation_id_buffers[RPC_CLIENT_MAX_PENDING_COMMANDS]
                                      [AZ_MQTT5_RPC_CORRELATION_ID_LENGTH];
 static pending_commands_array pending_commands;
 
-static az_mqtt5_options options = {
-  .certificate_authority_trusted_roots = AZ_SPAN_LITERAL_EMPTY,
-  .disable_tls_validation = true,
-};
-
 // State variables
 static az_mqtt5_connection mqtt_connection;
 static az_context connection_context;
@@ -251,7 +246,7 @@ int main(int argc, char* argv[])
   az_mqtt5 mqtt5;
   struct mosquitto* mosq = NULL;
 
-  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, &mosq, &options));
+  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, &mosq, NULL));
 
   az_mqtt5_x509_client_certificate primary_credential = (az_mqtt5_x509_client_certificate){
     .cert = cert_path1,

--- a/sdk/samples/core/mosquitto_rpc_client_sample.c
+++ b/sdk/samples/core/mosquitto_rpc_client_sample.c
@@ -54,7 +54,7 @@ static az_mqtt5_rpc_client_codec rpc_client_codec;
 
 volatile bool sample_finished = false;
 
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event, const void* callback_context);
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, void* callback_context);
 void handle_response(az_span response_payload);
 az_result invoke_begin(az_span invoke_command_name, az_span payload);
 void remove_expired_commands();
@@ -76,7 +76,7 @@ void handle_response(az_span response_payload)
  * @brief MQTT client callback function for all clients
  * @note If you add other clients, you can add handling for their events here
  */
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event, const void* callback_context)
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, void* callback_context)
 {
   (void)client;
   (void)callback_context;

--- a/sdk/samples/core/mosquitto_rpc_server_sample.c
+++ b/sdk/samples/core/mosquitto_rpc_server_sample.c
@@ -59,7 +59,7 @@ az_result check_for_commands();
 az_result copy_execution_event_data(
     az_mqtt5_rpc_server_execution_req_event_data* destination,
     az_mqtt5_rpc_server_execution_req_event_data source);
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event, const void* callback_context);
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, void* callback_context);
 
 void az_platform_critical_error()
 {
@@ -236,7 +236,7 @@ az_result copy_execution_event_data(
  * @brief MQTT client callback function for all clients
  * @note If you add other clients, you can add handling for their events here
  */
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event, const void* callback_context)
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, void* callback_context)
 {
   (void)client;
   (void)callback_context;

--- a/sdk/samples/core/mosquitto_rpc_server_sample.c
+++ b/sdk/samples/core/mosquitto_rpc_server_sample.c
@@ -29,11 +29,6 @@ static const az_span content_type = AZ_SPAN_LITERAL_FROM_STR("application/json")
 static const az_span subscription_topic_format
     = AZ_SPAN_LITERAL_FROM_STR("vehicles/{serviceId}/commands/{executorId}/{name}");
 
-static az_mqtt5_options options = {
-  .certificate_authority_trusted_roots = AZ_SPAN_LITERAL_EMPTY,
-  .disable_tls_validation = true,
-};
-
 // Static memory allocation.
 static char subscription_topic_buffer[256];
 static char response_payload_buffer[256];
@@ -341,7 +336,7 @@ int main(int argc, char* argv[])
   az_mqtt5 mqtt5;
   struct mosquitto* mosq = NULL;
 
-  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, &mosq, &options));
+  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, &mosq, NULL));
 
   az_mqtt5_x509_client_certificate primary_credential = (az_mqtt5_x509_client_certificate){
     .cert = cert_path1,

--- a/sdk/samples/core/paho_multiple_rpc_sample.c
+++ b/sdk/samples/core/paho_multiple_rpc_sample.c
@@ -577,6 +577,15 @@ int main(int argc, char* argv[])
   // clean-up functions shown for completeness
   LOG_AND_EXIT_IF_FAILED(az_mqtt5_connection_close(&mqtt_connection));
 
+  // Clean up Paho
+  while (!sample_finished)
+  {
+    LOG_AND_EXIT_IF_FAILED(az_platform_sleep_msec(1000));
+  }
+  MQTTProperties_free(&client_prop);
+  MQTTProperties_free(&server_prop);
+  MQTTAsync_destroy(&mqtt_handle);
+
   printf(LOG_APP "Done.                                \n");
   return 0;
 }

--- a/sdk/samples/core/paho_multiple_rpc_sample.c
+++ b/sdk/samples/core/paho_multiple_rpc_sample.c
@@ -78,7 +78,7 @@ az_result check_for_commands_to_execute();
 az_result copy_execution_event_data(
     az_mqtt5_rpc_server_execution_req_event_data* destination,
     az_mqtt5_rpc_server_execution_req_event_data source);
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event);
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, void* callback_context);
 void handle_response(az_span response_payload);
 az_result invoke_stop_module();
 az_result invoke_start_module();
@@ -252,9 +252,10 @@ void handle_response(az_span response_payload)
  * @brief MQTT client callback function for all clients
  * @note If you add other clients, you can add handling for their events here
  */
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event)
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, void* callback_context)
 {
   (void)client;
+  (void)callback_context;
   az_app_log_callback(event.type, AZ_SPAN_FROM_STR("APP/callback"));
   switch (event.type)
   {
@@ -492,7 +493,7 @@ int main(int argc, char* argv[])
   connection_options.client_certificates[0] = primary_credential;
 
   LOG_AND_EXIT_IF_FAILED(az_mqtt5_connection_init(
-      &mqtt_connection, &connection_context, &mqtt5, mqtt_callback, &connection_options));
+      &mqtt_connection, &connection_context, &mqtt5, mqtt_callback, &connection_options, NULL));
 
   LOG_AND_EXIT_IF_FAILED(az_platform_mutex_init(&pending_server_command_mutex));
 

--- a/sdk/samples/core/paho_multiple_rpc_sample.c
+++ b/sdk/samples/core/paho_multiple_rpc_sample.c
@@ -39,11 +39,6 @@ static const az_span client_subscription_topic_format
 static const az_span client_request_topic_format
     = AZ_SPAN_LITERAL_FROM_STR("device/{executorId}/command/{name}");
 
-static az_mqtt5_options options = {
-  .certificate_authority_trusted_roots = AZ_SPAN_LITERAL_EMPTY,
-  .disable_tls_validation = true,
-};
-
 // Static memory allocation
 static char client_response_topic_buffer[256];
 static char client_request_topic_buffer[256];
@@ -509,8 +504,7 @@ int main(int argc, char* argv[])
 
   az_mqtt5_property_bag server_property_bag;
   MQTTProperties server_prop = MQTTProperties_initializer;
-  LOG_AND_EXIT_IF_FAILED(
-      az_mqtt5_property_bag_init(&server_property_bag, &mqtt5, &server_prop));
+  LOG_AND_EXIT_IF_FAILED(az_mqtt5_property_bag_init(&server_property_bag, &mqtt5, &server_prop));
 
   az_mqtt5_rpc_server_codec_options server_codec_options
       = az_mqtt5_rpc_server_codec_options_default();
@@ -529,8 +523,7 @@ int main(int argc, char* argv[])
 
   az_mqtt5_property_bag client_property_bag;
   MQTTProperties client_prop = MQTTProperties_initializer;
-  LOG_AND_EXIT_IF_FAILED(
-      az_mqtt5_property_bag_init(&client_property_bag, &mqtt5, &client_prop));
+  LOG_AND_EXIT_IF_FAILED(az_mqtt5_property_bag_init(&client_property_bag, &mqtt5, &client_prop));
 
   az_mqtt5_rpc_client_codec_options client_codec_options
       = az_mqtt5_rpc_client_codec_options_default();

--- a/sdk/samples/core/paho_multiple_rpc_sample.c
+++ b/sdk/samples/core/paho_multiple_rpc_sample.c
@@ -3,7 +3,7 @@
 
 /**
  * @file
- * @brief RPC Server & Client sample for Mosquitto MQTT that supports multiple commands under the
+ * @brief RPC Server & Client sample for Paho MQTT that supports multiple commands under the
  * same subscription
  *
  */

--- a/sdk/samples/core/paho_rpc_client_sample.c
+++ b/sdk/samples/core/paho_rpc_client_sample.c
@@ -54,7 +54,7 @@ static az_mqtt5_rpc_client_codec rpc_client_codec;
 
 volatile bool sample_finished = false;
 
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event);
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, void* callback_context);
 void handle_response(az_span response_payload);
 az_result invoke_begin(az_span invoke_command_name, az_span payload);
 void remove_expired_commands();
@@ -76,9 +76,10 @@ void handle_response(az_span response_payload)
  * @brief MQTT client callback function for all clients
  * @note If you add other clients, you can add handling for their events here
  */
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event)
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, void* callback_context)
 {
   (void)client;
+  (void)callback_context;
   az_app_log_callback(event.type, AZ_SPAN_FROM_STR("APP/callback"));
   switch (event.type)
   {
@@ -251,7 +252,7 @@ int main(int argc, char* argv[])
   connection_options.client_certificates[0] = primary_credential;
 
   LOG_AND_EXIT_IF_FAILED(az_mqtt5_connection_init(
-      &mqtt_connection, &connection_context, &mqtt5, mqtt_callback, &connection_options));
+      &mqtt_connection, &connection_context, &mqtt5, mqtt_callback, &connection_options, NULL));
 
   az_mqtt5_property_bag property_bag;
   MQTTProperties prop = MQTTProperties_initializer;

--- a/sdk/samples/core/paho_rpc_client_sample.c
+++ b/sdk/samples/core/paho_rpc_client_sample.c
@@ -45,11 +45,6 @@ static uint8_t correlation_id_buffers[RPC_CLIENT_MAX_PENDING_COMMANDS]
                                      [AZ_MQTT5_RPC_CORRELATION_ID_LENGTH];
 static pending_commands_array pending_commands;
 
-static az_mqtt5_options options = {
-  .certificate_authority_trusted_roots = AZ_SPAN_LITERAL_EMPTY,
-  .disable_tls_validation = true,
-};
-
 // State variables
 static az_mqtt5_connection mqtt_connection;
 static az_context connection_context;
@@ -241,7 +236,7 @@ int main(int argc, char* argv[])
   az_mqtt5 mqtt5;
   MQTTAsync mqtt_handle;
 
-  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, &mqtt_handle, &options));
+  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, &mqtt_handle, NULL));
 
   az_mqtt5_x509_client_certificate primary_credential = (az_mqtt5_x509_client_certificate){
     .cert = cert_path1,

--- a/sdk/samples/core/paho_rpc_client_sample.c
+++ b/sdk/samples/core/paho_rpc_client_sample.c
@@ -304,6 +304,14 @@ int main(int argc, char* argv[])
   // clean-up functions shown for completeness
   LOG_AND_EXIT_IF_FAILED(az_mqtt5_connection_close(&mqtt_connection));
 
+  // Clean up Paho
+  while (!sample_finished)
+  {
+    LOG_AND_EXIT_IF_FAILED(az_platform_sleep_msec(1000));
+  }
+  MQTTProperties_free(&prop);
+  MQTTAsync_destroy(&mqtt_handle);
+
   printf(LOG_APP "Done.                                \n");
   return 0;
 }

--- a/sdk/samples/core/paho_rpc_client_sample.c
+++ b/sdk/samples/core/paho_rpc_client_sample.c
@@ -3,7 +3,7 @@
 
 /**
  * @file
- * @brief RPC client sample for Mosquitto MQTT
+ * @brief RPC client sample for Paho MQTT
  *
  */
 

--- a/sdk/samples/core/paho_rpc_server_sample.c
+++ b/sdk/samples/core/paho_rpc_server_sample.c
@@ -384,6 +384,14 @@ int main(int argc, char* argv[])
   // clean-up functions shown for completeness
   LOG_AND_EXIT_IF_FAILED(az_mqtt5_connection_close(&mqtt_connection));
 
+  // Clean up Paho
+  while (!sample_finished)
+  {
+    LOG_AND_EXIT_IF_FAILED(az_platform_sleep_msec(1000));
+  }
+  MQTTProperties_free(&prop);
+  MQTTAsync_destroy(&mqtt_handle);
+
   printf(LOG_APP "Done.                                \n");
   return 0;
 }

--- a/sdk/samples/core/paho_rpc_server_sample.c
+++ b/sdk/samples/core/paho_rpc_server_sample.c
@@ -59,7 +59,7 @@ az_result check_for_commands();
 az_result copy_execution_event_data(
     az_mqtt5_rpc_server_execution_req_event_data* destination,
     az_mqtt5_rpc_server_execution_req_event_data source);
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event);
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, void* callback_context);
 
 void az_platform_critical_error()
 {
@@ -236,9 +236,10 @@ az_result copy_execution_event_data(
  * @brief MQTT client callback function for all clients
  * @note If you add other clients, you can add handling for their events here
  */
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event)
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, void* callback_context)
 {
   (void)client;
+  (void)callback_context;
   az_app_log_callback(event.type, AZ_SPAN_FROM_STR("APP/callback"));
   switch (event.type)
   {
@@ -341,7 +342,7 @@ int main(int argc, char* argv[])
   connection_options.client_certificates[0] = primary_credential;
 
   LOG_AND_EXIT_IF_FAILED(az_mqtt5_connection_init(
-      &mqtt_connection, &connection_context, &mqtt5, mqtt_callback, &connection_options));
+      &mqtt_connection, &connection_context, &mqtt5, mqtt_callback, &connection_options, NULL));
 
   LOG_AND_EXIT_IF_FAILED(az_platform_mutex_init(&pending_command_mutex));
 

--- a/sdk/samples/core/paho_rpc_server_sample.c
+++ b/sdk/samples/core/paho_rpc_server_sample.c
@@ -64,7 +64,7 @@ az_result check_for_commands();
 az_result copy_execution_event_data(
     az_mqtt5_rpc_server_execution_req_event_data* destination,
     az_mqtt5_rpc_server_execution_req_event_data source);
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event, const void* callback_context);
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event);
 
 void az_platform_critical_error()
 {
@@ -241,10 +241,9 @@ az_result copy_execution_event_data(
  * @brief MQTT client callback function for all clients
  * @note If you add other clients, you can add handling for their events here
  */
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event, const void* callback_context)
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event)
 {
   (void)client;
-  (void)callback_context;
   az_app_log_callback(event.type, AZ_SPAN_FROM_STR("APP/callback"));
   switch (event.type)
   {
@@ -323,15 +322,6 @@ int main(int argc, char* argv[])
   (void)argc;
   (void)argv;
 
-  /* Required before calling other mosquitto functions */
-  if (mosquitto_lib_init() != MOSQ_ERR_SUCCESS)
-  {
-    printf(LOG_APP "Failed to initialize MosquittoLib\n");
-    return -1;
-  }
-
-  printf(LOG_APP "Using MosquittoLib version %d\n", mosquitto_lib_version(NULL, NULL, NULL));
-
   az_log_set_message_callback(az_sdk_log_callback);
   az_log_set_classification_filter_callback(az_sdk_log_filter_callback);
 
@@ -339,9 +329,9 @@ int main(int argc, char* argv[])
       &az_context_application, az_context_get_expiration(&az_context_application));
 
   az_mqtt5 mqtt5;
-  struct mosquitto* mosq = NULL;
+  MQTTAsync mqtt_handle;
 
-  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, &mosq, &options));
+  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, &mqtt_handle, &options));
 
   az_mqtt5_x509_client_certificate primary_credential = (az_mqtt5_x509_client_certificate){
     .cert = cert_path1,
@@ -356,7 +346,7 @@ int main(int argc, char* argv[])
   connection_options.client_certificates[0] = primary_credential;
 
   LOG_AND_EXIT_IF_FAILED(az_mqtt5_connection_init(
-      &mqtt_connection, &connection_context, &mqtt5, mqtt_callback, &connection_options, NULL));
+      &mqtt_connection, &connection_context, &mqtt5, mqtt_callback, &connection_options));
 
   LOG_AND_EXIT_IF_FAILED(az_platform_mutex_init(&pending_command_mutex));
 
@@ -367,8 +357,8 @@ int main(int argc, char* argv[])
   pending_command.request_topic = AZ_SPAN_FROM_BUFFER(request_topic_buffer);
 
   az_mqtt5_property_bag property_bag;
-  mosquitto_property* mosq_prop = NULL;
-  LOG_AND_EXIT_IF_FAILED(az_mqtt5_property_bag_init(&property_bag, &mqtt5, &mosq_prop));
+  MQTTProperties prop = MQTTProperties_initializer;
+  LOG_AND_EXIT_IF_FAILED(az_mqtt5_property_bag_init(&property_bag, &mqtt5, &prop));
 
   az_mqtt5_rpc_server_codec_options server_codec_options
       = az_mqtt5_rpc_server_codec_options_default();
@@ -398,21 +388,6 @@ int main(int argc, char* argv[])
 
   // clean-up functions shown for completeness
   LOG_AND_EXIT_IF_FAILED(az_mqtt5_connection_close(&mqtt_connection));
-
-  if (mosq != NULL)
-  {
-    mosquitto_loop_stop(mosq, false);
-    mosquitto_destroy(mosq);
-  }
-
-  // mosquitto allocates the property bag for us, but we're responsible for free'ing it
-  mosquitto_property_free_all(&mosq_prop);
-
-  if (mosquitto_lib_cleanup() != MOSQ_ERR_SUCCESS)
-  {
-    printf(LOG_APP "Failed to cleanup MosquittoLib\n");
-    return -1;
-  }
 
   printf(LOG_APP "Done.                                \n");
   return 0;

--- a/sdk/samples/core/paho_rpc_server_sample.c
+++ b/sdk/samples/core/paho_rpc_server_sample.c
@@ -3,7 +3,7 @@
 
 /**
  * @file
- * @brief Mosquitto rpc server sample
+ * @brief RPC server sample for Paho MQTT.
  *
  */
 

--- a/sdk/samples/core/paho_rpc_server_sample.c
+++ b/sdk/samples/core/paho_rpc_server_sample.c
@@ -29,11 +29,6 @@ static const az_span content_type = AZ_SPAN_LITERAL_FROM_STR("application/json")
 static const az_span subscription_topic_format
     = AZ_SPAN_LITERAL_FROM_STR("vehicles/{serviceId}/commands/{executorId}/{name}");
 
-static az_mqtt5_options options = {
-  .certificate_authority_trusted_roots = AZ_SPAN_LITERAL_EMPTY,
-  .disable_tls_validation = true,
-};
-
 // Static memory allocation.
 static char subscription_topic_buffer[256];
 static char response_payload_buffer[256];
@@ -331,7 +326,7 @@ int main(int argc, char* argv[])
   az_mqtt5 mqtt5;
   MQTTAsync mqtt_handle;
 
-  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, &mqtt_handle, &options));
+  LOG_AND_EXIT_IF_FAILED(az_mqtt5_init(&mqtt5, &mqtt_handle, NULL));
 
   az_mqtt5_x509_client_certificate primary_credential = (az_mqtt5_x509_client_certificate){
     .cert = cert_path1,

--- a/sdk/src/azure/core/az_mqtt5_connection.c
+++ b/sdk/src/azure/core/az_mqtt5_connection.c
@@ -29,7 +29,7 @@ AZ_NODISCARD az_result az_mqtt5_connection_init(
     az_mqtt5* mqtt_client,
     az_mqtt5_connection_callback event_callback,
     az_mqtt5_connection_options* options,
-    const void* event_callback_context)
+    void* event_callback_context)
 {
   _az_PRECONDITION_NOT_NULL(client);
   _az_PRECONDITION_NOT_NULL(mqtt_client);

--- a/sdk/src/azure/core/az_mqtt5_rpc.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc.c
@@ -30,21 +30,137 @@ AZ_NODISCARD static az_result _az_rpc_substitute_key_for_value(
     az_span value,
     az_span out_topic);
 
-AZ_NODISCARD bool az_span_topic_matches_sub(az_span sub, az_span topic)
+/**
+ * @brief Helper function to obtain the next level of a topic.
+ *
+ * @param topic Topic to get the next level of.
+ * @return An #az_span value containing the next level of the topic including the backslash.
+ */
+AZ_NODISCARD AZ_INLINE az_span _get_next_topic_level(az_span topic)
 {
-  bool ret;
-#if defined(TRANSPORT_MOSQUITTO)
-  if (MOSQ_ERR_SUCCESS
-      != mosquitto_topic_matches_sub((char*)az_span_ptr(sub), (char*)az_span_ptr(topic), &ret))
+  int32_t pos = az_span_find(topic, AZ_SPAN_FROM_STR("/"));
+  if (pos == -1)
   {
-    ret = false;
+    int32_t pos_null_char = az_span_find(topic, AZ_SPAN_FROM_STR("\0"));
+    if (pos_null_char == -1)
+    {
+      return topic;
+    }
+    return az_span_slice(topic, 0, pos_null_char);
   }
-#else // TRANSPORT_MOSQUITTO
-  (void)sub;
-  (void)topic;
-  ret = false;
-#endif
-  return ret;
+
+  return az_span_slice(topic, 0, pos + 1);
+}
+
+/**
+ * @brief Helper function to check if a topic has a backslash at the end of it.
+ *
+ * @param topic Topic to check.
+ * @return True if the topic has a backslash at the end of it, false otherwise.
+ */
+AZ_NODISCARD AZ_INLINE bool _has_backslash_in_topic(az_span topic)
+{
+  if (az_span_size(topic) == 0)
+  {
+    return false;
+  }
+  return az_span_find(topic, AZ_SPAN_FROM_STR("/")) == az_span_size(topic) - 1;
+}
+
+AZ_NODISCARD bool _az_span_topic_matches_filter(az_span topic_filter, az_span topic)
+{
+  if (az_span_size(topic_filter) == 0 || az_span_size(topic) == 0)
+  {
+    return false;
+  }
+
+  // Checking for invalid wildcard usage in topic.
+  if (az_span_find(topic, AZ_SPAN_FROM_STR("#")) > 0
+      || az_span_find(topic, AZ_SPAN_FROM_STR("+")) > 0)
+  {
+    return false;
+  }
+
+  az_span filter_remaining = topic_filter;
+  az_span topic_remaining = topic;
+
+  az_span filter_level = _get_next_topic_level(filter_remaining);
+  az_span topic_level = _get_next_topic_level(topic_remaining);
+
+  while (az_span_size(filter_level) != 0)
+  {
+    if (az_span_ptr(filter_level)[0] == '#')
+    {
+      if (az_span_size(filter_level) != 1)
+      {
+        return false;
+      }
+      return true;
+    }
+    else if (az_span_ptr(filter_level)[0] == '+')
+    {
+      if (az_span_size(filter_level) == 1)
+      {
+        if (_has_backslash_in_topic(topic_level))
+        {
+          return false;
+        }
+        return true;
+      }
+      else if (az_span_size(filter_level) == 2 && _has_backslash_in_topic(filter_level))
+      {
+        // Special case: Topic Filter = "foo/+/#" and Topic = "foo/bar"
+        if (!_has_backslash_in_topic(topic_level))
+        {
+          filter_remaining = az_span_slice_to_end(filter_remaining, az_span_size(filter_level));
+          filter_level = _get_next_topic_level(filter_remaining);
+          if (az_span_size(filter_level) == 1 && az_span_ptr(filter_level)[0] == '#')
+          {
+            return true;
+          }
+          return false;
+        }
+      }
+      else
+      {
+        return false;
+      }
+    }
+    else
+    {
+      if (!az_span_is_content_equal(filter_level, topic_level))
+      {
+        // Special case: Topic Filter = "foo/#" and Topic = "foo"
+        if (!_has_backslash_in_topic(topic_level) && _has_backslash_in_topic(filter_level))
+        {
+          az_span sub_no_backslash = az_span_slice(filter_level, 0, az_span_size(filter_level) - 1);
+          if (az_span_is_content_equal(sub_no_backslash, topic_level))
+          {
+            filter_remaining = az_span_slice_to_end(filter_remaining, az_span_size(filter_level));
+            filter_level = _get_next_topic_level(filter_remaining);
+            if (az_span_size(filter_level) == 1 && az_span_ptr(filter_level)[0] == '#')
+            {
+              return true;
+            }
+          }
+        }
+        return false;
+      }
+    }
+
+    filter_remaining = az_span_slice_to_end(filter_remaining, az_span_size(filter_level));
+    topic_remaining = az_span_slice_to_end(topic_remaining, az_span_size(topic_level));
+
+    filter_level = _get_next_topic_level(filter_remaining);
+    topic_level = _get_next_topic_level(topic_remaining);
+  }
+
+  if (az_span_size(topic_level) != 0)
+  {
+    return false;
+  }
+
+  return true;
 }
 
 AZ_NODISCARD bool az_mqtt5_rpc_status_failed(az_mqtt5_rpc_status status)

--- a/sdk/src/azure/core/az_mqtt5_rpc_client_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_client_codec.c
@@ -39,7 +39,8 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_response_topic(
     az_mqtt5_rpc_client_codec* client,
     az_span server_client_id,
     az_span command_name,
-    az_span out_response_topic)
+    az_span out_response_topic,
+    int32_t* out_topic_length)
 {
   return az_rpc_get_topic_from_format(
       client->_internal.options.subscription_topic_format,
@@ -49,7 +50,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_response_topic(
       _az_span_is_valid(client->_internal.command_name, 1, 0) ? client->_internal.command_name
                                                               : command_name,
       out_response_topic,
-      NULL);
+      out_topic_length);
 }
 
 AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_request_topic(

--- a/sdk/src/azure/core/az_mqtt5_rpc_client_hfsm.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_client_hfsm.c
@@ -396,11 +396,12 @@ send_resp_inbound_if_topic_matches(az_mqtt5_rpc_client* this_policy, az_event ev
     az_span status_val_str = az_mqtt5_property_stringpair_get_value(&status);
     az_span error_message_val_str = az_mqtt5_property_stringpair_get_value(&error_message);
 
-    az_mqtt5_rpc_client_rsp_event_data resp_data = { .response_payload = recv_data->payload,
-                                                     .status = AZ_MQTT5_RPC_STATUS_UNKNOWN,
-                                                     .error_message = AZ_SPAN_EMPTY,
-                                                     .content_type = az_mqtt5_property_get_string(&content_type),
-                                                     .correlation_id = az_mqtt5_property_get_binarydata(&correlation_data) };
+    az_mqtt5_rpc_client_rsp_event_data resp_data
+        = { .response_payload = recv_data->payload,
+            .status = AZ_MQTT5_RPC_STATUS_UNKNOWN,
+            .error_message = AZ_SPAN_EMPTY,
+            .content_type = az_mqtt5_property_get_string(&content_type),
+            .correlation_id = az_mqtt5_property_get_binarydata(&correlation_data) };
 
     az_result rc = AZ_OK;
     if (az_span_is_content_equal(resp_data.correlation_id, AZ_SPAN_EMPTY))

--- a/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
@@ -246,6 +246,10 @@ AZ_INLINE az_result _handle_request(az_mqtt5_rpc_server* this_policy, az_mqtt5_r
         this_policy->_internal.connection,
         (az_event){ .type = AZ_MQTT5_EVENT_RPC_SERVER_EXECUTE_COMMAND_REQ, .data = &command_data });
   }
+  else
+  {
+    ret = AZ_ERROR_ITEM_NOT_FOUND;
+  }
 
   az_mqtt5_property_read_free_string(&content_type);
   az_mqtt5_property_read_free_binarydata(&correlation_data);

--- a/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
@@ -269,7 +269,7 @@ AZ_INLINE az_result _send_response_pub(az_mqtt5_rpc_server* me, az_mqtt5_pub_dat
       (az_event_policy*)me, (az_event){ .type = AZ_MQTT5_EVENT_PUB_REQ, .data = &data });
 
   // empty the property bag so it can be reused
-  _az_RETURN_IF_FAILED(az_mqtt5_property_bag_clear(&me->_internal.property_bag));
+  az_mqtt5_property_bag_clear(&me->_internal.property_bag);
   return ret;
 }
 
@@ -351,10 +351,17 @@ static az_result waiting(az_event_policy* me, az_event event)
       {
         // create response payload
         az_mqtt5_pub_data data;
-        _az_RETURN_IF_FAILED(_build_response(this_policy, event_data, &data));
+        ret = _build_response(this_policy, event_data, &data);
+        if (az_result_failed(ret))
+        {
+          az_mqtt5_property_bag_clear(&this_policy->_internal.property_bag);
+          return ret;
+        }
 
         // send publish
         _send_response_pub(this_policy, data);
+
+        az_mqtt5_property_bag_clear(&this_policy->_internal.property_bag);
       }
       else
       {

--- a/sdk/src/azure/platform/az_mosquitto5.c
+++ b/sdk/src/azure/platform/az_mosquitto5.c
@@ -393,15 +393,13 @@ AZ_NODISCARD az_result az_mqtt5_property_bag_init(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_mqtt5_property_bag_clear(az_mqtt5_property_bag* property_bag)
+void az_mqtt5_property_bag_clear(az_mqtt5_property_bag* property_bag)
 {
   _az_PRECONDITION_NOT_NULL(property_bag);
 
   mosquitto_property_free_all(property_bag->mosq_properties);
 
   *(property_bag->mosq_properties) = NULL;
-
-  return AZ_OK;
 }
 
 AZ_NODISCARD az_result az_mqtt5_property_bag_append_string(

--- a/sdk/src/azure/platform/az_nomqtt5.c
+++ b/sdk/src/azure/platform/az_nomqtt5.c
@@ -62,11 +62,7 @@ az_mqtt5_property_bag_init(az_mqtt5_property_bag* property_bag, az_mqtt5* mqtt5,
   return AZ_ERROR_NOT_IMPLEMENTED;
 }
 
-AZ_NODISCARD az_result az_mqtt5_property_bag_clear(az_mqtt5_property_bag* property_bag)
-{
-  (void)property_bag;
-  return AZ_ERROR_NOT_IMPLEMENTED;
-}
+void az_mqtt5_property_bag_clear(az_mqtt5_property_bag* property_bag) { (void)property_bag; }
 
 AZ_NODISCARD az_result az_mqtt5_property_bag_append_string(
     az_mqtt5_property_bag* property_bag,

--- a/sdk/src/azure/platform/az_nomqtt5.c
+++ b/sdk/src/azure/platform/az_nomqtt5.c
@@ -71,7 +71,7 @@ AZ_NODISCARD az_result az_mqtt5_property_bag_clear(az_mqtt5_property_bag* proper
 AZ_NODISCARD az_result az_mqtt5_property_bag_append_string(
     az_mqtt5_property_bag* property_bag,
     az_mqtt5_property_type type,
-    az_mqtt5_property_string* prop_str)
+    az_span* prop_str)
 {
   (void)property_bag;
   (void)type;
@@ -82,7 +82,7 @@ AZ_NODISCARD az_result az_mqtt5_property_bag_append_string(
 AZ_NODISCARD az_result az_mqtt5_property_bag_append_stringpair(
     az_mqtt5_property_bag* property_bag,
     az_mqtt5_property_type type,
-    az_mqtt5_property_stringpair* prop_strpair)
+    az_span* prop_strpair)
 {
   (void)property_bag;
   (void)type;
@@ -126,7 +126,7 @@ AZ_NODISCARD az_result az_mqtt5_property_bag_append_binary(
 AZ_NODISCARD az_result az_mqtt5_property_bag_read_string(
     az_mqtt5_property_bag* property_bag,
     az_mqtt5_property_type type,
-    az_mqtt5_property_string* out_prop_str)
+    az_span* out_prop_str)
 {
   (void)property_bag;
   (void)type;
@@ -138,7 +138,7 @@ AZ_NODISCARD az_result az_mqtt5_property_bag_find_stringpair(
     az_mqtt5_property_bag* property_bag,
     az_mqtt5_property_type type,
     az_span key,
-    az_mqtt5_property_stringpair* out_prop_strpair)
+    az_span* out_prop_strpair)
 {
   (void)property_bag;
   (void)type;
@@ -180,7 +180,7 @@ AZ_NODISCARD az_result az_mqtt5_property_bag_read_binarydata(
   return AZ_ERROR_NOT_IMPLEMENTED;
 }
 
-AZ_NODISCARD az_span az_mqtt5_property_get_string(az_mqtt5_property_string* prop_str)
+AZ_NODISCARD az_span az_mqtt5_property_get_string(az_span* prop_str)
 {
   (void)prop_str;
 
@@ -210,7 +210,7 @@ AZ_NODISCARD az_span az_mqtt5_property_get_binarydata(az_mqtt5_property_binaryda
   return AZ_SPAN_EMPTY;
 }
 
-void az_mqtt5_property_free_string(az_mqtt5_property_string* prop_str) { (void)prop_str; }
+void az_mqtt5_property_free_string(az_span* prop_str) { (void)prop_str; }
 
 void az_mqtt5_property_free_stringpair(az_mqtt5_property_stringpair* prop_strpair)
 {

--- a/sdk/src/azure/platform/az_pahoasync5.c
+++ b/sdk/src/azure/platform/az_pahoasync5.c
@@ -430,7 +430,6 @@ void az_mqtt5_property_bag_clear(az_mqtt5_property_bag* property_bag)
   _az_PRECONDITION_NOT_NULL(property_bag);
 
   MQTTProperties_free(property_bag->pahoasync_properties);
-  property_bag->pahoasync_properties->count = 0;
 }
 
 AZ_NODISCARD az_result az_mqtt5_property_bag_append_string(

--- a/sdk/src/azure/platform/az_pahoasync5.c
+++ b/sdk/src/azure/platform/az_pahoasync5.c
@@ -425,14 +425,12 @@ AZ_NODISCARD az_result az_mqtt5_property_bag_init(
   return AZ_OK;
 }
 
-AZ_NODISCARD az_result az_mqtt5_property_bag_clear(az_mqtt5_property_bag* property_bag)
+void az_mqtt5_property_bag_clear(az_mqtt5_property_bag* property_bag)
 {
   _az_PRECONDITION_NOT_NULL(property_bag);
 
   MQTTProperties_free(property_bag->pahoasync_properties);
   property_bag->pahoasync_properties->count = 0;
-
-  return AZ_OK;
 }
 
 AZ_NODISCARD az_result az_mqtt5_property_bag_append_string(

--- a/sdk/tests/core/CMakeLists.txt
+++ b/sdk/tests/core/CMakeLists.txt
@@ -28,7 +28,7 @@ if (UNIX)
     set(MATH_LIB_UNIX "m")
 endif()
 
-if (AZ_PLATFORM_IMPL STREQUAL "POSIX" AND NOT APPLE AND UNIT_TESTING_MOCKS AND NOT AZ_MQTT_TRANSPORT_IMPL STREQUAL "PAHO")
+if (AZ_PLATFORM_IMPL STREQUAL "POSIX" AND NOT APPLE AND UNIT_TESTING_MOCKS)
     add_cmocka_test(az_core_test SOURCES
                     main.c
                     mock_az_mqtt5.c

--- a/sdk/tests/core/main.c
+++ b/sdk/tests/core/main.c
@@ -21,8 +21,7 @@ int main()
   // negative numbers
   result += test_az_base64();
   result += test_az_context();
-#if !defined(__APPLE__) && defined(PLATFORM_POSIX) && defined(_az_MOCK_ENABLED) \
-    && !defined(TRANSPORT_PAHO)
+#if !defined(__APPLE__) && defined(PLATFORM_POSIX) && defined(_az_MOCK_ENABLED)
   result += test_az_event_pipeline();
   result += test_az_hfsm();
   result += test_az_mqtt5_connection();

--- a/sdk/tests/core/test_az_mqtt5_connection.c
+++ b/sdk/tests/core/test_az_mqtt5_connection.c
@@ -107,7 +107,7 @@ static az_result test_subclient_policy_2_root(az_event_policy* me, az_event even
   return AZ_OK;
 }
 
-static az_result test_mqtt_connection_callback(az_mqtt5_connection* client, az_event event, const void* callback_context)
+static az_result test_mqtt_connection_callback(az_mqtt5_connection* client, az_event event, void* callback_context)
 {
   (void)client;
   (void)callback_context;

--- a/sdk/tests/core/test_az_mqtt5_rpc.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc.c
@@ -223,6 +223,225 @@ static void test_az_rpc_get_topic_from_format_no_command_name_success(void** sta
                        "/__for_" TEST_CLIENT_ID "\0")));
 }
 
+static void test_az_rpc_topic_match_sub(void** state)
+{
+  (void)state;
+
+  /* Topic Subscription Match Testing */
+
+  /* Testing Empty */
+
+  // Sub: AZ_SPAN_EMPTY Topic: "A" (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_EMPTY, AZ_SPAN_FROM_STR("A")));
+
+  // Sub: "A" Topic: AZ_SPAN_EMPTY (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A"), AZ_SPAN_EMPTY));
+
+  // Sub: "" Topic: "A" (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR(""), AZ_SPAN_FROM_STR("A")));
+
+  // Sub: "A" Topic: "" (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A"), AZ_SPAN_FROM_STR("")));
+
+  /* Testing Illegal Topic */
+
+  // Sub: "$" Topic: "A" (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("$"), AZ_SPAN_FROM_STR("A")));
+
+  // Sub: "A" Topic: "#" (Illegal)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A"), AZ_SPAN_FROM_STR("#")));
+
+  // Sub: "A" Topic: "+" (Illegal)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A"), AZ_SPAN_FROM_STR("+")));
+
+  // Sub: "A/" Topic: "A/#" (Illegal)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A/"), AZ_SPAN_FROM_STR("A/#")));
+
+  // Sub: "A/" Topic: "A/+" (Illegal)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A/"), AZ_SPAN_FROM_STR("A/+")));
+
+  // Sub: "A" Topic: "A\n" (Illegal)
+  // assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A"), AZ_SPAN_FROM_STR("A\0")));
+
+  /* Testing Illegal Subscription */
+
+  // Sub: "A" Topic: "$" (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A"), AZ_SPAN_FROM_STR("$")));
+
+  // Sub: "#A/B" Topic: "A/B" (Illegal)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("#A/B"), AZ_SPAN_FROM_STR("A/B")));
+
+  // Sub: "+A/B" Topic: "A/B" (Illegal)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("+A/B"), AZ_SPAN_FROM_STR("A/B")));
+
+  // Sub: "A/#B" Topic: "A/B" (Illegal)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A/#B"), AZ_SPAN_FROM_STR("A/B")));
+
+  // Sub: "A/+B" Topic: "A/B" (Illegal)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A/+B"), AZ_SPAN_FROM_STR("A/B")));
+
+  // Sub: "A/B#" Topic: "A/B" (Illegal)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A/B#"), AZ_SPAN_FROM_STR("A/B")));
+
+  // Sub: "A/B+" Topic: "A/B" (Illegal)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A/B+"), AZ_SPAN_FROM_STR("A/B")));
+
+  // Sub: "A\n" Topic: "A" (Illegal)
+  // assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A\0"), AZ_SPAN_FROM_STR("A")));
+
+  // Sub: "A\n" Topic: "A\n" (Illegal)
+  // assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A\0"), AZ_SPAN_FROM_STR("A\0")));
+
+  /* Testing Illegal Multi-Level Wildcard */
+
+  // Sub: "#/" Topic: "A/" (Illegal)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("#/"), AZ_SPAN_FROM_STR("A/")));
+
+  // Sub: "A/#/C" Topic: "A/B/C" (Illegal)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A/#/C"), AZ_SPAN_FROM_STR("A/B/C")));
+
+  /* Matching Multi-Level Wildcard */
+
+  // Sub: "#" Topic: "ABC/DEF/GHI" (True)
+  assert_true(
+      _az_span_topic_matches_filter(AZ_SPAN_FROM_STR("#"), AZ_SPAN_FROM_STR("ABC/DEF/GHI")));
+
+  // Sub: "#" Topic: "/" (True)
+  assert_true(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("#"), AZ_SPAN_FROM_STR("/")));
+
+  // Sub: "ABC/#" Topic: "ABC/DEF/GHI" (True)
+  assert_true(
+      _az_span_topic_matches_filter(AZ_SPAN_FROM_STR("ABC/#"), AZ_SPAN_FROM_STR("ABC/DEF/GHI")));
+
+  // Sub: "ABC/#" Topic: "ABC" (True)
+  assert_true(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("ABC/#"), AZ_SPAN_FROM_STR("ABC")));
+
+  // Sub: "ABC/#" Topic: "ABC/" (True)
+  assert_true(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("ABC/#"), AZ_SPAN_FROM_STR("ABC/")));
+
+  // Sub: "ABC/+/#" Topic: "ABC/DEF" (True)
+  assert_true(
+      _az_span_topic_matches_filter(AZ_SPAN_FROM_STR("ABC/+/#"), AZ_SPAN_FROM_STR("ABC/DEF")));
+
+  /* Matching Single-Level Wildcard */
+
+  // Sub: "+" Topic: "/" (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("+"), AZ_SPAN_FROM_STR("/")));
+
+  // Sub: "+" Topic: "ABC" (True)
+  assert_true(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("+"), AZ_SPAN_FROM_STR("ABC")));
+
+  // Sub: "+/" Topic: "ABC" (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("+/"), AZ_SPAN_FROM_STR("ABC")));
+
+  // Sub: "+/+" Topic: "/ABC" (True)
+  assert_true(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("+/+"), AZ_SPAN_FROM_STR("/ABC")));
+
+  // Sub: "/+" Topic: "/ABC" (True)
+  assert_true(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("/+"), AZ_SPAN_FROM_STR("/ABC")));
+
+  // Sub: "+" Topic: "/ABC" (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("+"), AZ_SPAN_FROM_STR("/ABC")));
+
+  // Sub: "ABC/+" Topic: "ABC/DEF/GHI" (False)
+  assert_false(
+      _az_span_topic_matches_filter(AZ_SPAN_FROM_STR("ABC/+"), AZ_SPAN_FROM_STR("ABC/DEF/GHI")));
+
+  // Sub: "ABC/DEF/+" Topic: "ABC/DEF/" (True)
+  assert_true(
+      _az_span_topic_matches_filter(AZ_SPAN_FROM_STR("ABC/DEF/+"), AZ_SPAN_FROM_STR("ABC/DEF/")));
+
+  // Sub: "ABC/DEF/+" Topic: "ABC/DEF" (False)
+  assert_false(
+      _az_span_topic_matches_filter(AZ_SPAN_FROM_STR("ABC/DEF/+"), AZ_SPAN_FROM_STR("ABC/DEF")));
+
+  // Sub: "ABC/+/GHI" Topic: "ABC/DEF/GHI" (True)
+  assert_true(_az_span_topic_matches_filter(
+      AZ_SPAN_FROM_STR("ABC/+/GHI"), AZ_SPAN_FROM_STR("ABC/DEF/GHI")));
+
+  // Sub: "+/+/+" Topic: "ABC/DEF/GHI" (True)
+  assert_true(
+      _az_span_topic_matches_filter(AZ_SPAN_FROM_STR("+/+/+"), AZ_SPAN_FROM_STR("ABC/DEF/GHI")));
+
+  // Sub: "+/DEF/+" Topic: "ABC/DEF/GHI" (True)
+  assert_true(
+      _az_span_topic_matches_filter(AZ_SPAN_FROM_STR("+/DEF/+"), AZ_SPAN_FROM_STR("ABC/DEF/GHI")));
+
+  // Sub: "A/+/" Topic: "A//" (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A/+"), AZ_SPAN_FROM_STR("A//")));
+
+  // Sub: "/+/+/+" Topic: "///" (True)
+  assert_true(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("/+/+/+"), AZ_SPAN_FROM_STR("///")));
+
+  // Sub: "ABC/DEF/+/" Topic: "ABC/DEF/GHI/" (True)
+  assert_true(_az_span_topic_matches_filter(
+      AZ_SPAN_FROM_STR("ABC/DEF/+/"), AZ_SPAN_FROM_STR("ABC/DEF/GHI/")));
+
+  // Sub: "ABC/DEF/+" Topic: "ABC/DEF/GHI" (True)
+  assert_true(_az_span_topic_matches_filter(
+      AZ_SPAN_FROM_STR("ABC/DEF/+"), AZ_SPAN_FROM_STR("ABC/DEF/GHI")));
+
+  /* Matching Non-Wildcard */
+
+  // Sub: " " Topic: " " (True)
+  assert_true(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR(" "), AZ_SPAN_FROM_STR(" ")));
+
+  // Sub: "/" Topic: "/" (True)
+  assert_true(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("/"), AZ_SPAN_FROM_STR("/")));
+
+  // Sub: "ABC" Topic: "/" (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A"), AZ_SPAN_FROM_STR("/")));
+
+  // Sub: "/ABC" Topic: "/" (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("/A"), AZ_SPAN_FROM_STR("/")));
+
+  // Sub: "ABC" Topic: "ABC" (True)
+  assert_true(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("ABC"), AZ_SPAN_FROM_STR("ABC")));
+
+  // Sub: "AbC" Topic: "ABC" (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("ABC"), AZ_SPAN_FROM_STR("AbC")));
+
+  // Sub: /ABC Topic: "ABC" (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("/ABC"), AZ_SPAN_FROM_STR("ABC")));
+
+  // Sub: "ABC/" Topic: "ABC" (False)
+  assert_false(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("ABC/"), AZ_SPAN_FROM_STR("ABC")));
+
+  // Sub: "A/B/C" Topic: "A/B/C" (True)
+  assert_true(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("A/B/C"), AZ_SPAN_FROM_STR("A/B/C")));
+
+  // Sub: "ABC/DEF/GHI" Topic: "ABC/DEF/GHI" (True)
+  assert_true(_az_span_topic_matches_filter(
+      AZ_SPAN_FROM_STR("ABC/DEF/GHI"), AZ_SPAN_FROM_STR("ABC/DEF/GHI")));
+
+  // Sub: "ABC/DEF/GHI/" Topic: "ABC/DEF/GHI" (False)
+  assert_false(_az_span_topic_matches_filter(
+      AZ_SPAN_FROM_STR("ABC/DEF/GHI/"), AZ_SPAN_FROM_STR("ABC/DEF/GHI")));
+
+  // Sub: "ABC/DEF/GHI" Topic: "ABC/DEF/GHI/" (False)
+  assert_false(_az_span_topic_matches_filter(
+      AZ_SPAN_FROM_STR("ABC/DEF/GHI"), AZ_SPAN_FROM_STR("ABC/DEF/GHI/")));
+
+  // Sub: "/ABC/DEF/GHI" Topic: "ABC/DEF/GHI" (False)
+  assert_false(_az_span_topic_matches_filter(
+      AZ_SPAN_FROM_STR("/ABC/DEF/GHI"), AZ_SPAN_FROM_STR("ABC/DEF/GHI")));
+
+  // Sub: "ABC/DEF/GHI" Topic: "/ABC/DEF/GHI" (False)
+  assert_false(_az_span_topic_matches_filter(
+      AZ_SPAN_FROM_STR("ABC/DEF/GHI"), AZ_SPAN_FROM_STR("/ABC/DEF/GHI")));
+
+  // Sub: "ABC/DEF" Topic: "ABC/DEF/GHI" (False)
+  assert_false(
+      _az_span_topic_matches_filter(AZ_SPAN_FROM_STR("ABC/DEF"), AZ_SPAN_FROM_STR("ABC/DEF/GHI")));
+
+  // Sub: "ABC/DEF//GHI" Topic: "ABC/DEF/GHI" (False)
+  assert_false(_az_span_topic_matches_filter(
+      AZ_SPAN_FROM_STR("ABC/DEF//GHI"), AZ_SPAN_FROM_STR("ABC/DEF/GHI")));
+
+  // Sub: "/////" Topic: "/////" (True)
+  assert_true(_az_span_topic_matches_filter(AZ_SPAN_FROM_STR("/////"), AZ_SPAN_FROM_STR("/////")));
+}
+
 int test_az_mqtt5_rpc()
 {
   const struct CMUnitTest tests[] = {
@@ -234,6 +453,7 @@ int test_az_mqtt5_rpc()
     cmocka_unit_test(test_az_rpc_get_topic_from_format_no_server_id_success),
     cmocka_unit_test(test_az_rpc_get_topic_from_format_no_client_id_success),
     cmocka_unit_test(test_az_rpc_get_topic_from_format_no_command_name_success),
+    cmocka_unit_test(test_az_rpc_topic_match_sub),
 
   };
   return cmocka_run_group_tests_name("az_core_mqtt5_rpc", tests, NULL, NULL);

--- a/sdk/tests/core/test_az_mqtt5_rpc_client_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_client_codec.c
@@ -180,10 +180,15 @@ static void test_az_mqtt5_rpc_client_get_response_topic_success(void** state)
   char test_response_topic_buffer[256];
   az_span resp_topic = AZ_SPAN_FROM_BUFFER(test_response_topic_buffer);
   az_span_fill(resp_topic, ' ');
+  int32_t resp_topic_len = 0;
 
   assert_int_equal(
       az_mqtt5_rpc_client_codec_get_response_topic(
-          &test_rpc_client_codec, AZ_SPAN_FROM_STR(TEST_SERVER_ID), AZ_SPAN_EMPTY, resp_topic),
+          &test_rpc_client_codec,
+          AZ_SPAN_FROM_STR(TEST_SERVER_ID),
+          AZ_SPAN_EMPTY,
+          resp_topic,
+          &resp_topic_len),
       AZ_OK);
 
   assert_true(az_span_is_content_equal(

--- a/sdk/tests/core/test_az_mqtt5_rpc_client_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_client_hfsm.c
@@ -131,7 +131,7 @@ static az_result test_subclient_policy_1_root(az_event_policy* me, az_event even
   return AZ_OK;
 }
 
-static az_result test_mqtt_connection_callback(az_mqtt5_connection* client, az_event event, const void* event_callback_context)
+static az_result test_mqtt_connection_callback(az_mqtt5_connection* client, az_event event, void* event_callback_context)
 {
   (void)client;
   (void)event_callback_context;

--- a/sdk/tests/core/test_az_mqtt5_rpc_client_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_client_hfsm.c
@@ -891,6 +891,7 @@ static void test_az_mqtt5_rpc_client_invoke_begin_faulted_failure(void** state)
   assert_int_equal(ref_pub_req, 0);
 
 #if defined(TRANSPORT_PAHO)
+  MQTTProperties_free(&test_prop);
   MQTTAsync_destroy(&test_client);
 #endif // TRANSPORT_PAHO
 }

--- a/sdk/tests/core/test_az_mqtt5_rpc_client_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_client_hfsm.c
@@ -51,6 +51,7 @@ static az_mqtt5_property_bag test_property_bag;
 #ifdef TRANSPORT_MOSQUITTO
 static mosquitto_property* test_prop = NULL;
 #else // TRANSPORT_PAHO
+MQTTAsync test_client; // Included so properties can be used for Paho
 static MQTTProperties test_prop = MQTTProperties_initializer;
 #endif // TRANSPORT_MOSQUITTO
 
@@ -165,6 +166,12 @@ static void test_az_mqtt5_rpc_client_init_success(void** state)
 
   az_log_set_message_callback(az_sdk_log_callback);
   az_log_set_classification_filter_callback(az_sdk_log_filter_callback);
+
+#if defined(TRANSPORT_PAHO)
+  int test_ret = MQTTAsync_create(
+      &test_client, TEST_HOSTNAME, TEST_CLIENT_ID, MQTTCLIENT_PERSISTENCE_NONE, NULL);
+  (void)test_ret;
+#endif // TRANSPORT_PAHO
 
   assert_int_equal(az_mqtt5_init(&mock_mqtt5, NULL, &mock_mqtt5_options), AZ_OK);
   mock_connection_options = az_mqtt5_connection_options_default();
@@ -468,7 +475,7 @@ static void test_az_mqtt5_rpc_client_recv_response_success(void** state)
 
   assert_int_equal(ref_rpc_rsp, 1);
 
-  assert_int_equal(az_mqtt5_property_bag_clear(&test_resp_property_bag), AZ_OK);
+  az_mqtt5_property_bag_clear(&test_resp_property_bag);
 }
 
 static void test_az_mqtt5_rpc_client_recv_fail_response_success(void** state)
@@ -524,7 +531,7 @@ static void test_az_mqtt5_rpc_client_recv_fail_response_success(void** state)
 
   assert_int_equal(ref_rpc_rsp, 1);
 
-  assert_int_equal(az_mqtt5_property_bag_clear(&test_resp_property_bag), AZ_OK);
+  az_mqtt5_property_bag_clear(&test_resp_property_bag);
 }
 
 static void test_az_mqtt5_rpc_client_recv_respose_no_properties_failure(void** state)
@@ -570,7 +577,7 @@ static void test_az_mqtt5_rpc_client_recv_response_no_correlation_data_failure(v
 
   assert_int_equal(ref_rpc_err_rsp, 1);
 
-  assert_int_equal(az_mqtt5_property_bag_clear(&test_resp_property_bag), AZ_OK);
+  az_mqtt5_property_bag_clear(&test_resp_property_bag);
 }
 
 static void test_az_mqtt5_rpc_client_recv_response_no_content_type_failure(void** state)
@@ -616,7 +623,7 @@ static void test_az_mqtt5_rpc_client_recv_response_no_content_type_failure(void*
 
   assert_int_equal(ref_rpc_err_rsp, 1);
 
-  assert_int_equal(az_mqtt5_property_bag_clear(&test_resp_property_bag), AZ_OK);
+  az_mqtt5_property_bag_clear(&test_resp_property_bag);
 }
 
 static void test_az_mqtt5_rpc_client_recv_response_no_status_failure(void** state)
@@ -658,7 +665,7 @@ static void test_az_mqtt5_rpc_client_recv_response_no_status_failure(void** stat
 
   assert_int_equal(ref_rpc_err_rsp, 1);
 
-  assert_int_equal(az_mqtt5_property_bag_clear(&test_resp_property_bag), AZ_OK);
+  az_mqtt5_property_bag_clear(&test_resp_property_bag);
 }
 
 static void test_az_mqtt5_rpc_client_recv_response_invalid_status_failure(void** state)
@@ -705,7 +712,7 @@ static void test_az_mqtt5_rpc_client_recv_response_invalid_status_failure(void**
 
   assert_int_equal(ref_rpc_err_rsp, 1);
 
-  assert_int_equal(az_mqtt5_property_bag_clear(&test_resp_property_bag), AZ_OK);
+  az_mqtt5_property_bag_clear(&test_resp_property_bag);
 }
 
 static void test_az_mqtt5_rpc_client_recv_response_no_payload_failure(void** state)
@@ -751,7 +758,7 @@ static void test_az_mqtt5_rpc_client_recv_response_no_payload_failure(void** sta
 
   assert_int_equal(ref_rpc_err_rsp, 1);
 
-  assert_int_equal(az_mqtt5_property_bag_clear(&test_resp_property_bag), AZ_OK);
+  az_mqtt5_property_bag_clear(&test_resp_property_bag);
 }
 
 static void test_az_mqtt5_rpc_client_unsubscribe_begin_success(void** state)
@@ -837,7 +844,7 @@ static void test_az_mqtt5_rpc_client_recv_response_in_idle_success(void** state)
   assert_int_equal(ref_rpc_rsp, 1);
   assert_int_equal(ref_rpc_ready, 1);
 
-  assert_int_equal(az_mqtt5_property_bag_clear(&test_resp_property_bag), AZ_OK);
+  az_mqtt5_property_bag_clear(&test_resp_property_bag);
 
   // reset to idle
   ref_unsub_req = 0;
@@ -882,6 +889,10 @@ static void test_az_mqtt5_rpc_client_invoke_begin_faulted_failure(void** state)
       az_mqtt5_rpc_client_invoke_begin(&test_rpc_client, NULL), AZ_ERROR_HFSM_INVALID_STATE);
 
   assert_int_equal(ref_pub_req, 0);
+
+#if defined(TRANSPORT_PAHO)
+  MQTTAsync_destroy(&test_client);
+#endif // TRANSPORT_PAHO
 }
 
 int test_az_mqtt5_rpc_client()

--- a/sdk/tests/core/test_az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_server_hfsm.c
@@ -110,7 +110,7 @@ static az_result test_subclient_policy_1_root(az_event_policy* me, az_event even
   return AZ_OK;
 }
 
-static az_result test_mqtt_connection_callback(az_mqtt5_connection* client, az_event event, const void* event_callback_context)
+static az_result test_mqtt_connection_callback(az_mqtt5_connection* client, az_event event, void* event_callback_context)
 {
   (void)client;
   (void)event_callback_context;

--- a/sdk/tests/core/test_az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_server_hfsm.c
@@ -41,7 +41,11 @@ static az_mqtt5_rpc_server_codec test_rpc_server_codec;
 static az_mqtt5_rpc_server test_rpc_server;
 
 static az_mqtt5_property_bag test_property_bag;
-static mosquitto_property* test_mosq_prop = NULL;
+#ifdef TRANSPORT_MOSQUITTO
+mosquitto_property* test_prop = NULL;
+#else // TRANSPORT_PAHO
+static MQTTProperties test_prop = MQTTProperties_initializer;
+#endif // TRANSPORT_MOSQUITTO
 
 char subscription_topic_buffer[256];
 
@@ -162,9 +166,10 @@ static void test_az_mqtt5_rpc_server_init_success(void** state)
 
   mock_client_1.policy = (az_event_policy*)&mock_client_hfsm_1;
 
-  test_mosq_prop = NULL;
-  assert_int_equal(
-      az_mqtt5_property_bag_init(&test_property_bag, &mock_mqtt5, &test_mosq_prop), AZ_OK);
+#ifdef TRANSPORT_MOSQUITTO
+  test_prop = NULL;
+#endif // TRANSPORT_MOSQUITTO
+  assert_int_equal(az_mqtt5_property_bag_init(&test_property_bag, &mock_mqtt5, &test_prop), AZ_OK);
 
   az_mqtt5_rpc_server_codec_options test_server_codec_options
       = az_mqtt5_rpc_server_codec_options_default();
@@ -233,29 +238,33 @@ static void test_az_mqtt5_rpc_server_recv_request_success(void** state)
   ref_rpc_cmd_req = 0;
 
   az_mqtt5_property_bag test_req_property_bag;
-  mosquitto_property* test_req_mosq_prop = NULL;
+#ifdef TRANSPORT_MOSQUITTO
+  mosquitto_property* test_req_prop = NULL;
+#else // TRANSPORT_PAHO
+  MQTTProperties test_req_prop = MQTTProperties_initializer;
+#endif // TRANSPORT_MOSQUITTO
   assert_int_equal(
-      az_mqtt5_property_bag_init(&test_req_property_bag, &mock_mqtt5, &test_req_mosq_prop), AZ_OK);
+      az_mqtt5_property_bag_init(&test_req_property_bag, &mock_mqtt5, &test_req_prop), AZ_OK);
 
-  az_mqtt5_property_string content_type
-      = az_mqtt5_property_create_string(AZ_SPAN_FROM_STR(TEST_CONTENT_TYPE));
-  assert_int_equal(
-      az_mqtt5_property_bag_append_string(
-          &test_req_property_bag, AZ_MQTT5_PROPERTY_TYPE_CONTENT_TYPE, &content_type),
-      AZ_OK);
-
-  az_mqtt5_property_string response_topic
-      = az_mqtt5_property_create_string(AZ_SPAN_FROM_STR(TEST_RESPONSE_TOPIC));
   assert_int_equal(
       az_mqtt5_property_bag_append_string(
-          &test_req_property_bag, AZ_MQTT5_PROPERTY_TYPE_RESPONSE_TOPIC, &response_topic),
+          &test_req_property_bag,
+          AZ_MQTT5_PROPERTY_TYPE_CONTENT_TYPE,
+          AZ_SPAN_FROM_STR(TEST_CONTENT_TYPE)),
       AZ_OK);
 
-  az_mqtt5_property_binarydata correlation_data
-      = az_mqtt5_property_create_binarydata(AZ_SPAN_FROM_STR(TEST_CORRELATION_ID));
+  assert_int_equal(
+      az_mqtt5_property_bag_append_string(
+          &test_req_property_bag,
+          AZ_MQTT5_PROPERTY_TYPE_RESPONSE_TOPIC,
+          AZ_SPAN_FROM_STR(TEST_RESPONSE_TOPIC)),
+      AZ_OK);
+
   assert_int_equal(
       az_mqtt5_property_bag_append_binary(
-          &test_req_property_bag, AZ_MQTT5_PROPERTY_TYPE_CORRELATION_DATA, &correlation_data),
+          &test_req_property_bag,
+          AZ_MQTT5_PROPERTY_TYPE_CORRELATION_DATA,
+          AZ_SPAN_FROM_STR(TEST_CORRELATION_ID)),
       AZ_OK);
 
   az_mqtt5_recv_data test_req_data

--- a/sdk/tests/platform/test_az_mqtt5_policy.c
+++ b/sdk/tests/platform/test_az_mqtt5_policy.c
@@ -472,9 +472,11 @@ static void test_az_mqtt5_policy_outbound_pub_properties_success(void** state)
   assert_int_equal(ref_puback, 1);
   assert_true(ref_recv > 0);
 
-#ifdef TRANSPORT_MOSQUITTO
+#if defined(TRANSPORT_MOSQUITTO)
   mosquitto_property_free_all(&prop);
-#endif
+#elif defined(TRANSPORT_PAHO)
+  MQTTProperties_free(&prop);
+#endif // TRANSPORT_PAHO
 }
 
 static void test_az_mqtt5_policy_outbound_unsub_success(void** state)

--- a/sdk/tests/platform/test_az_mqtt5_policy.c
+++ b/sdk/tests/platform/test_az_mqtt5_policy.c
@@ -122,51 +122,38 @@ static az_result test_inbound_hfsm_root(az_event_policy* me, az_event event)
 
       if (expect_msg_properties != 0)
       {
-        az_mqtt5_property_string test_mqtt5_property_string = AZ_MQTT5_PROPERTY_STRING_EMPTY;
-        assert_int_equal(
-            az_mqtt5_property_bag_read_string(
-                test_recv_data->properties,
-                AZ_MQTT5_PROPERTY_TYPE_CONTENT_TYPE,
-                &test_mqtt5_property_string),
-            AZ_OK);
+        az_mqtt5_property_string test_mqtt5_property_string = az_mqtt5_property_bag_read_string(
+            test_recv_data->properties, AZ_MQTT5_PROPERTY_TYPE_CONTENT_TYPE);
         assert_true(az_span_is_content_equal(
             az_mqtt5_property_get_string(&test_mqtt5_property_string),
             AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_CONTENT_TYPE)));
-        az_mqtt5_property_free_string(&test_mqtt5_property_string);
+        az_mqtt5_property_read_free_string(&test_mqtt5_property_string);
 
         az_mqtt5_property_stringpair test_mqtt5_property_string_pair1
-            = AZ_MQTT5_PROPERTY_STRINGPAIR_EMPTY;
-        assert_int_equal(
-            az_mqtt5_property_bag_find_stringpair(
+            = az_mqtt5_property_bag_find_stringpair(
                 test_recv_data->properties,
                 AZ_MQTT5_PROPERTY_TYPE_USER_PROPERTY,
-                AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY1),
-                &test_mqtt5_property_string_pair1),
-            AZ_OK);
+                AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY1));
         assert_true(az_span_is_content_equal(
             az_mqtt5_property_stringpair_get_key(&test_mqtt5_property_string_pair1),
             AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY1)));
         assert_true(az_span_is_content_equal(
             az_mqtt5_property_stringpair_get_value(&test_mqtt5_property_string_pair1),
             AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_VALUE1)));
-        az_mqtt5_property_free_stringpair(&test_mqtt5_property_string_pair1);
+        az_mqtt5_property_read_free_stringpair(&test_mqtt5_property_string_pair1);
 
         az_mqtt5_property_stringpair test_mqtt5_property_string_pair2
-            = AZ_MQTT5_PROPERTY_STRINGPAIR_EMPTY;
-        assert_int_equal(
-            az_mqtt5_property_bag_find_stringpair(
+            = az_mqtt5_property_bag_find_stringpair(
                 test_recv_data->properties,
                 AZ_MQTT5_PROPERTY_TYPE_USER_PROPERTY,
-                AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY2),
-                &test_mqtt5_property_string_pair2),
-            AZ_OK);
+                AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY2));
         assert_true(az_span_is_content_equal(
             az_mqtt5_property_stringpair_get_key(&test_mqtt5_property_string_pair2),
             AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY2)));
         assert_true(az_span_is_content_equal(
             az_mqtt5_property_stringpair_get_value(&test_mqtt5_property_string_pair2),
             AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_VALUE2)));
-        az_mqtt5_property_free_stringpair(&test_mqtt5_property_string_pair2);
+        az_mqtt5_property_read_free_stringpair(&test_mqtt5_property_string_pair2);
 
         uint32_t test_mqtt5_property_int_32;
         assert_int_equal(
@@ -187,47 +174,46 @@ static az_result test_inbound_hfsm_root(az_event_policy* me, az_event event)
         assert_int_equal(test_mqtt5_property_int_8, TEST_MQTT_PROPERTY_PAYLOAD_FORMAT_INDICATOR);
 
         az_mqtt5_property_binarydata test_mqtt5_property_binary_data
-            = AZ_MQTT5_PROPERTY_BINARYDATA_EMPTY;
-        assert_int_equal(
-            az_mqtt5_property_bag_read_binarydata(
-                test_recv_data->properties,
-                AZ_MQTT5_PROPERTY_TYPE_CORRELATION_DATA,
-                &test_mqtt5_property_binary_data),
-            AZ_OK);
+            = az_mqtt5_property_bag_read_binarydata(
+                test_recv_data->properties, AZ_MQTT5_PROPERTY_TYPE_CORRELATION_DATA);
         assert_true(az_span_is_content_equal(
-            test_mqtt5_property_binary_data.bindata,
+            az_mqtt5_property_get_binarydata(&test_mqtt5_property_binary_data),
             AZ_SPAN_FROM_BUFFER(TEST_MQTT_PROPERTY_CORRELATION_DATA)));
-        az_mqtt5_property_free_binarydata(&test_mqtt5_property_binary_data);
+        az_mqtt5_property_read_free_binarydata(&test_mqtt5_property_binary_data);
       }
       else
       {
-        az_mqtt5_property_string test_mqtt5_property_string = AZ_MQTT5_PROPERTY_STRING_EMPTY;
-        assert_int_equal(
-            az_mqtt5_property_bag_read_string(
-                test_recv_data->properties,
-                AZ_MQTT5_PROPERTY_TYPE_CONTENT_TYPE,
-                &test_mqtt5_property_string),
-            AZ_ERROR_ITEM_NOT_FOUND);
+        az_mqtt5_property_string test_mqtt5_property_string = az_mqtt5_property_bag_read_string(
+            test_recv_data->properties, AZ_MQTT5_PROPERTY_TYPE_CONTENT_TYPE);
+        assert_true(az_span_is_content_equal(
+            az_mqtt5_property_get_string(&test_mqtt5_property_string), AZ_SPAN_EMPTY));
+        az_mqtt5_property_read_free_string(&test_mqtt5_property_string);
 
         az_mqtt5_property_stringpair test_mqtt5_property_string_pair1
-            = AZ_MQTT5_PROPERTY_STRINGPAIR_EMPTY;
-        assert_int_equal(
-            az_mqtt5_property_bag_find_stringpair(
+            = az_mqtt5_property_bag_find_stringpair(
                 test_recv_data->properties,
                 AZ_MQTT5_PROPERTY_TYPE_USER_PROPERTY,
-                AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY1),
-                &test_mqtt5_property_string_pair1),
-            AZ_ERROR_ITEM_NOT_FOUND);
+                AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY1));
+        assert_true(az_span_is_content_equal(
+            az_mqtt5_property_stringpair_get_key(&test_mqtt5_property_string_pair1),
+            AZ_SPAN_EMPTY));
+        assert_true(az_span_is_content_equal(
+            az_mqtt5_property_stringpair_get_value(&test_mqtt5_property_string_pair1),
+            AZ_SPAN_EMPTY));
+        az_mqtt5_property_read_free_stringpair(&test_mqtt5_property_string_pair1);
 
         az_mqtt5_property_stringpair test_mqtt5_property_string_pair2
-            = AZ_MQTT5_PROPERTY_STRINGPAIR_EMPTY;
-        assert_int_equal(
-            az_mqtt5_property_bag_find_stringpair(
+            = az_mqtt5_property_bag_find_stringpair(
                 test_recv_data->properties,
                 AZ_MQTT5_PROPERTY_TYPE_USER_PROPERTY,
-                AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY2),
-                &test_mqtt5_property_string_pair2),
-            AZ_ERROR_ITEM_NOT_FOUND);
+                AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY2));
+        assert_true(az_span_is_content_equal(
+            az_mqtt5_property_stringpair_get_key(&test_mqtt5_property_string_pair2),
+            AZ_SPAN_EMPTY));
+        assert_true(az_span_is_content_equal(
+            az_mqtt5_property_stringpair_get_value(&test_mqtt5_property_string_pair2),
+            AZ_SPAN_EMPTY));
+        az_mqtt5_property_read_free_stringpair(&test_mqtt5_property_string_pair2);
 
         uint32_t test_mqtt5_property_int_32;
         assert_int_equal(
@@ -246,13 +232,11 @@ static az_result test_inbound_hfsm_root(az_event_policy* me, az_event event)
             AZ_ERROR_ITEM_NOT_FOUND);
 
         az_mqtt5_property_binarydata test_mqtt5_property_binary_data
-            = AZ_MQTT5_PROPERTY_BINARYDATA_EMPTY;
-        assert_int_equal(
-            az_mqtt5_property_bag_read_binarydata(
-                test_recv_data->properties,
-                AZ_MQTT5_PROPERTY_TYPE_CORRELATION_DATA,
-                &test_mqtt5_property_binary_data),
-            AZ_ERROR_ITEM_NOT_FOUND);
+            = az_mqtt5_property_bag_read_binarydata(
+                test_recv_data->properties, AZ_MQTT5_PROPERTY_TYPE_CORRELATION_DATA);
+        assert_true(az_span_is_content_equal(
+            az_mqtt5_property_get_binarydata(&test_mqtt5_property_binary_data), AZ_SPAN_EMPTY));
+        az_mqtt5_property_read_free_binarydata(&test_mqtt5_property_binary_data);
       }
 
       break;
@@ -415,18 +399,17 @@ static void test_az_mqtt5_policy_outbound_pub_properties_success(void** state)
 #endif
 
   az_mqtt5_property_bag test_mqtt5_property_bag;
-  az_mqtt5_property_string test_mqtt5_property_string
-      = az_mqtt5_property_create_string(AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_CONTENT_TYPE));
-  az_mqtt5_property_stringpair test_mqtt5_property_string_pair1
-      = az_mqtt5_property_create_stringpair(
-          AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY1),
-          AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_VALUE1));
-  az_mqtt5_property_stringpair test_mqtt5_property_string_pair2
-      = az_mqtt5_property_create_stringpair(
-          AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY2),
-          AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_VALUE2));
-  az_mqtt5_property_binarydata test_mqtt5_property_binary_data
-      = { .bindata = AZ_SPAN_FROM_BUFFER(TEST_MQTT_PROPERTY_CORRELATION_DATA) };
+  az_span test_mqtt5_property_string = AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_CONTENT_TYPE);
+  az_span test_mqtt5_property_stringpair1_key
+      = AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY1);
+  az_span test_mqtt5_property_stringpair1_value
+      = AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_VALUE1);
+  az_span test_mqtt5_property_stringpair2_key
+      = AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_KEY2);
+  az_span test_mqtt5_property_stringpair2_value
+      = AZ_SPAN_FROM_STR(TEST_MQTT_PROPERTY_STRING_PAIR_VALUE2);
+  az_span test_mqtt5_property_binary_data
+      = AZ_SPAN_FROM_BUFFER(TEST_MQTT_PROPERTY_CORRELATION_DATA);
 
   assert_int_equal(
       az_mqtt5_property_bag_init(&test_mqtt5_property_bag, &test_mqtt5_client, &prop), AZ_OK);
@@ -434,19 +417,21 @@ static void test_az_mqtt5_policy_outbound_pub_properties_success(void** state)
       az_mqtt5_property_bag_append_string(
           &test_mqtt5_property_bag,
           AZ_MQTT5_PROPERTY_TYPE_CONTENT_TYPE,
-          &test_mqtt5_property_string),
+          test_mqtt5_property_string),
       AZ_OK);
   assert_int_equal(
       az_mqtt5_property_bag_append_stringpair(
           &test_mqtt5_property_bag,
           AZ_MQTT5_PROPERTY_TYPE_USER_PROPERTY,
-          &test_mqtt5_property_string_pair1),
+          test_mqtt5_property_stringpair1_key,
+          test_mqtt5_property_stringpair1_value),
       AZ_OK);
   assert_int_equal(
       az_mqtt5_property_bag_append_stringpair(
           &test_mqtt5_property_bag,
           AZ_MQTT5_PROPERTY_TYPE_USER_PROPERTY,
-          &test_mqtt5_property_string_pair2),
+          test_mqtt5_property_stringpair2_key,
+          test_mqtt5_property_stringpair2_value),
       AZ_OK);
   assert_int_equal(
       az_mqtt5_property_bag_append_int(
@@ -464,7 +449,7 @@ static void test_az_mqtt5_policy_outbound_pub_properties_success(void** state)
       az_mqtt5_property_bag_append_binary(
           &test_mqtt5_property_bag,
           AZ_MQTT5_PROPERTY_TYPE_CORRELATION_DATA,
-          &test_mqtt5_property_binary_data),
+          test_mqtt5_property_binary_data),
       AZ_OK);
 
   az_mqtt5_pub_data test_mqtt5_pub_data = {


### PR DESCRIPTION
In this PR:
- Integration of Paho Async C with the RPC code. 
- Two new samples for Paho RPC.
- Re-work of MQTT property read and free. 

NOTE: Added topic filter to received topic matching function using az_span. This is temporary.