### PR TITLE
Change RPC commands to take just one topic format, support cmdPhase

### DIFF
--- a/sdk/inc/azure/core/az_mqtt5_rpc.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc.h
@@ -22,18 +22,11 @@
 #include <azure/core/_az_cfg_prefix.h>
 
 /**
- * @brief The default topic format for making RPC requests.
+ * @brief The default topic format for RPC requests and responses.
  */
-#define AZ_MQTT5_RPC_DEFAULT_REQUEST_TOPIC_FORMAT                                         \
+#define AZ_MQTT5_RPC_DEFAULT_TOPIC_FORMAT                                         \
   "services/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN \
-  "/command/" _az_MQTT5_TOPIC_PARSER_NAME_TOKEN "/request"
-/**
- * @brief The default topic format where RPC responses are published.
- */
-#define AZ_MQTT5_RPC_DEFAULT_RESPONSE_TOPIC_FORMAT                                         \
-  "clients/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN                                        \
-  "/services/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN \
-  "/command/" _az_MQTT5_TOPIC_PARSER_NAME_TOKEN "/response"
+  "/command/" _az_MQTT5_TOPIC_PARSER_NAME_TOKEN "/" _az_MQTT5_TOPIC_PARSER_CMD_PHASE_TOKEN
 
 /**
  * @brief The default timeout in seconds for subscribing/publishing.

--- a/sdk/inc/azure/core/az_mqtt5_rpc_client_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc_client_codec.h
@@ -27,29 +27,18 @@
 typedef struct
 {
   /**
-   * @brief The topic format to use for the subscription topic.
+   * @brief The topic format to use for the request and subscription topics.
    *
    *
    * @note Can include {name} for command name, {serviceId} for model id, {executorId} for the
-   * server's client_id, and/or {invokerClientId} for the client's client_id. The default value is
-   * "clients/{invokerClientId}/services/{serviceId}/{executorId}/command/{name}/response".
+   * server's client_id, and/or {invokerClientId} for the client's client_id. and {cmdPhase} for
+   * differentiating between request and response topics. The default value is
+   * "clients/{invokerClientId}/services/{serviceId}/{executorId}/command/{name}/{cmdPhase}".
    *
    * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
    * topic.
    */
-  az_span subscription_topic_format;
-
-  /**
-   * @brief The topic format to use for the request topic.
-   *
-   * @note Can include {name} for command name, {serviceId} for model id, and/or {executorId} for
-   * the server's client_id. The default value is
-   * "services/{serviceId}/{executorId}/command/{name}/request".
-   *
-   * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
-   * topic.
-   */
-  az_span request_topic_format;
+  az_span topic_format;
 
 } az_mqtt5_rpc_client_codec_options;
 

--- a/sdk/inc/azure/core/az_mqtt5_rpc_server_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc_server_codec.h
@@ -37,14 +37,15 @@ typedef struct
    * @brief The topic format to use for the subscription topic.
    *
    * @note Can include {name} for command name if server can accept multiple commands, {serviceId}
-   * for model id, and/or {executorId} for the server's client_id. The default value is
-   * services/{serviceId}/{executorId}/command/{name}/request.
+   * for model id, and/or {executorId} for the server's client_id, and {cmdPhase} for
+   * differentiating between request and response topics. The default value is
+   * services/{serviceId}/{executorId}/command/{name}/{cmdPhase}.
    *
    * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
    * topic.
    *
    */
-  az_span subscription_topic_format;
+  az_span topic_format;
 
 } az_mqtt5_rpc_server_codec_options;
 

--- a/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
+++ b/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
@@ -40,11 +40,14 @@
  * @brief Value used to replace the command phase token in a command topic format with "response".
  */
 #define _az_MQTT5_TOPIC_PARSER_CMD_PHASE_RESPONSE "response"
-
 /**
  * @brief Token used to indicate the invoker client id in a topic format.
  */
 #define _az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN "{invokerClientId}"
+/**
+ * @brief Prefix for client (invoker) command response topic format.
+ */
+#define _az_MQTT5_TOPIC_PARSER_RPC_CLIENT_RESPONSE_FORMAT_PREFIX "clients/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN "/"
 /**
  * @brief Hash of the client id token. Exact string used to calculate the hash is "invokerClientId".
  *
@@ -140,7 +143,9 @@ AZ_INLINE uint32_t _az_mqtt5_topic_parser_calculate_hash(az_span token)
  * @brief Helper function to replace tokens in a topic format.
  *
  * @param[out] mqtt_topic_span Buffer to write the result to.
- * @param[in] topic_format The topic format to replace tokens in.
+ * @param[in] topic_formats The topic formats to replace tokens in.
+ *                          The formats are concatenated in the order they are provided.
+ * @param[in] topic_formats_count The number of topic formats provided.
  * @param[in] service_group_id #az_span containing the service group id or #AZ_SPAN_EMPTY.
  * @param[in] client_id #az_span containing the client id or #AZ_SPAN_EMPTY.
  * @param[in] service_id #az_span containing the service id.
@@ -154,7 +159,8 @@ AZ_INLINE uint32_t _az_mqtt5_topic_parser_calculate_hash(az_span token)
  */
 AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
     az_span mqtt_topic_span,
-    az_span topic_format,
+    az_span* topic_formats,
+    int32_t topic_formats_count,
     az_span service_group_id,
     az_span client_id,
     az_span service_id,
