### PR TITLE
Use 1ES release deployments

### DIFF
--- a/eng/pipelines/templates/stages/archetype-c-release.yml
+++ b/eng/pipelines/templates/stages/archetype-c-release.yml
@@ -4,86 +4,100 @@ stages:
     displayName: 'Release C SDK'
     dependsOn: Build
 
+    variables:
+      - template: /eng/pipelines/templates/variables/image.yml
+
     jobs:
-      - deployment: TagRepository
+      - deployment: ReleaseGate
+        environment: package-publish
+
+        pool:
+          name: azsdk-pool-mms-win-2022-general
+          image: azsdk-pool-mms-win-2022-1espt
+          os: windows
+
+        templateContext:
+          type: releaseJob
+          isProduction: true
+
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - pwsh: Write-Host "Release gate passed. Dependent jobs will run."
+                  displayName: Release gate passed
+
+      - job: TagRepository
         displayName: "Create release tag"
         condition: ne(variables['Skip.TagRepository'], 'true')
-        environment: github
+        dependsOn: ReleaseGate
 
         pool:
           name: azsdk-pool-mms-win-2022-general
           image: azsdk-pool-mms-win-2022-1espt
           os: windows
 
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - checkout: self
-                - template: /eng/common/pipelines/templates/steps/retain-run.yml
-                - task: Powershell@2
-                  inputs:
-                    filePath: $(Build.SourcesDirectory)/eng/common/scripts/Verify-ChangeLog.ps1
-                    arguments: >
-                      -ChangeLogLocation $(Pipeline.Workspace)/release-info/CHANGELOG.md
-                      -VersionString (Get-Content $(Pipeline.Workspace)/release-info/package-info.json | ConvertFrom-Json).version
-                      -ForRelease $true
-                    pwsh: true
-                  displayName: Verify CHANGELOG.md contents
-                - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
-                  parameters:
-                    ArtifactLocation: $(Pipeline.Workspace)/release-info
-                    PackageRepository: C
-                    ReleaseSha: $(Build.SourceVersion)
-                    RepoId: $(Build.Repository.Name)
-                    WorkingDirectory: $(Build.SourcesDirectory)
-                    ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts/
+        steps:
+          - checkout: self
+          - template: /eng/common/pipelines/templates/steps/retain-run.yml
+          - task: Powershell@2
+            inputs:
+              filePath: $(Build.SourcesDirectory)/eng/common/scripts/Verify-ChangeLog.ps1
+              arguments: >
+                -ChangeLogLocation $(Pipeline.Workspace)/release-info/CHANGELOG.md
+                -VersionString (Get-Content $(Pipeline.Workspace)/release-info/package-info.json | ConvertFrom-Json).version
+                -ForRelease $true
+              pwsh: true
+            displayName: Verify CHANGELOG.md contents
+          - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+            parameters:
+              ArtifactLocation: $(Pipeline.Workspace)/release-info
+              PackageRepository: C
+              ReleaseSha: $(Build.SourceVersion)
+              RepoId: $(Build.Repository.Name)
+              WorkingDirectory: $(Build.SourcesDirectory)
+              ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts/
 
-      - deployment: PublishDocs
+      - job: PublishDocs
         displayName: Publish Docs to GitHub pages
         condition: ne(variables['Skip.PublishDocs'], 'true')
-        environment: githubio
+        dependsOn: ReleaseGate
 
         pool:
           name: azsdk-pool-mms-win-2022-general
           image: azsdk-pool-mms-win-2022-1espt
           os: windows
 
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - checkout: self
-                - pwsh: |
-                    Get-ChildItem -Recurse $(Pipeline.Workspace)/docs
-                  displayName: Output Visible Artifacts
-                - template: /eng/common/pipelines/templates/steps/publish-blobs.yml
-                  parameters:
-                    FolderForUpload: '$(Pipeline.Workspace)/docs'
-                    TargetLanguage: 'c'
-                    ArtifactLocation: $(Pipeline.Workspace)/release-info
+        steps:
+          - checkout: self
+          - pwsh: |
+              Get-ChildItem -Recurse $(Pipeline.Workspace)/docs
+            displayName: Output Visible Artifacts
+          - template: /eng/common/pipelines/templates/steps/publish-blobs.yml
+            parameters:
+              FolderForUpload: '$(Pipeline.Workspace)/docs'
+              TargetLanguage: 'c'
+              ArtifactLocation: $(Pipeline.Workspace)/release-info
 
