### PR TITLE
Telemetry codec

### DIFF
--- a/sdk/inc/azure/core/az_mqtt5_rpc.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc.h
@@ -26,14 +26,14 @@
  */
 #define AZ_MQTT5_RPC_DEFAULT_REQUEST_TOPIC_FORMAT                                     \
   "services/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_KEY "/" _az_MQTT5_RPC_EXECUTOR_ID_KEY \
-  "/command/" _az_MQTT5_TOPIC_PARSER_COMMAND_ID_KEY "/request"
+  "/command/" _az_MQTT5_TOPIC_PARSER_NAME_KEY "/request"
 /**
  * @brief The default topic format where RPC responses are published.
  */
 #define AZ_MQTT5_RPC_DEFAULT_RESPONSE_TOPIC_FORMAT                                     \
   "clients/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_KEY                                      \
   "/services/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_KEY "/" _az_MQTT5_RPC_EXECUTOR_ID_KEY \
-  "/command/" _az_MQTT5_TOPIC_PARSER_COMMAND_ID_KEY "/response"
+  "/command/" _az_MQTT5_TOPIC_PARSER_NAME_KEY "/response"
 
 /**
  * @brief The default timeout in seconds for subscribing/publishing.

--- a/sdk/inc/azure/core/az_mqtt5_rpc.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc.h
@@ -24,16 +24,16 @@
 /**
  * @brief The default topic format for making RPC requests.
  */
-#define AZ_MQTT5_RPC_DEFAULT_REQUEST_TOPIC_FORMAT                                     \
-  "services/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_KEY "/" _az_MQTT5_RPC_EXECUTOR_ID_KEY \
-  "/command/" _az_MQTT5_TOPIC_PARSER_NAME_KEY "/request"
+#define AZ_MQTT5_RPC_DEFAULT_REQUEST_TOPIC_FORMAT                                         \
+  "services/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN \
+  "/command/" _az_MQTT5_TOPIC_PARSER_NAME_TOKEN "/request"
 /**
  * @brief The default topic format where RPC responses are published.
  */
-#define AZ_MQTT5_RPC_DEFAULT_RESPONSE_TOPIC_FORMAT                                     \
-  "clients/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_KEY                                      \
-  "/services/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_KEY "/" _az_MQTT5_RPC_EXECUTOR_ID_KEY \
-  "/command/" _az_MQTT5_TOPIC_PARSER_NAME_KEY "/response"
+#define AZ_MQTT5_RPC_DEFAULT_RESPONSE_TOPIC_FORMAT                                         \
+  "clients/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN                                        \
+  "/services/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN \
+  "/command/" _az_MQTT5_TOPIC_PARSER_NAME_TOKEN "/response"
 
 /**
  * @brief The default timeout in seconds for subscribing/publishing.

--- a/sdk/inc/azure/core/az_mqtt5_rpc_server_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc_server_codec.h
@@ -95,8 +95,6 @@ AZ_NODISCARD az_mqtt5_rpc_server_codec_options az_mqtt5_rpc_server_codec_options
  * @brief Generates the subscription topic for the RPC Server Codec.
  *
  * @param[in] server The #az_mqtt5_rpc_server_codec to use.
- * @param[in] service_group_id The service group id to use for the subscription topic. May be
- * AZ_SPAN_EMPTY if not using a shared subscription topic.
  * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic filter. If
  * successful, contains a null-terminated string with the topic filter that needs to be passed to
  * the MQTT client.
@@ -113,7 +111,6 @@ AZ_NODISCARD az_mqtt5_rpc_server_codec_options az_mqtt5_rpc_server_codec_options
  */
 AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_get_subscribe_topic(
     az_mqtt5_rpc_server_codec* server,
-    az_span service_group_id,
     char* mqtt_topic,
     size_t mqtt_topic_size,
     size_t* out_mqtt_topic_length);

--- a/sdk/inc/azure/core/az_mqtt5_rpc_server_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc_server_codec.h
@@ -103,7 +103,7 @@ AZ_NODISCARD az_mqtt5_rpc_server_codec_options az_mqtt5_rpc_server_codec_options
  * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
  * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of \p
  * mqtt_topic. Can be `NULL`.
- * @pre \p client must not be `NULL`.
+ * @pre \p server must not be `NULL`.
  * @pre \p mqtt_topic must not be `NULL`.
  * @pre \p mqtt_topic_size must be greater than 0.
  *
@@ -145,7 +145,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_parse_received_topic(
  * used in the subscription topic.
  * @param[in] options Any #az_mqtt5_rpc_server_codec_options to use for the RPC Server or NULL to
  * use the defaults.
- * @pre \p client must not be `NULL`.
+ * @pre \p server must not be `NULL`.
  *
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The client was initialized successfully.

--- a/sdk/inc/azure/core/az_mqtt5_telemetry.h
+++ b/sdk/inc/azure/core/az_mqtt5_telemetry.h
@@ -21,8 +21,8 @@
  * @brief MQTT5 Telemetry default topic format.
  *
  */
-#define AZ_MQTT5_TELEMETRY_DEFAULT_TOPIC_FORMAT                                              \
-  "services/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_KEY "/" _az_MQTT5_TOPIC_PARSER_SENDER_ID_KEY \
+#define AZ_MQTT5_TELEMETRY_DEFAULT_TOPIC_FORMAT                                                  \
+  "services/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN \
   "/telemetry"
 
 #include <azure/core/_az_cfg_suffix.h>

--- a/sdk/inc/azure/core/az_mqtt5_telemetry.h
+++ b/sdk/inc/azure/core/az_mqtt5_telemetry.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @brief Common include for az_mqtt5_telemetry consumer and producer.
+ *
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * prefixed with an underscore ('_') directly in your application code. These symbols
+ * are part of Azure SDK's internal implementation; we do not document these symbols
+ * and they are subject to change in future versions of the SDK which would break your code.
+ */
+
+#ifndef _az_MQTT5_TELEMETRY_H
+#define _az_MQTT5_TELEMETRY_H
+
+#include <azure/core/internal/az_mqtt5_topic_parser_internal.h>
+
+#include <azure/core/_az_cfg_prefix.h>
+
+/**
+ * @brief MQTT5 Telemetry default topic format.
+ *
+ */
+#define AZ_MQTT5_TELEMETRY_DEFAULT_TOPIC_FORMAT                                              \
+  "services/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_KEY "/" _az_MQTT5_TOPIC_PARSER_SENDER_ID_KEY \
+  "/telemetry"
+
+#include <azure/core/_az_cfg_suffix.h>
+
+#endif // _az_MQTT5_TELEMETRY_H

--- a/sdk/inc/azure/core/az_mqtt5_telemetry_consumer_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_telemetry_consumer_codec.h
@@ -27,6 +27,13 @@
 typedef struct
 {
   /**
+   * @brief The service group id to use for the subscription topic, specifying this allows the
+   * telemetry consumer to subscribe to a shared subscription topic. It can be AZ_SPAN_EMPTY if not
+   * using a shared subscription topic.
+   */
+  az_span service_group_id;
+
+  /**
    * @brief The topic format to use for the subscription topic to receive telemetry.
    *
    * @note Can include {name} for telemetry name, {serviceId} for model id, and/or {senderId} for
@@ -88,8 +95,6 @@ az_mqtt5_telemetry_consumer_codec_options_default();
  * @brief Generates the subscription topic to receive telemetry for the telemetry consumer.
  *
  * @param[in] consumer The #az_mqtt5_telemetry_consumer_codec to use.
- * @param[in] service_group_id The service group id to use for the subscription topic. May be
- * AZ_SPAN_EMPTY if not using a shared subscription topic.
  * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic filter. If
  * successful, contains a null-terminated string with the topic filter that needs to be passed to
  * the MQTT client.
@@ -106,7 +111,6 @@ az_mqtt5_telemetry_consumer_codec_options_default();
  */
 AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
     az_mqtt5_telemetry_consumer_codec* consumer,
-    az_span service_group_id,
     char* mqtt_topic,
     size_t mqtt_topic_size,
     size_t* out_mqtt_topic_length);

--- a/sdk/inc/azure/core/az_mqtt5_telemetry_consumer_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_telemetry_consumer_codec.h
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file
+ *
+ * @brief Definition of #az_mqtt5_telemetry_consumer_codec.
+ *
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * prefixed with an underscore ('_') directly in your application code. These symbols
+ * are part of Azure SDK's internal implementation; we do not document these symbols
+ * and they are subject to change in future versions of the SDK which would break your code.
+ */
+
+#ifndef _az_MQTT5_TELEMETRY_CONSUMER_CODEC_H
+#define _az_MQTT5_TELEMETRY_CONSUMER_CODEC_H
+
+#include <azure/core/az_result.h>
+#include <azure/core/az_span.h>
+
+#include <azure/core/_az_cfg_prefix.h>
+
+/**
+ * @brief MQTT5 Telemetry Consumer Codec options.
+ *
+ */
+typedef struct
+{
+  /**
+   * @brief The topic format to use for the subscription topic to receive telemetry.
+   *
+   * @note Can include {name} for telemetry name, {serviceId} for model id, and/or {senderId} for
+   * the sender's client_id. The default value is services/{serviceId}/{senderId}/telemetry.
+   *
+   * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
+   * topic.
+   *
+   */
+  az_span telemetry_topic_format;
+} az_mqtt5_telemetry_consumer_codec_options;
+
+/**
+ * @brief MQTT5 Telemetry Consumer Codec.
+ *
+ */
+typedef struct
+{
+  struct
+  {
+    az_span model_id;
+    az_span sender_id;
+
+    az_mqtt5_telemetry_consumer_codec_options options;
+  } _internal;
+} az_mqtt5_telemetry_consumer_codec;
+
+/**
+ * @brief Represents the parsed data from telemetry.
+ */
+typedef struct
+{
+  /**
+   * @brief The model id of the telemetry.
+   */
+  az_span service_id;
+
+  /**
+   * @brief The id of the sender of the telemetry.
+   *
+   */
+  az_span sender_id;
+
+  /**
+   * @brief The name of the telemetry.
+   */
+  az_span command_name;
+} az_mqtt5_telemetry_consumer_codec_data;
+
+/**
+ * @brief Initializes a telemetry consumer codec options with default values.
+ *
+ * @return An #az_mqtt5_telemetry_consumer_codec_options object with default values.
+ */
+AZ_NODISCARD az_mqtt5_telemetry_consumer_codec_options
+az_mqtt5_telemetry_consumer_codec_options_default();
+
+/**
+ * @brief Generates the subscription topic to receive telemetry for the telemetry consumer.
+ *
+ * @param[in] consumer The #az_mqtt5_telemetry_consumer_codec to use.
+ * @param[in] service_group_id The service group id to use for the subscription topic. May be
+ * AZ_SPAN_EMPTY if not using a shared subscription topic.
+ * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic filter. If
+ * successful, contains a null-terminated string with the topic filter that needs to be passed to
+ * the MQTT client.
+ * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
+ * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of \p
+ * mqtt_topic. Can be `NULL`.
+ * @pre \p consumer must not be `NULL`.
+ * @pre \p mqtt_topic must not be `NULL`.
+ * @pre \p mqtt_topic_size must be greater than 0.
+ *
+ * @return An #az_result value indicating the result of the operation.
+ * @retval #AZ_OK The topic was created successfully.
+ * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small.
+ */
+AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
+    az_mqtt5_telemetry_consumer_codec* consumer,
+    az_span service_group_id,
+    char* mqtt_topic,
+    size_t mqtt_topic_size,
+    size_t* out_mqtt_topic_length);
+
+/**
+ * @brief Attempts to parse the topic of a received telemetry.
+ *
+ * @param[in] consumer The #az_mqtt5_telemetry_consumer_codec to use.
+ * @param[in] received_topic An #az_span containing the received topic.
+ * @param[out] out_data If the message is meant for this consumer, contains the model id,
+ * sender id, and name of the telemetry.
+ * @return An #az_result value indicating the result of the operation.
+ * @retval #AZ_OK The topic was parsed successfully.
+ * @retval #AZ_ERROR_IOT_TOPIC_NO_MATCH If the topic is not matching the expected format or is not
+ * meant for this consumer.
+ */
+AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_parse_received_topic(
+    az_mqtt5_telemetry_consumer_codec* consumer,
+    az_span received_topic,
+    az_mqtt5_telemetry_consumer_codec_data* out_data);
+
+/**
+ * @brief Initializes an MQTT5 Telemetry Consumer Codec.
+ *
+ * @param[out] consumer The #az_mqtt5_telemetry_consumer_codec to initialize.
+ * @param[in] model_id The model id to use for the subscription topic. May be AZ_SPAN_EMPTY if not
+ * used in the subscription topic.
+ * @param[in] sender_id The sender id to use for the subscription topic. May be AZ_SPAN_EMPTY if not
+ * used in the subscription topic, or if the sender id is not needed.
+ * @param[in] options Any #az_mqtt5_telemetry_consumer_codec_options to use for the telemetry
+ * consumer or NULL to use the defaults.
+ * @pre \p consumer must not be `NULL`.
+ *
+ * @return An #az_result value indicating the result of the operation.
+ * @retval #AZ_OK The telemetry consumer was initialized successfully.
+ * @retval #AZ_ERROR_ARG An invalid argument was provided.
+ */
+AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_init(
+    az_mqtt5_telemetry_consumer_codec* consumer,
+    az_span model_id,
+    az_span sender_id,
+    az_mqtt5_telemetry_consumer_codec_options* options);
+
+#endif // _az_MQTT5_TELEMETRY_CONSUMER_CODEC_H

