### PR TITLE
RPC Pattern and Telemetry Update

### DIFF
--- a/sdk/inc/azure/core/az_mqtt5_rpc.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc.h
@@ -24,15 +24,15 @@
 /**
  * @brief The default topic format for making RPC requests.
  */
-#define AZ_MQTT5_RPC_DEFAULT_REQUEST_TOPIC_FORMAT                                         \
-  "services/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN \
+#define AZ_MQTT5_RPC_DEFAULT_REQUEST_TOPIC_FORMAT                                       \
+  "services/" _az_MQTT5_TOPIC_PARSER_MODEL_ID_TOKEN "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN \
   "/command/" _az_MQTT5_TOPIC_PARSER_NAME_TOKEN "/request"
 /**
  * @brief The default topic format where RPC responses are published.
  */
-#define AZ_MQTT5_RPC_DEFAULT_RESPONSE_TOPIC_FORMAT                                         \
-  "clients/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN                                        \
-  "/services/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN \
+#define AZ_MQTT5_RPC_DEFAULT_RESPONSE_TOPIC_FORMAT                                       \
+  "clients/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN                                      \
+  "/services/" _az_MQTT5_TOPIC_PARSER_MODEL_ID_TOKEN "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN \
   "/command/" _az_MQTT5_TOPIC_PARSER_NAME_TOKEN "/response"
 
 /**

--- a/sdk/inc/azure/core/az_mqtt5_rpc.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc.h
@@ -26,14 +26,14 @@
  */
 #define AZ_MQTT5_RPC_DEFAULT_REQUEST_TOPIC_FORMAT                                       \
   "services/" _az_MQTT5_TOPIC_PARSER_MODEL_ID_TOKEN "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN \
-  "/command/" _az_MQTT5_TOPIC_PARSER_NAME_TOKEN "/request"
+  "/command/" _az_MQTT5_TOPIC_PARSER_COMMAND_NAME_TOKEN "/request"
 /**
  * @brief The default topic format where RPC responses are published.
  */
 #define AZ_MQTT5_RPC_DEFAULT_RESPONSE_TOPIC_FORMAT                                       \
   "clients/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN                                      \
   "/services/" _az_MQTT5_TOPIC_PARSER_MODEL_ID_TOKEN "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN \
