### PR TITLE
Separate az_iot_calculate_retry_delay into own core module

### DIFF
--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -58,6 +58,10 @@ enum az_log_classification_core
   AZ_LOG_HTTP_RETRY = _az_LOG_MAKE_CLASSIFICATION(
       _az_FACILITY_CORE_HTTP,
       3), ///< First HTTP request did not succeed and will be retried.
+
+  AZ_LOG_RETRY = _az_LOG_MAKE_CLASSIFICATION(
+      _az_FACILITY_CORE,
+      1)
 };
 
 /**

--- a/sdk/inc/azure/core/az_log.h
+++ b/sdk/inc/azure/core/az_log.h
@@ -59,9 +59,7 @@ enum az_log_classification_core
       _az_FACILITY_CORE_HTTP,
       3), ///< First HTTP request did not succeed and will be retried.
 
-  AZ_LOG_RETRY = _az_LOG_MAKE_CLASSIFICATION(
-      _az_FACILITY_CORE,
-      1)
+  AZ_LOG_RETRY = _az_LOG_MAKE_CLASSIFICATION(_az_FACILITY_CORE, 1)
 };
 
 /**

--- a/sdk/inc/azure/core/az_retry.h
+++ b/sdk/inc/azure/core/az_retry.h
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file
+ *
+ * @brief Definition of #az_retry. Api for supporting general retry logic.
+ *
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
+ * prefixed with an underscore ('_') directly in your application code. These symbols
+ * are part of Azure SDK's internal implementation; we do not document these symbols
+ * and they are subject to change in future versions of the SDK which would break your code.
+ */
+
+#ifndef _az_RETRY_H
+#define _az_RETRY_H
+
+#include <azure/core/az_result.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <azure/core/_az_cfg_prefix.h>
+
+/**
+ * @brief Calculates the recommended delay before retrying an operation that failed.
+ *
+ * @param[in] operation_msec The time it took, in milliseconds, to perform the operation that
+ *                           failed.
+ * @param[in] attempt The number of failed retry attempts.
+ * @param[in] min_retry_delay_msec The minimum time, in milliseconds, to wait before a retry.
+ * @param[in] max_retry_delay_msec The maximum time, in milliseconds, to wait before a retry.
+ * @param[in] random_jitter_msec A random value between 0 and the maximum allowed jitter, in
+ * milliseconds.
+ * @pre \p operation_msec must be between 0 and INT32_MAX - 1.
+ * @pre \p attempt must be between 0 and INT16_MAX - 1.
+ * @pre \p min_retry_delay_msec must be between 0 and INT32_MAX - 1.
+ * @pre \p max_retry_delay_msec must be between 0 and INT32_MAX - 1.
+ * @pre \p random_jitter_msec must be between 0 and INT32_MAX - 1.
+ * @return The recommended delay in milliseconds.
+ */
+AZ_NODISCARD int32_t az_retry_calculate_delay(
+    int32_t operation_msec,
+    int16_t attempt,
+    int32_t min_retry_delay_msec,
+    int32_t max_retry_delay_msec,
+    int32_t random_jitter_msec);
+
+#include <azure/core/_az_cfg_suffix.h>
+
+#endif // _az_RETRY_H

--- a/sdk/inc/azure/core/az_retry.h
+++ b/sdk/inc/azure/core/az_retry.h
@@ -4,7 +4,7 @@
 /**
  * @file
  *
- * @brief Definition of #az_retry. Api for supporting general retry logic.
+ * @brief Api for supporting general retry logic.
  *
  * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols

--- a/sdk/inc/azure/iot/az_iot_common.h
+++ b/sdk/inc/azure/iot/az_iot_common.h
@@ -266,30 +266,6 @@ AZ_NODISCARD AZ_INLINE bool az_iot_status_retriable(az_iot_status status)
   return ((status == AZ_IOT_STATUS_THROTTLED) || (status == AZ_IOT_STATUS_SERVER_ERROR));
 }
 
-/**
- * @brief Calculates the recommended delay before retrying an operation that failed.
- *
- * @param[in] operation_msec The time it took, in milliseconds, to perform the operation that
- *                           failed.
- * @param[in] attempt The number of failed retry attempts.
- * @param[in] min_retry_delay_msec The minimum time, in milliseconds, to wait before a retry.
- * @param[in] max_retry_delay_msec The maximum time, in milliseconds, to wait before a retry.
- * @param[in] random_jitter_msec A random value between 0 and the maximum allowed jitter, in
- * milliseconds.
- * @pre \p operation_msec must be between 0 and INT32_MAX - 1.
- * @pre \p attempt must be between 0 and INT16_MAX - 1.
- * @pre \p min_retry_delay_msec must be between 0 and INT32_MAX - 1.
- * @pre \p max_retry_delay_msec must be between 0 and INT32_MAX - 1.
- * @pre \p random_jitter_msec must be between 0 and INT32_MAX - 1.
- * @return The recommended delay in milliseconds.
- */
-AZ_NODISCARD int32_t az_iot_calculate_retry_delay(
-    int32_t operation_msec,
-    int16_t attempt,
-    int32_t min_retry_delay_msec,
-    int32_t max_retry_delay_msec,
-    int32_t random_jitter_msec);
-
 #include <azure/core/_az_cfg_suffix.h>
 
 #endif // _az_IOT_CORE_H