--- a/sdk/inc/azure/core/az_mqtt5_telemetry_producer_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_telemetry_producer_codec.h
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file
+ *
+ * @brief Definition of #az_mqtt5_telemetry_producer_codec.
+ *
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * prefixed with an underscore ('_') directly in your application code. These symbols
+ * are part of Azure SDK's internal implementation; we do not document these symbols
+ * and they are subject to change in future versions of the SDK which would break your code.
+ */
+
+#ifndef _az_MQTT5_TELEMETRY_PRODUCER_CODEC_H
+#define _az_MQTT5_TELEMETRY_PRODUCER_CODEC_H
+
+#include <azure/core/az_result.h>
+#include <azure/core/az_span.h>
+
+#include <azure/core/_az_cfg_prefix.h>
+
+/**
+ * @brief MQTT5 Telemetry Producer Codec options.
+ *
+ */
+typedef struct
+{
+  /**
+   * @brief The topic format to use for the publish topic to send telemetry.
+   *
+   * @note Can include {name} for telemetry name, {serviceId} for model id, and/or {senderId} for
+   * the sender's client_id. The default value is services/{serviceId}/{senderId}/telemetry.
+   *
+   * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
+   * topic.
+   *
+   */
+  az_span telemetry_topic_format;
+} az_mqtt5_telemetry_producer_codec_options;
+
+/**
+ * @brief MQTT5 Telemetry Producer Codec.
+ *
+ */
+typedef struct
+{
+  struct
+  {
+    az_span model_id;
+    az_span client_id;
+
+    az_mqtt5_telemetry_producer_codec_options options;
+  } _internal;
+} az_mqtt5_telemetry_producer_codec;
+
+/**
+ * @brief Initializes a telemetry producer codec options with default values.
+ *
+ * @return An #az_mqtt5_telemetry_producer_codec_options object with default values.
+ */
+AZ_NODISCARD az_mqtt5_telemetry_producer_codec_options
+az_mqtt5_telemetry_producer_codec_options_default();
+
+/**
+ * @brief Generates the publish topic to publish telemetry for the telemetry producer.
+ *
+ * @param[in] producer The #az_mqtt5_telemetry_producer_codec to use.
+ * @param[in] telemetry_name An #az_span containing the name of the telemetry.
+ * @param[out] mqtt_topic A buffer with sufficient capacity to hold the MQTT topic filter. If
+ * successful, contains a null-terminated string with the topic filter that needs to be passed to
+ * the MQTT client.
+ * @param[in] mqtt_topic_size The size, in bytes of \p mqtt_topic.
+ * @param[out] out_mqtt_topic_length __[nullable]__ Contains the string length, in bytes, of \p
+ * mqtt_topic. Can be `NULL`.
+ * @pre \p producer must not be `NULL`.
+ * @pre \p mqtt_topic must not be `NULL`.
+ * @pre \p mqtt_topic_size must be greater than 0.
+ *
+ * @return An #az_result value indicating the result of the operation.
+ * @retval #AZ_OK The topic was created successfully.
+ * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small.
+ */
+AZ_NODISCARD az_result az_mqtt5_telemetry_producer_codec_get_publish_topic(
+    az_mqtt5_telemetry_producer_codec* producer,
+    az_span telemetry_name,
+    char* mqtt_topic,
+    size_t mqtt_topic_size,
+    size_t* out_mqtt_topic_length);
+
+/**
+ * @brief Initializes an MQTT5 Telemetry Producer Codec.
+ *
+ * @param[out] producer The #az_mqtt5_telemetry_producer_codec to initialize.
+ * @param[in] model_id The model id to use for the publish topic. May be AZ_SPAN_EMPTY if not
+ * used in the publish topic.
+ * @param[in] sender_id The sender id to use for the publish topic. May be AZ_SPAN_EMPTY if not
+ * token is not used in the subscription topic format.
+ * @param[in] options Any #az_mqtt5_telemetry_producer_codec_options to use for the telemetry
+ * producer or NULL to use the defaults.
+ * @pre \p producer must not be `NULL`.
+ *
+ * @return An #az_result value indicating the result of the operation.
+ * @retval #AZ_OK The telemetry producer was initialized successfully.
+ * @retval #AZ_ERROR_ARG An invalid argument was provided.
+ */
+AZ_NODISCARD az_result az_mqtt5_telemetry_producer_codec_init(
+    az_mqtt5_telemetry_producer_codec* producer,
+    az_span model_id,
+    az_span sender_id,
+    az_mqtt5_telemetry_producer_codec_options* options);
+
+#endif // _az_MQTT5_TELEMETRY_PRODUCER_CODEC_H

--- a/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
+++ b/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
@@ -82,7 +82,7 @@
 #define _az_MQTT5_TOPIC_PARSER_COMMAND_ID_HASH 2624200456
 
 /**
- * @brief Key used to indicate the sender id in a topic format.
+ * @brief Key used to indicate the sender id in a telemetry topic format.
  */
 #define _az_MQTT5_TOPIC_PARSER_SENDER_ID_KEY "{senderId}"
 /**
@@ -154,8 +154,8 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
  * NULL if not needed.
  * @param[out] extracted_sender_id Pointer to an #az_span to write the extracted sender id to or
  * NULL if not needed.
- * @param[out] extracted_name Pointer to an #az_span to write the extracted command name to
- * or NULL if not needed.
+ * @param[out] extracted_name Pointer to an #az_span to write the extracted command/telemetry name
+ * to or NULL if not needed.
  *
  * @return An #az_result value indicating the result of the operation.
  */

--- a/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
+++ b/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
@@ -69,9 +69,9 @@
 #define _az_MQTT5_TOPIC_PARSER_EXECUTOR_ID_HASH 3913329219
 
 /**
- * @brief Key used to indicate the command id in a topic format.
+ * @brief Key used to indicate the name of the command or telemetry in a topic format.
  */
-#define _az_MQTT5_TOPIC_PARSER_COMMAND_ID_KEY "{name}"
+#define _az_MQTT5_TOPIC_PARSER_NAME_KEY "{name}"
 /**
  * @brief Hash of the command id key. Exact string used to calculate the hash is "name".
  *
@@ -80,6 +80,19 @@
  * #az_span containing the key (ex. "serviceId"). If the key changes, update the hash here.
  */
 #define _az_MQTT5_TOPIC_PARSER_COMMAND_ID_HASH 2624200456
+
+/**
+ * @brief Key used to indicate the sender id in a topic format.
+ */
+#define _az_MQTT5_TOPIC_PARSER_SENDER_ID_KEY "{senderId}"
+/**
+ * @brief Hash of the sender id key. Exact string used to calculate the hash is "senderId".
+ *
+ * @details The value below is a hash of a key used in a topic format, it has been calculated
+ * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
+ * #az_span containing the key (ex. "serviceId"). If the key changes, update the hash here.
+ */
+#define _az_MQTT5_TOPIC_PARSER_SENDER_ID_HASH 3332431765
 
 /**
  * @brief Function to calculate the hash of a token.
@@ -107,7 +120,8 @@ AZ_INLINE uint32_t _az_mqtt5_topic_parser_calculate_hash(az_span token)
  * @param[in] client_id #az_span containing the client id or #AZ_SPAN_EMPTY.
  * @param[in] service_id #az_span containing the service id.
  * @param[in] executor_id #az_span containing the executor id or #AZ_SPAN_EMPTY.
- * @param[in] command_id #az_span containing the command id.
+ * @param[in] sender_id #az_span containing the sender id or #AZ_SPAN_EMPTY.
+ * @param[in] name #az_span containing the command or telemetry name.
  * @param[out] required_length The required length of the buffer to write the result to.
  *
  * @return An #az_result value indicating the result of the operation.
@@ -119,7 +133,8 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
     az_span client_id,
     az_span service_id,
     az_span executor_id,
-    az_span command_id,
+    az_span sender_id,
+    az_span name,
     uint32_t* required_length);
 
 /**
@@ -130,13 +145,16 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
  * @param[in] client_id #az_span containing the client id or #AZ_SPAN_EMPTY.
  * @param[in] service_id #az_span containing the service id or #AZ_SPAN_EMPTY.
  * @param[in] executor_id #az_span containing the executor id or #AZ_SPAN_EMPTY.
+ * @param[in] sender_id #az_span containing the sender id or #AZ_SPAN_EMPTY.
  * @param[out] extracted_client_id Pointer to an #az_span to write the extracted client id to or
  * NULL if not needed.
  * @param[out] extracted_service_id Pointer to an #az_span to write the extracted service id to or
  * NULL if not needed.
  * @param[out] extracted_executor_id Pointer to an #az_span to write the extracted executor id to or
  * NULL if not needed.
- * @param[out] extracted_command_name Pointer to an #az_span to write the extracted command name to
+ * @param[out] extracted_sender_id Pointer to an #az_span to write the extracted sender id to or
+ * NULL if not needed.
+ * @param[out] extracted_name Pointer to an #az_span to write the extracted command name to
  * or NULL if not needed.
  *
  * @return An #az_result value indicating the result of the operation.
@@ -147,10 +165,12 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_extract_tokens_from_topic(
     az_span client_id,
     az_span service_id,
     az_span executor_id,
+    az_span sender_id,
     az_span* extracted_client_id,
     az_span* extracted_service_id,
     az_span* extracted_executor_id,
-    az_span* extracted_command_name);
+    az_span* extracted_sender_id,
+    az_span* extracted_name);
 
 /**
  * @brief Helper function to check if a topic format is valid.

--- a/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
+++ b/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
@@ -21,76 +21,80 @@
 #include <azure/core/_az_cfg_prefix.h>
 
 /**
- * @brief Key appended to a topic to indicate a shared subscription.
+ * @brief Token used to indicate a single level wildcard in a topic format.
  */
-#define _az_MQTT5_TOPIC_PARSER_SERVICE_GROUP_ID_KEY "$share/"
+#define _az_MQTT5_TOPIC_PARSER_SINGLE_LEVEL_WILDCARD_TOKEN "+"
 /**
- * @brief Key used to replace the executor id in a topic format with any executor id.
+ * @brief Token appended to a topic to indicate a shared subscription.
+ */
+#define _az_MQTT5_TOPIC_PARSER_SERVICE_GROUP_ID_TOKEN "$share/"
+/**
+ * @brief Token used to replace the executor id in a topic format with any executor id.
  */
 #define _az_MQTT5_TOPIC_PARSER_ANY_EXECUTOR_ID "_any_"
 
 /**
- * @brief Key used to indicate the invoker client id in a topic format.
+ * @brief Token used to indicate the invoker client id in a topic format.
  */
-#define _az_MQTT5_TOPIC_PARSER_CLIENT_ID_KEY "{invokerClientId}"
+#define _az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN "{invokerClientId}"
 /**
- * @brief Hash of the client id key. Exact string used to calculate the hash is "invokerClientId".
+ * @brief Hash of the client id token. Exact string used to calculate the hash is "invokerClientId".
  *
- * @details The value below is a hash of a key used in a topic format, it has been calculated
+ * @details The value below is a hash of a token used in a topic format, it has been calculated
  * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
- * #az_span containing the key (ex. "serviceId"). If the key changes, update the hash here.
+ * #az_span containing the token (ex. "serviceId"). If the token changes, update the hash here.
  */
 #define _az_MQTT5_TOPIC_PARSER_CLIENT_ID_HASH 3426466449
 
 /**
- * @brief Key used to indicate the service id in a topic format.
+ * @brief Token used to indicate the service id in a topic format.
  */
-#define _az_MQTT5_TOPIC_PARSER_SERVICE_ID_KEY "{serviceId}"
+#define _az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN "{serviceId}"
 /**
- * @brief Hash of the service id key. Exact string used to calculate the hash is "serviceId".
+ * @brief Hash of the service id token. Exact string used to calculate the hash is "serviceId".
  *
- * @details The value below is a hash of a key used in a topic format, it has been calculated
+ * @details The value below is a hash of a token used in a topic format, it has been calculated
  * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
- * #az_span containing the key (ex. "serviceId"). If the key changes, update the hash here.
+ * #az_span containing the token (ex. "serviceId"). If the token changes, update the hash here.
  */
 #define _az_MQTT5_TOPIC_PARSER_SERVICE_ID_HASH 4175641829
 
 /**
- * @brief Key used to indicate the executor id in a topic format.
+ * @brief Token used to indicate the executor id in a topic format.
  */
-#define _az_MQTT5_RPC_EXECUTOR_ID_KEY "{executorId}"
+#define _az_MQTT5_RPC_EXECUTOR_ID_TOKEN "{executorId}"
 /**
- * @brief Hash of the executor id key. Exact string used to calculate the hash is "executorId".
+ * @brief Hash of the executor id token. Exact string used to calculate the hash is "executorId".
  *
- * @details The value below is a hash of a key used in a topic format, it has been calculated
+ * @details The value below is a hash of a token used in a topic format, it has been calculated
  * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
- * #az_span containing the key (ex. "serviceId"). If the key changes, update the hash here.
+ * #az_span containing the token (ex. "serviceId"). If the token changes, update the hash here.
  */
 #define _az_MQTT5_TOPIC_PARSER_EXECUTOR_ID_HASH 3913329219
 
 /**
- * @brief Key used to indicate the name of the command or telemetry in a topic format.
+ * @brief Token used to indicate the name of the command or telemetry in a topic format.
  */
