### PR TITLE
Add context to az_mqtt5_connection_callback + additional fixes

### DIFF
--- a/sdk/inc/azure/core/az_mqtt5_connection.h
+++ b/sdk/inc/azure/core/az_mqtt5_connection.h
@@ -64,7 +64,7 @@ enum az_event_type_mqtt5_connection
  * @brief Callback for MQTT 5 connection events.
  *
  */
-typedef az_result (*az_mqtt5_connection_callback)(az_mqtt5_connection* client, az_event event);
+typedef az_result (*az_mqtt5_connection_callback)(az_mqtt5_connection* client, az_event event, const void* event_callback_context);
 
 /**
  * @brief MQTT 5 connection options.
@@ -155,6 +155,12 @@ struct az_mqtt5_connection
     az_mqtt5_connection_callback event_callback;
 
     /**
+     * @brief Context for MQTT 5 connection events callback.
+     *
+     */
+    const void* event_callback_context;
+
+    /**
      * @brief Options for the MQTT 5 connection.
      *
      */
@@ -183,7 +189,8 @@ AZ_NODISCARD az_result az_mqtt5_connection_init(
     az_context* context,
     az_mqtt5* mqtt_client,
     az_mqtt5_connection_callback event_callback,
-    az_mqtt5_connection_options* options);
+    az_mqtt5_connection_options* options,
+    const void* event_callback_context);
 
 /**
  * @brief Opens the connection to the broker.
@@ -222,7 +229,7 @@ AZ_INLINE az_result _az_mqtt5_connection_api_callback(az_mqtt5_connection* clien
 {
   if (client->_internal.event_callback != NULL)
   {
-    _az_RETURN_IF_FAILED(client->_internal.event_callback(client, event));
+    _az_RETURN_IF_FAILED(client->_internal.event_callback(client, event, client->_internal.event_callback_context));
   }
 
   return AZ_OK;

--- a/sdk/inc/azure/core/az_mqtt5_connection.h
+++ b/sdk/inc/azure/core/az_mqtt5_connection.h
@@ -182,6 +182,7 @@ AZ_NODISCARD az_mqtt5_connection_options az_mqtt5_connection_options_default();
  * @param mqtt_client MQTT 5 client to be used by the MQTT connection.
  * @param event_callback Callback for MQTT 5 connection events.
  * @param options MQTT 5 connection options.
+ * @param event_callback_context User-defined context for event_callback.
  * @return An #az_result value indicating the result of the operation.
  */
 AZ_NODISCARD az_result az_mqtt5_connection_init(

--- a/sdk/inc/azure/core/az_mqtt5_rpc.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc.h
@@ -20,6 +20,8 @@
 
 #include <azure/core/_az_cfg_prefix.h>
 
+#include "mosquitto.h"
+
 /**
  * @brief The default timeout in seconds for subscribing/publishing.
  */

--- a/sdk/inc/azure/core/az_mqtt5_rpc.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc.h
@@ -20,8 +20,6 @@
 
 #include <azure/core/_az_cfg_prefix.h>
 
-#include "mosquitto.h"
-
 /**
  * @brief The default timeout in seconds for subscribing/publishing.
  */

--- a/sdk/samples/core/mosquitto_multiple_rpc_sample.c
+++ b/sdk/samples/core/mosquitto_multiple_rpc_sample.c
@@ -78,7 +78,7 @@ az_result check_for_commands_to_execute();
 az_result copy_execution_event_data(
     az_mqtt5_rpc_server_execution_req_event_data* destination,
     az_mqtt5_rpc_server_execution_req_event_data source);
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event);
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, const void* callback_context);
 void handle_response(az_span response_payload);
 az_result invoke_stop_module();
 az_result invoke_start_module();
@@ -252,9 +252,10 @@ void handle_response(az_span response_payload)
  * @brief MQTT client callback function for all clients
  * @note If you add other clients, you can add handling for their events here
  */
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event)
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, const void* callback_context)
 {
   (void)client;
+  (void)callback_context;
   az_app_log_callback(event.type, AZ_SPAN_FROM_STR("APP/callback"));
   switch (event.type)
   {
@@ -501,7 +502,7 @@ int main(int argc, char* argv[])
   connection_options.client_certificates[0] = primary_credential;
 
   LOG_AND_EXIT_IF_FAILED(az_mqtt5_connection_init(
-      &mqtt_connection, &connection_context, &mqtt5, mqtt_callback, &connection_options));
+      &mqtt_connection, &connection_context, &mqtt5, mqtt_callback, &connection_options, NULL));
 
   LOG_AND_EXIT_IF_FAILED(az_platform_mutex_init(&pending_server_command_mutex));
 