-  "/command/" _az_MQTT5_TOPIC_PARSER_NAME_TOKEN "/response"
+  "/command/" _az_MQTT5_TOPIC_PARSER_COMMAND_NAME_TOKEN "/response"
 
 /**
  * @brief The default timeout in seconds for subscribing/publishing.

--- a/sdk/inc/azure/core/az_mqtt5_rpc_client_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc_client_codec.h
@@ -30,9 +30,9 @@ typedef struct
    * @brief The topic format to use for the subscription topic.
    *
    *
-   * @note Can include {name} for command name, {modelId} for model id, {executorId} for the
+   * @note Can include {commandName} for command name, {modelId} for model id, {executorId} for the
    * server's client_id, and/or {invokerClientId} for the client's client_id. The default value is
-   * "clients/{invokerClientId}/services/{modelId}/{executorId}/command/{name}/response".
+   * "clients/{invokerClientId}/services/{modelId}/{executorId}/command/{commandName}/response".
    *
    * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
    * topic.
@@ -42,9 +42,9 @@ typedef struct
   /**
    * @brief The topic format to use for the request topic.
    *
-   * @note Can include {name} for command name, {modelId} for model id, and/or {executorId} for
-   * the server's client_id. The default value is
-   * "services/{modelId}/{executorId}/command/{name}/request".
+   * @note Can include {commandName} for command name, {modelId} for model id, and/or {executorId}
+   * for the server's client_id. The default value is
+   * "services/{modelId}/{executorId}/command/{commandName}/request".
    *
    * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
    * topic.
@@ -174,7 +174,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_response_property_topic(
  *
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic was created successfully.
- * @retval @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small. \p out_mqtt_topic_length will
+ * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small. \p out_mqtt_topic_length will
  * contain the required size.
  */
 AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_subscribe_topic(

--- a/sdk/inc/azure/core/az_mqtt5_rpc_client_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc_client_codec.h
@@ -30,9 +30,9 @@ typedef struct
    * @brief The topic format to use for the subscription topic.
    *
    *
-   * @note Can include {name} for command name, {serviceId} for model id, {executorId} for the
+   * @note Can include {name} for command name, {modelId} for model id, {executorId} for the
    * server's client_id, and/or {invokerClientId} for the client's client_id. The default value is
-   * "clients/{invokerClientId}/services/{serviceId}/{executorId}/command/{name}/response".
+   * "clients/{invokerClientId}/services/{modelId}/{executorId}/command/{name}/response".
    *
    * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
    * topic.
@@ -42,9 +42,9 @@ typedef struct
   /**
    * @brief The topic format to use for the request topic.
    *
-   * @note Can include {name} for command name, {serviceId} for model id, and/or {executorId} for
+   * @note Can include {name} for command name, {modelId} for model id, and/or {executorId} for
    * the server's client_id. The default value is
-   * "services/{serviceId}/{executorId}/command/{name}/request".
+   * "services/{modelId}/{executorId}/command/{name}/request".
    *
    * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
    * topic.

--- a/sdk/inc/azure/core/az_mqtt5_rpc_client_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc_client_codec.h
@@ -116,7 +116,8 @@ AZ_NODISCARD az_mqtt5_rpc_client_codec_options az_mqtt5_rpc_client_codec_options
  *
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic was created successfully.
- * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small.
+ * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small. \p out_mqtt_topic_length will contain
+ * the required size.
  */
 AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_publish_topic(
     az_mqtt5_rpc_client_codec* client,
@@ -145,7 +146,8 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_publish_topic(
  *
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic was created successfully.
- * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small.
+ * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small. \p out_mqtt_topic_length will contain
+ * the required size.
  */
 AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_response_property_topic(
     az_mqtt5_rpc_client_codec* client,
@@ -172,7 +174,8 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_response_property_topic(
  *
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic was created successfully.
- * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small.
+ * @retval @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small. \p out_mqtt_topic_length will
+ * contain the required size.
  */
 AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_subscribe_topic(
     az_mqtt5_rpc_client_codec* client,

--- a/sdk/inc/azure/core/az_mqtt5_rpc_server.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc_server.h
@@ -165,9 +165,9 @@ typedef struct
    */
   az_span content_type;
   /**
-   * @brief The service id of the request.
+   * @brief The service model identifier of the request.
    */
-  az_span service_id;
+  az_span model_id;
   /**
    * @brief The command name of the request.
    */

--- a/sdk/inc/azure/core/az_mqtt5_rpc_server_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc_server_codec.h
@@ -69,9 +69,9 @@ typedef struct
 typedef struct
 {
   /**
-   * @brief The model id of the service.
+   * @brief The identifier of the service model.
    */
-  az_span service_id;
+  az_span model_id;
 
   /**
    * @brief The client id of the specified server that should execute the command.
@@ -107,7 +107,8 @@ AZ_NODISCARD az_mqtt5_rpc_server_codec_options az_mqtt5_rpc_server_codec_options
  *
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic was created successfully.
- * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small.
+ * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small. \p out_mqtt_topic_length will contain
+ * the required size.
  */
 AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_get_subscribe_topic(
     az_mqtt5_rpc_server_codec* server,

--- a/sdk/inc/azure/core/az_mqtt5_rpc_server_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc_server_codec.h
@@ -36,9 +36,9 @@ typedef struct
   /**
    * @brief The topic format to use for the subscription topic.
    *
-   * @note Can include {name} for command name if server can accept multiple commands, {modelId}
-   * for model id, and/or {executorId} for the server's client_id. The default value is
-   * services/{modelId}/{executorId}/command/{name}/request.
+   * @note Can include {commandName} for command name if server can accept multiple commands,
+   * {modelId} for model id, and/or {executorId} for the server's client_id. The default value is
+   * services/{modelId}/{executorId}/command/{commandName}/request.
    *
    * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
    * topic.

--- a/sdk/inc/azure/core/az_mqtt5_rpc_server_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_rpc_server_codec.h
@@ -36,9 +36,9 @@ typedef struct
   /**
    * @brief The topic format to use for the subscription topic.
    *
-   * @note Can include {name} for command name if server can accept multiple commands, {serviceId}
+   * @note Can include {name} for command name if server can accept multiple commands, {modelId}
    * for model id, and/or {executorId} for the server's client_id. The default value is
-   * services/{serviceId}/{executorId}/command/{name}/request.
+   * services/{modelId}/{executorId}/command/{name}/request.
    *
    * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
    * topic.

--- a/sdk/inc/azure/core/az_mqtt5_telemetry.h
+++ b/sdk/inc/azure/core/az_mqtt5_telemetry.h
@@ -21,8 +21,8 @@
  * @brief MQTT5 Telemetry default topic format.
  *
  */
-#define AZ_MQTT5_TELEMETRY_DEFAULT_TOPIC_FORMAT                                                  \
-  "services/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN \
+#define AZ_MQTT5_TELEMETRY_DEFAULT_TOPIC_FORMAT                                                \
+  "services/" _az_MQTT5_TOPIC_PARSER_MODEL_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN \
   "/telemetry"
 
 /**

--- a/sdk/inc/azure/core/az_mqtt5_telemetry_consumer_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_telemetry_consumer_codec.h
@@ -36,8 +36,8 @@ typedef struct
   /**
    * @brief The topic format to use for the subscription topic to receive telemetry.
    *
-   * @note Can include {name} for telemetry name, {serviceId} for model id, and/or {senderId} for
-   * the sender's client_id. The default value is services/{serviceId}/{senderId}/telemetry.
+   * @note Can include {name} for telemetry name, {modelId} for model id, and/or {senderId} for
+   * the sender's client_id. The default value is services/{modelId}/{senderId}/telemetry.
    *
    * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
    * topic.

--- a/sdk/inc/azure/core/az_mqtt5_telemetry_consumer_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_telemetry_consumer_codec.h
@@ -67,9 +67,9 @@ typedef struct
 typedef struct
 {
   /**
-   * @brief The model id of the telemetry.
+   * @brief The identifier of the service model.
    */
-  az_span service_id;
+  az_span model_id;
 
   /**
    * @brief The id of the sender of the telemetry.
@@ -80,7 +80,7 @@ typedef struct
   /**
    * @brief The name of the telemetry.
    */
-  az_span command_name;
+  az_span telemetry_name;
 } az_mqtt5_telemetry_consumer_codec_data;
 
 /**
@@ -107,7 +107,8 @@ az_mqtt5_telemetry_consumer_codec_options_default();
  *
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic was created successfully.
- * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small.
+ * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small. \p out_mqtt_topic_length will contain
+ * the required size.
  */
 AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
     az_mqtt5_telemetry_consumer_codec* consumer,

--- a/sdk/inc/azure/core/az_mqtt5_telemetry_consumer_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_telemetry_consumer_codec.h
@@ -36,8 +36,8 @@ typedef struct
   /**
    * @brief The topic format to use for the subscription topic to receive telemetry.
    *
-   * @note Can include {name} for telemetry name, {modelId} for model id, and/or {senderId} for
-   * the sender's client_id. The default value is services/{modelId}/{senderId}/telemetry.
+   * @note Can include {telemetryName} for telemetry name, {modelId} for model id, and/or {senderId}
+   * for the sender's client_id. The default value is services/{modelId}/{senderId}/telemetry.
    *
    * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
    * topic.

--- a/sdk/inc/azure/core/az_mqtt5_telemetry_producer_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_telemetry_producer_codec.h
@@ -29,8 +29,8 @@ typedef struct
   /**
    * @brief The topic format to use for the publish topic to send telemetry.
    *
-   * @note Can include {name} for telemetry name, {serviceId} for model id, and/or {senderId} for
-   * the sender's client_id. The default value is services/{serviceId}/{senderId}/telemetry.
+   * @note Can include {name} for telemetry name, {modelId} for model id, and/or {senderId} for
+   * the sender's client_id. The default value is services/{modelId}/{senderId}/telemetry.
    *
    * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
    * topic.

--- a/sdk/inc/azure/core/az_mqtt5_telemetry_producer_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_telemetry_producer_codec.h
@@ -79,7 +79,8 @@ az_mqtt5_telemetry_producer_codec_options_default();
  *
  * @return An #az_result value indicating the result of the operation.
  * @retval #AZ_OK The topic was created successfully.
- * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small.
+ * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The buffer is too small. \p out_mqtt_topic_length will contain
+ * the required size.
  */
 AZ_NODISCARD az_result az_mqtt5_telemetry_producer_codec_get_publish_topic(
     az_mqtt5_telemetry_producer_codec* producer,

--- a/sdk/inc/azure/core/az_mqtt5_telemetry_producer_codec.h
+++ b/sdk/inc/azure/core/az_mqtt5_telemetry_producer_codec.h
@@ -29,8 +29,8 @@ typedef struct
   /**
    * @brief The topic format to use for the publish topic to send telemetry.
    *
-   * @note Can include {name} for telemetry name, {modelId} for model id, and/or {senderId} for
-   * the sender's client_id. The default value is services/{modelId}/{senderId}/telemetry.
+   * @note Can include {telemetryName} for telemetry name, {modelId} for model id, and/or {senderId}
+   * for the sender's client_id. The default value is services/{modelId}/{senderId}/telemetry.
    *
    * @note Tokens must be surrounded by slashes, unless they are at the beginning or end of the
    * topic.

--- a/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
+++ b/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
@@ -73,17 +73,31 @@
 #define _az_MQTT5_TOPIC_PARSER_EXECUTOR_ID_HASH 3913329219
 
 /**
- * @brief Token used to indicate the name of the command or telemetry in a topic format.
+ * @brief Token used to indicate the name of the command in a topic format.
  */
-#define _az_MQTT5_TOPIC_PARSER_NAME_TOKEN "{name}"
+#define _az_MQTT5_TOPIC_PARSER_COMMAND_NAME_TOKEN "{commandName}"
 /**
- * @brief Hash of the command id token. Exact string used to calculate the hash is "name".
+ * @brief Hash of the command name token. Exact string used to calculate the hash is "commandName".
  *
  * @details The value below is a hash of a token used in a topic format, it has been calculated
  * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
  * #az_span containing the token (ex. "modelId"). If the token changes, update the hash here.
  */
-#define _az_MQTT5_TOPIC_PARSER_NAME_HASH 2624200456
+#define _az_MQTT5_TOPIC_PARSER_COMMAND_NAME_HASH 2924294247
+
+/**
+ * @brief Token used to indicate the name of the telemetry in a topic format.
+ */
+#define _az_MQTT5_TOPIC_PARSER_TELEMETRY_NAME_TOKEN "{telemetryName}"
+/**
+ * @brief Hash of the telemetry name token. Exact string used to calculate the hash is
+ * "telemetryName".
+ *
+ * @details The value below is a hash of a token used in a topic format, it has been calculated
+ * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
+ * #az_span containing the token (ex. "modelId"). If the token changes, update the hash here.
+ */
+#define _az_MQTT5_TOPIC_PARSER_TELEMETRY_NAME_HASH 2033926211
 
 /**
  * @brief Token used to indicate the sender id in a telemetry topic format.
@@ -122,10 +136,11 @@ AZ_INLINE uint32_t _az_mqtt5_topic_parser_calculate_hash(az_span token)
  * @param[in] topic_format The topic format to replace tokens in.
  * @param[in] service_group_id #az_span containing the service group id or #AZ_SPAN_EMPTY.
  * @param[in] client_id #az_span containing the client id or #AZ_SPAN_EMPTY.
- * @param[in] service_id #az_span containing the service id.
+ * @param[in] model_id #az_span containing the identifier of the service model.
  * @param[in] executor_id #az_span containing the executor id or #AZ_SPAN_EMPTY.
  * @param[in] sender_id #az_span containing the sender id or #AZ_SPAN_EMPTY.
- * @param[in] name #az_span containing the command or telemetry name.
+ * @param[in] command_name #az_span containing the command name or #AZ_SPAN_EMPTY.
+ * @param[in] telemetry_name #az_span containing the telemetry name or #AZ_SPAN_EMPTY.
  * @param[out] required_length The required length of the buffer to write the result to.
  *
  * @return An #az_result value indicating the result of the operation.
@@ -135,10 +150,11 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
     az_span topic_format,
     az_span service_group_id,
     az_span client_id,
-    az_span service_id,
+    az_span model_id,
     az_span executor_id,
     az_span sender_id,
-    az_span name,
+    az_span command_name,
+    az_span telemetry_name,
     uint32_t* required_length);
 
 /**
@@ -147,7 +163,7 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
  * @param[in] topic_format The topic format to reference when extracting tokens.
  * @param[in] received_topic The topic to extract tokens from.
  * @param[in] client_id #az_span containing the client id or #AZ_SPAN_EMPTY.
- * @param[in] service_id #az_span containing the service id or #AZ_SPAN_EMPTY.
+ * @param[in] model_id #az_span containing the identifier of the service model or #AZ_SPAN_EMPTY.
  * @param[in] executor_id #az_span containing the executor id or #AZ_SPAN_EMPTY.
  * @param[in] sender_id #az_span containing the sender id or #AZ_SPAN_EMPTY.
  * @param[out] extracted_client_id Pointer to an #az_span to write the extracted client id to or
@@ -158,7 +174,9 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
  * NULL if not needed.
  * @param[out] extracted_sender_id Pointer to an #az_span to write the extracted sender id to or
  * NULL if not needed.
- * @param[out] extracted_name Pointer to an #az_span to write the extracted command/telemetry name
+ * @param[out] extracted_command_name Pointer to an #az_span to write the extracted command name to
+ * or NULL if not needed.
+ * @param[out] extracted_telemetry_name Pointer to an #az_span to write the extracted telemetry name
  * to or NULL if not needed.
  *
  * @return An #az_result value indicating the result of the operation.
@@ -167,14 +185,15 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_extract_tokens_from_topic(
     az_span topic_format,
     az_span received_topic,
     az_span client_id,
-    az_span service_id,
+    az_span model_id,
     az_span executor_id,
     az_span sender_id,
     az_span* extracted_client_id,
     az_span* extracted_service_id,
     az_span* extracted_executor_id,
     az_span* extracted_sender_id,
-    az_span* extracted_name);
+    az_span* extracted_command_name,
+    az_span* extracted_telemetry_name);
 
 /**
  * @brief Helper function to check if a topic format is valid.

--- a/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
+++ b/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
@@ -51,13 +51,13 @@
  */
 #define _az_MQTT5_TOPIC_PARSER_MODEL_ID_TOKEN "{modelId}"
 /**
- * @brief Hash of the service id token. Exact string used to calculate the hash is "modelId".
+ * @brief Hash of the service model id token. Exact string used to calculate the hash is "modelId".
  *
  * @details The value below is a hash of a token used in a topic format, it has been calculated
  * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
  * #az_span containing the token (ex. "modelId"). If the token changes, update the hash here.
  */
-#define _az_MQTT5_TOPIC_PARSER_SERVICE_ID_HASH 540743365
+#define _az_MQTT5_TOPIC_PARSER_MODEL_ID_HASH 540743365
 
 /**
  * @brief Token used to indicate the executor id in a topic format.

--- a/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
+++ b/sdk/inc/azure/core/internal/az_mqtt5_topic_parser_internal.h
@@ -42,22 +42,22 @@
  *
  * @details The value below is a hash of a token used in a topic format, it has been calculated
  * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
- * #az_span containing the token (ex. "serviceId"). If the token changes, update the hash here.
+ * #az_span containing the token (ex. "modelId"). If the token changes, update the hash here.
  */
 #define _az_MQTT5_TOPIC_PARSER_CLIENT_ID_HASH 3426466449
 
 /**
- * @brief Token used to indicate the service id in a topic format.
+ * @brief Token used to indicate the service model in a topic format.
  */
-#define _az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN "{serviceId}"
+#define _az_MQTT5_TOPIC_PARSER_MODEL_ID_TOKEN "{modelId}"
 /**
- * @brief Hash of the service id token. Exact string used to calculate the hash is "serviceId".
+ * @brief Hash of the service id token. Exact string used to calculate the hash is "modelId".
  *
  * @details The value below is a hash of a token used in a topic format, it has been calculated
  * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
- * #az_span containing the token (ex. "serviceId"). If the token changes, update the hash here.
+ * #az_span containing the token (ex. "modelId"). If the token changes, update the hash here.
  */
-#define _az_MQTT5_TOPIC_PARSER_SERVICE_ID_HASH 4175641829
+#define _az_MQTT5_TOPIC_PARSER_SERVICE_ID_HASH 540743365
 
 /**
  * @brief Token used to indicate the executor id in a topic format.
@@ -68,7 +68,7 @@
  *
  * @details The value below is a hash of a token used in a topic format, it has been calculated
  * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
- * #az_span containing the token (ex. "serviceId"). If the token changes, update the hash here.
+ * #az_span containing the token (ex. "modelId"). If the token changes, update the hash here.
  */
 #define _az_MQTT5_TOPIC_PARSER_EXECUTOR_ID_HASH 3913329219
 
@@ -81,7 +81,7 @@
  *
  * @details The value below is a hash of a token used in a topic format, it has been calculated
  * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
- * #az_span containing the token (ex. "serviceId"). If the token changes, update the hash here.
+ * #az_span containing the token (ex. "modelId"). If the token changes, update the hash here.
  */
 #define _az_MQTT5_TOPIC_PARSER_NAME_HASH 2624200456
 
@@ -94,7 +94,7 @@
  *
  * @details The value below is a hash of a token used in a topic format, it has been calculated
  * using the #_az_mqtt5_rpc_calculate_hash function. To re-calculate it call the function with a
- * #az_span containing the token (ex. "serviceId"). If the token changes, update the hash here.
+ * #az_span containing the token (ex. "modelId"). If the token changes, update the hash here.
  */
 #define _az_MQTT5_TOPIC_PARSER_SENDER_ID_HASH 3332431765
 

--- a/sdk/src/azure/core/az_mqtt5_rpc_client_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_client_codec.c
@@ -51,6 +51,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_publish_topic(
                                                            : executor_id,
       AZ_SPAN_EMPTY,
       command_name,
+      AZ_SPAN_EMPTY,
       &required_length);
 
   if (out_mqtt_topic_length)
@@ -88,6 +89,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_response_property_topic(
                                                            : executor_id,
       AZ_SPAN_EMPTY,
       command_name,
+      AZ_SPAN_EMPTY,
       &required_length);
 
   if (out_mqtt_topic_length)
@@ -124,6 +126,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_get_subscribe_topic(
       single_level_wildcard,
       AZ_SPAN_EMPTY,
       single_level_wildcard,
+      AZ_SPAN_EMPTY,
       &required_length);
 
   if (out_mqtt_topic_length)
@@ -154,7 +157,8 @@ AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_parse_received_topic(
       NULL,
       &out_response->executor_id,
       NULL,
-      &out_response->command_name);
+      &out_response->command_name,
+      NULL);
 }
 
 AZ_NODISCARD az_result az_mqtt5_rpc_client_codec_init(

--- a/sdk/src/azure/core/az_mqtt5_rpc_server_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_server_codec.c
@@ -49,6 +49,7 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_get_subscribe_topic(
           : server->_internal.client_id,
       AZ_SPAN_EMPTY,
       AZ_SPAN_FROM_STR(_az_MQTT5_TOPIC_PARSER_SINGLE_LEVEL_WILDCARD_TOKEN),
+      AZ_SPAN_EMPTY,
       &required_length);
 
   if (out_mqtt_topic_length)
@@ -78,10 +79,11 @@ AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_parse_received_topic(
           : _az_mqtt5_rpc_any_executor_id,
       AZ_SPAN_EMPTY,
       NULL,
-      &out_request->service_id,
+      &out_request->model_id,
       &out_request->executor_id,
       NULL,
-      &out_request->command_name);
+      &out_request->command_name,
+      NULL);
 }
 
 AZ_NODISCARD az_result az_mqtt5_rpc_server_codec_init(

--- a/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/src/azure/core/az_mqtt5_rpc_server_hfsm.c
@@ -231,15 +231,15 @@ AZ_INLINE az_result _handle_request(
   {
     // TODO: validate request isn't expired?
     az_mqtt5_rpc_server_execution_req_event_data command_data
-        = (az_mqtt5_rpc_server_execution_req_event_data){
-            .correlation_id = correlation_data_bindata,
-            .response_topic = response_topic_str,
-            .request_data = data->payload,
-            .request_topic = data->topic,
-            .content_type = content_type_str,
-            .command_name = req_event_data->command_name,
-            .service_id = req_event_data->service_id
-          };
+        = (az_mqtt5_rpc_server_execution_req_event_data){ .correlation_id
+                                                          = correlation_data_bindata,
+                                                          .response_topic = response_topic_str,
+                                                          .request_data = data->payload,
+                                                          .request_topic = data->topic,
+                                                          .content_type = content_type_str,
+                                                          .command_name
+                                                          = req_event_data->command_name,
+                                                          .model_id = req_event_data->model_id };
 
     ret = az_event_policy_send_inbound_event(
         (az_event_policy*)this_policy,

--- a/sdk/src/azure/core/az_mqtt5_telemetry_consumer_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_telemetry_consumer_codec.c
@@ -44,6 +44,7 @@ AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_get_subscribe_topic(
       consumer->_internal.model_id,
       AZ_SPAN_EMPTY,
       consumer->_internal.sender_id,
+      AZ_SPAN_EMPTY,
       AZ_SPAN_FROM_STR(_az_MQTT5_TOPIC_PARSER_SINGLE_LEVEL_WILDCARD_TOKEN),
       &required_length);
 
@@ -72,10 +73,11 @@ AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_parse_received_topic(
       AZ_SPAN_EMPTY,
       consumer->_internal.sender_id,
       NULL,
-      &out_data->service_id,
+      &out_data->model_id,
       NULL,
       &out_data->sender_id,
-      &out_data->command_name);
+      NULL,
+      &out_data->telemetry_name);
 }
 
 AZ_NODISCARD az_result az_mqtt5_telemetry_consumer_codec_init(

--- a/sdk/src/azure/core/az_mqtt5_telemetry_producer_codec.c
+++ b/sdk/src/azure/core/az_mqtt5_telemetry_producer_codec.c
@@ -44,6 +44,7 @@ AZ_NODISCARD az_result az_mqtt5_telemetry_producer_codec_get_publish_topic(
       producer->_internal.model_id,
       AZ_SPAN_EMPTY,
       producer->_internal.client_id,
+      AZ_SPAN_EMPTY,
       telemetry_name,
       &required_length);
 

--- a/sdk/src/azure/core/az_mqtt5_topic_parser.c
+++ b/sdk/src/azure/core/az_mqtt5_topic_parser.c
@@ -19,8 +19,7 @@
 
 static const az_span service_group_id_key
     = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SERVICE_GROUP_ID_TOKEN);
-static const az_span model_id_key
-    = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN);
+static const az_span model_id_key = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_MODEL_ID_TOKEN);
 static const az_span sender_id_key
     = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN);
 static const az_span name_key = AZ_SPAN_LITERAL_FROM_STR(_az_MQTT5_TOPIC_PARSER_NAME_TOKEN);

--- a/sdk/src/azure/core/az_mqtt5_topic_parser.c
+++ b/sdk/src/azure/core/az_mqtt5_topic_parser.c
@@ -148,7 +148,7 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_replace_tokens_in_format(
             client_id, &remainder, required_length, buffer_length);
         i += az_span_size(invoker_client_id_key) - 1;
       }
-      else if (curr_hash == _az_MQTT5_TOPIC_PARSER_SERVICE_ID_HASH)
+      else if (curr_hash == _az_MQTT5_TOPIC_PARSER_MODEL_ID_HASH)
       {
         ret = _az_mqtt5_rpc_verify_buffer_length_and_copy(
             model_id, &remainder, required_length, buffer_length);
@@ -212,7 +212,7 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_extract_tokens_from_topic(
     az_span executor_id,
     az_span sender_id,
     az_span* extracted_client_id,
-    az_span* extracted_service_id,
+    az_span* extracted_model_id,
     az_span* extracted_executor_id,
     az_span* extracted_sender_id,
     az_span* extracted_command_name,
@@ -222,9 +222,9 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_extract_tokens_from_topic(
   {
     *extracted_client_id = AZ_SPAN_EMPTY;
   }
-  if (extracted_service_id)
+  if (extracted_model_id)
   {
-    *extracted_service_id = AZ_SPAN_EMPTY;
+    *extracted_model_id = AZ_SPAN_EMPTY;
   }
   if (extracted_executor_id)
   {
@@ -278,10 +278,10 @@ AZ_NODISCARD az_result _az_mqtt5_topic_parser_extract_tokens_from_topic(
           i += az_span_size(extracted_token) - 1;
           format_idx += az_span_size(invoker_client_id_key) - 1;
         }
-        else if (curr_hash == _az_MQTT5_TOPIC_PARSER_SERVICE_ID_HASH)
+        else if (curr_hash == _az_MQTT5_TOPIC_PARSER_MODEL_ID_HASH)
         {
           _az_RETURN_IF_FAILED(
-              _az_mqtt5_rpc_verify_match_and_copy(model_id, extracted_token, extracted_service_id));
+              _az_mqtt5_rpc_verify_match_and_copy(model_id, extracted_token, extracted_model_id));
           i += az_span_size(extracted_token) - 1;
           format_idx += az_span_size(model_id_key) - 1;
         }

--- a/sdk/tests/core/test_az_mqtt5_rpc_client_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_client_codec.c
@@ -18,15 +18,14 @@
 #define TEST_MODEL_ID "test_model_id"
 #define TEST_CLIENT_ID "test_client_id"
 #define TEST_SERVER_ID "test_server_id"
-#define TEST_DEFAULT_PUBLISH_TOPIC_FORMAT "services/{serviceId}/{executorId}/command/{name}/request"
+#define TEST_DEFAULT_PUBLISH_TOPIC_FORMAT "services/{modelId}/{executorId}/command/{name}/request"
 #define TEST_DEFAULT_PUBLISH_TOPIC \
   "services/" TEST_MODEL_ID "/" TEST_SERVER_ID "/command/" TEST_COMMAND_NAME "/request\0"
-#define TEST_CUSTOM_PUBLISH_TOPIC_FORMAT \
-  "controller/{serviceId}/{executorId}/command/{name}/request"
+#define TEST_CUSTOM_PUBLISH_TOPIC_FORMAT "controller/{modelId}/{executorId}/command/{name}/request"
 #define TEST_CUSTOM_PUBLISH_TOPIC \
   "controller/" TEST_MODEL_ID "/" TEST_SERVER_ID "/command/" TEST_COMMAND_NAME "/request\0"
 #define TEST_DEFAULT_SUBSCRIBE_TOPIC_FORMAT \
-  "clients/{invokerClientId}/services/{serviceId}/{executorId}/command/{name}/response"
+  "clients/{invokerClientId}/services/{modelId}/{executorId}/command/{name}/response"
 #define TEST_DEFAULT_SUBSCRIBE_TOPIC \
   "clients/" TEST_CLIENT_ID "/services/" TEST_MODEL_ID "/+/command/+/response\0"
 #define TEST_DEFAULT_RESPONSE_TOPIC                                       \
@@ -39,7 +38,7 @@
   "clients/" TEST_CLIENT_ID "/services/" TEST_MODEL_ID "/" TEST_SERVER_ID \
   "/command/" TEST_COMMAND_NAME "/respons"
 #define TEST_CUSTOM_SUBSCRIBE_TOPIC_FORMAT \
-  "vehicles/{serviceId}/commands/{executorId}/{name}/{invokerClientId}"
+  "vehicles/{modelId}/commands/{executorId}/{name}/{invokerClientId}"
 #define TEST_CUSTOM_SUBSCRIBE_TOPIC "vehicles/" TEST_MODEL_ID "/commands/+/+/" TEST_CLIENT_ID "\0"
 #define TEST_CUSTOM_RESPONSE_TOPIC                                                               \
   "vehicles/" TEST_MODEL_ID "/commands/" TEST_SERVER_ID "/" TEST_COMMAND_NAME "/" TEST_CLIENT_ID \
@@ -202,6 +201,7 @@ static void test_az_mqtt5_rpc_client_codec_get_publish_topic_buffer_size_failure
 static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_success(void** state)
 {
   (void)state;
+  az_span test_default_response_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_RESPONSE_TOPIC);
 
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
 
@@ -213,7 +213,7 @@ static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_success(v
           NULL),
       AZ_OK);
 
-  char test_response_property_topic_buffer[96]; // Exact size
+  char test_response_property_topic_buffer[az_span_size(test_default_response_topic)]; // Exact size
   size_t test_response_property_topic_size = 0;
 
   assert_int_equal(
@@ -228,7 +228,6 @@ static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_success(v
 
   az_span test_response_topic = az_span_create(
       (uint8_t*)test_response_property_topic_buffer, (int32_t)test_response_property_topic_size);
-  az_span test_default_response_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_RESPONSE_TOPIC);
 
   assert_true(az_span_is_content_equal(test_response_topic, test_default_response_topic));
 }
@@ -236,7 +235,7 @@ static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_success(v
 static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_custom_success(void** state)
 {
   (void)state;
-
+  az_span test_default_response_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_RESPONSE_TOPIC);
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
   az_mqtt5_rpc_client_codec_options options = az_mqtt5_rpc_client_codec_options_default();
   options.subscription_topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIBE_TOPIC_FORMAT);
@@ -249,7 +248,7 @@ static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_custom_su
           &options),
       AZ_OK);
 
-  char test_response_property_topic_buffer[256]; // Exact size
+  char test_response_property_topic_buffer[az_span_size(test_default_response_topic)]; // Exact size
   size_t test_response_property_topic_size = 0;
 
   assert_int_equal(
@@ -264,7 +263,6 @@ static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_custom_su
 
   az_span test_response_topic = az_span_create(
       (uint8_t*)test_response_property_topic_buffer, (int32_t)test_response_property_topic_size);
-  az_span test_default_response_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_RESPONSE_TOPIC);
 
   assert_true(az_span_is_content_equal(test_response_topic, test_default_response_topic));
 }
@@ -301,7 +299,7 @@ static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_buffer_si
 static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_success(void** state)
 {
   (void)state;
-
+  az_span test_default_subscribe_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_SUBSCRIBE_TOPIC);
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
 
   assert_int_equal(
@@ -312,7 +310,7 @@ static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_success(void** st
           NULL),
       AZ_OK);
 
-  char test_subscribe_topic_buffer[67]; // Exact size
+  char test_subscribe_topic_buffer[az_span_size(test_default_subscribe_topic)]; // Exact size
   size_t test_subscribe_topic_size = 0;
 
   assert_int_equal(
@@ -325,7 +323,6 @@ static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_success(void** st
 
   az_span test_subscribe_topic
       = az_span_create((uint8_t*)test_subscribe_topic_buffer, (int32_t)test_subscribe_topic_size);
-  az_span test_default_subscribe_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_SUBSCRIBE_TOPIC);
 
   assert_true(az_span_is_content_equal(test_subscribe_topic, test_default_subscribe_topic));
 }
@@ -367,7 +364,7 @@ static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_custom_success(vo
 static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_buffer_size_failure(void** state)
 {
   (void)state;
-
+  az_span test_default_subscribe_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIBE_TOPIC);
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
 
   assert_int_equal(
@@ -378,7 +375,8 @@ static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_buffer_size_failu
           NULL),
       AZ_OK);
 
-  char test_subscribe_topic_buffer[66]; // Exact size - 1
+  char
+      test_subscribe_topic_buffer[az_span_size(test_default_subscribe_topic) - 1]; // Exact size - 1
   size_t test_subscribe_topic_size = 0;
 
   assert_int_equal(

--- a/sdk/tests/core/test_az_mqtt5_rpc_client_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_client_codec.c
@@ -196,6 +196,8 @@ static void test_az_mqtt5_rpc_client_codec_get_publish_topic_buffer_size_failure
           sizeof(test_publish_topic_buffer),
           &test_publish_topic_out_size),
       AZ_ERROR_NOT_ENOUGH_SPACE);
+
+  assert_int_equal(test_publish_topic_out_size, az_span_size(test_default_pub_topic));
 }
 
 static void test_az_mqtt5_rpc_client_codec_get_publish_topic_missing_token_failure(void** state)