-      - deployment: UpdateSdkVersion
+      - job: UpdateSdkVersion
         displayName: "Update SDK Version"
         condition: and(succeeded(), ne(variables['Skip.UpdateSdkVersion'], 'true'))
-        environment: github
+        dependsOn: ReleaseGate
 
         pool:
           name: azsdk-pool-mms-win-2022-general
           image: azsdk-pool-mms-win-2022-1espt
           os: windows
 
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - checkout: self
-                - pwsh: |
-                    eng/scripts/Update-SdkVersion.ps1
-                  displayName: Increment SDK version
-                - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
-                  parameters:
-                    RepoName: azure-sdk-for-c
-                    PRBranchName: increment-sdk-version-$(Build.BuildId)
-                    CommitMsg: "Increment sdk version after release of C SDK"
-                    PRTitle: "Increment version for C SDK releases"
+
+        steps:
+          - checkout: self
+          - pwsh: |
+              eng/scripts/Update-SdkVersion.ps1
+            displayName: Increment SDK version
+          - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+            parameters:
+              RepoName: azure-sdk-for-c
+              PRBranchName: increment-sdk-version-$(Build.BuildId)
+              CommitMsg: "Increment sdk version after release of C SDK"
+              PRTitle: "Increment version for C SDK releases"

--- a/eng/pipelines/templates/stages/archetype-c-release.yml
+++ b/eng/pipelines/templates/stages/archetype-c-release.yml
@@ -33,8 +33,8 @@ stages:
         dependsOn: ReleaseGate
 
         pool:
-          name: azsdk-pool-mms-win-2022-general
-          image: azsdk-pool-mms-win-2022-1espt
+          name: $(WINDOWSPOOL)
+          image: $(WINDOWSVMIMAGE)
           os: windows
 
         steps:
@@ -64,8 +64,8 @@ stages:
         dependsOn: ReleaseGate
 
         pool:
-          name: azsdk-pool-mms-win-2022-general
-          image: azsdk-pool-mms-win-2022-1espt
+          name: $(WINDOWSPOOL)
+          image: $(WINDOWSVMIMAGE)
           os: windows
 
         steps:
@@ -85,8 +85,8 @@ stages:
         dependsOn: ReleaseGate
 
         pool:
-          name: azsdk-pool-mms-win-2022-general
-          image: azsdk-pool-mms-win-2022-1espt
+          name: $(WINDOWSPOOL)
+          image: $(WINDOWSVMIMAGE)
           os: windows
 
 

--- a/eng/pipelines/templates/stages/archetype-c-release.yml
+++ b/eng/pipelines/templates/stages/archetype-c-release.yml
@@ -39,6 +39,11 @@ stages:
 
         steps:
           - checkout: self
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifactName: release-info
+              targetPath: release-info
+
           - template: /eng/common/pipelines/templates/steps/retain-run.yml
           - task: Powershell@2
             inputs:
@@ -70,6 +75,17 @@ stages:
 
         steps:
           - checkout: self
+
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifactName: release-info
+              targetPath: release-info
+
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifactName: docs
+              targetPath: docs
+
           - pwsh: |
               Get-ChildItem -Recurse $(Pipeline.Workspace)/docs
             displayName: Output Visible Artifacts

--- a/eng/pipelines/templates/stages/archetype-c-release.yml
+++ b/eng/pipelines/templates/stages/archetype-c-release.yml
@@ -42,7 +42,7 @@ stages:
           - task: DownloadPipelineArtifact@2
             inputs:
               artifactName: release-info
-              targetPath: release-info
+              targetPath: $(Pipeline.Workspace)/release-info
 
           - template: /eng/common/pipelines/templates/steps/retain-run.yml
           - task: Powershell@2
@@ -79,12 +79,12 @@ stages:
           - task: DownloadPipelineArtifact@2
             inputs:
               artifactName: release-info