--- a/sdk/samples/core/mosquitto_rpc_client_sample.c
+++ b/sdk/samples/core/mosquitto_rpc_client_sample.c
@@ -54,7 +54,7 @@ static az_mqtt5_rpc_client_codec rpc_client_codec;
 
 volatile bool sample_finished = false;
 
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event);
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, const void* callback_context);
 void handle_response(az_span response_payload);
 az_result invoke_begin(az_span invoke_command_name, az_span payload);
 void remove_expired_commands();
@@ -76,9 +76,10 @@ void handle_response(az_span response_payload)
  * @brief MQTT client callback function for all clients
  * @note If you add other clients, you can add handling for their events here
  */
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event)
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, const void* callback_context)
 {
   (void)client;
+  (void)callback_context;
   az_app_log_callback(event.type, AZ_SPAN_FROM_STR("APP/callback"));
   switch (event.type)
   {
@@ -260,7 +261,7 @@ int main(int argc, char* argv[])
   connection_options.client_certificates[0] = primary_credential;
 
   LOG_AND_EXIT_IF_FAILED(az_mqtt5_connection_init(
-      &mqtt_connection, &connection_context, &mqtt5, mqtt_callback, &connection_options));
+      &mqtt_connection, &connection_context, &mqtt5, mqtt_callback, &connection_options, NULL));
 
   az_mqtt5_property_bag property_bag;
   mosquitto_property* mosq_prop = NULL;