-#define _az_MQTT5_TOPIC_PARSER_NAME_KEY "{name}"
+#define _az_MQTT5_TOPIC_PARSER_NAME_TOKEN "{name}"
 /**
- * @brief Hash of the command id key. Exact string used to calculate the hash is "name".
+ * @brief Hash of the command id token. Exact string used to calculate the hash is "name".
  *
- * @details The value below is a hash of a key used in a topic format, it has been calculated
+ * @details The value below is a hash of a token used in a topic format, it has been calculated
  * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
- * #az_span containing the key (ex. "serviceId"). If the key changes, update the hash here.
+ * #az_span containing the token (ex. "serviceId"). If the token changes, update the hash here.
  */
-#define _az_MQTT5_TOPIC_PARSER_COMMAND_ID_HASH 2624200456
+#define _az_MQTT5_TOPIC_PARSER_NAME_HASH 2624200456
 
 /**
- * @brief Key used to indicate the sender id in a telemetry topic format.
+ * @brief Token used to indicate the sender id in a telemetry topic format.
  */
-#define _az_MQTT5_TOPIC_PARSER_SENDER_ID_KEY "{senderId}"
+#define _az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN "{senderId}"
 /**
- * @brief Hash of the sender id key. Exact string used to calculate the hash is "senderId".
+ * @brief Hash of the sender id token. Exact string used to calculate the hash is "senderId".
  *
- * @details The value below is a hash of a key used in a topic format, it has been calculated
+ * @details The value below is a hash of a token used in a topic format, it has been calculated
  * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
- * #az_span containing the key (ex. "serviceId"). If the key changes, update the hash here.
+ * #az_span containing the token (ex. "serviceId"). If the token changes, update the hash here.
  */
 #define _az_MQTT5_TOPIC_PARSER_SENDER_ID_HASH 3332431765
 

--- a/sdk/src/azure/core/CMakeLists.txt
+++ b/sdk/src/azure/core/CMakeLists.txt
@@ -66,6 +66,8 @@ if (AZ_PLATFORM_IMPL STREQUAL "POSIX" AND NOT APPLE)
     ${CMAKE_CURRENT_LIST_DIR}/az_mqtt5_rpc_server_codec.c
     ${CMAKE_CURRENT_LIST_DIR}/az_mqtt5_rpc_client_hfsm.c
     ${CMAKE_CURRENT_LIST_DIR}/az_mqtt5_rpc_client_codec.c
+    ${CMAKE_CURRENT_LIST_DIR}/az_mqtt5_telemetry_consumer_codec.c
+    ${CMAKE_CURRENT_LIST_DIR}/az_mqtt5_telemetry_producer_codec.c
     ${CMAKE_CURRENT_LIST_DIR}/az_mqtt5_topic_parser.c
     ${CMAKE_CURRENT_LIST_DIR}/az_precondition.c
     ${CMAKE_CURRENT_LIST_DIR}/az_span.c

--- a/sdk/src/azure/core/az_mqtt5_rpc_client_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_client_codec.c
@@ -47,6 +47,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_publish_topic(
       client->_internal.model_id,
       az_span_is_content_equal(executor_id, AZ_SPAN_EMPTY) ? _az_mqtt5_rpc_any_executor_id
                                                            : executor_id,
+      AZ_SPAN_EMPTY,
       command_name,
       &required_length));
 
@@ -81,6 +82,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_response_property_topic(
       client->_internal.model_id,
       az_span_is_content_equal(executor_id, AZ_SPAN_EMPTY) ? _az_mqtt5_rpc_any_executor_id
                                                            : executor_id,
+      AZ_SPAN_EMPTY,
       command_name,
       &required_length));
 
@@ -113,6 +115,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_subscribe_topic(
       client->_internal.client_id,
       client->_internal.model_id,
       single_level_wildcard,
+      AZ_SPAN_EMPTY,
       single_level_wildcard,
       &required_length));
 
@@ -139,9 +142,11 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_parse_received_topic(
       client->_internal.client_id,
       client->_internal.model_id,
       AZ_SPAN_EMPTY,
+      AZ_SPAN_EMPTY,
       NULL,
       NULL,
       &out_response->executor_id,
+      NULL,
       &out_response->command_name);
 }
 