--- a/sdk/samples/core/CMakeLists.txt
+++ b/sdk/samples/core/CMakeLists.txt
@@ -23,7 +23,6 @@ if (TRANSPORT_MOSQUITTO)
   target_link_libraries(mosquitto_rpc_server_sample
     PRIVATE
     az_core
-    az_iot_common
   )
 
   create_map_file(mosquitto_rpc_server_sample mosquitto_rpc_server_sample.map)
@@ -43,7 +42,6 @@ if (TRANSPORT_MOSQUITTO)
     PRIVATE
     uuid
     az_core
-    az_iot_common
   )
 
   create_map_file(mosquitto_rpc_client_sample mosquitto_rpc_client_sample.map)
@@ -63,7 +61,6 @@ if (TRANSPORT_MOSQUITTO)
     PRIVATE
     uuid
     az_core
-    az_iot_common
   )
 
   create_map_file(mosquitto_multiple_rpc_sample mosquitto_multiple_rpc_sample.map)
@@ -82,7 +79,6 @@ if (TRANSPORT_MOSQUITTO)
   target_link_libraries(mosquitto_telemetry_producer_sample
     PRIVATE
     az_core
-    az_iot_common
   )
 
   create_map_file(mosquitto_telemetry_producer_sample mosquitto_telemetry_producer_sample.map)
@@ -101,7 +97,6 @@ if (TRANSPORT_MOSQUITTO)
   target_link_libraries(mosquitto_telemetry_consumer_sample
     PRIVATE
     az_core
-    az_iot_common
   )
 
   create_map_file(mosquitto_telemetry_consumer_sample mosquitto_telemetry_consumer_sample.map)
@@ -121,7 +116,6 @@ elseif (TRANSPORT_PAHO)
   target_link_libraries(paho_rpc_server_sample
     PRIVATE
     az_core
-    az_iot_common
   )
 
   create_map_file(paho_rpc_server_sample paho_rpc_server_sample.map)
@@ -141,7 +135,6 @@ elseif (TRANSPORT_PAHO)
     PRIVATE
     uuid
     az_core
-    az_iot_common
   )
 
   create_map_file(paho_rpc_client_sample paho_rpc_client_sample.map)
@@ -161,7 +154,6 @@ elseif (TRANSPORT_PAHO)
     PRIVATE
     uuid
     az_core
-    az_iot_common
   )
 
   create_map_file(paho_multiple_rpc_sample paho_multiple_rpc_sample.map)
@@ -180,7 +172,6 @@ elseif (TRANSPORT_PAHO)
   target_link_libraries(paho_telemetry_producer_sample
     PRIVATE
     az_core
-    az_iot_common
   )
 
   create_map_file(paho_telemetry_producer_sample paho_telemetry_producer_sample.map)
@@ -199,7 +190,6 @@ elseif (TRANSPORT_PAHO)
   target_link_libraries(paho_telemetry_consumer_sample
     PRIVATE
     az_core
-    az_iot_common
   )
 
   create_map_file(paho_telemetry_consumer_sample paho_telemetry_consumer_sample.map)

