### PR TITLE
Update CODEOWNERS for eng/common

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,4 +35,5 @@
 ###########
 # Eng Sys
 ###########
-/eng/       @danieljurek @weshaggard @benbp
+/eng/           @danieljurek @weshaggard @benbp
+/eng/common/    @Azure/azure-sdk-eng


### PR DESCRIPTION
Add engsys team as owner for files under eng/common to enable engsys team to be able to approve and merge eng/common sync PRs.