--- a/sdk/src/azure/core/az_mqtt5_rpc_client_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_client_codec.c
@@ -111,7 +111,8 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_subscribe_topic(
   az_result ret = AZ_OK;
 
   az_span mqtt_topic_span = az_span_create((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
-  az_span single_level_wildcard = AZ_SPAN_FROM_STR("+");
+  az_span single_level_wildcard
+      = AZ_SPAN_FROM_STR(_az_MQTT5_TOPIC_PARSER_SINGLE_LEVEL_WILDCARD_TOKEN);
   uint32_t required_length = 0;
 
   ret = _az_mqtt5_topic_parser_replace_tokens_in_format(

--- a/sdk/src/azure/core/az_mqtt5_rpc_client_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_client_codec.c
@@ -36,10 +36,12 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_publish_topic(
   _az_PRECONDITION_NOT_NULL(mqtt_topic);
   _az_PRECONDITION_RANGE(1, mqtt_topic_size, INT32_MAX);
 
+  az_result ret = AZ_OK;
+
   az_span mqtt_topic_span = az_span_create((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   uint32_t required_length = 0;
 
-  _az_RETURN_IF_FAILED(_az_mqtt5_topic_parser_replace_tokens_in_format(
+  ret = _az_mqtt5_topic_parser_replace_tokens_in_format(
       mqtt_topic_span,
       client->_internal.options.request_topic_format,
       AZ_SPAN_EMPTY,
@@ -49,14 +51,14 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_publish_topic(
                                                            : executor_id,
       AZ_SPAN_EMPTY,
       command_name,
-      &required_length));
+      &required_length);
 
   if (out_mqtt_topic_length)
   {
     *out_mqtt_topic_length = (size_t)required_length;
   }
 
-  return AZ_OK;
+  return ret;
 }
 
 AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_response_property_topic(
@@ -71,10 +73,12 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_response_property_topic(
   _az_PRECONDITION_NOT_NULL(mqtt_topic);
   _az_PRECONDITION_RANGE(1, mqtt_topic_size, INT32_MAX);
 
+  az_result ret = AZ_OK;
+
   az_span mqtt_topic_span = az_span_create((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   uint32_t required_length = 0;
 
-  _az_RETURN_IF_FAILED(_az_mqtt5_topic_parser_replace_tokens_in_format(
+  ret = _az_mqtt5_topic_parser_replace_tokens_in_format(
       mqtt_topic_span,
       client->_internal.options.subscription_topic_format,
       AZ_SPAN_EMPTY,
@@ -84,14 +88,14 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_response_property_topic(
                                                            : executor_id,
       AZ_SPAN_EMPTY,
       command_name,
-      &required_length));
+      &required_length);
 
   if (out_mqtt_topic_length)
   {
     *out_mqtt_topic_length = (size_t)required_length;
   }
 
-  return AZ_OK;
+  return ret;
 }
 
 AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_subscribe_topic(
@@ -104,11 +108,13 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_subscribe_topic(
   _az_PRECONDITION_NOT_NULL(mqtt_topic);
   _az_PRECONDITION_RANGE(1, mqtt_topic_size, INT32_MAX);
 
+  az_result ret = AZ_OK;
+
   az_span mqtt_topic_span = az_span_create((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   az_span single_level_wildcard = AZ_SPAN_FROM_STR("+");
   uint32_t required_length = 0;
 
-  _az_RETURN_IF_FAILED(_az_mqtt5_topic_parser_replace_tokens_in_format(
+  ret = _az_mqtt5_topic_parser_replace_tokens_in_format(
       mqtt_topic_span,
       client->_internal.options.subscription_topic_format,
       AZ_SPAN_EMPTY,
@@ -117,14 +123,14 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_subscribe_topic(
       single_level_wildcard,
       AZ_SPAN_EMPTY,
       single_level_wildcard,
-      &required_length));
+      &required_length);
 
   if (out_mqtt_topic_length)
   {
     *out_mqtt_topic_length = (size_t)required_length;
   }
 
-  return AZ_OK;
+  return ret;
 }
 
 AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_parse_received_topic(
@@ -172,9 +178,6 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_init(
   {
     return AZ_ERROR_ARG;
   }
-
-  client->_internal.options
-      = options == NULL ? az_mqtt5_rpc_client_codec_options_default() : *options;
 
   client->_internal.client_id = client_id;
   client->_internal.model_id = model_id;

--- a/sdk/src/azure/core/az_mqtt5_rpc_server_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_server_codec.c
@@ -48,6 +48,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_get_subscribe_topic(
       server->_internal.model_id,
       !az_span_is_content_equal(service_group_id, AZ_SPAN_EMPTY) ? _az_mqtt5_rpc_any_executor_id
                                                                  : server->_internal.client_id,
+      AZ_SPAN_EMPTY,
       _az_mqtt5_single_level_wildcard,
       &required_length));
 
@@ -86,9 +87,11 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_parse_received_topic(
       az_span_is_content_equal(server->_internal.options.service_group_id, AZ_SPAN_EMPTY)
           ? server->_internal.client_id
           : _az_mqtt5_rpc_any_executor_id,
+      AZ_SPAN_EMPTY,
       NULL,
       &out_request->service_id,
       &out_request->executor_id,
+      NULL,
       &out_request->command_name);
 }
 

--- a/sdk/src/azure/core/az_mqtt5_rpc_server_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_server_codec.c
@@ -13,8 +13,6 @@
 
 #include <azure/core/_az_cfg.h>
 
-static const az_span _az_mqtt5_rpc_service_group_id_key
-    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SERVICE_GROUP_ID_KEY);
 static const az_span _az_mqtt5_rpc_any_executor_id
     = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_ANY_EXECUTOR_ID);
 static const az_span _az_mqtt5_single_level_wildcard = AZ_SPAN_LITERAL_FROM_STR("+");
@@ -28,7 +26,6 @@ AZ_NODISCARD az_mqtt5_rpc_server_codec_options az_mqtt5_rpc_server_codec_options
 
 AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_get_subscribe_topic(
     az_mqtt5_rpc_server_codec* server,
-    az_span service_group_id,
     char* mqtt_topic,
     size_t mqtt_topic_size,
     size_t* out_mqtt_topic_length)
@@ -37,37 +34,30 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_get_subscribe_topic(
   _az_PRECONDITION_NOT_NULL(mqtt_topic);
   _az_PRECONDITION_RANGE(1, mqtt_topic_size, INT32_MAX);
 
+  az_result ret = AZ_OK;
+
   az_span mqtt_topic_span = az_span_create((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   uint32_t required_length = 0;
 
-  _az_RETURN_IF_FAILED(_az_mqtt5_topic_parser_replace_tokens_in_format(
+  ret = _az_mqtt5_topic_parser_replace_tokens_in_format(
       mqtt_topic_span,
       server->_internal.options.subscription_topic_format,
-      service_group_id,
+      server->_internal.options.service_group_id,
       AZ_SPAN_EMPTY,
       server->_internal.model_id,
-      !az_span_is_content_equal(service_group_id, AZ_SPAN_EMPTY) ? _az_mqtt5_rpc_any_executor_id
-                                                                 : server->_internal.client_id,
+      !az_span_is_content_equal(server->_internal.options.service_group_id, AZ_SPAN_EMPTY)
+          ? _az_mqtt5_rpc_any_executor_id
+          : server->_internal.client_id,
       AZ_SPAN_EMPTY,
       _az_mqtt5_single_level_wildcard,
-      &required_length));
-
-  _az_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_span, (int32_t)required_length);
-
-  az_span remainder = mqtt_topic_span;
-  if (!az_span_is_content_equal(service_group_id, AZ_SPAN_EMPTY))
-  {
-    remainder = az_span_copy(mqtt_topic_span, _az_mqtt5_rpc_service_group_id_key);
-    remainder = az_span_copy(remainder, service_group_id);
-    remainder = az_span_copy_u8(remainder, '/');
-  }
+      &required_length);
 
   if (out_mqtt_topic_length)
   {
     *out_mqtt_topic_length = (size_t)required_length;
   }
 
-  return AZ_OK;
+  return ret;
 }
 
 AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_parse_received_topic(
@@ -115,9 +105,6 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_init(
   {
     return AZ_ERROR_ARG;
   }
-
-  server->_internal.options
-      = options == NULL ? az_mqtt5_rpc_server_codec_options_default() : *options;
 
   server->_internal.client_id = client_id;
   server->_internal.model_id = model_id;

--- a/sdk/src/azure/core/az_mqtt5_rpc_server_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_server_codec.c
@@ -15,7 +15,6 @@
 
 static const az_span _az_mqtt5_rpc_any_executor_id
     = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_ANY_EXECUTOR_ID);
-static const az_span _az_mqtt5_single_level_wildcard = AZ_SPAN_LITERAL_FROM_STR("+");
 
 AZ_NODISCARD az_mqtt5_rpc_server_codec_options az_mqtt5_rpc_server_codec_options_default()
 {
@@ -49,7 +48,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_get_subscribe_topic(
           ? _az_mqtt5_rpc_any_executor_id
           : server->_internal.client_id,
       AZ_SPAN_EMPTY,
-      _az_mqtt5_single_level_wildcard,
+      AZ_SPAN_FROM_STR(_az_MQTT5_TOPIC_PARSER_SINGLE_LEVEL_WILDCARD_TOKEN),
       &required_length);
 
   if (out_mqtt_topic_length)

--- a/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
@@ -489,7 +489,6 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_init(
   size_t topic_length;
   _az_RETURN_IF_FAILED(az_mqtt5_rpc_server_codec_get_subscribe_topic(
       client->_internal.rpc_server_codec,
-      options->service_group_id,
       (char*)az_span_ptr(subscription_topic),
       (size_t)az_span_size(subscription_topic),
       &topic_length));

--- a/sdk/src/azure/core/az_mqtt5_telemetry_consumer_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_telemetry_consumer_codec.c
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <azure/core/az_mqtt5_telemetry.h>
+#include <azure/core/az_mqtt5_telemetry_consumer_codec.h>
+#include <azure/core/az_result.h>
+#include <azure/core/internal/az_log_internal.h>
+#include <azure/core/internal/az_mqtt5_topic_parser_internal.h>
+#include <azure/core/internal/az_precondition_internal.h>
+#include <azure/core/internal/az_result_internal.h>
+#include <stdlib.h>
+
+#include <azure/core/_az_cfg.h>
+
+static const az_span _az_mqtt5_telemetry_consumer_service_group_id_key
+    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SERVICE_GROUP_ID_KEY);
+static const az_span _az_mqtt5_single_level_wildcard = AZ_SPAN_LITERAL_FROM_STR("+");
+
+AZ_NODISCARD az_mqtt5_telemetry_consumer_codec_options
+az_mqtt5_telemetry_consumer_codec_options_default()
+{
+  return (az_mqtt5_telemetry_consumer_codec_options){
+    .telemetry_topic_format = AZ_SPAN_LITERAL_FROM_STR(AZ_MQTT5_TELEMETRY_DEFAULT_TOPIC_FORMAT)
+  };
+}
+
+AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
+    az_mqtt5_telemetry_consumer_codec* consumer,
+    az_span service_group_id,
+    char* mqtt_topic,
+    size_t mqtt_topic_size,
+    size_t* out_mqtt_topic_length)
+{
+  _az_PRECONDITION_NOT_NULL(consumer);
+  _az_PRECONDITION_NOT_NULL(mqtt_topic);
+  _az_PRECONDITION_RANGE(1, mqtt_topic_size, INT32_MAX);
+
+  az_span mqtt_topic_span = az_span_create((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
+  uint32_t required_length = 0;
+
+  _az_RETURN_IF_FAILED(_az_mqtt5_topic_parser_replace_tokens_in_format(
+      mqtt_topic_span,
+      consumer->_internal.options.telemetry_topic_format,
+      service_group_id,
+      AZ_SPAN_EMPTY,
+      consumer->_internal.model_id,
+      AZ_SPAN_EMPTY,
+      consumer->_internal.sender_id,
+      _az_mqtt5_single_level_wildcard,
+      &required_length));
+
+  _az_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_span, (int32_t)required_length);
+
+  az_span remainder = mqtt_topic_span;
+  if (!az_span_is_content_equal(service_group_id, AZ_SPAN_EMPTY))
+  {
+    remainder = az_span_copy(mqtt_topic_span, _az_mqtt5_telemetry_consumer_service_group_id_key);
+    remainder = az_span_copy(remainder, service_group_id);
+    remainder = az_span_copy_u8(remainder, '/');
+  }
+
+  if (out_mqtt_topic_length)
+  {
+    *out_mqtt_topic_length = (size_t)required_length;
+  }
+
+  return AZ_OK;
+}
+
+AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_parse_received_topic(
+    az_mqtt5_telemetry_consumer_codec* consumer,
+    az_span received_topic,
+    az_mqtt5_telemetry_consumer_codec_data* out_data)
+{
+  _az_PRECONDITION_NOT_NULL(consumer);
+  _az_PRECONDITION_VALID_SPAN(received_topic, 1, false);
+  _az_PRECONDITION_NOT_NULL(out_data);
+
+  return _az_mqtt5_topic_parser_extract_tokens_from_topic(
+      consumer->_internal.options.telemetry_topic_format,
+      received_topic,
+      AZ_SPAN_EMPTY,
+      consumer->_internal.model_id,
+      AZ_SPAN_EMPTY,
+      consumer->_internal.sender_id,
+      NULL,
+      &out_data->service_id,
+      NULL,
+      &out_data->sender_id,
+      &out_data->command_name);
+}
+
+AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_init(
+    az_mqtt5_telemetry_consumer_codec* consumer,
+    az_span model_id,
+    az_span sender_id,
+    az_mqtt5_telemetry_consumer_codec_options* options)
+{
+  _az_PRECONDITION_NOT_NULL(consumer);
+
+  if (options == NULL)
+  {
+    consumer->_internal.options = az_mqtt5_telemetry_consumer_codec_options_default();
+  }
+  else if (_az_mqtt5_topic_parser_valid_topic_format(options->telemetry_topic_format))
+  {
+    consumer->_internal.options = *options;
+  }
+  else
+  {
+    return AZ_ERROR_ARG;
+  }
+
+  consumer->_internal.options
+      = options == NULL ? az_mqtt5_telemetry_consumer_codec_options_default() : *options;
+
+  consumer->_internal.model_id = model_id;
+  consumer->_internal.sender_id = sender_id;
+
+  return AZ_OK;
+}

--- a/sdk/src/azure/core/az_mqtt5_telemetry_consumer_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_telemetry_consumer_codec.c
@@ -12,21 +12,19 @@
 
 #include <azure/core/_az_cfg.h>
 
-static const az_span _az_mqtt5_telemetry_consumer_service_group_id_key
-    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SERVICE_GROUP_ID_KEY);
 static const az_span _az_mqtt5_single_level_wildcard = AZ_SPAN_LITERAL_FROM_STR("+");
 
 AZ_NODISCARD az_mqtt5_telemetry_consumer_codec_options
 az_mqtt5_telemetry_consumer_codec_options_default()
 {
   return (az_mqtt5_telemetry_consumer_codec_options){
-    .telemetry_topic_format = AZ_SPAN_LITERAL_FROM_STR(AZ_MQTT5_TELEMETRY_DEFAULT_TOPIC_FORMAT)
+    .service_group_id = AZ_SPAN_EMPTY,
+    .telemetry_topic_format = AZ_SPAN_LITERAL_FROM_STR(AZ_MQTT5_TELEMETRY_DEFAULT_TOPIC_FORMAT),
   };
 }
 
 AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
     az_mqtt5_telemetry_consumer_codec* consumer,
-    az_span service_group_id,
     char* mqtt_topic,
     size_t mqtt_topic_size,
     size_t* out_mqtt_topic_length)
@@ -35,36 +33,28 @@ AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
   _az_PRECONDITION_NOT_NULL(mqtt_topic);
   _az_PRECONDITION_RANGE(1, mqtt_topic_size, INT32_MAX);
 
+  az_result ret = AZ_OK;
+
   az_span mqtt_topic_span = az_span_create((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   uint32_t required_length = 0;
 
-  _az_RETURN_IF_FAILED(_az_mqtt5_topic_parser_replace_tokens_in_format(
+  ret = _az_mqtt5_topic_parser_replace_tokens_in_format(
       mqtt_topic_span,
       consumer->_internal.options.telemetry_topic_format,
-      service_group_id,
+      consumer->_internal.options.service_group_id,
       AZ_SPAN_EMPTY,
       consumer->_internal.model_id,
       AZ_SPAN_EMPTY,
       consumer->_internal.sender_id,
       _az_mqtt5_single_level_wildcard,
-      &required_length));
-
-  _az_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_span, (int32_t)required_length);
-
-  az_span remainder = mqtt_topic_span;
-  if (!az_span_is_content_equal(service_group_id, AZ_SPAN_EMPTY))
-  {
-    remainder = az_span_copy(mqtt_topic_span, _az_mqtt5_telemetry_consumer_service_group_id_key);
-    remainder = az_span_copy(remainder, service_group_id);
-    remainder = az_span_copy_u8(remainder, '/');
-  }
+      &required_length);
 
   if (out_mqtt_topic_length)
   {
     *out_mqtt_topic_length = (size_t)required_length;
   }
 
-  return AZ_OK;
+  return ret;
 }
 
 AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_parse_received_topic(
@@ -110,9 +100,6 @@ AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_init(
   {
     return AZ_ERROR_ARG;
   }
-
-  consumer->_internal.options
-      = options == NULL ? az_mqtt5_telemetry_consumer_codec_options_default() : *options;
 
   consumer->_internal.model_id = model_id;
   consumer->_internal.sender_id = sender_id;

--- a/sdk/src/azure/core/az_mqtt5_telemetry_consumer_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_telemetry_consumer_codec.c
@@ -12,8 +12,6 @@
 
 #include <azure/core/_az_cfg.h>
 
-static const az_span _az_mqtt5_single_level_wildcard = AZ_SPAN_LITERAL_FROM_STR("+");
-
 AZ_NODISCARD az_mqtt5_telemetry_consumer_codec_options
 az_mqtt5_telemetry_consumer_codec_options_default()
 {
@@ -46,7 +44,7 @@ AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
       consumer->_internal.model_id,
       AZ_SPAN_EMPTY,
       consumer->_internal.sender_id,
-      _az_mqtt5_single_level_wildcard,
+      AZ_SPAN_FROM_STR(_az_MQTT5_TOPIC_PARSER_SINGLE_LEVEL_WILDCARD_TOKEN),
       &required_length);
 
   if (out_mqtt_topic_length)

--- a/sdk/src/azure/core/az_mqtt5_telemetry_producer_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_telemetry_producer_codec.c
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <azure/core/az_mqtt5_telemetry.h>
+#include <azure/core/az_mqtt5_telemetry_producer_codec.h>
+#include <azure/core/az_result.h>
+#include <azure/core/internal/az_log_internal.h>
+#include <azure/core/internal/az_mqtt5_topic_parser_internal.h>
+#include <azure/core/internal/az_precondition_internal.h>
+#include <azure/core/internal/az_result_internal.h>
+#include <stdlib.h>
+
+#include <azure/core/_az_cfg.h>
+
+AZ_NODISCARD az_mqtt5_telemetry_producer_codec_options
+az_mqtt5_telemetry_producer_codec_options_default()
+{
+  return (az_mqtt5_telemetry_producer_codec_options){
+    .telemetry_topic_format = AZ_SPAN_LITERAL_FROM_STR(AZ_MQTT5_TELEMETRY_DEFAULT_TOPIC_FORMAT)
+  };
+}
+
+AZ_NODISCARD az_result az_mqtt5_telemetry_producer_codec_get_publish_topic(
+    az_mqtt5_telemetry_producer_codec* producer,
+    az_span telemetry_name,
+    char* mqtt_topic,
+    size_t mqtt_topic_size,
+    size_t* out_mqtt_topic_length)
+{
+  _az_PRECONDITION_NOT_NULL(producer);
+  _az_PRECONDITION_NOT_NULL(mqtt_topic);
+  _az_PRECONDITION_RANGE(1, mqtt_topic_size, INT32_MAX);
+
+  az_span mqtt_topic_span = az_span_create((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
+  uint32_t required_length = 0;
+
+  _az_RETURN_IF_FAILED(_az_mqtt5_topic_parser_replace_tokens_in_format(
+      mqtt_topic_span,
+      producer->_internal.options.telemetry_topic_format,
+      AZ_SPAN_EMPTY,
+      AZ_SPAN_EMPTY,
+      producer->_internal.model_id,
+      AZ_SPAN_EMPTY,
+      producer->_internal.client_id,
+      telemetry_name,
+      &required_length));
+
+  _az_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_span, (int32_t)required_length);
+
+  if (out_mqtt_topic_length)
+  {
+    *out_mqtt_topic_length = (size_t)required_length;
+  }
+
+  return AZ_OK;
+}
+
+AZ_NODISCARD az_result az_mqtt5_telemetry_producer_codec_init(
+    az_mqtt5_telemetry_producer_codec* producer,
+    az_span model_id,
+    az_span client_id,
+    az_mqtt5_telemetry_producer_codec_options* options)
+{
+  _az_PRECONDITION_NOT_NULL(producer);
+
+  if (options == NULL)
+  {
+    producer->_internal.options = az_mqtt5_telemetry_producer_codec_options_default();
+  }
+  else if (_az_mqtt5_topic_parser_valid_topic_format(options->telemetry_topic_format))
+  {
+    producer->_internal.options = *options;
+  }
+  else
+  {
+    return AZ_ERROR_ARG;
+  }
+
+  producer->_internal.options
+      = options == NULL ? az_mqtt5_telemetry_producer_codec_options_default() : *options;
+
+  producer->_internal.model_id = model_id;
+  producer->_internal.client_id = client_id;
+
+  return AZ_OK;
+}

--- a/sdk/src/azure/core/az_mqtt5_telemetry_producer_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_telemetry_producer_codec.c
@@ -31,10 +31,12 @@ AZ_NODISCARD az_result az_mqtt5_telemetry_producer_codec_get_publish_topic(
   _az_PRECONDITION_NOT_NULL(mqtt_topic);
   _az_PRECONDITION_RANGE(1, mqtt_topic_size, INT32_MAX);
 
+  az_result ret = AZ_OK;
+
   az_span mqtt_topic_span = az_span_create((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   uint32_t required_length = 0;
 
-  _az_RETURN_IF_FAILED(_az_mqtt5_topic_parser_replace_tokens_in_format(
+  ret = _az_mqtt5_topic_parser_replace_tokens_in_format(
       mqtt_topic_span,
       producer->_internal.options.telemetry_topic_format,
       AZ_SPAN_EMPTY,
@@ -43,16 +45,14 @@ AZ_NODISCARD az_result az_mqtt5_telemetry_producer_codec_get_publish_topic(
       AZ_SPAN_EMPTY,
       producer->_internal.client_id,
       telemetry_name,
-      &required_length));
-
-  _az_RETURN_IF_NOT_ENOUGH_SIZE(mqtt_topic_span, (int32_t)required_length);
+      &required_length);
 
   if (out_mqtt_topic_length)
   {
     *out_mqtt_topic_length = (size_t)required_length;
   }
 
-  return AZ_OK;
+  return ret;
 }
 
 AZ_NODISCARD az_result az_mqtt5_telemetry_producer_codec_init(
@@ -75,9 +75,6 @@ AZ_NODISCARD az_result az_mqtt5_telemetry_producer_codec_init(
   {
     return AZ_ERROR_ARG;
   }
-
-  producer->_internal.options
-      = options == NULL ? az_mqtt5_telemetry_producer_codec_options_default() : *options;
 
   producer->_internal.model_id = model_id;
   producer->_internal.client_id = client_id;

--- a/sdk/src/azure/core/az_mqtt5_topic_parser.c
+++ b/sdk/src/azure/core/az_mqtt5_topic_parser.c
@@ -20,8 +20,8 @@
 static const az_span service_group_id_key
     = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SERVICE_GROUP_ID_KEY);
 static const az_span model_id_key = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SERVICE_ID_KEY);
-static const az_span command_name_key
-    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_COMMAND_ID_KEY);
+static const az_span sender_id_key = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SENDER_ID_KEY);
+static const az_span command_name_key = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_NAME_KEY);
 static const az_span executor_client_id_key
     = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_RPC_EXECUTOR_ID_KEY);
 static const az_span invoker_client_id_key
@@ -91,7 +91,8 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
     az_span client_id,
     az_span service_id,
     az_span executor_id,
-    az_span command_id,
+    az_span sender_id,
+    az_span name,
     uint32_t* required_length)
 {
   az_result ret = AZ_OK;
@@ -154,10 +155,16 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
             executor_id, &remainder, required_length, buffer_length);
         i += az_span_size(executor_client_id_key) - 1;
       }
+      else if (curr_hash == _az_MQTT5_TOPIC_PARSER_SENDER_ID_HASH)
+      {
+        ret = _az_mqtt5_rpc_verify_buffer_length_and_copy(
+            sender_id, &remainder, required_length, buffer_length);
+        i += az_span_size(sender_id_key) - 1;
+      }
       else if (curr_hash == _az_MQTT5_TOPIC_PARSER_COMMAND_ID_HASH)
       {
         ret = _az_mqtt5_rpc_verify_buffer_length_and_copy(
-            command_id, &remainder, required_length, buffer_length);
+            name, &remainder, required_length, buffer_length);
         i += az_span_size(command_name_key) - 1;
       }
       else
@@ -185,10 +192,12 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_extract_tokens_from_topic(
     az_span client_id,
     az_span service_id,
     az_span executor_id,
+    az_span sender_id,
     az_span* extracted_client_id,
     az_span* extracted_service_id,
     az_span* extracted_executor_id,
-    az_span* extracted_command_name)
+    az_span* extracted_sender_id,
+    az_span* extracted_name)
 {
   int32_t format_idx = 0;
   uint8_t format_char;
@@ -239,10 +248,17 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_extract_tokens_from_topic(
           i += az_span_size(extracted_token) - 1;
           format_idx += az_span_size(executor_client_id_key) - 1;
         }
+        else if (curr_hash == _az_MQTT5_TOPIC_PARSER_SENDER_ID_HASH)
+        {
+          _az_RETURN_IF_FAILED(
+              _az_mqtt5_rpc_verify_match_and_copy(sender_id, extracted_token, extracted_sender_id));
+          i += az_span_size(extracted_token) - 1;
+          format_idx += az_span_size(sender_id_key) - 1;
+        }
         else if (curr_hash == _az_MQTT5_TOPIC_PARSER_COMMAND_ID_HASH)
         {
-          _az_RETURN_IF_FAILED(_az_mqtt5_rpc_verify_match_and_copy(
-              AZ_SPAN_EMPTY, extracted_token, extracted_command_name));
+          _az_RETURN_IF_FAILED(
+              _az_mqtt5_rpc_verify_match_and_copy(AZ_SPAN_EMPTY, extracted_token, extracted_name));
           i += az_span_size(extracted_token) - 1;
           format_idx += az_span_size(command_name_key) - 1;
         }

--- a/sdk/src/azure/core/az_mqtt5_topic_parser.c
+++ b/sdk/src/azure/core/az_mqtt5_topic_parser.c
@@ -21,7 +21,7 @@ static const az_span service_group_id_key
     = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SERVICE_GROUP_ID_KEY);
 static const az_span model_id_key = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SERVICE_ID_KEY);
 static const az_span sender_id_key = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SENDER_ID_KEY);
-static const az_span command_name_key = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_NAME_KEY);
+static const az_span name_key = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_NAME_KEY);
 static const az_span executor_client_id_key
     = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_RPC_EXECUTOR_ID_KEY);
 static const az_span invoker_client_id_key
@@ -165,7 +165,7 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
       {
         ret = _az_mqtt5_rpc_verify_buffer_length_and_copy(
             name, &remainder, required_length, buffer_length);
-        i += az_span_size(command_name_key) - 1;
+        i += az_span_size(name_key) - 1;
       }
       else
       {
@@ -199,6 +199,27 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_extract_tokens_from_topic(
     az_span* extracted_sender_id,
     az_span* extracted_name)
 {
+  if (extracted_client_id)
+  {
+    *extracted_client_id = AZ_SPAN_EMPTY;
+  }
+  if (extracted_service_id)
+  {
+    *extracted_service_id = AZ_SPAN_EMPTY;
+  }
+  if (extracted_executor_id)
+  {
+    *extracted_executor_id = AZ_SPAN_EMPTY;
+  }
+  if (extracted_sender_id)
+  {
+    *extracted_sender_id = AZ_SPAN_EMPTY;
+  }
+  if (extracted_name)
+  {
+    *extracted_name = AZ_SPAN_EMPTY;
+  }
+
   int32_t format_idx = 0;
   uint8_t format_char;
   for (int32_t i = 0; i < az_span_size(received_topic); i++)
@@ -260,7 +281,7 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_extract_tokens_from_topic(
           _az_RETURN_IF_FAILED(
               _az_mqtt5_rpc_verify_match_and_copy(AZ_SPAN_EMPTY, extracted_token, extracted_name));
           i += az_span_size(extracted_token) - 1;
-          format_idx += az_span_size(command_name_key) - 1;
+          format_idx += az_span_size(name_key) - 1;
         }
       }
       else if (c != format_char)
@@ -361,11 +382,11 @@ AZ_NODISCARD bool _az_mqtt5_topic_parser_valid_topic_format(az_span topic_format
     }
   }
 
-  int32_t command_name_index = az_span_find(topic_format, command_name_key);
+  int32_t command_name_index = az_span_find(topic_format, name_key);
   if (command_name_index != -1)
   {
     if (!_az_mqtt5_is_key_surrounded_by_slash(
-            command_name_index, az_span_size(command_name_key), topic_format))
+            command_name_index, az_span_size(name_key), topic_format))
     {
       return false;
     }

--- a/sdk/src/azure/core/az_mqtt5_topic_parser.c
+++ b/sdk/src/azure/core/az_mqtt5_topic_parser.c
@@ -18,14 +18,16 @@
 #include <azure/core/_az_cfg.h>
 
 static const az_span service_group_id_key
-    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SERVICE_GROUP_ID_KEY);
-static const az_span model_id_key = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SERVICE_ID_KEY);
-static const az_span sender_id_key = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SENDER_ID_KEY);
-static const az_span name_key = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_NAME_KEY);
+    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SERVICE_GROUP_ID_TOKEN);
+static const az_span model_id_key
+    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN);
+static const az_span sender_id_key
+    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN);
+static const az_span name_key = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_NAME_TOKEN);
 static const az_span executor_client_id_key
