### PR TITLE
Turn on EnforceMaxLifeOfIssues Rule

### DIFF
--- a/.github/event-processor.config
+++ b/.github/event-processor.config
@@ -22,5 +22,5 @@
   "IdentifyStalePullRequests": "On",
   "CloseAddressedIssues": "On",
   "LockClosedIssues": "On",
-  "EnforceMaxLifeOfIssues": "Off"
+  "EnforceMaxLifeOfIssues": "On"
 }


### PR DESCRIPTION
Activating the EnforceMaxLifeOfIssues Rule in this repo to auto close issues older than 2 years with no activity within the last 30 days.