--- a/sdk/src/azure/core/CMakeLists.txt
+++ b/sdk/src/azure/core/CMakeLists.txt
@@ -71,6 +71,7 @@ if (AZ_PLATFORM_IMPL STREQUAL "POSIX" AND NOT APPLE)
     ${CMAKE_CURRENT_LIST_DIR}/az_mqtt5_request_hfsm.c
     ${CMAKE_CURRENT_LIST_DIR}/az_mqtt5_topic_parser.c
     ${CMAKE_CURRENT_LIST_DIR}/az_precondition.c
+    ${CMAKE_CURRENT_LIST_DIR}/az_retry.c
     ${CMAKE_CURRENT_LIST_DIR}/az_span.c
   )
 else()

--- a/sdk/src/azure/core/az_mqtt5_connection.c
+++ b/sdk/src/azure/core/az_mqtt5_connection.c
@@ -6,10 +6,9 @@
 #include <azure/core/az_mqtt5_connection.h>
 #include <azure/core/az_platform.h>
 #include <azure/core/az_result.h>
-#include <azure/core/az_span.h>
 #include <azure/core/az_retry.h>
+#include <azure/core/az_span.h>
 #include <azure/core/internal/az_log_internal.h>
-#include <azure/core/internal/az_retry_internal.h>
 #include <azure/iot/az_iot_common.h>
 
 #include "azure/core/az_mqtt5_rpc_client.h"
@@ -32,7 +31,8 @@ AZ_NODISCARD az_mqtt5_connection_options az_mqtt5_connection_options_default()
     .retry_delay_function = az_retry_calculate_delay,
     .credential_swap_condition = az_mqtt5_connection_credential_swap_condition_default,
     .hostname = AZ_SPAN_EMPTY,
-    .port = AZ_MQTT5_DEFAULT_CONNECT_PORT,    .client_certificates_count = 0,
+    .port = AZ_MQTT5_DEFAULT_CONNECT_PORT,
+    .client_certificates_count = 0,
     .disable_sdk_connection_management = false,
     .client_id_buffer = AZ_SPAN_EMPTY,
     .username_buffer = AZ_SPAN_EMPTY,

--- a/sdk/src/azure/core/az_mqtt5_connection.c
+++ b/sdk/src/azure/core/az_mqtt5_connection.c
@@ -7,7 +7,9 @@
 #include <azure/core/az_platform.h>
 #include <azure/core/az_result.h>
 #include <azure/core/az_span.h>
+#include <azure/core/az_retry.h>
 #include <azure/core/internal/az_log_internal.h>
+#include <azure/core/internal/az_retry_internal.h>
 #include <azure/iot/az_iot_common.h>
 
 #include "azure/core/az_mqtt5_rpc_client.h"