-    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_RPC_EXECUTOR_ID_KEY);
+    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_RPC_EXECUTOR_ID_TOKEN);
 static const az_span invoker_client_id_key
-    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_CLIENT_ID_KEY);
+    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN);
 static const az_span token_format_end_character = AZ_SPAN_LITERAL_FROM_STR("}");
 static const az_span token_topic_end_character = AZ_SPAN_LITERAL_FROM_STR("/");
 
@@ -161,7 +163,7 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
             sender_id, &remainder, required_length, buffer_length);
         i += az_span_size(sender_id_key) - 1;
       }
-      else if (curr_hash == _az_MQTT5_TOPIC_PARSER_COMMAND_ID_HASH)
+      else if (curr_hash == _az_MQTT5_TOPIC_PARSER_NAME_HASH)
       {
         ret = _az_mqtt5_rpc_verify_buffer_length_and_copy(
             name, &remainder, required_length, buffer_length);
@@ -276,7 +278,7 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_extract_tokens_from_topic(
           i += az_span_size(extracted_token) - 1;
           format_idx += az_span_size(sender_id_key) - 1;
         }
-        else if (curr_hash == _az_MQTT5_TOPIC_PARSER_COMMAND_ID_HASH)
+        else if (curr_hash == _az_MQTT5_TOPIC_PARSER_NAME_HASH)
         {
           _az_RETURN_IF_FAILED(
               _az_mqtt5_rpc_verify_match_and_copy(AZ_SPAN_EMPTY, extracted_token, extracted_name));

--- a/sdk/tests/core/CMakeLists.txt
+++ b/sdk/tests/core/CMakeLists.txt
@@ -45,6 +45,8 @@ if (AZ_PLATFORM_IMPL STREQUAL "POSIX" AND NOT APPLE AND UNIT_TESTING_MOCKS)
                     test_az_mqtt5_rpc_client_hfsm.c
                     test_az_mqtt5_rpc_server_codec.c
                     test_az_mqtt5_rpc_server_hfsm.c
+                    test_az_mqtt5_telemetry_consumer_codec.c
+                    test_az_mqtt5_telemetry_producer_codec.c
                     test_az_pipeline.c
                     test_az_policy.c
                     test_az_span.c

--- a/sdk/tests/core/az_test_definitions.h
+++ b/sdk/tests/core/az_test_definitions.h
@@ -13,6 +13,8 @@ int test_az_mqtt5_rpc_server();
 int test_az_mqtt5_rpc_server_codec();
 int test_az_mqtt5_rpc_client();
 int test_az_mqtt5_rpc_client_codec();
+int test_az_mqtt5_telemetry_consumer_codec();
+int test_az_mqtt5_telemetry_producer_codec();
 #endif // _az_MOCK_ENABLED
 #endif // !defined(__APPLE__) && defined(PLATFORM_POSIX)
 int test_az_http();

--- a/sdk/tests/core/main.c
+++ b/sdk/tests/core/main.c
@@ -30,6 +30,8 @@ int main()
   result += test_az_mqtt5_rpc_server();
   result += test_az_mqtt5_rpc_client_codec();
   result += test_az_mqtt5_rpc_client();
+  result += test_az_mqtt5_telemetry_consumer_codec();
+  result += test_az_mqtt5_telemetry_producer_codec();
 #endif // !defined(__APPLE__) && defined(PLATFORM_POSIX) && defined(_az_MOCK_ENABLED)
   result += test_az_http();
   result += test_az_json();

--- a/sdk/tests/core/test_az_mqtt5_rpc_server_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_server_codec.c
@@ -81,7 +81,7 @@ static void test_az_mqtt5_rpc_server_codec_init_options_success(void** state)
       AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_FORMAT_1)));
 }
 
-static void az_mqtt5_rpc_server_codec_get_subscribe_topic_specific_endpoint_success(void** state)
+static void az_mqtt5_rpc_server_codec_get_subscribe_topic_default_endpoint_success(void** state)
 {
   (void)state;
   az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_SUBSCRIPTION_TOPIC);
@@ -116,7 +116,7 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_specific_endpoint_succ
 static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_success(void** state)
 {
   (void)state;
-  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_1);
+  az_span test_custom_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_1);
 
   az_mqtt5_rpc_server_codec_options test_server_options
       = az_mqtt5_rpc_server_codec_options_default();
@@ -130,7 +130,7 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_succes
           &test_server_options),
       AZ_OK);
 