@@ -167,7 +173,9 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
 /**
  * @brief Helper function to extract tokens from a topic.
  *
- * @param[in] topic_format The topic format to reference when extracting tokens.
+ * @param[in] topic_formats The topic formats to reference when extracting tokens.
+ *                          The formats are concatenated in the order they are provided.
+ * @param[in] topic_formats_count The number of topic formats provided.
  * @param[in] received_topic The topic to extract tokens from.
  * @param[in] client_id #az_span containing the client id or #AZ_SPAN_EMPTY.
  * @param[in] service_id #az_span containing the service id or #AZ_SPAN_EMPTY.
@@ -187,7 +195,8 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
  * @return An #az_result value indicating the result of the operation.
  */
 AZ_NODISCARD az_result _az_mqtt5_topic_parser_extract_tokens_from_topic(
-    az_span topic_format,
+    az_span* topic_formats,
+    int32_t topic_formats_count,
     az_span received_topic,
     az_span client_id,
     az_span service_id,

--- a/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
+++ b/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
@@ -32,6 +32,14 @@
  * @brief Token used to replace the executor id in a topic format with any executor id.
  */
 #define _az_MQTT5_TOPIC_PARSER_ANY_EXECUTOR_ID "_any_"
+/**
+ * @brief Value used to replace the command phase token in a command topic format with "request".
+ */
+#define _az_MQTT5_TOPIC_PARSER_CMD_PHASE_REQUEST "request"
+/**
+ * @brief Value used to replace the command phase token in a command topic format with "response".
+ */
+#define _az_MQTT5_TOPIC_PARSER_CMD_PHASE_RESPONSE "response"
 
 /**
  * @brief Token used to indicate the invoker client id in a topic format.
@@ -99,6 +107,19 @@
 #define _az_MQTT5_TOPIC_PARSER_SENDER_ID_HASH 3332431765
 
 /**
+ * @brief Token used to indicate the phase (request or response) in the command topic format.
+ */
+#define _az_MQTT5_TOPIC_PARSER_CMD_PHASE_TOKEN "{cmdPhase}"
+/**
+ * @brief Hash of the command phase token. Exact string used to calculate the hash is "cmdPhase".
+ *
+ * @details The value below is a hash of a token used in a topic format, it has been calculated
+ * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
+ * #az_span containing the token (ex. "cmdPhase"). If the token changes, update the hash here.
+ */
+#define _az_MQTT5_TOPIC_PARSER_CMD_PHASE_HASH 1369004396
+
+/**
  * @brief Function to calculate the hash of a token.
  *
  * @param token[in] The token to calculate the hash of.
@@ -126,6 +147,7 @@ AZ_INLINE uint32_t _az_mqtt5_topic_parser_calculate_hash(az_span token)
  * @param[in] executor_id #az_span containing the executor id or #AZ_SPAN_EMPTY.
  * @param[in] sender_id #az_span containing the sender id or #AZ_SPAN_EMPTY.
  * @param[in] name #az_span containing the command or telemetry name.
+ * @param[in] command_phase #az_span containing the command phase (e.g. "request" or "response").
  * @param[out] required_length The required length of the buffer to write the result to.
  *
  * @return An #az_result value indicating the result of the operation.
@@ -139,6 +161,7 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
     az_span executor_id,
     az_span sender_id,
     az_span name,
+    az_span command_phase,
     uint32_t* required_length);
 
 /**

--- a/sdk/src/azure/core/az_mqtt5_rpc_client_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_client_codec.c
@@ -15,12 +15,16 @@
 static const az_span _az_mqtt5_rpc_any_executor_id
     = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_ANY_EXECUTOR_ID);
 
+static const az_span _az_mqtt5_rpc_cmd_phase_request
+    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_CMD_PHASE_REQUEST);
+
+static const az_span _az_mqtt5_rpc_cmd_phase_response
+    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_CMD_PHASE_RESPONSE);
+
 AZ_NODISCARD az_mqtt5_rpc_client_codec_options az_mqtt5_rpc_client_codec_options_default()
 {
   return (az_mqtt5_rpc_client_codec_options){
-    .subscription_topic_format
-    = AZ_SPAN_LITERAL_FROM_STR(AZ_MQTT5_RPC_DEFAULT_RESPONSE_TOPIC_FORMAT),
-    .request_topic_format = AZ_SPAN_LITERAL_FROM_STR(AZ_MQTT5_RPC_DEFAULT_REQUEST_TOPIC_FORMAT),
+    .topic_format = AZ_SPAN_LITERAL_FROM_STR(AZ_MQTT5_RPC_DEFAULT_TOPIC_FORMAT)
   };
 }
 
@@ -43,7 +47,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_publish_topic(
 
   ret = _az_mqtt5_topic_parser_replace_tokens_in_format(
       mqtt_topic_span,
-      client->_internal.options.request_topic_format,
+      client->_internal.options.topic_format,
       AZ_SPAN_EMPTY,
       AZ_SPAN_EMPTY,
       client->_internal.model_id,
@@ -51,6 +55,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_publish_topic(
                                                            : executor_id,
       AZ_SPAN_EMPTY,
       command_name,
+      _az_mqtt5_rpc_cmd_phase_request,
       &required_length);
 
   if (out_mqtt_topic_length)
@@ -80,7 +85,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_response_property_topic(
 
   ret = _az_mqtt5_topic_parser_replace_tokens_in_format(
       mqtt_topic_span,
-      client->_internal.options.subscription_topic_format,
+      client->_internal.options.topic_format,
       AZ_SPAN_EMPTY,
       client->_internal.client_id,
       client->_internal.model_id,
@@ -88,6 +93,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_response_property_topic(
                                                            : executor_id,
       AZ_SPAN_EMPTY,
       command_name,
+      _az_mqtt5_rpc_cmd_phase_response,
       &required_length);
 
   if (out_mqtt_topic_length)
@@ -117,13 +123,14 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_subscribe_topic(
 
   ret = _az_mqtt5_topic_parser_replace_tokens_in_format(
       mqtt_topic_span,
-      client->_internal.options.subscription_topic_format,
+      client->_internal.options.topic_format,
       AZ_SPAN_EMPTY,
       client->_internal.client_id,
       client->_internal.model_id,
       single_level_wildcard,
       AZ_SPAN_EMPTY,
       single_level_wildcard,
+      _az_mqtt5_rpc_cmd_phase_response,
       &required_length);
 
   if (out_mqtt_topic_length)
@@ -144,7 +151,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_parse_received_topic(
   _az_PRECONDITION_NOT_NULL(out_response);
 
   return _az_mqtt5_topic_parser_extract_tokens_from_topic(
-      client->_internal.options.subscription_topic_format,
+      client->_internal.options.topic_format,
       received_topic,
       client->_internal.client_id,
       client->_internal.model_id,
@@ -170,8 +177,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_init(
     client->_internal.options = az_mqtt5_rpc_client_codec_options_default();
   }
   else if (
-      _az_mqtt5_topic_parser_valid_topic_format(options->subscription_topic_format)
-      && _az_mqtt5_topic_parser_valid_topic_format(options->request_topic_format))
+      _az_mqtt5_topic_parser_valid_topic_format(options->topic_format))
   {
     client->_internal.options = *options;
   }

--- a/sdk/src/azure/core/az_mqtt5_rpc_server_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_server_codec.c
@@ -16,11 +16,14 @@
 static const az_span _az_mqtt5_rpc_any_executor_id
     = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_ANY_EXECUTOR_ID);
 
+static const az_span _az_mqtt5_rpc_cmd_phase_request
+    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_CMD_PHASE_REQUEST);
+
 AZ_NODISCARD az_mqtt5_rpc_server_codec_options az_mqtt5_rpc_server_codec_options_default()
 {
   return (az_mqtt5_rpc_server_codec_options){ .service_group_id = AZ_SPAN_EMPTY,
-                                              .subscription_topic_format = AZ_SPAN_LITERAL_FROM_STR(
-                                                  AZ_MQTT5_RPC_DEFAULT_REQUEST_TOPIC_FORMAT) };
+                                              .topic_format = AZ_SPAN_LITERAL_FROM_STR(
+                                                  AZ_MQTT5_RPC_DEFAULT_TOPIC_FORMAT) };
 }
 
 AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_get_subscribe_topic(
@@ -40,7 +43,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_get_subscribe_topic(
 
   ret = _az_mqtt5_topic_parser_replace_tokens_in_format(
       mqtt_topic_span,
-      server->_internal.options.subscription_topic_format,
+      server->_internal.options.topic_format,
       server->_internal.options.service_group_id,
       AZ_SPAN_EMPTY,
       server->_internal.model_id,
@@ -49,6 +52,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_get_subscribe_topic(
           : server->_internal.client_id,
       AZ_SPAN_EMPTY,
       AZ_SPAN_FROM_STR(_az_MQTT5_TOPIC_PARSER_SINGLE_LEVEL_WILDCARD_TOKEN),
+      _az_mqtt5_rpc_cmd_phase_request,
       &required_length);
 
   if (out_mqtt_topic_length)
@@ -69,7 +73,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_parse_received_topic(
   _az_PRECONDITION_NOT_NULL(out_request);
 
   return _az_mqtt5_topic_parser_extract_tokens_from_topic(
-      server->_internal.options.subscription_topic_format,
+      server->_internal.options.topic_format,
       received_topic,
       AZ_SPAN_EMPTY,
       server->_internal.model_id,
@@ -96,7 +100,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_init(
   {
     server->_internal.options = az_mqtt5_rpc_server_codec_options_default();
   }
-  else if (_az_mqtt5_topic_parser_valid_topic_format(options->subscription_topic_format))
+  else if (_az_mqtt5_topic_parser_valid_topic_format(options->topic_format))
   {
     server->_internal.options = *options;
   }

--- a/sdk/src/azure/core/az_mqtt5_rpc_server_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_server_codec.c
@@ -13,6 +13,9 @@
 
 #include <azure/core/_az_cfg.h>
 
+#define sizeofarray(arrayXYZ) \
+  (sizeof(arrayXYZ)/sizeof(arrayXYZ[0]))
+
 static const az_span _az_mqtt5_rpc_any_executor_id
     = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_ANY_EXECUTOR_ID);
 
@@ -40,10 +43,12 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_get_subscribe_topic(
 
   az_span mqtt_topic_span = az_span_create((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   uint32_t required_length = 0;
+  az_span topic_formats[] = { server->_internal.options.topic_format };
 
   ret = _az_mqtt5_topic_parser_replace_tokens_in_format(
       mqtt_topic_span,
-      server->_internal.options.topic_format,
+      topic_formats,
+      sizeofarray(topic_formats),
       server->_internal.options.service_group_id,
       AZ_SPAN_EMPTY,
       server->_internal.model_id,
@@ -72,8 +77,11 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_parse_received_topic(
   _az_PRECONDITION_VALID_SPAN(received_topic, 1, false);
   _az_PRECONDITION_NOT_NULL(out_request);
 
+  az_span topic_formats[] = { server->_internal.options.topic_format };
+
   return _az_mqtt5_topic_parser_extract_tokens_from_topic(
-      server->_internal.options.topic_format,
+      topic_formats,
+      sizeofarray(topic_formats),
       received_topic,
       AZ_SPAN_EMPTY,
       server->_internal.model_id,

--- a/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
@@ -180,13 +180,13 @@ AZ_INLINE az_result _build_response(
 
   // Set the status user property
   char status_str[5];
-  sprintf(status_str, "%d", event_data->status);
+  int status_str_len = sprintf(status_str, "%d", event_data->status);
 
   _az_RETURN_IF_FAILED(az_mqtt5_property_bag_append_stringpair(
       &this_policy->_internal.property_bag,
       AZ_MQTT5_PROPERTY_TYPE_USER_PROPERTY,
       AZ_SPAN_FROM_STR(AZ_MQTT5_RPC_STATUS_PROPERTY_NAME),
-      az_span_create_from_str(status_str)));
+      az_span_create((uint8_t*)status_str, status_str_len)));
 
   // Set the correlation data property
   _az_PRECONDITION_VALID_SPAN(event_data->correlation_id, 0, true);
@@ -396,7 +396,9 @@ static az_result waiting(az_event_policy* me, az_event event)
       else
       {
         // log and ignore (this is probably meant for a different policy)
-        printf("topic does not match subscription, ignoring\n");
+        _az_LOG_WRITE(
+            AZ_HFSM_EVENT_ERROR,
+            AZ_SPAN_FROM_STR("topic does not match subscription, ignoring"));
       }
       break;
     }

--- a/sdk/src/azure/core/az_mqtt5_telemetry_consumer_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_telemetry_consumer_codec.c
@@ -12,6 +12,9 @@
 
 #include <azure/core/_az_cfg.h>
 
+#define sizeofarray(arrayXYZ) \
+  (sizeof(arrayXYZ)/sizeof(arrayXYZ[0]))
+
 AZ_NODISCARD az_mqtt5_telemetry_consumer_codec_options
 az_mqtt5_telemetry_consumer_codec_options_default()
 {
@@ -35,10 +38,11 @@ AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
 
   az_span mqtt_topic_span = az_span_create((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   uint32_t required_length = 0;
+  az_span topic_formats[] = { consumer->_internal.options.telemetry_topic_format };
 
   ret = _az_mqtt5_topic_parser_replace_tokens_in_format(
       mqtt_topic_span,
-      consumer->_internal.options.telemetry_topic_format,
+      topic_formats, 1,
       consumer->_internal.options.service_group_id,
       AZ_SPAN_EMPTY,
       consumer->_internal.model_id,
@@ -65,8 +69,11 @@ AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_parse_received_topic(
   _az_PRECONDITION_VALID_SPAN(received_topic, 1, false);
   _az_PRECONDITION_NOT_NULL(out_data);
 
+  az_span topic_formats[] = { consumer->_internal.options.telemetry_topic_format };
+
   return _az_mqtt5_topic_parser_extract_tokens_from_topic(
-      consumer->_internal.options.telemetry_topic_format,
+      topic_formats,
+      sizeofarray(topic_formats),
       received_topic,
       AZ_SPAN_EMPTY,
       consumer->_internal.model_id,

--- a/sdk/src/azure/core/az_mqtt5_telemetry_consumer_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_telemetry_consumer_codec.c
@@ -45,6 +45,7 @@ AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
       AZ_SPAN_EMPTY,
       consumer->_internal.sender_id,
       AZ_SPAN_FROM_STR(_az_MQTT5_TOPIC_PARSER_SINGLE_LEVEL_WILDCARD_TOKEN),
+      AZ_SPAN_EMPTY,
       &required_length);
 
   if (out_mqtt_topic_length)

--- a/sdk/src/azure/core/az_mqtt5_telemetry_producer_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_telemetry_producer_codec.c
@@ -35,10 +35,11 @@ AZ_NODISCARD az_result az_mqtt5_telemetry_producer_codec_get_publish_topic(
 
   az_span mqtt_topic_span = az_span_create((uint8_t*)mqtt_topic, (int32_t)mqtt_topic_size);
   uint32_t required_length = 0;
+  az_span topic_formats[] = { producer->_internal.options.telemetry_topic_format };
 
   ret = _az_mqtt5_topic_parser_replace_tokens_in_format(
       mqtt_topic_span,
-      producer->_internal.options.telemetry_topic_format,
+      topic_formats, 1,
       AZ_SPAN_EMPTY,
       AZ_SPAN_EMPTY,
       producer->_internal.model_id,

--- a/sdk/src/azure/core/az_mqtt5_telemetry_producer_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_telemetry_producer_codec.c
@@ -45,6 +45,7 @@ AZ_NODISCARD az_result az_mqtt5_telemetry_producer_codec_get_publish_topic(
       AZ_SPAN_EMPTY,
       producer->_internal.client_id,
       telemetry_name,
+      AZ_SPAN_EMPTY,
       &required_length);
 
   if (out_mqtt_topic_length)

--- a/sdk/tests/core/test_az_mqtt5_rpc_client_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_client_codec.c
@@ -18,31 +18,30 @@
 #define TEST_MODEL_ID "test_model_id"
 #define TEST_CLIENT_ID "test_client_id"
 #define TEST_SERVER_ID "test_server_id"
+
 #define TEST_DEFAULT_TOPIC_FORMAT "services/{serviceId}/{executorId}/command/{name}/{cmdPhase}"
 #define TEST_DEFAULT_PUBLISH_TOPIC \
   "services/" TEST_MODEL_ID "/" TEST_SERVER_ID "/command/" TEST_COMMAND_NAME "/request\0"
-#define TEST_CUSTOM_TOPIC_FORMAT \
-  "controller/{serviceId}/{executorId}/command/{name}/{cmdPhase}"
-#define TEST_CUSTOM_PUBLISH_TOPIC \
-  "controller/" TEST_MODEL_ID "/" TEST_SERVER_ID "/command/" TEST_COMMAND_NAME "/request\0"
-#define TEST_DEFAULT_SUBSCRIBE_TOPIC_FORMAT \
-  "clients/{invokerClientId}/services/{serviceId}/{executorId}/command/{name}/response"
 #define TEST_DEFAULT_SUBSCRIBE_TOPIC \
   "clients/" TEST_CLIENT_ID "/services/" TEST_MODEL_ID "/+/command/+/response\0"
 #define TEST_DEFAULT_RESPONSE_TOPIC                                       \
   "clients/" TEST_CLIENT_ID "/services/" TEST_MODEL_ID "/" TEST_SERVER_ID \
   "/command/" TEST_COMMAND_NAME "/response\0"
+
 #define TEST_DEFAULT_RESPONSE_TOPIC_INBOUND                               \
   "clients/" TEST_CLIENT_ID "/services/" TEST_MODEL_ID "/" TEST_SERVER_ID \
   "/command/" TEST_COMMAND_NAME "/response"
 #define TEST_DEFAULT_RESPONSE_TOPIC_FAILURE_INBOUND                       \
   "clients/" TEST_CLIENT_ID "/services/" TEST_MODEL_ID "/" TEST_SERVER_ID \
-  "/command/" TEST_COMMAND_NAME "/respons"
-#define TEST_CUSTOM_SUBSCRIBE_TOPIC_FORMAT \
-  "vehicles/{serviceId}/commands/{executorId}/{name}/{invokerClientId}"
-#define TEST_CUSTOM_SUBSCRIBE_TOPIC "vehicles/" TEST_MODEL_ID "/commands/+/+/" TEST_CLIENT_ID "\0"
+  "/commandERROR/" TEST_COMMAND_NAME "/response"
+
+#define TEST_CUSTOM_TOPIC_FORMAT \
+  "controller/{serviceId}/{executorId}/command/{name}/{cmdPhase}"
+#define TEST_CUSTOM_PUBLISH_TOPIC \
+  "controller/" TEST_MODEL_ID "/" TEST_SERVER_ID "/command/" TEST_COMMAND_NAME "/request\0"
+#define TEST_CUSTOM_SUBSCRIBE_TOPIC "clients/" TEST_CLIENT_ID "/controller/" TEST_MODEL_ID "/+/command/+/response" "\0"
 #define TEST_CUSTOM_RESPONSE_TOPIC                                                               \
-  "vehicles/" TEST_MODEL_ID "/commands/" TEST_SERVER_ID "/" TEST_COMMAND_NAME "/" TEST_CLIENT_ID \
+  "clients/" TEST_CLIENT_ID "/controller/" TEST_MODEL_ID "/" TEST_SERVER_ID "/command/" TEST_COMMAND_NAME "/response" \
   "\0"
 
 static void test_az_mqtt5_rpc_client_codec_init_no_options_success(void** state)
@@ -431,10 +430,10 @@ static void test_az_mqtt5_client_codec_parse_received_topic_failure(void** state
   az_span test_received_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_RESPONSE_TOPIC_FAILURE_INBOUND);
   az_mqtt5_rpc_client_codec_request_response test_response;
 
-  assert_int_equal(
-      az_mqtt5_rpc_client_codec_parse_received_topic(
-          &test_rpc_client_codec, test_received_topic, &test_response),
-      AZ_ERROR_IOT_TOPIC_NO_MATCH);
+  az_result result = az_mqtt5_rpc_client_codec_parse_received_topic(
+          &test_rpc_client_codec, test_received_topic, &test_response);
+
+  assert_int_equal(result, AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
 int test_az_mqtt5_rpc_client_codec()

--- a/sdk/tests/core/test_az_mqtt5_rpc_client_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_client_codec.c
@@ -18,11 +18,11 @@
 #define TEST_MODEL_ID "test_model_id"
 #define TEST_CLIENT_ID "test_client_id"
 #define TEST_SERVER_ID "test_server_id"
-#define TEST_DEFAULT_PUBLISH_TOPIC_FORMAT "services/{serviceId}/{executorId}/command/{name}/request"
+#define TEST_DEFAULT_TOPIC_FORMAT "services/{serviceId}/{executorId}/command/{name}/{cmdPhase}"
 #define TEST_DEFAULT_PUBLISH_TOPIC \
   "services/" TEST_MODEL_ID "/" TEST_SERVER_ID "/command/" TEST_COMMAND_NAME "/request\0"
-#define TEST_CUSTOM_PUBLISH_TOPIC_FORMAT \
-  "controller/{serviceId}/{executorId}/command/{name}/request"
+#define TEST_CUSTOM_TOPIC_FORMAT \
+  "controller/{serviceId}/{executorId}/command/{name}/{cmdPhase}"
 #define TEST_CUSTOM_PUBLISH_TOPIC \
   "controller/" TEST_MODEL_ID "/" TEST_SERVER_ID "/command/" TEST_COMMAND_NAME "/request\0"
 #define TEST_DEFAULT_SUBSCRIBE_TOPIC_FORMAT \
@@ -64,11 +64,11 @@ static void test_az_mqtt5_rpc_client_codec_init_no_options_success(void** state)
   assert_true(az_span_is_content_equal(
       test_rpc_client_codec._internal.model_id, AZ_SPAN_FROM_STR(TEST_MODEL_ID)));
   assert_true(az_span_is_content_equal(
-      test_rpc_client_codec._internal.options.subscription_topic_format,
-      AZ_SPAN_FROM_STR(TEST_DEFAULT_SUBSCRIBE_TOPIC_FORMAT)));
+      test_rpc_client_codec._internal.options.topic_format,
+      AZ_SPAN_FROM_STR(TEST_DEFAULT_TOPIC_FORMAT)));
   assert_true(az_span_is_content_equal(
-      test_rpc_client_codec._internal.options.request_topic_format,
-      AZ_SPAN_FROM_STR(TEST_DEFAULT_PUBLISH_TOPIC_FORMAT)));
+      test_rpc_client_codec._internal.options.topic_format,
+      AZ_SPAN_FROM_STR(TEST_DEFAULT_TOPIC_FORMAT)));
 }
 
 static void test_az_mqtt5_rpc_client_codec_init_options_success(void** state)
@@ -78,8 +78,7 @@ static void test_az_mqtt5_rpc_client_codec_init_options_success(void** state)
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
 
   az_mqtt5_rpc_client_codec_options options = az_mqtt5_rpc_client_codec_options_default();
-  options.subscription_topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIBE_TOPIC_FORMAT);
-  options.request_topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_PUBLISH_TOPIC_FORMAT);
+  options.topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_TOPIC_FORMAT);
 
   assert_int_equal(
       az_mqtt5_rpc_client_codec_init(
@@ -94,11 +93,8 @@ static void test_az_mqtt5_rpc_client_codec_init_options_success(void** state)
   assert_true(az_span_is_content_equal(
       test_rpc_client_codec._internal.model_id, AZ_SPAN_FROM_STR(TEST_MODEL_ID)));
   assert_true(az_span_is_content_equal(
-      test_rpc_client_codec._internal.options.subscription_topic_format,
-      AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIBE_TOPIC_FORMAT)));
-  assert_true(az_span_is_content_equal(
-      test_rpc_client_codec._internal.options.request_topic_format,
-      AZ_SPAN_FROM_STR(TEST_CUSTOM_PUBLISH_TOPIC_FORMAT)));
+      test_rpc_client_codec._internal.options.topic_format,
+      AZ_SPAN_FROM_STR(TEST_CUSTOM_TOPIC_FORMAT)));
 }
 
 static void test_az_mqtt5_rpc_client_codec_get_publish_topic_success(void** state)
@@ -141,7 +137,7 @@ static void test_az_mqtt5_rpc_client_codec_get_publish_topic_custom_success(void
 
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
   az_mqtt5_rpc_client_codec_options options = az_mqtt5_rpc_client_codec_options_default();
-  options.request_topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_PUBLISH_TOPIC_FORMAT);
+  options.topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_TOPIC_FORMAT);
 
   assert_int_equal(
       az_mqtt5_rpc_client_codec_init(
@@ -239,7 +235,7 @@ static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_custom_su
 
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
   az_mqtt5_rpc_client_codec_options options = az_mqtt5_rpc_client_codec_options_default();
-  options.subscription_topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIBE_TOPIC_FORMAT);
+  options.topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_TOPIC_FORMAT);
 
   assert_int_equal(
       az_mqtt5_rpc_client_codec_init(
@@ -336,7 +332,7 @@ static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_custom_success(vo
 
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
   az_mqtt5_rpc_client_codec_options options = az_mqtt5_rpc_client_codec_options_default();
-  options.subscription_topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIBE_TOPIC_FORMAT);
+  options.topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_TOPIC_FORMAT);
 
   assert_int_equal(
       az_mqtt5_rpc_client_codec_init(

--- a/sdk/tests/core/test_az_mqtt5_rpc_client_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_client_hfsm.c
@@ -33,7 +33,7 @@
 #define TEST_KEY "test_key"
 #define TEST_SUBSCRIPTION_TOPIC_FORMAT \
   "vehicles/{serviceId}/commands/{executorId}/{name}/for/{invokerClientId}"
-#define TEST_REQUEST_TOPIC_FORMAT "vehicles/{serviceId}/commands/{executorId}/{name}"
+#define TEST_TOPIC_FORMAT "vehicles/{serviceId}/commands/{executorId}/{name}/{cmdPhase}"
 
 static az_mqtt5 mock_mqtt5;
 static az_mqtt5_options mock_mqtt5_options = { 0 };
@@ -224,9 +224,8 @@ static void test_az_mqtt5_rpc_client_init_success(void** state)
 
   az_mqtt5_rpc_client_codec_options test_client_codec_options
       = az_mqtt5_rpc_client_codec_options_default();
-  test_client_codec_options.subscription_topic_format
-      = AZ_SPAN_FROM_STR(TEST_SUBSCRIPTION_TOPIC_FORMAT);
-  test_client_codec_options.request_topic_format = AZ_SPAN_FROM_STR(TEST_REQUEST_TOPIC_FORMAT);
+  test_client_codec_options.topic_format
+      = AZ_SPAN_FROM_STR(TEST_TOPIC_FORMAT);
 
   assert_int_equal(
       az_mqtt5_rpc_client_init(

--- a/sdk/tests/core/test_az_mqtt5_rpc_server_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_server_codec.c
@@ -19,6 +19,8 @@
 #define TEST_SERVICE_GROUP_ID "test_service_group_id"
 #define TEST_MODEL_ID "test_model_id"
 #define TEST_CLIENT_ID "test_server_id"
+#define TEST_TOPIC_FORMAT_DEFAULT \
+  "services/{serviceId}/{executorId}/command/{name}/{cmdPhase}"
 #define TEST_SUBSCRIPTION_TOPIC_FORMAT_DEFAULT \
   "services/{serviceId}/{executorId}/command/{name}/request"
 #define TEST_DEFAULT_SUBSCRIPTION_TOPIC \
@@ -29,13 +31,13 @@
   "services/" TEST_MODEL_ID "/" TEST_CLIENT_ID "/command/" TEST_COMMAND_NAME "request"
 #define TEST_DEFAULT_FUNGIBLE_SUBSCRIPTION_TOPIC \
   "$share/" TEST_SERVICE_GROUP_ID "/services/" TEST_MODEL_ID "/_any_/command/+/request\0"
-#define TEST_CUSTOM_SUBSCRIPTION_TOPIC_FORMAT_1 \
+#define TEST_CUSTOM_TOPIC_FORMAT_1 \
   "controller/{executorId}/service/{serviceId}/command/{name}"
 #define TEST_CUSTOM_SUBSCRIPTION_TOPIC_1 \
   "controller/" TEST_CLIENT_ID "/service/" TEST_MODEL_ID "/command/+\0"
-#define TEST_CUSTOM_SUBSCRIPTION_TOPIC_FORMAT_2 "controller/{executorId}/service/command/{name}"
+#define TEST_CUSTOM_TOPIC_FORMAT_2 "controller/{executorId}/service/command/{name}"
 #define TEST_CUSTOM_SUBSCRIPTION_TOPIC_2 "controller/" TEST_CLIENT_ID "/service/command/+\0"
-#define TEST_CUSTOM_SUBSCRIPTION_TOPIC_FORMAT_3 "controller/service/command/+"
+#define TEST_CUSTOM_TOPIC_FORMAT_3 "controller/service/command/+"
 #define TEST_CUSTOM_SUBSCRIPTION_TOPIC_3 "controller/service/command/+\0"
 
 static az_mqtt5_rpc_server_codec test_rpc_server_codec; // TODO_L: Move this to each function
@@ -57,8 +59,8 @@ static void test_az_mqtt5_rpc_server_codec_init_no_options_success(void** state)
   assert_true(az_span_is_content_equal(
       test_rpc_server_codec._internal.model_id, AZ_SPAN_FROM_STR(TEST_MODEL_ID)));
   assert_true(az_span_is_content_equal(
-      test_rpc_server_codec._internal.options.subscription_topic_format,
-      AZ_SPAN_FROM_STR(TEST_SUBSCRIPTION_TOPIC_FORMAT_DEFAULT)));
+      test_rpc_server_codec._internal.options.topic_format,
+      AZ_SPAN_FROM_STR(TEST_TOPIC_FORMAT_DEFAULT)));
 }
 
 static void test_az_mqtt5_rpc_server_codec_init_options_success(void** state)
@@ -66,7 +68,7 @@ static void test_az_mqtt5_rpc_server_codec_init_options_success(void** state)
   (void)state;
 
   az_mqtt5_rpc_server_codec_options options = az_mqtt5_rpc_server_codec_options_default();
-  options.subscription_topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_FORMAT_1);
+  options.topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_TOPIC_FORMAT_1);
 
   assert_int_equal(
       az_mqtt5_rpc_server_codec_init(
@@ -77,8 +79,8 @@ static void test_az_mqtt5_rpc_server_codec_init_options_success(void** state)
       AZ_OK);
 
   assert_true(az_span_is_content_equal(
-      test_rpc_server_codec._internal.options.subscription_topic_format,
-      AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_FORMAT_1)));
+      test_rpc_server_codec._internal.options.topic_format,
+      AZ_SPAN_FROM_STR(TEST_CUSTOM_TOPIC_FORMAT_1)));
 }
 
 static void az_mqtt5_rpc_server_codec_get_subscribe_topic_default_endpoint_success(void** state)
@@ -120,8 +122,8 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_succes
 
   az_mqtt5_rpc_server_codec_options test_server_options
       = az_mqtt5_rpc_server_codec_options_default();
-  test_server_options.subscription_topic_format
-      = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_FORMAT_1);
+  test_server_options.topic_format
+      = AZ_SPAN_FROM_STR(TEST_CUSTOM_TOPIC_FORMAT_1);
   assert_int_equal(
       az_mqtt5_rpc_server_codec_init(
           &test_rpc_server_codec,
@@ -155,8 +157,8 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_execut
 
   az_mqtt5_rpc_server_codec_options test_server_options
       = az_mqtt5_rpc_server_codec_options_default();
-  test_server_options.subscription_topic_format
-      = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_FORMAT_2);
+  test_server_options.topic_format
+      = AZ_SPAN_FROM_STR(TEST_CUSTOM_TOPIC_FORMAT_2);
   assert_int_equal(
       az_mqtt5_rpc_server_codec_init(
           &test_rpc_server_codec,
@@ -190,8 +192,8 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_custom_endpoint_no_ele
 
   az_mqtt5_rpc_server_codec_options test_server_options
       = az_mqtt5_rpc_server_codec_options_default();
-  test_server_options.subscription_topic_format
-      = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_FORMAT_3);
+  test_server_options.topic_format
+      = AZ_SPAN_FROM_STR(TEST_CUSTOM_TOPIC_FORMAT_3);
   assert_int_equal(
       az_mqtt5_rpc_server_codec_init(
           &test_rpc_server_codec,

--- a/sdk/tests/core/test_az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_server_hfsm.c
@@ -24,7 +24,7 @@
 #define TEST_PAYLOAD "test_payload"
 #define TEST_CORRELATION_ID "test_correlation_id"
 #define TEST_RESPONSE_TOPIC "test_response_topic"
-#define TEST_SUBSCRIPTION_TOPIC_FORMAT "vehicles/{serviceId}/commands/{executorId}/{name}"
+#define TEST_TOPIC_FORMAT "vehicles/{serviceId}/commands/{executorId}/{name}"
 #define TEST_SUBSCRIPTION_TOPIC \
   "vehicles/" TEST_MODEL_ID "/commands/" TEST_CLIENT_ID "/" TEST_COMMAND_NAME "\0"
 #define TEST_STATUS_SUCCESS "200"
@@ -184,8 +184,8 @@ static void test_az_mqtt5_rpc_server_init_specific_endpoint_success(void** state
 
   az_mqtt5_rpc_server_codec_options test_server_codec_options
       = az_mqtt5_rpc_server_codec_options_default();
-  test_server_codec_options.subscription_topic_format
-      = AZ_SPAN_FROM_STR(TEST_SUBSCRIPTION_TOPIC_FORMAT);
+  test_server_codec_options.topic_format
+      = AZ_SPAN_FROM_STR(TEST_TOPIC_FORMAT);
   assert_int_equal(
       az_mqtt5_rpc_server_init(
           &test_rpc_server,

--- a/sdk/tests/core/test_az_mqtt5_topic_parser.c
+++ b/sdk/tests/core/test_az_mqtt5_topic_parser.c
@@ -72,10 +72,11 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_success(void** s
   uint8_t test_buffer[132];
   az_span test_buffer_span = AZ_SPAN_FROM_BUFFER(test_buffer);
   uint32_t test_size = 0;
+  az_span topic_formats[] = { test_sample_format };
 
   az_result res = _az_mqtt5_topic_parser_replace_tokens_in_format(
       test_buffer_span,
-      test_sample_format,
+      topic_formats, 1,
       test_service_group_id,
       test_sample_client_id,
       test_sample_service_id,
@@ -99,10 +100,11 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_failure(void** s
   uint8_t test_buffer[1];
   az_span test_buffer_span = AZ_SPAN_FROM_BUFFER(test_buffer);
   uint32_t test_size = 0;
+  az_span topic_formats[] = { test_sample_format };
 
   az_result res = _az_mqtt5_topic_parser_replace_tokens_in_format(
       test_buffer_span,
-      test_sample_format,
+      topic_formats, 1,
       test_service_group_id,
       test_sample_client_id,
       test_sample_service_id,
@@ -124,10 +126,11 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_no_service_group
   uint8_t test_buffer[1];
   az_span test_buffer_span = AZ_SPAN_FROM_BUFFER(test_buffer);
   uint32_t test_size = 0;
+  az_span topic_formats[] = { test_sample_format };
 
   az_result res = _az_mqtt5_topic_parser_replace_tokens_in_format(
       test_buffer_span,
-      test_sample_format,
+      topic_formats, 1,
       AZ_SPAN_EMPTY,
       test_sample_client_id,
       test_sample_service_id,

--- a/sdk/tests/core/test_az_mqtt5_topic_parser.c
+++ b/sdk/tests/core/test_az_mqtt5_topic_parser.c
@@ -16,10 +16,10 @@
 #define TEST_SAMPLE_FORMAT                                                                   \
   "test/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN \
   "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_NAME_TOKEN                  \
-  "/" _az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN "/endoftest"
+  "/" _az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_CMD_PHASE_TOKEN "/endoftest"
 #define TEST_SAMPLE_FORMAT_REPLACED                                                    \
   "$share/test_service_group_id/test/test_client_id/test_service_id/test_executor_id/" \
-  "test_name/test_sender_id/endoftest\0"
+  "test_name/test_sender_id/test_cmd_phase/endoftest\0"
 static const az_span test_sample_format = AZ_SPAN_LITERAL_FROM_STR(TEST_SAMPLE_FORMAT);
 static const az_span test_sample_format_replaced
     = AZ_SPAN_LITERAL_FROM_STR(TEST_SAMPLE_FORMAT_REPLACED);
@@ -29,6 +29,7 @@ static const az_span test_sample_service_id = AZ_SPAN_LITERAL_FROM_STR("test_ser
 static const az_span test_sample_executor_id = AZ_SPAN_LITERAL_FROM_STR("test_executor_id");
 static const az_span test_sample_name_id = AZ_SPAN_LITERAL_FROM_STR("test_name");
 static const az_span test_sample_sender_id = AZ_SPAN_LITERAL_FROM_STR("test_sender_id");
+static const az_span test_sample_cmd_phase = AZ_SPAN_LITERAL_FROM_STR("test_cmd_phase");
 
 AZ_INLINE az_span test_az_mqtt5_get_key_no_braces(char* key)
 {
@@ -68,7 +69,7 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_success(void** s
 {
   (void)state;
 
-  uint8_t test_buffer[117];
+  uint8_t test_buffer[132];
   az_span test_buffer_span = AZ_SPAN_FROM_BUFFER(test_buffer);
   uint32_t test_size = 0;
 
@@ -81,6 +82,7 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_success(void** s
       test_sample_executor_id,
       test_sample_sender_id,
       test_sample_name_id,
+      test_sample_cmd_phase,
       &test_size);
 
   assert_int_equal(res, AZ_OK);
@@ -107,10 +109,11 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_failure(void** s
       test_sample_executor_id,
       test_sample_sender_id,
       test_sample_name_id,
+      test_sample_cmd_phase,
       &test_size);
 
   assert_int_equal(res, AZ_ERROR_NOT_ENOUGH_SPACE);
-  assert_int_equal(test_size, 117);
+  assert_int_equal(test_size, 132);
 }
 
 static void test_az_mqtt5_topic_parser_replace_tokens_in_format_no_service_group_failure(
@@ -131,10 +134,11 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_no_service_group
       test_sample_executor_id,
       test_sample_sender_id,
       test_sample_name_id,
+      test_sample_cmd_phase,
       &test_size);
 
   assert_int_equal(res, AZ_ERROR_NOT_ENOUGH_SPACE);
-  assert_int_equal(test_size, 88);
+  assert_int_equal(test_size, 103);
 }
 
 int test_az_mqtt5_topic_parser()


### PR DESCRIPTION
This follows the documentation defined by Varun here: https://github.com/microsoft/mqtt-patterns/blob/main/docs/RPC/RPC.topics.md

And according to comment in codegen PR https://github.com/microsoft/mqtt-patterns/pull/171#discussion_r1402785119 