@@ -27,11 +29,10 @@ AZ_NODISCARD bool az_mqtt5_connection_credential_swap_condition_default(
 AZ_NODISCARD az_mqtt5_connection_options az_mqtt5_connection_options_default()
 {
   return (az_mqtt5_connection_options){
-    .retry_delay_function = az_iot_calculate_retry_delay,
+    .retry_delay_function = az_retry_calculate_delay,
     .credential_swap_condition = az_mqtt5_connection_credential_swap_condition_default,
     .hostname = AZ_SPAN_EMPTY,
-    .port = AZ_MQTT5_DEFAULT_CONNECT_PORT,
-    .client_certificates_count = 0,
+    .port = AZ_MQTT5_DEFAULT_CONNECT_PORT,    .client_certificates_count = 0,
     .disable_sdk_connection_management = false,
     .client_id_buffer = AZ_SPAN_EMPTY,
     .username_buffer = AZ_SPAN_EMPTY,

--- a/sdk/src/azure/core/az_retry.c
+++ b/sdk/src/azure/core/az_retry.c
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-#include <azure/core/az_result.h>
-#include <azure/core/az_span.h>
 #include <azure/core/az_precondition.h>
+#include <azure/core/az_result.h>
 #include <azure/core/az_retry.h>
+#include <azure/core/az_span.h>
+#include <azure/core/internal/az_log_internal.h>
 #include <azure/core/internal/az_precondition_internal.h>
 #include <azure/core/internal/az_retry_internal.h>
-#include <azure/core/internal/az_log_internal.h>
 
 #include <azure/core/_az_cfg.h>
 

--- a/sdk/src/azure/core/az_retry.c
+++ b/sdk/src/azure/core/az_retry.c
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <azure/core/az_result.h>
+#include <azure/core/az_span.h>
+#include <azure/core/az_precondition.h>
+#include <azure/core/az_retry.h>
+#include <azure/core/internal/az_precondition_internal.h>
+#include <azure/core/internal/az_retry_internal.h>
+#include <azure/core/internal/az_log_internal.h>
+
+#include <azure/core/_az_cfg.h>
+
+AZ_NODISCARD int32_t az_retry_calculate_delay(
+    int32_t operation_msec,
+    int16_t attempt,
+    int32_t min_retry_delay_msec,
+    int32_t max_retry_delay_msec,
+    int32_t random_jitter_msec)
+{
+  _az_PRECONDITION_RANGE(0, operation_msec, INT32_MAX - 1);
+  _az_PRECONDITION_RANGE(0, attempt, INT16_MAX - 1);
+  _az_PRECONDITION_RANGE(0, min_retry_delay_msec, INT32_MAX - 1);
+  _az_PRECONDITION_RANGE(0, max_retry_delay_msec, INT32_MAX - 1);
+  _az_PRECONDITION_RANGE(0, random_jitter_msec, INT32_MAX - 1);
+
+  if (_az_LOG_SHOULD_WRITE(AZ_LOG_RETRY))
+  {
+    _az_LOG_WRITE(AZ_LOG_RETRY, AZ_SPAN_EMPTY);
+  }
+
+  int32_t delay = _az_retry_calc_delay(attempt, min_retry_delay_msec, max_retry_delay_msec);
+
+  if (delay < 0)
+  {
+    delay = max_retry_delay_msec;
+  }
+
+  if (max_retry_delay_msec - delay > random_jitter_msec)
+  {
+    delay += random_jitter_msec;
+  }
+
+  delay -= operation_msec;
+
+  return delay > 0 ? delay : 0;
+}

--- a/sdk/src/azure/iot/az_iot_common.c
+++ b/sdk/src/azure/iot/az_iot_common.c
@@ -138,41 +138,6 @@ AZ_NODISCARD az_result az_iot_message_properties_next(
   return AZ_OK;
 }
 
-AZ_NODISCARD int32_t az_iot_calculate_retry_delay(
-    int32_t operation_msec,
-    int16_t attempt,
-    int32_t min_retry_delay_msec,
-    int32_t max_retry_delay_msec,
-    int32_t random_jitter_msec)
-{
-  _az_PRECONDITION_RANGE(0, operation_msec, INT32_MAX - 1);
-  _az_PRECONDITION_RANGE(0, attempt, INT16_MAX - 1);
-  _az_PRECONDITION_RANGE(0, min_retry_delay_msec, INT32_MAX - 1);
-  _az_PRECONDITION_RANGE(0, max_retry_delay_msec, INT32_MAX - 1);
-  _az_PRECONDITION_RANGE(0, random_jitter_msec, INT32_MAX - 1);
-
-  if (_az_LOG_SHOULD_WRITE(AZ_LOG_IOT_RETRY))
-  {
-    _az_LOG_WRITE(AZ_LOG_IOT_RETRY, AZ_SPAN_EMPTY);
-  }
-
-  int32_t delay = _az_retry_calc_delay(attempt, min_retry_delay_msec, max_retry_delay_msec);
-
-  if (delay < 0)
-  {
-    delay = max_retry_delay_msec;
-  }
-
-  if (max_retry_delay_msec - delay > random_jitter_msec)
-  {
-    delay += random_jitter_msec;
-  }
-
-  delay -= operation_msec;
-
-  return delay > 0 ? delay : 0;
-}
-
 AZ_NODISCARD int32_t _az_iot_u32toa_size(uint32_t number)
 {
   if (number == 0)

--- a/sdk/tests/core/CMakeLists.txt
+++ b/sdk/tests/core/CMakeLists.txt
@@ -44,6 +44,7 @@ if (AZ_PLATFORM_IMPL STREQUAL "POSIX" AND NOT APPLE)
     ${AZ_CORE_PATH}/az_mqtt5_telemetry_producer_codec.c
     ${AZ_CORE_PATH}/az_mqtt5_topic_parser.c
     ${AZ_CORE_PATH}/az_precondition.c
+    ${AZ_CORE_PATH}/az_retry.c
     ${AZ_CORE_PATH}/az_span.c
   )
 else()
@@ -62,6 +63,7 @@ else()
     ${AZ_CORE_PATH}/az_json_writer.c
     ${AZ_CORE_PATH}/az_log.c
     ${AZ_CORE_PATH}/az_precondition.c
+    ${AZ_CORE_PATH}/az_retry.c
     ${AZ_CORE_PATH}/az_span.c
   )
 endif()
@@ -155,6 +157,7 @@ if (AZ_PLATFORM_IMPL STREQUAL "POSIX" AND NOT APPLE AND UNIT_TESTING_MOCKS)
                     test_az_mqtt5_telemetry_producer_hfsm.c
                     test_az_pipeline.c
                     test_az_policy.c
+                    test_az_retry.c
                     test_az_span.c
                     test_az_url_encode.c
                     COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS} ${NO_CLOBBERED_WARNING}
@@ -173,6 +176,7 @@ else()
                     test_az_logging.c
                     test_az_pipeline.c
                     test_az_policy.c
+                    test_az_retry.c
                     test_az_span.c
                     test_az_url_encode.c
                     COMPILE_OPTIONS ${DEFAULT_C_COMPILE_FLAGS} ${NO_CLOBBERED_WARNING}
@@ -182,11 +186,6 @@ else()
                     INCLUDE_DIRECTORIES ${CMOCKA_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/sdk/src/azure/core/
                     )
 endif()
-
-target_link_libraries(az_core_test_lib_test
-  PUBLIC
-    az_iot_common
-)
 
 create_map_file(az_core_test_lib_test az_core_test_lib_test.map)
 

--- a/sdk/tests/core/az_test_definitions.h
+++ b/sdk/tests/core/az_test_definitions.h
@@ -27,3 +27,4 @@ int test_az_pipeline();
 int test_az_policy();
 int test_az_span();
 int test_az_url_encode();
+int test_az_retry();

--- a/sdk/tests/core/main.c
+++ b/sdk/tests/core/main.c
@@ -43,6 +43,7 @@ int main()
   result += test_az_policy();
   result += test_az_span();
   result += test_az_url_encode();
+  result += test_az_retry();
 
   return result;
 }