-              targetPath: release-info
+              targetPath: $(Pipeline.Workspace)/release-info
 
           - task: DownloadPipelineArtifact@2
             inputs:
               artifactName: docs
-              targetPath: docs
+              targetPath: $(Pipeline.Workspace)/docs
 
           - pwsh: |
               Get-ChildItem -Recurse $(Pipeline.Workspace)/docs

--- a/eng/pipelines/templates/stages/archetype-c-release.yml
+++ b/eng/pipelines/templates/stages/archetype-c-release.yml
@@ -54,14 +54,14 @@ stages:
                 -ForRelease $true
               pwsh: true
             displayName: Verify CHANGELOG.md contents
-          - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
-            parameters:
-              ArtifactLocation: $(Pipeline.Workspace)/release-info
-              PackageRepository: C
-              ReleaseSha: $(Build.SourceVersion)
-              RepoId: $(Build.Repository.Name)
-              WorkingDirectory: $(Build.SourcesDirectory)
-              ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts/
+          # - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+          #   parameters:
+          #     ArtifactLocation: $(Pipeline.Workspace)/release-info
+          #     PackageRepository: C
+          #     ReleaseSha: $(Build.SourceVersion)
+          #     RepoId: $(Build.Repository.Name)
+          #     WorkingDirectory: $(Build.SourcesDirectory)
+          #     ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts/
 
       - job: PublishDocs
         displayName: Publish Docs to GitHub pages
@@ -90,10 +90,10 @@ stages:
               Get-ChildItem -Recurse $(Pipeline.Workspace)/docs
             displayName: Output Visible Artifacts
           - template: /eng/common/pipelines/templates/steps/publish-blobs.yml
-            parameters:
-              FolderForUpload: '$(Pipeline.Workspace)/docs'
-              TargetLanguage: 'c'
-              ArtifactLocation: $(Pipeline.Workspace)/release-info
+            # parameters:
+            #   FolderForUpload: '$(Pipeline.Workspace)/docs'
+            #   TargetLanguage: 'c'
+            #   ArtifactLocation: $(Pipeline.Workspace)/release-info
 
       - job: UpdateSdkVersion
         displayName: "Update SDK Version"

--- a/eng/pipelines/templates/stages/archetype-c-release.yml
+++ b/eng/pipelines/templates/stages/archetype-c-release.yml
@@ -54,14 +54,14 @@ stages:
                 -ForRelease $true
               pwsh: true
             displayName: Verify CHANGELOG.md contents
-          # - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
-          #   parameters:
-          #     ArtifactLocation: $(Pipeline.Workspace)/release-info
-          #     PackageRepository: C
-          #     ReleaseSha: $(Build.SourceVersion)
-          #     RepoId: $(Build.Repository.Name)
-          #     WorkingDirectory: $(Build.SourcesDirectory)
-          #     ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts/
+          - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+            parameters:
+              ArtifactLocation: $(Pipeline.Workspace)/release-info
+              PackageRepository: C
+              ReleaseSha: $(Build.SourceVersion)
+              RepoId: $(Build.Repository.Name)
+              WorkingDirectory: $(Build.SourcesDirectory)
+              ScriptDirectory: $(Build.SourcesDirectory)/eng/common/scripts/
 
       - job: PublishDocs
         displayName: Publish Docs to GitHub pages
@@ -90,10 +90,10 @@ stages:
               Get-ChildItem -Recurse $(Pipeline.Workspace)/docs
             displayName: Output Visible Artifacts
           - template: /eng/common/pipelines/templates/steps/publish-blobs.yml
-            # parameters:
-            #   FolderForUpload: '$(Pipeline.Workspace)/docs'
-            #   TargetLanguage: 'c'
-            #   ArtifactLocation: $(Pipeline.Workspace)/release-info
+            parameters:
+              FolderForUpload: '$(Pipeline.Workspace)/docs'
+              TargetLanguage: 'c'
+              ArtifactLocation: $(Pipeline.Workspace)/release-info
 
       - job: UpdateSdkVersion
         displayName: "Update SDK Version"


### PR DESCRIPTION
* Use deployment job for approvals 
* Convert deployments which require source to jobs. These jobs do not release binaries