### PR TITLE
Update aziot_esp32.ino

### DIFF
--- a/sdk/samples/iot/aziot_esp32/aziot_esp32.ino
+++ b/sdk/samples/iot/aziot_esp32/aziot_esp32.ino
@@ -41,7 +41,7 @@ static esp_mqtt_client_handle_t mqtt_client;
 static az_iot_hub_client client;
 
 static char mqtt_client_id[128];
-static char mqtt_username[128];
+static char mqtt_username[200];
 static char mqtt_password[200];
 static uint8_t sas_signature_buffer[256];
 static unsigned long next_telemetry_send_time_ms = 0;


### PR DESCRIPTION
changed: 
static char mqtt_username[128]; 
to :
static char mqtt_username[200]; 

because:
 az_iot_hub_client_get_user_name(&client, mqtt_username, sizeofarray(mqtt_username), NULL)

Fails when using long device ID's,  the mqtt_username array is not large enough for the returned username.