@@ -259,7 +261,7 @@ static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_success(v
 static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_custom_success(void** state)
 {
   (void)state;
-  az_span test_default_response_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_RESPONSE_TOPIC);
+  az_span test_custom_response_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_RESPONSE_TOPIC);
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
   az_mqtt5_rpc_client_codec_options options = az_mqtt5_rpc_client_codec_options_default();
   options.subscription_topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIBE_TOPIC_FORMAT);
@@ -272,7 +274,7 @@ static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_custom_su
           &options),
       AZ_OK);
 
-  char test_response_property_topic_buffer[az_span_size(test_default_response_topic)]; // Exact size
+  char test_response_property_topic_buffer[az_span_size(test_custom_response_topic)]; // Exact size
   size_t test_response_property_topic_size = 0;
 
   assert_int_equal(
@@ -288,7 +290,7 @@ static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_custom_su
   az_span test_response_topic = az_span_create(
       (uint8_t*)test_response_property_topic_buffer, (int32_t)test_response_property_topic_size);
 
-  assert_true(az_span_is_content_equal(test_response_topic, test_default_response_topic));
+  assert_true(az_span_is_content_equal(test_response_topic, test_custom_response_topic));
 }
 
 static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_buffer_size_failure(
@@ -380,7 +382,7 @@ static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_success(void** st
 static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_custom_success(void** state)
 {
   (void)state;
-  az_span test_default_subscribe_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIBE_TOPIC);
+  az_span test_custom_subscribe_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIBE_TOPIC);
 
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
   az_mqtt5_rpc_client_codec_options options = az_mqtt5_rpc_client_codec_options_default();
@@ -394,7 +396,7 @@ static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_custom_success(vo
           &options),
       AZ_OK);
 
