### PR TITLE
[RPC Server] fix segfault on incoming publish with missing properties

### DIFF
--- a/sdk/inc/azure/core/az_event_policy.h
+++ b/sdk/inc/azure/core/az_event_policy.h
@@ -78,7 +78,7 @@ az_event_policy_send_inbound_event(az_event_policy* policy, az_event const event
   {
     // Replace the original event with an error event that is flowed to the application.
     ret = inbound->inbound_handler(
-        policy,
+        inbound,
         (az_event){ AZ_HFSM_EVENT_ERROR,
                     &(az_hfsm_event_data_error){
                         .error_type = ret,

--- a/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
@@ -59,9 +59,20 @@ static az_result root(az_event_policy* me, az_event event)
 
     case AZ_HFSM_EVENT_ERROR:
     {
-      if (az_result_failed(az_event_policy_send_inbound_event(me, event)))
+      az_mqtt5_rpc_server* this_policy = (az_mqtt5_rpc_server*)me;
+      if ((az_event_policy*)me->inbound_policy != NULL)
       {
-        az_platform_critical_error();
+        if (az_result_failed(az_event_policy_send_inbound_event(me, event)))
+        {
+          az_platform_critical_error();
+        }
+      }
+      else
+      {
+        if (az_result_failed(_az_mqtt5_connection_api_callback(this_policy->_internal.connection, event)))
+        {
+          az_platform_critical_error();
+        }
       }
       break;
     }

--- a/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
@@ -337,7 +337,13 @@ static az_result waiting(az_event_policy* me, az_event event)
         }
 
         // parse the request details and send it to the application for execution
-        _az_RETURN_IF_FAILED(_handle_request(this_policy, recv_data));
+        if (az_result_failed(_handle_request(this_policy, recv_data)))
+        {
+          if (_az_LOG_SHOULD_WRITE(AZ_HFSM_EVENT_ERROR))
+          {
+            _az_LOG_WRITE(AZ_HFSM_EVENT_ERROR, AZ_SPAN_FROM_STR("az_rpc_server/waiting Error handling incoming publish - missing required property"));
+          }
+        }
       }
       break;
     }

--- a/sdk/tests/core/test_az_event_pipeline.c
+++ b/sdk/tests/core/test_az_event_pipeline.c
@@ -62,6 +62,7 @@ static int send_inbound_0 = 0;
 static int send_inbound_1 = 0;
 static int send_inbound_2 = 0;
 static int send_inbound_3 = 0;
+static int send_inbound_4 = 0;
 static int send_outbound_0 = 0;
 static int send_outbound_1 = 0;
 static int send_inbound_error_0 = 0;
@@ -109,23 +110,6 @@ static az_result policy_01_root(az_event_policy* me, az_event event)
       ret = az_event_policy_send_inbound_event((az_event_policy*)me, send_inbound_error_evt);
       break;
 
-    case AZ_HFSM_EVENT_ERROR:
-      _az_PRECONDITION_NOT_NULL(event.data);
-      az_hfsm_event_data_error* test_error = (az_hfsm_event_data_error*)event.data;
-      if (test_error->error_type == AZ_ERROR_ARG)
-      {
-        timeout_1++;
-      }
-      else if (test_error->error_type == AZ_ERROR_CANCELED)
-      {
-        send_inbound_error_0++;
-      }
-      else
-      {
-        ret = AZ_ERROR_NOT_IMPLEMENTED;
-      }
-      break;
-
     default:
       ret = AZ_HFSM_RETURN_HANDLE_BY_SUPERSTATE;
       break;
@@ -165,6 +149,24 @@ static az_result policy_02_root(az_event_policy* me, az_event event)
     case SEND_INBOUND_ERROR:
       send_inbound_error_0++;
       ret = AZ_ERROR_CANCELED;
+      break;
+
+    case AZ_HFSM_EVENT_ERROR:
+      _az_PRECONDITION_NOT_NULL(event.data);
+      az_hfsm_event_data_error* test_error = (az_hfsm_event_data_error*)event.data;
+      if (test_error->error_type == AZ_ERROR_ARG)
+      {
+        send_inbound_4++;
+      }
+      else if (test_error->error_type == AZ_ERROR_CANCELED)
+      {
+        send_inbound_error_0++;
+      }
+
+      else
+      {
+        ret = AZ_ERROR_NOT_IMPLEMENTED;
+      }
       break;
 
     default:
@@ -326,11 +328,13 @@ static void test_az_event_pipeline_send_inbound_failure(void** state)
   (void)state;
   send_inbound_2 = 0;
   send_inbound_3 = 0;
+  send_inbound_4 = 0;
 
   assert_int_equal(
       _az_event_pipeline_post_outbound_event(&az_event_pipeline_test, send_inbound_2_evt), AZ_OK);
   assert_true(send_inbound_2 == 1);
   assert_true(send_inbound_3 == 1);
+  assert_true(send_inbound_4 == 1);
 }
 
 static void test_az_event_pipeline_send_inbound_failure_2(void** state)


### PR DESCRIPTION
Problem: On an incoming RPC execution request, if the required MQTT5 properties are missing, an error is sent back to the MQTT client, causing a seg fault

Fix: Instead of sending this error to the MQTT client, which can't do anything about the problem, instead just log and ignore the publish