--- a/sdk/tests/core/test_az_retry.c
+++ b/sdk/tests/core/test_az_retry.c
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "az_test_definitions.h"
+#include <azure/core/az_log.h>
+#include <azure/core/az_retry.h>
+#include <azure/core/az_result.h>
+#include <az_test_log.h>
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+
+#include <cmocka.h>
+
+#include <azure/core/_az_cfg.h>
+
+static int _log_retry = 0;
+static void _log_listener(az_log_classification classification, az_span message)
+{
+  switch (classification)
+  {
+    case AZ_LOG_RETRY:
+      _log_retry++;
+      assert_int_equal(az_span_size(message), 0);
+      break;
+    default:
+      assert_true(false);
+  }
+}
+
+static bool _should_write_iot_retry_only(az_log_classification classification)
+{
+  switch (classification)
+  {
+    case AZ_LOG_RETRY:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool _should_write_nothing(az_log_classification classification)
+{
+  (void)classification;
+  return false;
+}
+
+static void test_az_retry_calculate_delay_common_timings_success()
+{
+  assert_int_equal(2229, az_retry_calculate_delay(5, 1, 500, 100000, 1234));
+  assert_int_equal(321, az_retry_calculate_delay(5000, 1, 500, 100000, 4321));
+
+  // Operation already took more than the back-off interval.
+  assert_int_equal(0, az_retry_calculate_delay(10000, 1, 500, 100000, 4321));
+
+  // Max retry exceeded.
+  assert_int_equal(9995, az_retry_calculate_delay(5, 5, 500, 10000, 4321));
+}
+
+static void test_az_retry_calculate_delay_overflow_time_success()
+{
+  assert_int_equal(
+      0,
+      az_retry_calculate_delay(
+          INT32_MAX - 1, INT16_MAX - 1, INT32_MAX - 1, INT32_MAX - 1, INT32_MAX - 1));
+
+  assert_int_equal(
+      INT32_MAX - 1,
+      az_retry_calculate_delay(0, INT16_MAX - 1, INT32_MAX - 1, INT32_MAX - 1, INT32_MAX - 1));
+}
+
+static void test_az_retry_calculate_delay_logging_succeed()
+{
+  az_log_set_message_callback(_log_listener);
+  az_log_set_classification_filter_callback(_should_write_iot_retry_only);
+
+  _log_retry = 0;
+  assert_int_equal(2229, az_retry_calculate_delay(5, 1, 500, 100000, 1234));
+  assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_retry);
+
+  az_log_set_message_callback(NULL);
+  az_log_set_classification_filter_callback(NULL);
+}
+
+static void test_az_retry_calculate_delay_no_logging_succeed()
+{
+  az_log_set_message_callback(_log_listener);
+  az_log_set_classification_filter_callback(_should_write_nothing);
+
+  _log_retry = 0;
+  assert_int_equal(2229, az_retry_calculate_delay(5, 1, 500, 100000, 1234));
+  assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_retry);
+
+  az_log_set_message_callback(NULL);
+  az_log_set_classification_filter_callback(NULL);
+}
+
+int test_az_retry()
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test(test_az_retry_calculate_delay_common_timings_success),
+    cmocka_unit_test(test_az_retry_calculate_delay_overflow_time_success),
+    cmocka_unit_test(test_az_retry_calculate_delay_logging_succeed),
+    cmocka_unit_test(test_az_retry_calculate_delay_no_logging_succeed),
+  };
+  return cmocka_run_group_tests_name("az_core_retry", tests, NULL, NULL);
+}