-  char test_subscribe_topic_buffer[az_span_size(test_default_subscribe_topic)];
+  char test_subscribe_topic_buffer[az_span_size(test_custom_subscribe_topic)];
   size_t test_subscribe_topic_size = 0;
 
   assert_int_equal(
@@ -408,13 +410,13 @@ static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_custom_success(vo
   az_span test_subscribe_topic
       = az_span_create((uint8_t*)test_subscribe_topic_buffer, (int32_t)test_subscribe_topic_size);
 
-  assert_true(az_span_is_content_equal(test_subscribe_topic, test_default_subscribe_topic));
+  assert_true(az_span_is_content_equal(test_subscribe_topic, test_custom_subscribe_topic));
 }
 
 static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_buffer_size_failure(void** state)
 {
   (void)state;
-  az_span test_default_subscribe_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIBE_TOPIC);
+  az_span test_default_subscribe_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_SUBSCRIBE_TOPIC);
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
 
   assert_int_equal(
@@ -441,7 +443,7 @@ static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_buffer_size_failu
 static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_missing_token_failure(void** state)
 {
   (void)state;
-  az_span test_default_subscribe_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIBE_TOPIC);
+  az_span test_default_subscribe_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_SUBSCRIBE_TOPIC);
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
 
   assert_int_equal(

--- a/sdk/tests/core/test_az_mqtt5_rpc_client_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_client_codec.c
@@ -18,14 +18,16 @@
 #define TEST_MODEL_ID "test_model_id"
 #define TEST_CLIENT_ID "test_client_id"
 #define TEST_SERVER_ID "test_server_id"
-#define TEST_DEFAULT_PUBLISH_TOPIC_FORMAT "services/{modelId}/{executorId}/command/{name}/request"
+#define TEST_DEFAULT_PUBLISH_TOPIC_FORMAT \
+  "services/{modelId}/{executorId}/command/{commandName}/request"
 #define TEST_DEFAULT_PUBLISH_TOPIC \
   "services/" TEST_MODEL_ID "/" TEST_SERVER_ID "/command/" TEST_COMMAND_NAME "/request\0"
-#define TEST_CUSTOM_PUBLISH_TOPIC_FORMAT "controller/{modelId}/{executorId}/command/{name}/request"
+#define TEST_CUSTOM_PUBLISH_TOPIC_FORMAT \
+  "controller/{modelId}/{executorId}/command/{commandName}/request"
 #define TEST_CUSTOM_PUBLISH_TOPIC \
   "controller/" TEST_MODEL_ID "/" TEST_SERVER_ID "/command/" TEST_COMMAND_NAME "/request\0"
 #define TEST_DEFAULT_SUBSCRIBE_TOPIC_FORMAT \
-  "clients/{invokerClientId}/services/{modelId}/{executorId}/command/{name}/response"
+  "clients/{invokerClientId}/services/{modelId}/{executorId}/command/{commandName}/response"
 #define TEST_DEFAULT_SUBSCRIBE_TOPIC \
   "clients/" TEST_CLIENT_ID "/services/" TEST_MODEL_ID "/+/command/+/response\0"
 #define TEST_DEFAULT_RESPONSE_TOPIC                                       \
@@ -38,7 +40,7 @@
   "clients/" TEST_CLIENT_ID "/services/" TEST_MODEL_ID "/" TEST_SERVER_ID \
   "/command/" TEST_COMMAND_NAME "/respons"
 #define TEST_CUSTOM_SUBSCRIBE_TOPIC_FORMAT \
-  "vehicles/{modelId}/commands/{executorId}/{name}/{invokerClientId}"
+  "vehicles/{modelId}/commands/{executorId}/{commandName}/{invokerClientId}"
 #define TEST_CUSTOM_SUBSCRIBE_TOPIC "vehicles/" TEST_MODEL_ID "/commands/+/+/" TEST_CLIENT_ID "\0"
 #define TEST_CUSTOM_RESPONSE_TOPIC                                                               \
   "vehicles/" TEST_MODEL_ID "/commands/" TEST_SERVER_ID "/" TEST_COMMAND_NAME "/" TEST_CLIENT_ID \
@@ -103,7 +105,7 @@ static void test_az_mqtt5_rpc_client_codec_init_options_success(void** state)
 static void test_az_mqtt5_rpc_client_codec_get_publish_topic_success(void** state)
 {
   (void)state;
-
+  az_span test_default_pub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_PUBLISH_TOPIC);
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
 
   assert_int_equal(
@@ -114,7 +116,7 @@ static void test_az_mqtt5_rpc_client_codec_get_publish_topic_success(void** stat
           NULL),
       AZ_OK);
 
-  char test_publish_topic_buffer[72];
+  char test_publish_topic_buffer[az_span_size(test_default_pub_topic)];
   size_t test_publish_topic_out_size = 0;
 
   assert_int_equal(
@@ -129,7 +131,6 @@ static void test_az_mqtt5_rpc_client_codec_get_publish_topic_success(void** stat
 
   az_span test_pub_topic
       = az_span_create((uint8_t*)test_publish_topic_buffer, (int32_t)test_publish_topic_out_size);
-  az_span test_default_pub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_PUBLISH_TOPIC);
 
   assert_true(az_span_is_content_equal(test_pub_topic, test_default_pub_topic));
 }
@@ -137,7 +138,7 @@ static void test_az_mqtt5_rpc_client_codec_get_publish_topic_success(void** stat
 static void test_az_mqtt5_rpc_client_codec_get_publish_topic_custom_success(void** state)
 {
   (void)state;
-
+  az_span test_custom_pub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_PUBLISH_TOPIC);
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
   az_mqtt5_rpc_client_codec_options options = az_mqtt5_rpc_client_codec_options_default();
   options.request_topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_PUBLISH_TOPIC_FORMAT);
@@ -150,7 +151,7 @@ static void test_az_mqtt5_rpc_client_codec_get_publish_topic_custom_success(void
           &options),
       AZ_OK);
 
