### PR TITLE
Make @Azure/azure-sdk-eng the owner of .github/workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,3 +37,4 @@
 ###########
 /eng/           @danieljurek @weshaggard @benbp
 /eng/common/    @Azure/azure-sdk-eng
+/.github/workflows/                                 @Azure/azure-sdk-eng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,6 @@
 ###########
 # Eng Sys
 ###########
-/eng/           @danieljurek @weshaggard @benbp
-/eng/common/    @Azure/azure-sdk-eng
-/.github/workflows/                                 @Azure/azure-sdk-eng
+/eng/                          @danieljurek @weshaggard @benbp
+/eng/common/                   @Azure/azure-sdk-eng
+/.github/workflows/            @Azure/azure-sdk-eng


### PR DESCRIPTION
With branch protection turned on, azure-sdk-eng needs to be the owner of .github/workflows. This is necessary so we can approve the PRs created by the **azure-sdk-tools - sync - eng-workflows** which are owned by azure-sdk-eng and pushed out to the various repositories when they're updated in the azure-sdk-tools repository.