-  char test_subscription_topic_buffer[az_span_size(test_default_sub_topic)];
+  char test_subscription_topic_buffer[az_span_size(test_custom_sub_topic)];
   size_t test_subscription_topic_out_size = 0;
 
   assert_int_equal(
@@ -144,14 +144,14 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_succes
   az_span test_sub_topic = az_span_create(
       (uint8_t*)test_subscription_topic_buffer, (int32_t)test_subscription_topic_out_size);
 
-  assert_true(az_span_is_content_equal(test_sub_topic, test_default_sub_topic));
+  assert_true(az_span_is_content_equal(test_sub_topic, test_custom_sub_topic));
 }
 
 static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_executor_only_success(
     void** state)
 {
   (void)state;
-  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_2);
+  az_span test_custom_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_2);
 
   az_mqtt5_rpc_server_codec_options test_server_options
       = az_mqtt5_rpc_server_codec_options_default();
@@ -165,7 +165,7 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_execut
           &test_server_options),
       AZ_OK);
 
-  char test_subscription_topic_buffer[az_span_size(test_default_sub_topic)];
+  char test_subscription_topic_buffer[az_span_size(test_custom_sub_topic)];
   size_t test_subscription_topic_out_size = 0;
 
   assert_int_equal(
@@ -179,14 +179,14 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_execut
   az_span test_sub_topic = az_span_create(
       (uint8_t*)test_subscription_topic_buffer, (int32_t)test_subscription_topic_out_size);
 
-  assert_true(az_span_is_content_equal(test_sub_topic, test_default_sub_topic));
+  assert_true(az_span_is_content_equal(test_sub_topic, test_custom_sub_topic));
 }
 
 static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_no_elements_success(
     void** state)
 {
   (void)state;
-  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_3);
+  az_span test_custom_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_3);
 
   az_mqtt5_rpc_server_codec_options test_server_options
       = az_mqtt5_rpc_server_codec_options_default();
@@ -200,7 +200,7 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_no_ele
           &test_server_options),
       AZ_OK);
 
-  char test_subscription_topic_buffer[az_span_size(test_default_sub_topic)];
+  char test_subscription_topic_buffer[az_span_size(test_custom_sub_topic)];
   size_t test_subscription_topic_out_size = 0;
 
   assert_int_equal(
@@ -214,10 +214,10 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_no_ele
   az_span test_sub_topic = az_span_create(
       (uint8_t*)test_subscription_topic_buffer, (int32_t)test_subscription_topic_out_size);
 
-  assert_true(az_span_is_content_equal(test_sub_topic, test_default_sub_topic));
+  assert_true(az_span_is_content_equal(test_sub_topic, test_custom_sub_topic));
 }
 
-static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_buffer_size_failure(
+static void az_mqtt5_rpc_server_codec_get_subscribe_topic_default_endpoint_buffer_size_failure(
     void** state)
 {
   (void)state;
@@ -335,14 +335,14 @@ int test_az_mqtt5_rpc_server_codec()
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_az_mqtt5_rpc_server_codec_init_no_options_success),
     cmocka_unit_test(test_az_mqtt5_rpc_server_codec_init_options_success),
-    cmocka_unit_test(az_mqtt5_rpc_server_codec_get_subscribe_topic_specific_endpoint_success),
+    cmocka_unit_test(az_mqtt5_rpc_server_codec_get_subscribe_topic_default_endpoint_success),
     cmocka_unit_test(az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_success),
     cmocka_unit_test(
         az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_executor_only_success),
     cmocka_unit_test(
         az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_no_elements_success),
     cmocka_unit_test(
-        az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_buffer_size_failure),
+        az_mqtt5_rpc_server_codec_get_subscribe_topic_default_endpoint_buffer_size_failure),
     cmocka_unit_test(az_mqtt5_rpc_server_codec_get_subscribe_topic_fungible_endpoint_success),
     cmocka_unit_test(az_mqtt5_rpc_server_codec_parse_received_topic_success),
     cmocka_unit_test(az_mqtt5_rpc_server_codec_parse_received_topic_failure),

--- a/sdk/tests/core/test_az_mqtt5_rpc_server_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_server_codec.c
@@ -84,6 +84,7 @@ static void test_az_mqtt5_rpc_server_codec_init_options_success(void** state)
 static void az_mqtt5_rpc_server_codec_get_subscribe_topic_specific_endpoint_success(void** state)
 {
   (void)state;
+  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_SUBSCRIPTION_TOPIC);
 
   az_mqtt5_rpc_server_codec_options test_server_options
       = az_mqtt5_rpc_server_codec_options_default();
@@ -95,13 +96,12 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_specific_endpoint_succ
           &test_server_options),
       AZ_OK);
 
-  char test_subscription_topic_buffer[56]; // Exact size.
+  char test_subscription_topic_buffer[az_span_size(test_default_sub_topic)]; // Exact size.
   size_t test_subscription_topic_out_size = 0;
 
   assert_int_equal(
       az_mqtt5_rpc_server_codec_get_subscribe_topic(
           &test_rpc_server_codec,
-          AZ_SPAN_EMPTY,
           test_subscription_topic_buffer,
           sizeof(test_subscription_topic_buffer),
           &test_subscription_topic_out_size),
@@ -109,7 +109,6 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_specific_endpoint_succ
 
   az_span test_sub_topic = az_span_create(
       (uint8_t*)test_subscription_topic_buffer, (int32_t)test_subscription_topic_out_size);
-  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_SUBSCRIPTION_TOPIC);
 
   assert_true(az_span_is_content_equal(test_sub_topic, test_default_sub_topic));
 }
@@ -117,6 +116,7 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_specific_endpoint_succ
 static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_success(void** state)
 {
   (void)state;
+  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_1);
 
   az_mqtt5_rpc_server_codec_options test_server_options
       = az_mqtt5_rpc_server_codec_options_default();
@@ -130,13 +130,12 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_succes
           &test_server_options),
       AZ_OK);
 
-  char test_subscription_topic_buffer[256];
+  char test_subscription_topic_buffer[az_span_size(test_default_sub_topic)];
   size_t test_subscription_topic_out_size = 0;
 
   assert_int_equal(
       az_mqtt5_rpc_server_codec_get_subscribe_topic(
           &test_rpc_server_codec,
-          AZ_SPAN_EMPTY,
           test_subscription_topic_buffer,
           sizeof(test_subscription_topic_buffer),
           &test_subscription_topic_out_size),
@@ -144,7 +143,6 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_succes
 
   az_span test_sub_topic = az_span_create(
       (uint8_t*)test_subscription_topic_buffer, (int32_t)test_subscription_topic_out_size);
-  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_1);
 
   assert_true(az_span_is_content_equal(test_sub_topic, test_default_sub_topic));
 }
@@ -153,6 +151,7 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_execut
     void** state)
 {
   (void)state;
+  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_2);
 
   az_mqtt5_rpc_server_codec_options test_server_options
       = az_mqtt5_rpc_server_codec_options_default();
@@ -166,13 +165,12 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_execut
           &test_server_options),
       AZ_OK);
 
-  char test_subscription_topic_buffer[256];
+  char test_subscription_topic_buffer[az_span_size(test_default_sub_topic)];
   size_t test_subscription_topic_out_size = 0;
 
   assert_int_equal(
       az_mqtt5_rpc_server_codec_get_subscribe_topic(
           &test_rpc_server_codec,
-          AZ_SPAN_EMPTY,
           test_subscription_topic_buffer,
           sizeof(test_subscription_topic_buffer),
           &test_subscription_topic_out_size),
@@ -180,7 +178,6 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_execut
 
   az_span test_sub_topic = az_span_create(
       (uint8_t*)test_subscription_topic_buffer, (int32_t)test_subscription_topic_out_size);
-  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_2);
 
   assert_true(az_span_is_content_equal(test_sub_topic, test_default_sub_topic));
 }
@@ -189,6 +186,7 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_no_ele
     void** state)
 {
   (void)state;
+  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_3);
 
   az_mqtt5_rpc_server_codec_options test_server_options
       = az_mqtt5_rpc_server_codec_options_default();
@@ -202,13 +200,12 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_no_ele
           &test_server_options),
       AZ_OK);
 
-  char test_subscription_topic_buffer[256];
+  char test_subscription_topic_buffer[az_span_size(test_default_sub_topic)];
   size_t test_subscription_topic_out_size = 0;
 
   assert_int_equal(
       az_mqtt5_rpc_server_codec_get_subscribe_topic(
           &test_rpc_server_codec,
-          AZ_SPAN_EMPTY,
           test_subscription_topic_buffer,
           sizeof(test_subscription_topic_buffer),
           &test_subscription_topic_out_size),
@@ -216,7 +213,6 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_no_ele
 
   az_span test_sub_topic = az_span_create(
       (uint8_t*)test_subscription_topic_buffer, (int32_t)test_subscription_topic_out_size);
-  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_3);
 
   assert_true(az_span_is_content_equal(test_sub_topic, test_default_sub_topic));
 }
@@ -242,7 +238,6 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_buffer
   assert_int_equal(
       az_mqtt5_rpc_server_codec_get_subscribe_topic(
           &test_rpc_server_codec,
-          AZ_SPAN_EMPTY,
           test_subscription_topic_buffer,
           sizeof(test_subscription_topic_buffer),
           &test_subscription_topic_out_size),
@@ -252,9 +247,11 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_buffer
 static void az_mqtt5_rpc_server_codec_get_subscribe_topic_fungible_endpoint_success(void** state)
 {
   (void)state;
+  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_FUNGIBLE_SUBSCRIPTION_TOPIC);
 
   az_mqtt5_rpc_server_codec_options test_server_options
       = az_mqtt5_rpc_server_codec_options_default();
+  test_server_options.service_group_id = AZ_SPAN_FROM_STR(TEST_SERVICE_GROUP_ID);
   assert_int_equal(
       az_mqtt5_rpc_server_codec_init(
           &test_rpc_server_codec,
@@ -263,13 +260,12 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_fungible_endpoint_succ
           &test_server_options),
       AZ_OK);
 
-  char test_subscription_topic_buffer[76]; // Exact size.
+  char test_subscription_topic_buffer[az_span_size(test_default_sub_topic)]; // Exact size.
   size_t test_subscription_topic_out_size = 0;
 
   assert_int_equal(
       az_mqtt5_rpc_server_codec_get_subscribe_topic(
           &test_rpc_server_codec,
-          AZ_SPAN_FROM_STR(TEST_SERVICE_GROUP_ID),
           test_subscription_topic_buffer,
           sizeof(test_subscription_topic_buffer),
           &test_subscription_topic_out_size),
@@ -277,7 +273,6 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_fungible_endpoint_succ
 
   az_span test_sub_topic = az_span_create(
       (uint8_t*)test_subscription_topic_buffer, (int32_t)test_subscription_topic_out_size);
-  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_FUNGIBLE_SUBSCRIPTION_TOPIC);
 
   assert_true(az_span_is_content_equal(test_sub_topic, test_default_sub_topic));
 }