-  char test_publish_topic_buffer[256];
+  char test_publish_topic_buffer[az_span_size(test_custom_pub_topic)];
   size_t test_publish_topic_out_size = 0;
 
   assert_int_equal(
@@ -165,15 +166,14 @@ static void test_az_mqtt5_rpc_client_codec_get_publish_topic_custom_success(void
 
   az_span test_pub_topic
       = az_span_create((uint8_t*)test_publish_topic_buffer, (int32_t)test_publish_topic_out_size);
-  az_span test_default_pub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_PUBLISH_TOPIC);
 
-  assert_true(az_span_is_content_equal(test_pub_topic, test_default_pub_topic));
+  assert_true(az_span_is_content_equal(test_pub_topic, test_custom_pub_topic));
 }
 
 static void test_az_mqtt5_rpc_client_codec_get_publish_topic_buffer_size_failure(void** state)
 {
   (void)state;
-
+  az_span test_default_pub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_PUBLISH_TOPIC);
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
 
   assert_int_equal(
@@ -184,7 +184,7 @@ static void test_az_mqtt5_rpc_client_codec_get_publish_topic_buffer_size_failure
           NULL),
       AZ_OK);
 
-  char test_publish_topic_buffer[71];
+  char test_publish_topic_buffer[az_span_size(test_default_pub_topic) - 1];
   size_t test_publish_topic_out_size = 0;
 
   assert_int_equal(
@@ -196,6 +196,30 @@ static void test_az_mqtt5_rpc_client_codec_get_publish_topic_buffer_size_failure
           sizeof(test_publish_topic_buffer),
           &test_publish_topic_out_size),
       AZ_ERROR_NOT_ENOUGH_SPACE);
+}
+
+static void test_az_mqtt5_rpc_client_codec_get_publish_topic_missing_token_failure(void** state)
+{
+  (void)state;
+  az_span test_default_pub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_PUBLISH_TOPIC);
+  az_mqtt5_rpc_client_codec test_rpc_client_codec;
+
+  assert_int_equal(
+      az_mqtt5_rpc_client_codec_init(
+          &test_rpc_client_codec, AZ_SPAN_FROM_STR(TEST_CLIENT_ID), AZ_SPAN_EMPTY, NULL),
+      AZ_OK);
+
+  char test_publish_topic_buffer[az_span_size(test_default_pub_topic)];
+
+  assert_int_equal(
+      az_mqtt5_rpc_client_codec_get_publish_topic(
+          &test_rpc_client_codec,
+          AZ_SPAN_FROM_STR(TEST_SERVER_ID),
+          AZ_SPAN_FROM_STR(TEST_COMMAND_NAME),
+          test_publish_topic_buffer,
+          sizeof(test_publish_topic_buffer),
+          NULL),
+      AZ_ERROR_ARG);
 }
 
 static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_success(void** state)
@@ -296,6 +320,32 @@ static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_buffer_si
       AZ_ERROR_NOT_ENOUGH_SPACE);
 }
 
+static void test_az_mqtt5_rpc_client_codec_get_response_topic_property_missing_token_failure(
+    void** state)
+{
+  (void)state;
+  az_span test_default_response_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_RESPONSE_TOPIC);
+  az_mqtt5_rpc_client_codec test_rpc_client_codec;
+
+  assert_int_equal(
+      az_mqtt5_rpc_client_codec_init(
+          &test_rpc_client_codec, AZ_SPAN_EMPTY, AZ_SPAN_FROM_STR(TEST_MODEL_ID), NULL),
+      AZ_OK);
+
+  char test_response_property_topic_buffer[az_span_size(test_default_response_topic)];
+  size_t test_response_property_topic_size = 0;
+
+  assert_int_equal(
+      az_mqtt5_rpc_client_codec_get_response_property_topic(
+          &test_rpc_client_codec,
+          AZ_SPAN_FROM_STR(TEST_SERVER_ID),
+          AZ_SPAN_FROM_STR(TEST_COMMAND_NAME),
+          test_response_property_topic_buffer,
+          sizeof(test_response_property_topic_buffer),
+          &test_response_property_topic_size),
+      AZ_ERROR_ARG);
+}
+
 static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_success(void** state)
 {
   (void)state;
@@ -330,6 +380,7 @@ static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_success(void** st
 static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_custom_success(void** state)
 {
   (void)state;
+  az_span test_default_subscribe_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIBE_TOPIC);
 
   az_mqtt5_rpc_client_codec test_rpc_client_codec;
   az_mqtt5_rpc_client_codec_options options = az_mqtt5_rpc_client_codec_options_default();
@@ -343,7 +394,7 @@ static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_custom_success(vo
           &options),
       AZ_OK);
 
-  char test_subscribe_topic_buffer[256];
+  char test_subscribe_topic_buffer[az_span_size(test_default_subscribe_topic)];
   size_t test_subscribe_topic_size = 0;
 
   assert_int_equal(
@@ -356,7 +407,6 @@ static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_custom_success(vo
 
   az_span test_subscribe_topic
       = az_span_create((uint8_t*)test_subscribe_topic_buffer, (int32_t)test_subscribe_topic_size);
-  az_span test_default_subscribe_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIBE_TOPIC);
 
   assert_true(az_span_is_content_equal(test_subscribe_topic, test_default_subscribe_topic));
 }
@@ -386,6 +436,29 @@ static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_buffer_size_failu
           sizeof(test_subscribe_topic_buffer),
           &test_subscribe_topic_size),
       AZ_ERROR_NOT_ENOUGH_SPACE);
+}
+
+static void test_az_mqtt5_rpc_client_codec_get_subscribe_topic_missing_token_failure(void** state)
+{
+  (void)state;
+  az_span test_default_subscribe_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIBE_TOPIC);
+  az_mqtt5_rpc_client_codec test_rpc_client_codec;
+
+  assert_int_equal(
+      az_mqtt5_rpc_client_codec_init(
+          &test_rpc_client_codec, AZ_SPAN_EMPTY, AZ_SPAN_FROM_STR(TEST_MODEL_ID), NULL),
+      AZ_OK);
+
+  char test_subscribe_topic_buffer[az_span_size(test_default_subscribe_topic)];
+  size_t test_subscribe_topic_size = 0;
+
+  assert_int_equal(
+      az_mqtt5_rpc_client_codec_get_subscribe_topic(
+          &test_rpc_client_codec,
+          test_subscribe_topic_buffer,
+          sizeof(test_subscribe_topic_buffer),
+          &test_subscribe_topic_size),
+      AZ_ERROR_ARG);
 }
 
 static void test_az_mqtt5_rpc_client_codec_parse_received_topic_success(void** state)
@@ -447,13 +520,17 @@ int test_az_mqtt5_rpc_client_codec()
     cmocka_unit_test(test_az_mqtt5_rpc_client_codec_get_publish_topic_success),
     cmocka_unit_test(test_az_mqtt5_rpc_client_codec_get_publish_topic_custom_success),
     cmocka_unit_test(test_az_mqtt5_rpc_client_codec_get_publish_topic_buffer_size_failure),
+    cmocka_unit_test(test_az_mqtt5_rpc_client_codec_get_publish_topic_missing_token_failure),
     cmocka_unit_test(test_az_mqtt5_rpc_client_codec_get_response_topic_property_success),
     cmocka_unit_test(test_az_mqtt5_rpc_client_codec_get_response_topic_property_custom_success),
     cmocka_unit_test(
         test_az_mqtt5_rpc_client_codec_get_response_topic_property_buffer_size_failure),
+    cmocka_unit_test(
+        test_az_mqtt5_rpc_client_codec_get_response_topic_property_missing_token_failure),
     cmocka_unit_test(test_az_mqtt5_rpc_client_codec_get_subscribe_topic_success),
     cmocka_unit_test(test_az_mqtt5_rpc_client_codec_get_subscribe_topic_custom_success),
     cmocka_unit_test(test_az_mqtt5_rpc_client_codec_get_subscribe_topic_buffer_size_failure),
+    cmocka_unit_test(test_az_mqtt5_rpc_client_codec_get_subscribe_topic_missing_token_failure),
     cmocka_unit_test(test_az_mqtt5_rpc_client_codec_parse_received_topic_success),
     cmocka_unit_test(test_az_mqtt5_client_codec_parse_received_topic_failure),
 

--- a/sdk/tests/core/test_az_mqtt5_rpc_client_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_client_hfsm.c
@@ -35,8 +35,8 @@
 #define TEST_CERTIFICATE "test_certificate"
 #define TEST_KEY "test_key"
 #define TEST_SUBSCRIPTION_TOPIC_FORMAT \
-  "vehicles/{serviceId}/commands/{executorId}/{name}/for/{invokerClientId}"
-#define TEST_REQUEST_TOPIC_FORMAT "vehicles/{serviceId}/commands/{executorId}/{name}"
+  "vehicles/{modelId}/commands/{executorId}/{name}/for/{invokerClientId}"
+#define TEST_REQUEST_TOPIC_FORMAT "vehicles/{modelId}/commands/{executorId}/{name}"
 
 static az_mqtt5 mock_mqtt5;
 static az_mqtt5_options mock_mqtt5_options = { 0 };

--- a/sdk/tests/core/test_az_mqtt5_rpc_client_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_client_hfsm.c
@@ -35,8 +35,8 @@
 #define TEST_CERTIFICATE "test_certificate"
 #define TEST_KEY "test_key"
 #define TEST_SUBSCRIPTION_TOPIC_FORMAT \