--- a/sdk/samples/core/mosquitto_rpc_server_sample.c
+++ b/sdk/samples/core/mosquitto_rpc_server_sample.c
@@ -59,7 +59,7 @@ az_result check_for_commands();
 az_result copy_execution_event_data(
     az_mqtt5_rpc_server_execution_req_event_data* destination,
     az_mqtt5_rpc_server_execution_req_event_data source);
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event);
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, const void* callback_context);
 
 void az_platform_critical_error()
 {
@@ -236,9 +236,10 @@ az_result copy_execution_event_data(
  * @brief MQTT client callback function for all clients
  * @note If you add other clients, you can add handling for their events here
  */
-az_result mqtt_callback(az_mqtt5_connection* client, az_event event)
+az_result mqtt_callback(az_mqtt5_connection* client, az_event event, const void* callback_context)
 {
   (void)client;
+  (void)callback_context;
   az_app_log_callback(event.type, AZ_SPAN_FROM_STR("APP/callback"));
   switch (event.type)
   {
@@ -350,7 +351,7 @@ int main(int argc, char* argv[])
   connection_options.client_certificates[0] = primary_credential;
 
   LOG_AND_EXIT_IF_FAILED(az_mqtt5_connection_init(
-      &mqtt_connection, &connection_context, &mqtt5, mqtt_callback, &connection_options));
+      &mqtt_connection, &connection_context, &mqtt5, mqtt_callback, &connection_options, NULL));
 
   LOG_AND_EXIT_IF_FAILED(az_platform_mutex_init(&pending_command_mutex));
 

--- a/sdk/src/azure/core/az_mqtt5_connection.c
+++ b/sdk/src/azure/core/az_mqtt5_connection.c
@@ -28,7 +28,8 @@ AZ_NODISCARD az_result az_mqtt5_connection_init(
     az_context* context,
     az_mqtt5* mqtt_client,
     az_mqtt5_connection_callback event_callback,
-    az_mqtt5_connection_options* options)
+    az_mqtt5_connection_options* options,
+    const void* event_callback_context)
 {
   _az_PRECONDITION_NOT_NULL(client);
   _az_PRECONDITION_NOT_NULL(mqtt_client);
@@ -36,6 +37,7 @@ AZ_NODISCARD az_result az_mqtt5_connection_init(
 
   client->_internal.options = options == NULL ? az_mqtt5_connection_options_default() : *options;
   client->_internal.event_callback = event_callback;
+  client->_internal.event_callback_context = event_callback_context;
 
   if (!client->_internal.options.disable_sdk_connection_management)
   {

--- a/sdk/src/azure/core/az_mqtt5_rpc_client_hfsm.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_client_hfsm.c
@@ -583,6 +583,11 @@ static az_result ready(az_event_policy* me, az_event event)
         .properties = &this_policy->_internal.property_bag,
       };
 
+      if (az_span_size(this_policy->_internal.pending_pub_correlation_id) < az_span_size(event_data->correlation_id))
+      {
+        return AZ_ERROR_NOT_ENOUGH_SPACE;
+      }
+
       az_span_copy(this_policy->_internal.pending_pub_correlation_id, event_data->correlation_id);
       _az_RETURN_IF_FAILED(_az_hfsm_transition_substate((_az_hfsm*)me, ready, publishing));
       // send publish

--- a/sdk/tests/core/test_az_mqtt5_connection.c
+++ b/sdk/tests/core/test_az_mqtt5_connection.c
@@ -107,9 +107,10 @@ static az_result test_subclient_policy_2_root(az_event_policy* me, az_event even
   return AZ_OK;
 }
 
-static az_result test_mqtt_connection_callback(az_mqtt5_connection* client, az_event event)
+static az_result test_mqtt_connection_callback(az_mqtt5_connection* client, az_event event, const void* callback_context)
 {
   (void)client;
+  (void)callback_context;
   switch (event.type)
   {
     case AZ_MQTT5_EVENT_CONNECT_RSP:
@@ -157,7 +158,8 @@ static void test_az_mqtt5_connection_disabled_init_success(void** state)
           NULL,
           &mock_mqtt_disabled,
           test_mqtt_connection_callback,
-          &test_disabled_connection_options),
+          &test_disabled_connection_options,
+          NULL),
       AZ_OK);
 }
 
@@ -186,7 +188,8 @@ static void test_az_mqtt5_connection_enabled_init_success(void** state)
           NULL,
           &mock_mqtt5,
           test_mqtt_connection_callback,
-          &test_connection_options),
+          &test_connection_options,
+          NULL),
       AZ_OK);
 
   assert_int_equal(

--- a/sdk/tests/core/test_az_mqtt5_rpc_client_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_client_hfsm.c
@@ -126,9 +126,10 @@ static az_result test_subclient_policy_1_root(az_event_policy* me, az_event even
   return AZ_OK;
 }
 
-static az_result test_mqtt_connection_callback(az_mqtt5_connection* client, az_event event)
+static az_result test_mqtt_connection_callback(az_mqtt5_connection* client, az_event event, const void* event_callback_context)
 {
   (void)client;
+  (void)event_callback_context;
   switch (event.type)
   {
     case AZ_MQTT5_EVENT_SUBACK_RSP:
@@ -171,7 +172,8 @@ static void test_az_mqtt5_rpc_client_init_success(void** state)
           NULL,
           &mock_mqtt5,
           test_mqtt_connection_callback,
-          &mock_connection_options),
+          &mock_connection_options,
+          NULL),
       AZ_OK);
 
   // mock client policy so we can check what events are being sent

--- a/sdk/tests/core/test_az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_server_hfsm.c
@@ -105,9 +105,10 @@ static az_result test_subclient_policy_1_root(az_event_policy* me, az_event even
   return AZ_OK;
 }
 
-static az_result test_mqtt_connection_callback(az_mqtt5_connection* client, az_event event)
+static az_result test_mqtt_connection_callback(az_mqtt5_connection* client, az_event event, const void* event_callback_context)
 {
   (void)client;
+  (void)event_callback_context;
   switch (event.type)
   {
     case AZ_MQTT5_EVENT_SUBACK_RSP:
@@ -145,7 +146,8 @@ static void test_az_mqtt5_rpc_server_init_success(void** state)
           NULL,
           &mock_mqtt5,
           test_mqtt_connection_callback,
-          &mock_connection_options),
+          &mock_connection_options,
+          NULL),
       AZ_OK);
 
   // mock client policy so we can check what events are being sent


### PR DESCRIPTION
- Added an user-defined context to az_mqtt5_connection_callback
- Added check for available memory size before copying correlation_id in az_mqtt5_rpc_client_hfsm.c
- Added missing reference to mosquitto.h in az_mqtt5_rpc.h 