--- a/sdk/tests/core/test_az_mqtt5_telemetry_consumer_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_telemetry_consumer_codec.c
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "az_span_private.h"
+#include "az_test_definitions.h"
+#include <azure/core/az_mqtt5_telemetry.h>
+#include <azure/core/az_mqtt5_telemetry_consumer_codec.h>
+#include <azure/core/az_result.h>
+#include <azure/core/internal/az_mqtt5_topic_parser_internal.h>
+#include <azure/core/internal/az_span_internal.h>
+#include <azure/iot/az_iot_common.h>
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+
+#include <cmocka.h>
+
+#define TEST_SERVICE_GROUP_ID "test_service_group_id"
+#define TEST_MODEL_ID "test_model_id"
+#define TEST_SENDER_ID "test_sender_id"
+#define TEST_DEFAULT_CONSUMER_TOPIC "services/" TEST_MODEL_ID "/" TEST_SENDER_ID "/telemetry\0"
+#define TEST_DEFAULT_CONSUMER_TOPIC_RECEIVED \
+  "services/" TEST_MODEL_ID "/" TEST_SENDER_ID "/telemetry"
+#define TEST_DEFAULT_CONSUMER_FUNGIBLE_TOPIC \
+  "$share/" TEST_SERVICE_GROUP_ID "/services/" TEST_MODEL_ID "/" TEST_SENDER_ID "/telemetry\0"
+#define TEST_CUSTOM_CONSUMER_TOPIC_FORMAT "sender/{senderId}/service/{serviceId}/telemetry/{name}"
+#define TEST_CUSTOM_CONSUMER_TOPIC \
+  "sender/" TEST_SENDER_ID "/service/" TEST_MODEL_ID "/telemetry/+\0"
+
+static void test_az_mqtt5_telemetry_producer_codec_init_no_options_success(void** state)
+{
+  (void)state;
+  az_mqtt5_telemetry_consumer_codec consumer;
+  assert_int_equal(
+      az_mqtt5_telemetry_consumer_codec_init(
+          &consumer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_SENDER_ID), NULL),
+      AZ_OK);
+
+  assert_true(
+      az_span_is_content_equal(consumer._internal.model_id, AZ_SPAN_FROM_STR(TEST_MODEL_ID)));
+  assert_true(
+      az_span_is_content_equal(consumer._internal.sender_id, AZ_SPAN_FROM_STR(TEST_SENDER_ID)));
+  assert_true(az_span_is_content_equal(
+      consumer._internal.options.telemetry_topic_format,
+      AZ_SPAN_FROM_STR(AZ_MQTT5_TELEMETRY_DEFAULT_TOPIC_FORMAT)));
+}
+
+static void test_az_mqtt5_telemetry_consumer_codec_init_options_success(void** state)
+{
+  (void)state;
+  az_mqtt5_telemetry_consumer_codec consumer;
+  az_mqtt5_telemetry_consumer_codec_options options
+      = az_mqtt5_telemetry_consumer_codec_options_default();
+  options.telemetry_topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_CONSUMER_TOPIC_FORMAT);
+
+  assert_int_equal(
+      az_mqtt5_telemetry_consumer_codec_init(
+          &consumer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_SENDER_ID), &options),
+      AZ_OK);
+
+  assert_true(
+      az_span_is_content_equal(consumer._internal.model_id, AZ_SPAN_FROM_STR(TEST_MODEL_ID)));
+  assert_true(
+      az_span_is_content_equal(consumer._internal.sender_id, AZ_SPAN_FROM_STR(TEST_SENDER_ID)));
+  assert_true(az_span_is_content_equal(
+      consumer._internal.options.telemetry_topic_format,
+      AZ_SPAN_FROM_STR(TEST_CUSTOM_CONSUMER_TOPIC_FORMAT)));
+}
+
+static void test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_specific_endpoint_success(
+    void** state)
+{
+  (void)state;
+  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_CONSUMER_TOPIC);
+  az_mqtt5_telemetry_consumer_codec consumer;
+  az_result result = az_mqtt5_telemetry_consumer_codec_init(
+      &consumer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_SENDER_ID), NULL);
+  assert_int_equal(result, AZ_OK);
+
+  char test_subscription_topic_buffer[az_span_size(test_default_sub_topic)];
+  size_t test_subscription_topic_buffer_out_size = 0;
+  assert_int_equal(
+      az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
+          &consumer,
+          test_subscription_topic_buffer,
+          sizeof(test_subscription_topic_buffer),
+          &test_subscription_topic_buffer_out_size),
+      AZ_OK);
+
+  az_span test_sub_topic = az_span_create(
+      (uint8_t*)test_subscription_topic_buffer, (int32_t)test_subscription_topic_buffer_out_size);
+
+  assert_true(az_span_is_content_equal(test_sub_topic, test_default_sub_topic));
+}
+
+static void test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_fungible_endpoint_success(
+    void** state)
+{
+  (void)state;
+  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_CONSUMER_FUNGIBLE_TOPIC);
+  az_mqtt5_telemetry_consumer_codec consumer;
+  az_mqtt5_telemetry_consumer_codec_options options
+      = az_mqtt5_telemetry_consumer_codec_options_default();
+  options.service_group_id = AZ_SPAN_FROM_STR(TEST_SERVICE_GROUP_ID);
+  az_result result = az_mqtt5_telemetry_consumer_codec_init(
+      &consumer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_SENDER_ID), &options);
+  assert_int_equal(result, AZ_OK);
+
+  char test_subscription_topic_buffer[az_span_size(test_default_sub_topic)];
+  size_t test_subscription_topic_buffer_out_size = 0;
+  assert_int_equal(
+      az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
+          &consumer,
+          test_subscription_topic_buffer,
+          sizeof(test_subscription_topic_buffer),
+          &test_subscription_topic_buffer_out_size),
+      AZ_OK);
+
+  az_span test_sub_topic = az_span_create(
+      (uint8_t*)test_subscription_topic_buffer, (int32_t)test_subscription_topic_buffer_out_size);
+
+  assert_true(az_span_is_content_equal(test_sub_topic, test_default_sub_topic));
+}
+
+static void test_az_mqtt5_telemetry_consumer_codec_get_subscribe_custom_topic_success(void** state)
+{
+  (void)state;
+  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_CONSUMER_TOPIC);
+  az_mqtt5_telemetry_consumer_codec consumer;
+  az_mqtt5_telemetry_consumer_codec_options options
+      = az_mqtt5_telemetry_consumer_codec_options_default();
+  options.telemetry_topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_CONSUMER_TOPIC_FORMAT);
+
+  az_result result = az_mqtt5_telemetry_consumer_codec_init(
+      &consumer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_SENDER_ID), &options);
+  assert_int_equal(result, AZ_OK);
+
+  char test_subscription_topic_buffer[az_span_size(test_default_sub_topic)];
+  size_t test_subscription_topic_buffer_out_size = 0;
+  assert_int_equal(
+      az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
+          &consumer,
+          test_subscription_topic_buffer,
+          sizeof(test_subscription_topic_buffer),
+          &test_subscription_topic_buffer_out_size),
+      AZ_OK);
+
+  az_span test_sub_topic = az_span_create(
+      (uint8_t*)test_subscription_topic_buffer, (int32_t)test_subscription_topic_buffer_out_size);
+
+  assert_true(az_span_is_content_equal(test_sub_topic, test_default_sub_topic));
+}
+
+static void test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_buffer_size_failure(
+    void** state)
+{
+  (void)state;
+  az_mqtt5_telemetry_consumer_codec consumer;
+  az_result result = az_mqtt5_telemetry_consumer_codec_init(
+      &consumer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_SENDER_ID), NULL);
+  assert_int_equal(result, AZ_OK);
+
+  char test_subscription_topic_buffer[1];
+  size_t test_subscription_topic_buffer_out_size = 0;
+  assert_int_equal(
+      az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
+          &consumer,
+          test_subscription_topic_buffer,
+          sizeof(test_subscription_topic_buffer),
+          &test_subscription_topic_buffer_out_size),
+      AZ_ERROR_NOT_ENOUGH_SPACE);
+
+  assert_int_equal(test_subscription_topic_buffer_out_size, 48);
+}
+
+static void test_az_mqtt5_telemetry_consumer_codec_parse_received_specific_topic_success(
+    void** state)
+{
+  (void)state;
+  az_mqtt5_telemetry_consumer_codec consumer;
+  az_result result = az_mqtt5_telemetry_consumer_codec_init(
+      &consumer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_SENDER_ID), NULL);
+  assert_int_equal(result, AZ_OK);
+
+  az_span test_received_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_CONSUMER_TOPIC_RECEIVED);
+  az_mqtt5_telemetry_consumer_codec_data test_data;
+  result = az_mqtt5_telemetry_consumer_codec_parse_received_topic(
+      &consumer, test_received_topic, &test_data);
+  assert_int_equal(result, AZ_OK);
+
+  assert_true(az_span_is_content_equal(test_data.service_id, AZ_SPAN_FROM_STR(TEST_MODEL_ID)));
+  assert_true(az_span_is_content_equal(test_data.sender_id, AZ_SPAN_FROM_STR(TEST_SENDER_ID)));
+  assert_true(az_span_is_content_equal(test_data.command_name, AZ_SPAN_EMPTY));
+}
+
+int test_az_mqtt5_telemetry_consumer_codec()
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(test_az_mqtt5_telemetry_producer_codec_init_no_options_success),
+    cmocka_unit_test(test_az_mqtt5_telemetry_consumer_codec_init_options_success),
+    cmocka_unit_test(
+        test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_specific_endpoint_success),
+    cmocka_unit_test(
+        test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_fungible_endpoint_success),
+    cmocka_unit_test(test_az_mqtt5_telemetry_consumer_codec_get_subscribe_custom_topic_success),
+    cmocka_unit_test(
+        test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_buffer_size_failure),
+    cmocka_unit_test(test_az_mqtt5_telemetry_consumer_codec_parse_received_specific_topic_success),
+  };
+  return cmocka_run_group_tests_name("az_core_mqtt5_telemetry_consumer_codec", tests, NULL, NULL);
+}

--- a/sdk/tests/core/test_az_mqtt5_telemetry_consumer_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_telemetry_consumer_codec.c
@@ -68,8 +68,7 @@ static void test_az_mqtt5_telemetry_consumer_codec_init_options_success(void** s
       AZ_SPAN_FROM_STR(TEST_CUSTOM_CONSUMER_TOPIC_FORMAT)));
 }
 
-static void test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_specific_endpoint_success(
-    void** state)
+static void test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_default_success(void** state)
 {
   (void)state;
   az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_CONSUMER_TOPIC);
@@ -126,7 +125,7 @@ static void test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_fungible_
 static void test_az_mqtt5_telemetry_consumer_codec_get_subscribe_custom_topic_success(void** state)
 {
   (void)state;
-  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_CONSUMER_TOPIC);
+  az_span test_custom_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_CONSUMER_TOPIC);
   az_mqtt5_telemetry_consumer_codec consumer;
   az_mqtt5_telemetry_consumer_codec_options options
       = az_mqtt5_telemetry_consumer_codec_options_default();
@@ -136,7 +135,7 @@ static void test_az_mqtt5_telemetry_consumer_codec_get_subscribe_custom_topic_su
       &consumer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_SENDER_ID), &options);
   assert_int_equal(result, AZ_OK);
 
-  char test_subscription_topic_buffer[az_span_size(test_default_sub_topic)];
+  char test_subscription_topic_buffer[az_span_size(test_custom_sub_topic)];
   size_t test_subscription_topic_buffer_out_size = 0;
   assert_int_equal(
       az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
@@ -149,7 +148,7 @@ static void test_az_mqtt5_telemetry_consumer_codec_get_subscribe_custom_topic_su
   az_span test_sub_topic = az_span_create(
       (uint8_t*)test_subscription_topic_buffer, (int32_t)test_subscription_topic_buffer_out_size);
 
-  assert_true(az_span_is_content_equal(test_sub_topic, test_default_sub_topic));
+  assert_true(az_span_is_content_equal(test_sub_topic, test_custom_sub_topic));
 }
 
 static void test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_buffer_size_failure(
@@ -174,7 +173,7 @@ static void test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_buffer_si
   assert_int_equal(test_subscription_topic_buffer_out_size, 48);
 }
 
-static void test_az_mqtt5_telemetry_consumer_codec_parse_received_specific_topic_success(
+static void test_az_mqtt5_telemetry_consumer_codec_parse_received_default_topic_success(
     void** state)
 {
   (void)state;
@@ -199,14 +198,13 @@ int test_az_mqtt5_telemetry_consumer_codec()
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(test_az_mqtt5_telemetry_producer_codec_init_no_options_success),
     cmocka_unit_test(test_az_mqtt5_telemetry_consumer_codec_init_options_success),
-    cmocka_unit_test(
-        test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_specific_endpoint_success),
+    cmocka_unit_test(test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_default_success),
     cmocka_unit_test(
         test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_fungible_endpoint_success),
     cmocka_unit_test(test_az_mqtt5_telemetry_consumer_codec_get_subscribe_custom_topic_success),
     cmocka_unit_test(
         test_az_mqtt5_telemetry_consumer_codec_get_subscribe_topic_buffer_size_failure),
-    cmocka_unit_test(test_az_mqtt5_telemetry_consumer_codec_parse_received_specific_topic_success),
+    cmocka_unit_test(test_az_mqtt5_telemetry_consumer_codec_parse_received_default_topic_success),
   };
   return cmocka_run_group_tests_name("az_core_mqtt5_telemetry_consumer_codec", tests, NULL, NULL);
 }