-  "vehicles/{modelId}/commands/{executorId}/{name}/for/{invokerClientId}"
-#define TEST_REQUEST_TOPIC_FORMAT "vehicles/{modelId}/commands/{executorId}/{name}"
+  "vehicles/{modelId}/commands/{executorId}/{commandName}/for/{invokerClientId}"
+#define TEST_REQUEST_TOPIC_FORMAT "vehicles/{modelId}/commands/{executorId}/{commandName}"
 
 static az_mqtt5 mock_mqtt5;
 static az_mqtt5_options mock_mqtt5_options = { 0 };

--- a/sdk/tests/core/test_az_mqtt5_rpc_server_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_server_codec.c
@@ -222,7 +222,7 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_default_endpoint_buffe
     void** state)
 {
   (void)state;
-  az_span test_custom_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_3);
+  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_SUBSCRIPTION_TOPIC);
 
   az_mqtt5_rpc_server_codec_options test_server_options
       = az_mqtt5_rpc_server_codec_options_default();
@@ -234,7 +234,7 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_default_endpoint_buffe
           &test_server_options),
       AZ_OK);
 
-  char test_subscription_topic_buffer[az_span_size(test_custom_sub_topic) - 1]; // Exact size - 1
+  char test_subscription_topic_buffer[az_span_size(test_default_sub_topic) - 1]; // Exact size - 1
   size_t test_subscription_topic_out_size = 0;
 
   assert_int_equal(
@@ -339,11 +339,9 @@ static void az_mqtt5_rpc_server_codec_parse_received_topic_success(void** state)
 static void az_mqtt5_rpc_server_codec_parse_received_topic_failure(void** state)
 {
   (void)state;
-  az_span test_default_sub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_FUNGIBLE_SUBSCRIPTION_TOPIC);
 
   az_mqtt5_rpc_server_codec_options test_server_options
       = az_mqtt5_rpc_server_codec_options_default();
-  test_server_options.service_group_id = AZ_SPAN_FROM_STR(TEST_SERVICE_GROUP_ID);
   assert_int_equal(
       az_mqtt5_rpc_server_codec_init(
           &test_rpc_server_codec,
@@ -352,21 +350,13 @@ static void az_mqtt5_rpc_server_codec_parse_received_topic_failure(void** state)
           &test_server_options),
       AZ_OK);
 
-  char test_subscription_topic_buffer[az_span_size(test_default_sub_topic)]; // Exact size.
-  size_t test_subscription_topic_out_size = 0;
+  az_span test_response_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_RESPONSE_TOPIC_FAILURE);
+  az_mqtt5_rpc_server_codec_request test_request;
 
   assert_int_equal(
-      az_mqtt5_rpc_server_codec_get_subscribe_topic(
-          &test_rpc_server_codec,
-          test_subscription_topic_buffer,
-          sizeof(test_subscription_topic_buffer),
-          &test_subscription_topic_out_size),
-      AZ_OK);
-
-  az_span test_sub_topic = az_span_create(
-      (uint8_t*)test_subscription_topic_buffer, (int32_t)test_subscription_topic_out_size);
-
-  assert_true(az_span_is_content_equal(test_sub_topic, test_default_sub_topic));
+      az_mqtt5_rpc_server_codec_parse_received_topic(
+          &test_rpc_server_codec, test_response_topic, &test_request),
+      AZ_ERROR_IOT_TOPIC_NO_MATCH);
 }
 
 int test_az_mqtt5_rpc_server_codec()

--- a/sdk/tests/core/test_az_mqtt5_rpc_server_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_server_codec.c
@@ -20,7 +20,7 @@
 #define TEST_MODEL_ID "test_model_id"
 #define TEST_CLIENT_ID "test_server_id"
 #define TEST_SUBSCRIPTION_TOPIC_FORMAT_DEFAULT \
-  "services/{serviceId}/{executorId}/command/{name}/request"
+  "services/{modelId}/{executorId}/command/{name}/request"
 #define TEST_DEFAULT_SUBSCRIPTION_TOPIC \
   "services/" TEST_MODEL_ID "/" TEST_CLIENT_ID "/command/+/request\0"
 #define TEST_DEFAULT_RESPONSE_TOPIC \
@@ -30,7 +30,7 @@
 #define TEST_DEFAULT_FUNGIBLE_SUBSCRIPTION_TOPIC \
   "$share/" TEST_SERVICE_GROUP_ID "/services/" TEST_MODEL_ID "/_any_/command/+/request\0"
 #define TEST_CUSTOM_SUBSCRIPTION_TOPIC_FORMAT_1 \
-  "controller/{executorId}/service/{serviceId}/command/{name}"
+  "controller/{executorId}/service/{modelId}/command/{name}"
 #define TEST_CUSTOM_SUBSCRIPTION_TOPIC_1 \
   "controller/" TEST_CLIENT_ID "/service/" TEST_MODEL_ID "/command/+\0"
 #define TEST_CUSTOM_SUBSCRIPTION_TOPIC_FORMAT_2 "controller/{executorId}/service/command/{name}"
@@ -221,6 +221,7 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_default_endpoint_buffe
     void** state)
 {
   (void)state;
+  az_span test_custom_sub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_SUBSCRIPTION_TOPIC_3);
 
   az_mqtt5_rpc_server_codec_options test_server_options
       = az_mqtt5_rpc_server_codec_options_default();
@@ -232,7 +233,7 @@ static void az_mqtt5_rpc_server_codec_get_subscribe_topic_default_endpoint_buffe
           &test_server_options),
       AZ_OK);
 
-  char test_subscription_topic_buffer[55];
+  char test_subscription_topic_buffer[az_span_size(test_custom_sub_topic) - 1]; // Exact size - 1
   size_t test_subscription_topic_out_size = 0;
 
   assert_int_equal(

--- a/sdk/tests/core/test_az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_server_hfsm.c
@@ -27,7 +27,7 @@
 #define TEST_PAYLOAD "test_payload"
 #define TEST_CORRELATION_ID "test_correlation_id"
 #define TEST_RESPONSE_TOPIC "test_response_topic"
-#define TEST_SUBSCRIPTION_TOPIC_FORMAT "vehicles/{modelId}/commands/{executorId}/{name}"
+#define TEST_SUBSCRIPTION_TOPIC_FORMAT "vehicles/{modelId}/commands/{executorId}/{commandName}"
 #define TEST_SUBSCRIPTION_TOPIC \
   "vehicles/" TEST_MODEL_ID "/commands/" TEST_CLIENT_ID "/" TEST_COMMAND_NAME "\0"
 #define TEST_STATUS_SUCCESS "200"

--- a/sdk/tests/core/test_az_mqtt5_rpc_server_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_rpc_server_hfsm.c
@@ -27,7 +27,7 @@
 #define TEST_PAYLOAD "test_payload"
 #define TEST_CORRELATION_ID "test_correlation_id"
 #define TEST_RESPONSE_TOPIC "test_response_topic"
-#define TEST_SUBSCRIPTION_TOPIC_FORMAT "vehicles/{serviceId}/commands/{executorId}/{name}"
+#define TEST_SUBSCRIPTION_TOPIC_FORMAT "vehicles/{modelId}/commands/{executorId}/{name}"
 #define TEST_SUBSCRIPTION_TOPIC \
   "vehicles/" TEST_MODEL_ID "/commands/" TEST_CLIENT_ID "/" TEST_COMMAND_NAME "\0"
 #define TEST_STATUS_SUCCESS "200"

--- a/sdk/tests/core/test_az_mqtt5_telemetry_consumer_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_telemetry_consumer_codec.c
@@ -24,7 +24,7 @@
   "services/" TEST_MODEL_ID "/" TEST_SENDER_ID "/telemetry"
 #define TEST_DEFAULT_CONSUMER_FUNGIBLE_TOPIC \
   "$share/" TEST_SERVICE_GROUP_ID "/services/" TEST_MODEL_ID "/" TEST_SENDER_ID "/telemetry\0"
-#define TEST_CUSTOM_CONSUMER_TOPIC_FORMAT "sender/{senderId}/service/{serviceId}/telemetry/{name}"
+#define TEST_CUSTOM_CONSUMER_TOPIC_FORMAT "sender/{senderId}/service/{modelId}/telemetry/{name}"
 #define TEST_CUSTOM_CONSUMER_TOPIC \
   "sender/" TEST_SENDER_ID "/service/" TEST_MODEL_ID "/telemetry/+\0"
 

--- a/sdk/tests/core/test_az_mqtt5_telemetry_consumer_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_telemetry_consumer_hfsm.c
@@ -26,7 +26,8 @@
 #define TEST_PASSWORD "test_password"
 #define TEST_CONTENT_TYPE "test_content_type"
 #define TEST_PAYLOAD "test_payload"
-#define TEST_SUBSCRIPTION_TOPIC_FORMAT "sender/{senderId}/service/{modelId}/telemetry/{name}"
+#define TEST_SUBSCRIPTION_TOPIC_FORMAT \
+  "sender/{senderId}/service/{modelId}/telemetry/{telemetryName}"
 #define TEST_SUBSCRIPTION_TOPIC "sender/" TEST_SENDER_ID "/service/" TEST_MODEL_ID "/telemetry/+\0"
 
 #define TEST_STATUS_SUCCESS "200"

--- a/sdk/tests/core/test_az_mqtt5_telemetry_consumer_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_telemetry_consumer_hfsm.c
@@ -26,7 +26,7 @@
 #define TEST_PASSWORD "test_password"
 #define TEST_CONTENT_TYPE "test_content_type"
 #define TEST_PAYLOAD "test_payload"
-#define TEST_SUBSCRIPTION_TOPIC_FORMAT "sender/{senderId}/service/{serviceId}/telemetry/{name}"
+#define TEST_SUBSCRIPTION_TOPIC_FORMAT "sender/{senderId}/service/{modelId}/telemetry/{name}"
 #define TEST_SUBSCRIPTION_TOPIC "sender/" TEST_SENDER_ID "/service/" TEST_MODEL_ID "/telemetry/+\0"
 
 #define TEST_STATUS_SUCCESS "200"

--- a/sdk/tests/core/test_az_mqtt5_telemetry_producer_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_telemetry_producer_codec.c
@@ -20,7 +20,7 @@
 #define TEST_CLIENT_ID "test_client_id"
 #define TEST_TELEMETRY_NAME "test_telemetry_name"
 #define TEST_DEFAULT_PRODUCER_TOPIC "services/" TEST_MODEL_ID "/" TEST_CLIENT_ID "/telemetry\0"
-#define TEST_CUSTOM_PRODUCER_TOPIC_FORMAT "sender/{senderId}/service/{serviceId}/telemetry/{name}"
+#define TEST_CUSTOM_PRODUCER_TOPIC_FORMAT "sender/{senderId}/service/{modelId}/telemetry/{name}"
 #define TEST_CUSTOM_PRODUCER_TOPIC \
   "sender/" TEST_CLIENT_ID "/service/" TEST_MODEL_ID "/telemetry/" TEST_TELEMETRY_NAME "\0"
 

--- a/sdk/tests/core/test_az_mqtt5_telemetry_producer_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_telemetry_producer_codec.c
@@ -96,7 +96,7 @@ static void test_az_mqtt5_telemetry_producer_codec_get_publish_topic_default_suc
 static void test_az_mqtt5_telemetry_producer_codec_get_publish_topic_custom_success(void** state)
 {
   (void)state;
-  az_span test_default_pub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_PRODUCER_TOPIC);
+  az_span test_custom_pub_topic = AZ_SPAN_FROM_STR(TEST_CUSTOM_PRODUCER_TOPIC);
   az_mqtt5_telemetry_producer_codec producer;
   az_mqtt5_telemetry_producer_codec_options options
       = az_mqtt5_telemetry_producer_codec_options_default();
@@ -107,7 +107,7 @@ static void test_az_mqtt5_telemetry_producer_codec_get_publish_topic_custom_succ
           &producer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_CLIENT_ID), &options),
       AZ_OK);
 
