### PR TITLE
[CODEOWNERS] Remove automation section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,13 +32,6 @@
 # Platform
 /sdk/src/azure/platform/       @ahsonkhan @antkmsft @rickwinter @vhvb1989 @gearama @LarryOsterman
 
-################
-# Automation
-################
-
-# Git Hub integration and bot rules
-/.github/                     @jsquire @ronniegeraghty
-
 ###########
 # Eng Sys
 ###########


### PR DESCRIPTION
The focus of these changes is to remove the automation section, as CODEOWNERS changes no longer require manual syncing.