--- a/sdk/tests/core/test_az_retry.c
+++ b/sdk/tests/core/test_az_retry.c
@@ -46,8 +46,10 @@ static bool _should_write_nothing(az_log_classification classification)
   return false;
 }
 
-static void test_az_retry_calculate_delay_common_timings_success()
+static void test_az_retry_calculate_delay_common_timings_success(void** state)
 {
+  (void)state;
+
   assert_int_equal(2229, az_retry_calculate_delay(5, 1, 500, 100000, 1234));
   assert_int_equal(321, az_retry_calculate_delay(5000, 1, 500, 100000, 4321));
 
@@ -58,8 +60,10 @@ static void test_az_retry_calculate_delay_common_timings_success()
   assert_int_equal(9995, az_retry_calculate_delay(5, 5, 500, 10000, 4321));
 }
 
-static void test_az_retry_calculate_delay_overflow_time_success()
+static void test_az_retry_calculate_delay_overflow_time_success(void** state)
 {
+  (void)state;
+
   assert_int_equal(
       0,
       az_retry_calculate_delay(
@@ -70,8 +74,10 @@ static void test_az_retry_calculate_delay_overflow_time_success()
       az_retry_calculate_delay(0, INT16_MAX - 1, INT32_MAX - 1, INT32_MAX - 1, INT32_MAX - 1));
 }
 
-static void test_az_retry_calculate_delay_logging_succeed()
+static void test_az_retry_calculate_delay_logging_succeed(void** state)
 {
+  (void)state;
+
   az_log_set_message_callback(_log_listener);
   az_log_set_classification_filter_callback(_should_write_iot_retry_only);
 
@@ -83,8 +89,10 @@ static void test_az_retry_calculate_delay_logging_succeed()
   az_log_set_classification_filter_callback(NULL);
 }
 
-static void test_az_retry_calculate_delay_no_logging_succeed()
+static void test_az_retry_calculate_delay_no_logging_succeed(void** state)
 {
+  (void)state;
+
   az_log_set_message_callback(_log_listener);
   az_log_set_classification_filter_callback(_should_write_nothing);
 

--- a/sdk/tests/core/test_az_retry.c
+++ b/sdk/tests/core/test_az_retry.c
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 #include "az_test_definitions.h"
-#include <azure/core/az_log.h>
-#include <azure/core/az_retry.h>
-#include <azure/core/az_result.h>
 #include <az_test_log.h>
+#include <azure/core/az_log.h>
+#include <azure/core/az_result.h>
+#include <azure/core/az_retry.h>
 
 #include <setjmp.h>
 #include <stdarg.h>

--- a/sdk/tests/iot/common/test_az_iot_common.c
+++ b/sdk/tests/iot/common/test_az_iot_common.c
@@ -268,87 +268,6 @@ static void test_az_iot_status_retriable_translate_success()
   assert_false(az_iot_status_retriable(AZ_IOT_STATUS_UNAUTHORIZED));
 }
 
-static void test_az_iot_calculate_retry_delay_common_timings_success()
-{
-  assert_int_equal(2229, az_iot_calculate_retry_delay(5, 1, 500, 100000, 1234));
-  assert_int_equal(321, az_iot_calculate_retry_delay(5000, 1, 500, 100000, 4321));
-
-  // Operation already took more than the back-off interval.
-  assert_int_equal(0, az_iot_calculate_retry_delay(10000, 1, 500, 100000, 4321));
-
-  // Max retry exceeded.
-  assert_int_equal(9995, az_iot_calculate_retry_delay(5, 5, 500, 10000, 4321));
-}
-
-static void test_az_iot_calculate_retry_delay_overflow_time_success()
-{
-  assert_int_equal(
-      0,
-      az_iot_calculate_retry_delay(
-          INT32_MAX - 1, INT16_MAX - 1, INT32_MAX - 1, INT32_MAX - 1, INT32_MAX - 1));
-
-  assert_int_equal(
-      INT32_MAX - 1,
-      az_iot_calculate_retry_delay(0, INT16_MAX - 1, INT32_MAX - 1, INT32_MAX - 1, INT32_MAX - 1));
-}
-
-static int _log_retry = 0;
-static void _log_listener(az_log_classification classification, az_span message)
-{
-  switch (classification)
-  {
-    case AZ_LOG_IOT_RETRY:
-      _log_retry++;
-      assert_int_equal(az_span_size(message), 0);
-      break;
-    default:
-      assert_true(false);
-  }
-}
-
-static bool _should_write_iot_retry_only(az_log_classification classification)
-{
-  switch (classification)
-  {
-    case AZ_LOG_IOT_RETRY:
-      return true;
-    default:
-      return false;
-  }
-}
-
-static bool _should_write_nothing(az_log_classification classification)
-{
-  (void)classification;
-  return false;
-}
-
-static void test_az_iot_calculate_retry_delay_logging_succeed()
-{
-  az_log_set_message_callback(_log_listener);
-  az_log_set_classification_filter_callback(_should_write_iot_retry_only);
-
-  _log_retry = 0;
-  assert_int_equal(2229, az_iot_calculate_retry_delay(5, 1, 500, 100000, 1234));
-  assert_int_equal(_az_BUILT_WITH_LOGGING(1, 0), _log_retry);
-
-  az_log_set_message_callback(NULL);
-  az_log_set_classification_filter_callback(NULL);
-}
-
-static void test_az_iot_calculate_retry_delay_no_logging_succeed()
-{
-  az_log_set_message_callback(_log_listener);
-  az_log_set_classification_filter_callback(_should_write_nothing);
-
-  _log_retry = 0;
-  assert_int_equal(2229, az_iot_calculate_retry_delay(5, 1, 500, 100000, 1234));
-  assert_int_equal(_az_BUILT_WITH_LOGGING(0, 0), _log_retry);
-
-  az_log_set_message_callback(NULL);
-  az_log_set_classification_filter_callback(NULL);
-}
-
 static void test_az_span_copy_url_encode_succeed()
 {
   az_span url_decoded_span = AZ_SPAN_FROM_STR("abc/=%012");
@@ -795,10 +714,6 @@ int test_az_iot_common()
     cmocka_unit_test(test_az_iot_u64toa_size_success),
     cmocka_unit_test(test_az_iot_is_status_succeeded_translate_success),
     cmocka_unit_test(test_az_iot_status_retriable_translate_success),
-    cmocka_unit_test(test_az_iot_calculate_retry_delay_common_timings_success),
-    cmocka_unit_test(test_az_iot_calculate_retry_delay_overflow_time_success),
-    cmocka_unit_test(test_az_iot_calculate_retry_delay_logging_succeed),
-    cmocka_unit_test(test_az_iot_calculate_retry_delay_no_logging_succeed),
     cmocka_unit_test(test_az_span_copy_url_encode_succeed),
     cmocka_unit_test(test_az_span_copy_url_encode_insufficient_size_fail),
     cmocka_unit_test(test_az_iot_message_properties_init_succeed),


### PR DESCRIPTION
az_iot_calculate_retry_delay was defined in az_iot_common, but used in az_mqtt5_connection (az_core), which is a reverse dependency.
Created a new module in az_core just for retry, now containing the renamed function az_retry_calculate_delay.