-  char test_publish_topic_buffer[az_span_size(test_default_pub_topic)];
+  char test_publish_topic_buffer[az_span_size(test_custom_pub_topic)];
   size_t test_publish_topic_buffer_out_size = 0;
   assert_int_equal(
       az_mqtt5_telemetry_producer_codec_get_publish_topic(
@@ -121,7 +121,7 @@ static void test_az_mqtt5_telemetry_producer_codec_get_publish_topic_custom_succ
   az_span test_pub_topic = az_span_create(
       (uint8_t*)test_publish_topic_buffer, (int32_t)test_publish_topic_buffer_out_size);
 
-  assert_true(az_span_is_content_equal(test_pub_topic, test_default_pub_topic));
+  assert_true(az_span_is_content_equal(test_pub_topic, test_custom_pub_topic));
 }
 
 static void test_az_mqtt5_telemetry_producer_codec_get_publish_topic_buffer_size_failure(

--- a/sdk/tests/core/test_az_mqtt5_telemetry_producer_codec.c
+++ b/sdk/tests/core/test_az_mqtt5_telemetry_producer_codec.c
@@ -20,7 +20,8 @@
 #define TEST_CLIENT_ID "test_client_id"
 #define TEST_TELEMETRY_NAME "test_telemetry_name"
 #define TEST_DEFAULT_PRODUCER_TOPIC "services/" TEST_MODEL_ID "/" TEST_CLIENT_ID "/telemetry\0"
-#define TEST_CUSTOM_PRODUCER_TOPIC_FORMAT "sender/{senderId}/service/{modelId}/telemetry/{name}"
+#define TEST_CUSTOM_PRODUCER_TOPIC_FORMAT \
+  "sender/{senderId}/service/{modelId}/telemetry/{telemetryName}"
 #define TEST_CUSTOM_PRODUCER_TOPIC \
   "sender/" TEST_CLIENT_ID "/service/" TEST_MODEL_ID "/telemetry/" TEST_TELEMETRY_NAME "\0"
 
@@ -69,9 +70,11 @@ static void test_az_mqtt5_telemetry_producer_codec_get_publish_topic_default_suc
   (void)state;
   az_span test_default_pub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_PRODUCER_TOPIC);
   az_mqtt5_telemetry_producer_codec producer;
-  az_result result = az_mqtt5_telemetry_producer_codec_init(
-      &producer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_CLIENT_ID), NULL);
-  assert_int_equal(result, AZ_OK);
+
+  assert_int_equal(
+      az_mqtt5_telemetry_producer_codec_init(
+          &producer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_CLIENT_ID), NULL),
+      AZ_OK);
 
   char test_publish_topic_buffer[az_span_size(test_default_pub_topic)];
   size_t test_publish_topic_buffer_out_size = 0;
@@ -99,9 +102,10 @@ static void test_az_mqtt5_telemetry_producer_codec_get_publish_topic_custom_succ
       = az_mqtt5_telemetry_producer_codec_options_default();
   options.telemetry_topic_format = AZ_SPAN_FROM_STR(TEST_CUSTOM_PRODUCER_TOPIC_FORMAT);
 
-  az_result result = az_mqtt5_telemetry_producer_codec_init(
-      &producer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_CLIENT_ID), &options);
-  assert_int_equal(result, AZ_OK);
+  assert_int_equal(
+      az_mqtt5_telemetry_producer_codec_init(
+          &producer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_CLIENT_ID), &options),
+      AZ_OK);
 
   char test_publish_topic_buffer[az_span_size(test_default_pub_topic)];
   size_t test_publish_topic_buffer_out_size = 0;
@@ -125,9 +129,10 @@ static void test_az_mqtt5_telemetry_producer_codec_get_publish_topic_buffer_size
 {
   (void)state;
   az_mqtt5_telemetry_producer_codec producer;
-  az_result result = az_mqtt5_telemetry_producer_codec_init(
-      &producer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_CLIENT_ID), NULL);
-  assert_int_equal(result, AZ_OK);
+  assert_int_equal(
+      az_mqtt5_telemetry_producer_codec_init(
+          &producer, AZ_SPAN_FROM_STR(TEST_MODEL_ID), AZ_SPAN_FROM_STR(TEST_CLIENT_ID), NULL),
+      AZ_OK);
 
   char test_publish_topic_buffer[1];
   size_t test_publish_topic_buffer_out_size = 0;
@@ -143,6 +148,30 @@ static void test_az_mqtt5_telemetry_producer_codec_get_publish_topic_buffer_size
   assert_int_equal(test_publish_topic_buffer_out_size, 48);
 }
 
+static void test_az_mqtt5_telemetry_producer_codec_get_publish_topic_missing_token_failure(
+    void** state)
+{
+  (void)state;
+  az_span test_default_pub_topic = AZ_SPAN_FROM_STR(TEST_DEFAULT_PRODUCER_TOPIC);
+  az_mqtt5_telemetry_producer_codec producer;
+
+  assert_int_equal(
+      az_mqtt5_telemetry_producer_codec_init(
+          &producer, AZ_SPAN_EMPTY, AZ_SPAN_FROM_STR(TEST_CLIENT_ID), NULL),
+      AZ_OK);
+
+  char test_publish_topic_buffer[az_span_size(test_default_pub_topic)];
+  size_t test_publish_topic_buffer_out_size = 0;
+  assert_int_equal(
+      az_mqtt5_telemetry_producer_codec_get_publish_topic(
+          &producer,
+          AZ_SPAN_EMPTY,
+          test_publish_topic_buffer,
+          sizeof(test_publish_topic_buffer),
+          &test_publish_topic_buffer_out_size),
+      AZ_ERROR_ARG);
+}
+
 int test_az_mqtt5_telemetry_producer_codec()
 {
   const struct CMUnitTest tests[] = {
@@ -151,6 +180,8 @@ int test_az_mqtt5_telemetry_producer_codec()
     cmocka_unit_test(test_az_mqtt5_telemetry_producer_codec_get_publish_topic_default_success),
     cmocka_unit_test(test_az_mqtt5_telemetry_producer_codec_get_publish_topic_custom_success),
     cmocka_unit_test(test_az_mqtt5_telemetry_producer_codec_get_publish_topic_buffer_size_failure),
+    cmocka_unit_test(
+        test_az_mqtt5_telemetry_producer_codec_get_publish_topic_missing_token_failure),
   };
   return cmocka_run_group_tests_name("az_core_mqtt5_telemetry_producer_codec", tests, NULL, NULL);
 }

--- a/sdk/tests/core/test_az_mqtt5_telemetry_producer_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_telemetry_producer_hfsm.c
@@ -26,7 +26,7 @@
 #define TEST_PAYLOAD "test_payload"
 
 #define TEST_HOSTNAME "test.hostname.com"
-#define TEST_TELEMETRY_TOPIC_FORMAT "vehicles/{modelId}/telemetry/{senderId}/{name}"
+#define TEST_TELEMETRY_TOPIC_FORMAT "vehicles/{modelId}/telemetry/{senderId}/{telemetryName}"
 
 static az_mqtt5 mock_mqtt5;
 static az_mqtt5_options mock_mqtt5_options = { 0 };

--- a/sdk/tests/core/test_az_mqtt5_telemetry_producer_hfsm.c
+++ b/sdk/tests/core/test_az_mqtt5_telemetry_producer_hfsm.c
@@ -26,7 +26,7 @@
 #define TEST_PAYLOAD "test_payload"
 
 #define TEST_HOSTNAME "test.hostname.com"
-#define TEST_TELEMETRY_TOPIC_FORMAT "vehicles/{serviceId}/telemetry/{senderId}/{name}"
+#define TEST_TELEMETRY_TOPIC_FORMAT "vehicles/{modelId}/telemetry/{senderId}/{name}"
 
 static az_mqtt5 mock_mqtt5;
 static az_mqtt5_options mock_mqtt5_options = { 0 };

--- a/sdk/tests/core/test_az_mqtt5_topic_parser.c
+++ b/sdk/tests/core/test_az_mqtt5_topic_parser.c
@@ -13,9 +13,9 @@
 
 #include <cmocka.h>
 
-#define TEST_SAMPLE_FORMAT                                                                   \
-  "test/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN \
-  "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_NAME_TOKEN                  \
+#define TEST_SAMPLE_FORMAT                                                                 \
+  "test/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_MODEL_ID_TOKEN \
+  "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_NAME_TOKEN                \
   "/" _az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN "/endoftest"
 #define TEST_SAMPLE_FORMAT_REPLACED                                                    \
   "$share/test_service_group_id/test/test_client_id/test_service_id/test_executor_id/" \
@@ -42,7 +42,7 @@ static void test_az_mqtt5_topic_parser_calculate_hash_success(void** state)
 
   az_span invoker_client_id_key
       = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN);
-  az_span model_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_SERVICE_ID_TOKEN);
+  az_span model_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_MODEL_ID_TOKEN);
   az_span executor_client_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_RPC_EXECUTOR_ID_TOKEN);
   az_span sender_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN);
   az_span name_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_NAME_TOKEN);

--- a/sdk/tests/core/test_az_mqtt5_topic_parser.c
+++ b/sdk/tests/core/test_az_mqtt5_topic_parser.c
@@ -13,22 +13,29 @@
 
 #include <cmocka.h>
 