--- a/sdk/tests/core/test_az_mqtt5_telemetry_producer_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_telemetry_producer_codec.c
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "az_span_private.h"
+#include "az_test_definitions.h"
+#include <azure/core/az_mqtt5_telemetry.h>
+#include <azure/core/az_mqtt5_telemetry_producer_codec.h>
+#include <azure/core/az_result.h>
+#include <azure/core/internal/az_mqtt5_topic_parser_internal.h>
+#include <azure/core/internal/az_span_internal.h>
+#include <azure/iot/az_iot_common.h>
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+
+#include <cmocka.h>
+
+#define TEST_MODEL_ID "test_model_id"
+#define TEST_CLIENT_ID "test_client_id"
+#define TEST_TELEMETRY_NAME "test_telemetry_name"
+#define TEST_DEFAULT_PRODUCER_TOPIC "services/" TEST_MODEL_ID "/" TEST_CLIENT_ID "/telemetry\0"
+#define TEST_CUSTOM_PRODUCER_TOPIC_FORMAT "sender/{senderId}/service/{serviceId}/telemetry/{name}"
+#define TEST_CUSTOM_PRODUCER_TOPIC \
+  "sender/" TEST_CLIENT_ID "/service/" TEST_MODEL_ID "/telemetry/" TEST_TELEMETRY_NAME "\0"
+
+static void test_az_mqtt5_telemetry_producer_codec_init_no_options_success(void** state)
+{
+  (void)state;
+  az_mqtt5_telemetry_producer_codec producer;
+  assert_int_equal(
+      az_mqtt5_telemetry_producer_codec_init(
+          &producer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_CLIENT_ID), NULL),
+      AZ_OK);
+
+  assert_true(
+      az_span_is_content_equal(producer._internal.model_id, AZ_SPAN_FROM_STR(TEST_MODEL_ID)));
+  assert_true(
+      az_span_is_content_equal(producer._internal.client_id, AZ_SPAN_FROM_STR(TEST_CLIENT_ID)));
+  assert_true(az_span_is_content_equal(
+      producer._internal.options.telemetry_topic_format,
+      AZ_SPAN_FROM_STR(AZ_MQTT5_TELEMETRY_DEFAULT_TOPIC_FORMAT)));
+}
+
+static void test_az_mqtt5_telemetry_producer_codec_init_options_success(void** state)
+{
+  (void)state;
+  az_mqtt5_telemetry_producer_codec producer;
+  az_mqtt5_telemetry_producer_codec_options options
+      = az_mqtt5_telemetry_producer_codec_options_default();
+  options.telemetry_topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_PRODUCER_TOPIC_FORMAT);
+
+  assert_int_equal(
+      az_mqtt5_telemetry_producer_codec_init(
+          &producer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_CLIENT_ID), &options),
+      AZ_OK);
+
+  assert_true(
+      az_span_is_content_equal(producer._internal.model_id, AZ_SPAN_FROM_STR(TEST_MODEL_ID)));
+  assert_true(
+      az_span_is_content_equal(producer._internal.client_id, AZ_SPAN_FROM_STR(TEST_CLIENT_ID)));
+  assert_true(az_span_is_content_equal(
+      producer._internal.options.telemetry_topic_format,
+      AZ_SPAN_FROM_STR(TEST_CUSTOM_PRODUCER_TOPIC_FORMAT)));
+}
+
+static void test_az_mqtt5_telemetry_producer_codec_get_publish_topic_default_success(void** state)
+{
+  (void)state;
+  az_span test_default_pub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_PRODUCER_TOPIC);
+  az_mqtt5_telemetry_producer_codec producer;
+  az_result result = az_mqtt5_telemetry_producer_codec_init(
+      &producer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_CLIENT_ID), NULL);
+  assert_int_equal(result, AZ_OK);
+
+  char test_publish_topic_buffer[az_span_size(test_default_pub_topic)];
+  size_t test_publish_topic_buffer_out_size = 0;
+  assert_int_equal(
+      az_mqtt5_telemetry_producer_codec_get_publish_topic(
+          &producer,
+          AZ_SPAN_EMPTY,
+          test_publish_topic_buffer,
+          sizeof(test_publish_topic_buffer),
+          &test_publish_topic_buffer_out_size),
+      AZ_OK);
+
+  az_span test_pub_topic = az_span_create(
+      (uint8_t*)test_publish_topic_buffer, (int32_t)test_publish_topic_buffer_out_size);
+
+  assert_true(az_span_is_content_equal(test_pub_topic, test_default_pub_topic));
+}
+
+static void test_az_mqtt5_telemetry_producer_codec_get_publish_topic_custom_success(void** state)
+{
+  (void)state;
+  az_span test_default_pub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_PRODUCER_TOPIC);
+  az_mqtt5_telemetry_producer_codec producer;
+  az_mqtt5_telemetry_producer_codec_options options
+      = az_mqtt5_telemetry_producer_codec_options_default();
+  options.telemetry_topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_PRODUCER_TOPIC_FORMAT);
+
+  az_result result = az_mqtt5_telemetry_producer_codec_init(
+      &producer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_CLIENT_ID), &options);
+  assert_int_equal(result, AZ_OK);
+
+  char test_publish_topic_buffer[az_span_size(test_default_pub_topic)];
+  size_t test_publish_topic_buffer_out_size = 0;
+  assert_int_equal(
+      az_mqtt5_telemetry_producer_codec_get_publish_topic(
+          &producer,
+          AZ_SPAN_FROM_STR(TEST_TELEMETRY_NAME),
+          test_publish_topic_buffer,
+          sizeof(test_publish_topic_buffer),
+          &test_publish_topic_buffer_out_size),
+      AZ_OK);
+
+  az_span test_pub_topic = az_span_create(
+      (uint8_t*)test_publish_topic_buffer, (int32_t)test_publish_topic_buffer_out_size);
+
+  assert_true(az_span_is_content_equal(test_pub_topic, test_default_pub_topic));
+}
+
+static void test_az_mqtt5_telemetry_producer_codec_get_publish_topic_buffer_size_failure(
+    void** state)
+{
+  (void)state;
+  az_mqtt5_telemetry_producer_codec producer;
+  az_result result = az_mqtt5_telemetry_producer_codec_init(
+      &producer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_CLIENT_ID), NULL);
+  assert_int_equal(result, AZ_OK);
+
+  char test_publish_topic_buffer[1];
+  size_t test_publish_topic_buffer_out_size = 0;
+  assert_int_equal(
+      az_mqtt5_telemetry_producer_codec_get_publish_topic(
+          &producer,
+          AZ_SPAN_EMPTY,
+          test_publish_topic_buffer,
+          sizeof(test_publish_topic_buffer),
+          &test_publish_topic_buffer_out_size),
+      AZ_ERROR_NOT_ENOUGH_SPACE);
+
+  assert_int_equal(test_publish_topic_buffer_out_size, 48);
+}
+
+int test_az_mqtt5_telemetry_producer_codec()
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(test_az_mqtt5_telemetry_producer_codec_init_no_options_success),
+    cmocka_unit_test(test_az_mqtt5_telemetry_producer_codec_init_options_success),
+    cmocka_unit_test(test_az_mqtt5_telemetry_producer_codec_get_publish_topic_default_success),
+    cmocka_unit_test(test_az_mqtt5_telemetry_producer_codec_get_publish_topic_custom_success),
+    cmocka_unit_test(test_az_mqtt5_telemetry_producer_codec_get_publish_topic_buffer_size_failure),
+  };
+  return cmocka_run_group_tests_name("az_core_mqtt5_telemetry_producer_codec", tests, NULL, NULL);
+}

--- a/sdk/tests/core/test_az_mqtt5_topic_parser.c
+++ b/sdk/tests/core/test_az_mqtt5_topic_parser.c
@@ -15,10 +15,11 @@
 
 #define TEST_SAMPLE_FORMAT                                                               \
   "test/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_KEY "/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_KEY \
-  "/" _az_MQTT5_RPC_EXECUTOR_ID_KEY "/" _az_MQTT5_TOPIC_PARSER_COMMAND_ID_KEY "/endoftest"
+  "/" _az_MQTT5_RPC_EXECUTOR_ID_KEY "/" _az_MQTT5_TOPIC_PARSER_NAME_KEY                  \
+  "/" _az_MQTT5_TOPIC_PARSER_SENDER_ID_KEY "/endoftest"
 #define TEST_SAMPLE_FORMAT_REPLACED                                                    \
   "$share/test_service_group_id/test/test_client_id/test_service_id/test_executor_id/" \
-  "test_command_id/endoftest\0"
+  "test_name/test_sender_id/endoftest\0"
 static const az_span test_sample_format = AZ_SPAN_LITERAL_FROM_STR(TEST_SAMPLE_FORMAT);
 static const az_span test_sample_format_replaced
     = AZ_SPAN_LITERAL_FROM_STR(TEST_SAMPLE_FORMAT_REPLACED);
@@ -26,7 +27,8 @@ static const az_span test_service_group_id = AZ_SPAN_LITERAL_FROM_STR("test_serv
 static const az_span test_sample_client_id = AZ_SPAN_LITERAL_FROM_STR("test_client_id");
 static const az_span test_sample_service_id = AZ_SPAN_LITERAL_FROM_STR("test_service_id");
 static const az_span test_sample_executor_id = AZ_SPAN_LITERAL_FROM_STR("test_executor_id");
-static const az_span test_sample_command_id = AZ_SPAN_LITERAL_FROM_STR("test_command_id");
+static const az_span test_sample_name_id = AZ_SPAN_LITERAL_FROM_STR("test_name");
+static const az_span test_sample_sender_id = AZ_SPAN_LITERAL_FROM_STR("test_sender_id");
 
 AZ_INLINE az_span test_az_mqtt5_get_key_no_braces(char* key)
 {
@@ -42,7 +44,11 @@ static void test_az_mqtt5_topic_parser_calculate_hash_success(void** state)
       = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_CLIENT_ID_KEY);
   az_span model_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_SERVICE_ID_KEY);
   az_span executor_client_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_RPC_EXECUTOR_ID_KEY);
-  az_span command_name_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_COMMAND_ID_KEY);
+  az_span sender_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_SENDER_ID_KEY);
+  az_span name_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_NAME_KEY);
+
+  uint32_t sender_id_key_hash = _az_mqtt5_topic_parser_calculate_hash(sender_id_key);
+  (void)sender_id_key_hash;
 
   assert_int_equal(
       _az_MQTT5_TOPIC_PARSER_CLIENT_ID_HASH,
@@ -53,15 +59,16 @@ static void test_az_mqtt5_topic_parser_calculate_hash_success(void** state)
       _az_MQTT5_TOPIC_PARSER_EXECUTOR_ID_HASH,
       _az_mqtt5_topic_parser_calculate_hash(executor_client_id_key));
   assert_int_equal(
-      _az_MQTT5_TOPIC_PARSER_COMMAND_ID_HASH,
-      _az_mqtt5_topic_parser_calculate_hash(command_name_key));
+      _az_MQTT5_TOPIC_PARSER_SENDER_ID_HASH, _az_mqtt5_topic_parser_calculate_hash(sender_id_key));
+  assert_int_equal(
+      _az_MQTT5_TOPIC_PARSER_COMMAND_ID_HASH, _az_mqtt5_topic_parser_calculate_hash(name_key));
 }
 
 static void test_az_mqtt5_topic_parser_replace_tokens_in_format_success(void** state)
 {
   (void)state;
 
-  uint8_t test_buffer[108];
+  uint8_t test_buffer[117];
   az_span test_buffer_span = AZ_SPAN_FROM_BUFFER(test_buffer);
   uint32_t test_size = 0;
 
@@ -72,7 +79,8 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_success(void** s
       test_sample_client_id,
       test_sample_service_id,
       test_sample_executor_id,
-      test_sample_command_id,
+      test_sample_sender_id,
+      test_sample_name_id,
       &test_size);
 
   assert_int_equal(res, AZ_OK);
@@ -97,11 +105,12 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_failure(void** s
       test_sample_client_id,
       test_sample_service_id,
       test_sample_executor_id,
-      test_sample_command_id,
+      test_sample_sender_id,
+      test_sample_name_id,
       &test_size);
 
   assert_int_equal(res, AZ_ERROR_NOT_ENOUGH_SPACE);
-  assert_int_equal(test_size, 108);
+  assert_int_equal(test_size, 117);
 }
 
 static void test_az_mqtt5_topic_parser_replace_tokens_in_format_no_service_group_failure(
@@ -120,11 +129,12 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_no_service_group
       test_sample_client_id,
       test_sample_service_id,
       test_sample_executor_id,
-      test_sample_command_id,
+      test_sample_sender_id,
+      test_sample_name_id,
       &test_size);
 
   assert_int_equal(res, AZ_ERROR_NOT_ENOUGH_SPACE);
-  assert_int_equal(test_size, 79);
+  assert_int_equal(test_size, 88);
 }
 
 int test_az_mqtt5_topic_parser()

--- a/sdk/tests/core/test_az_mqtt5_topic_parser.c
+++ b/sdk/tests/core/test_az_mqtt5_topic_parser.c
@@ -13,10 +13,10 @@
 
 #include <cmocka.h>
 
-#define TEST_SAMPLE_FORMAT                                                               \
-  "test/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_KEY "/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_KEY \
-  "/" _az_MQTT5_RPC_EXECUTOR_ID_KEY "/" _az_MQTT5_TOPIC_PARSER_NAME_KEY                  \
-  "/" _az_MQTT5_TOPIC_PARSER_SENDER_ID_KEY "/endoftest"
+#define TEST_SAMPLE_FORMAT                                                                   \
+  "test/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN \
+  "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_NAME_TOKEN                  \
+  "/" _az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN "/endoftest"
 #define TEST_SAMPLE_FORMAT_REPLACED                                                    \
   "$share/test_service_group_id/test/test_client_id/test_service_id/test_executor_id/" \
   "test_name/test_sender_id/endoftest\0"
@@ -41,11 +41,11 @@ static void test_az_mqtt5_topic_parser_calculate_hash_success(void** state)
   (void)state;
 
   az_span invoker_client_id_key
-      = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_CLIENT_ID_KEY);
-  az_span model_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_SERVICE_ID_KEY);
-  az_span executor_client_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_RPC_EXECUTOR_ID_KEY);
-  az_span sender_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_SENDER_ID_KEY);
-  az_span name_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_NAME_KEY);
+      = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN);
+  az_span model_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN);
+  az_span executor_client_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_RPC_EXECUTOR_ID_TOKEN);
+  az_span sender_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN);
+  az_span name_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_NAME_TOKEN);
 
   uint32_t sender_id_key_hash = _az_mqtt5_topic_parser_calculate_hash(sender_id_key);
   (void)sender_id_key_hash;
@@ -61,7 +61,7 @@ static void test_az_mqtt5_topic_parser_calculate_hash_success(void** state)
   assert_int_equal(
       _az_MQTT5_TOPIC_PARSER_SENDER_ID_HASH, _az_mqtt5_topic_parser_calculate_hash(sender_id_key));
   assert_int_equal(
-      _az_MQTT5_TOPIC_PARSER_COMMAND_ID_HASH, _az_mqtt5_topic_parser_calculate_hash(name_key));
+      _az_MQTT5_TOPIC_PARSER_NAME_HASH, _az_mqtt5_topic_parser_calculate_hash(name_key));
 }
 
 static void test_az_mqtt5_topic_parser_replace_tokens_in_format_success(void** state)


### PR DESCRIPTION
Adding both the telemetry consumer and producer codecs.

Still need to add unit tests for both. Will add in a follow-up commit.