-#define TEST_SAMPLE_FORMAT                                                                 \
-  "test/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_MODEL_ID_TOKEN \
-  "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_NAME_TOKEN                \
-  "/" _az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN "/endoftest"
-#define TEST_SAMPLE_FORMAT_REPLACED                                                    \
+#define TEST_SAMPLE_FORMAT                                                                      \
+  "test/" _az_MQTT5_TOPIC_PARSER_CLIENT_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_MODEL_ID_TOKEN      \
+  "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN                \
+  "/" _az_MQTT5_TOPIC_PARSER_COMMAND_NAME_TOKEN "/" _az_MQTT5_TOPIC_PARSER_TELEMETRY_NAME_TOKEN \
+  "/endoftest"
+#define TEST_SAMPLE_FORMAT_REPLACED                       \
+  "test/test_client_id/test_service_id/test_executor_id/" \
+  "test_sender_id/test_command_name/test_telemetry_name/endoftest\0"
+#define TEST_SAMPLE_FORMAT_REPLACED_SERVICE_GROUP                                      \
   "$share/test_service_group_id/test/test_client_id/test_service_id/test_executor_id/" \
-  "test_name/test_sender_id/endoftest\0"
+  "test_sender_id/test_command_name/test_telemetry_name/endoftest\0"
 static const az_span test_sample_format = AZ_SPAN_LITERAL_FROM_STR(TEST_SAMPLE_FORMAT);
 static const az_span test_sample_format_replaced
     = AZ_SPAN_LITERAL_FROM_STR(TEST_SAMPLE_FORMAT_REPLACED);
+static const az_span test_sample_format_replaced_service_group
+    = AZ_SPAN_LITERAL_FROM_STR(TEST_SAMPLE_FORMAT_REPLACED_SERVICE_GROUP);
 static const az_span test_service_group_id = AZ_SPAN_LITERAL_FROM_STR("test_service_group_id");
 static const az_span test_sample_client_id = AZ_SPAN_LITERAL_FROM_STR("test_client_id");
 static const az_span test_sample_service_id = AZ_SPAN_LITERAL_FROM_STR("test_service_id");
 static const az_span test_sample_executor_id = AZ_SPAN_LITERAL_FROM_STR("test_executor_id");
-static const az_span test_sample_name_id = AZ_SPAN_LITERAL_FROM_STR("test_name");
 static const az_span test_sample_sender_id = AZ_SPAN_LITERAL_FROM_STR("test_sender_id");
+static const az_span test_sample_command_name = AZ_SPAN_LITERAL_FROM_STR("test_command_name");
+static const az_span test_sample_telemetry_name = AZ_SPAN_LITERAL_FROM_STR("test_telemetry_name");
 
 AZ_INLINE az_span test_az_mqtt5_get_key_no_braces(char* key)
 {
@@ -45,7 +52,10 @@ static void test_az_mqtt5_topic_parser_calculate_hash_success(void** state)
   az_span model_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_MODEL_ID_TOKEN);
   az_span executor_client_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_RPC_EXECUTOR_ID_TOKEN);
   az_span sender_id_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN);
-  az_span name_key = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_NAME_TOKEN);
+  az_span command_name_key
+      = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_COMMAND_NAME_TOKEN);
+  az_span telemetry_name_key
+      = test_az_mqtt5_get_key_no_braces(_az_MQTT5_TOPIC_PARSER_TELEMETRY_NAME_TOKEN);
 
   uint32_t sender_id_key_hash = _az_mqtt5_topic_parser_calculate_hash(sender_id_key);
   (void)sender_id_key_hash;
@@ -61,14 +71,18 @@ static void test_az_mqtt5_topic_parser_calculate_hash_success(void** state)
   assert_int_equal(
       _az_MQTT5_TOPIC_PARSER_SENDER_ID_HASH, _az_mqtt5_topic_parser_calculate_hash(sender_id_key));
   assert_int_equal(
-      _az_MQTT5_TOPIC_PARSER_NAME_HASH, _az_mqtt5_topic_parser_calculate_hash(name_key));
+      _az_MQTT5_TOPIC_PARSER_TELEMETRY_NAME_HASH,
+      _az_mqtt5_topic_parser_calculate_hash(telemetry_name_key));
+  assert_int_equal(
+      _az_MQTT5_TOPIC_PARSER_COMMAND_NAME_HASH,
+      _az_mqtt5_topic_parser_calculate_hash(command_name_key));
 }
 
 static void test_az_mqtt5_topic_parser_replace_tokens_in_format_success(void** state)
 {
   (void)state;
 
-  uint8_t test_buffer[117];
+  uint8_t test_buffer[145];
   az_span test_buffer_span = AZ_SPAN_FROM_BUFFER(test_buffer);
   uint32_t test_size = 0;
 
@@ -80,14 +94,16 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_success(void** s
       test_sample_service_id,
       test_sample_executor_id,
       test_sample_sender_id,
-      test_sample_name_id,
+      test_sample_command_name,
+      test_sample_telemetry_name,
       &test_size);
 
   assert_int_equal(res, AZ_OK);
 
   az_span test_buffer_span_replaced = az_span_create(test_buffer, (int32_t)test_size);
 
-  assert_true(az_span_is_content_equal(test_buffer_span_replaced, test_sample_format_replaced));
+  assert_true(az_span_is_content_equal(
+      test_buffer_span_replaced, test_sample_format_replaced_service_group));
 }
 
 static void test_az_mqtt5_topic_parser_replace_tokens_in_format_failure(void** state)
@@ -106,11 +122,12 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_failure(void** s
       test_sample_service_id,
       test_sample_executor_id,
       test_sample_sender_id,
-      test_sample_name_id,
+      test_sample_command_name,
+      test_sample_telemetry_name,
       &test_size);
 
   assert_int_equal(res, AZ_ERROR_NOT_ENOUGH_SPACE);
-  assert_int_equal(test_size, 117);
+  assert_int_equal(test_size, az_span_size(test_sample_format_replaced_service_group));
 }
 
 static void test_az_mqtt5_topic_parser_replace_tokens_in_format_no_service_group_failure(
@@ -130,11 +147,12 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_no_service_group
       test_sample_service_id,
       test_sample_executor_id,
       test_sample_sender_id,
-      test_sample_name_id,
+      test_sample_command_name,
+      test_sample_telemetry_name,
       &test_size);
 
   assert_int_equal(res, AZ_ERROR_NOT_ENOUGH_SPACE);
-  assert_int_equal(test_size, 88);
+  assert_int_equal(test_size, az_span_size(test_sample_format_replaced));
 }
 
 int test_az_mqtt5_topic_parser()

--- a/sdk/tests/core/test_az_mqtt5_topic_parser.c
+++ b/sdk/tests/core/test_az_mqtt5_topic_parser.c
@@ -18,11 +18,11 @@
   "/" _az_MQTT5_RPC_EXECUTOR_ID_TOKEN "/" _az_MQTT5_TOPIC_PARSER_SENDER_ID_TOKEN                \
   "/" _az_MQTT5_TOPIC_PARSER_COMMAND_NAME_TOKEN "/" _az_MQTT5_TOPIC_PARSER_TELEMETRY_NAME_TOKEN \
   "/endoftest"
-#define TEST_SAMPLE_FORMAT_REPLACED                       \
-  "test/test_client_id/test_service_id/test_executor_id/" \
+#define TEST_SAMPLE_FORMAT_REPLACED                     \
+  "test/test_client_id/test_model_id/test_executor_id/" \
   "test_sender_id/test_command_name/test_telemetry_name/endoftest\0"
-#define TEST_SAMPLE_FORMAT_REPLACED_SERVICE_GROUP                                      \
-  "$share/test_service_group_id/test/test_client_id/test_service_id/test_executor_id/" \
+#define TEST_SAMPLE_FORMAT_REPLACED_SERVICE_GROUP                                    \
+  "$share/test_service_group_id/test/test_client_id/test_model_id/test_executor_id/" \
   "test_sender_id/test_command_name/test_telemetry_name/endoftest\0"
 static const az_span test_sample_format = AZ_SPAN_LITERAL_FROM_STR(TEST_SAMPLE_FORMAT);
 static const az_span test_sample_format_replaced
@@ -31,7 +31,7 @@ static const az_span test_sample_format_replaced_service_group
     = AZ_SPAN_LITERAL_FROM_STR(TEST_SAMPLE_FORMAT_REPLACED_SERVICE_GROUP);
 static const az_span test_service_group_id = AZ_SPAN_LITERAL_FROM_STR("test_service_group_id");
 static const az_span test_sample_client_id = AZ_SPAN_LITERAL_FROM_STR("test_client_id");
-static const az_span test_sample_service_id = AZ_SPAN_LITERAL_FROM_STR("test_service_id");
+static const az_span test_sample_model_id = AZ_SPAN_LITERAL_FROM_STR("test_model_id");
 static const az_span test_sample_executor_id = AZ_SPAN_LITERAL_FROM_STR("test_executor_id");
 static const az_span test_sample_sender_id = AZ_SPAN_LITERAL_FROM_STR("test_sender_id");
 static const az_span test_sample_command_name = AZ_SPAN_LITERAL_FROM_STR("test_command_name");
@@ -64,7 +64,7 @@ static void test_az_mqtt5_topic_parser_calculate_hash_success(void** state)
       _az_MQTT5_TOPIC_PARSER_CLIENT_ID_HASH,
       _az_mqtt5_topic_parser_calculate_hash(invoker_client_id_key));
   assert_int_equal(
-      _az_MQTT5_TOPIC_PARSER_SERVICE_ID_HASH, _az_mqtt5_topic_parser_calculate_hash(model_id_key));
+      _az_MQTT5_TOPIC_PARSER_MODEL_ID_HASH, _az_mqtt5_topic_parser_calculate_hash(model_id_key));
   assert_int_equal(
       _az_MQTT5_TOPIC_PARSER_EXECUTOR_ID_HASH,
       _az_mqtt5_topic_parser_calculate_hash(executor_client_id_key));
@@ -91,7 +91,7 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_success(void** s
       test_sample_format,
       test_service_group_id,
       test_sample_client_id,
-      test_sample_service_id,
+      test_sample_model_id,
       test_sample_executor_id,
       test_sample_sender_id,
       test_sample_command_name,
@@ -119,7 +119,7 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_failure(void** s
       test_sample_format,
       test_service_group_id,
       test_sample_client_id,
-      test_sample_service_id,
+      test_sample_model_id,
       test_sample_executor_id,
       test_sample_sender_id,
       test_sample_command_name,
@@ -144,7 +144,7 @@ static void test_az_mqtt5_topic_parser_replace_tokens_in_format_no_service_group
       test_sample_format,
       AZ_SPAN_EMPTY,
       test_sample_client_id,
-      test_sample_service_id,
+      test_sample_model_id,
       test_sample_executor_id,
       test_sample_sender_id,
       test_sample_command_name,


### PR DESCRIPTION
Updating the RPC Pattern and Telemetry topic tokens to match the current specification:
- Switch from `serviceId` to `modelId`
- Switch from `name` to `commandName` and `telemetryName`

Addressed bug in topic parser and added tests.