### PR TITLE
Ubuntu 20 -> 22 migration

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -95,20 +95,6 @@
     },
     {
       "Component": {
-        "Type": "linux",
-        "linux": {
-          "Name": "clang-format",
-          "Version": "9.0.0-2",
-          "Distribution": "Ubuntu",
-          "Release": "18.04",
-          "Pool-URL": "http://archive.ubuntu.com/ubuntu",
-          "Key-URL": "http://archive.ubuntu.com/ubuntu/project/ubuntu-archive-keyring.gpg"
-        }
-      },
-      "DevelopmentDependency": true
-    },
-    {
-      "Component": {
         "Type": "other",
         "Other": {
           "Name": "doxygen",

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -40,8 +40,8 @@ jobs:
   strategy:
     matrix:
       LinuxARM_Release_Logging:
-        Pool: $(LINUXPOOL)
-        OSVmImage: $(LINUXVMIMAGE)
+        Pool: azsdk-pool-mms-ubuntu-2204-general
+        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -51,8 +51,8 @@ jobs:
         BuildType: Release
 
       LinuxARM:
-        Pool: $(LINUXPOOL)
-        OSVmImage: $(LINUXVMIMAGE)
+        Pool: azsdk-pool-mms-ubuntu-2204-general
+        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -62,8 +62,8 @@ jobs:
         BuildType: Debug
 
       Linux_Release_MapFiles_Logging_UnitTests_Mocks_Samples:
-        Pool: $(LINUXPOOL)
-        OSVmImage: $(LINUXVMIMAGE)
+        Pool: azsdk-pool-mms-ubuntu-2204-general
+        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: 'cmocka paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON -DTRANSPORT_PAHO=ON -DADDRESS_SANITIZER=ON'
@@ -72,8 +72,8 @@ jobs:
         BuildType: Release
 
       Linux_Logging_UnitTests_Mocks_Samples:
-        Pool: $(LINUXPOOL)
-        OSVmImage: $(LINUXVMIMAGE)
+        Pool: azsdk-pool-mms-ubuntu-2204-general
+        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DADDRESS_SANITIZER=ON -DUNIT_TESTING_MOCKS=ON'
@@ -81,8 +81,8 @@ jobs:
         BuildType: Debug
 
       LinuxARM_Release_Preconditions:
-        Pool: $(LINUXPOOL)
-        OSVmImage: $(LINUXVMIMAGE)
+        Pool: azsdk-pool-mms-ubuntu-2204-general
+        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -92,8 +92,8 @@ jobs:
         BuildType: Release
 
       LinuxARM_Preconditions_Logging:
-        Pool: $(LINUXPOOL)
-        OSVmImage: $(LINUXVMIMAGE)
+        Pool: azsdk-pool-mms-ubuntu-2204-general
+        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -103,8 +103,8 @@ jobs:
         BuildType: Debug
 
       Linux_Release_Preconditions_Logging_UnitTests_Mocks_Samples:
-        Pool: $(LINUXPOOL)
-        OSVmImage: $(LINUXVMIMAGE)
+        Pool: azsdk-pool-mms-ubuntu-2204-general
+        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON'
@@ -112,8 +112,8 @@ jobs:
         BuildType: Release
 
       Linux_Preconditions_Logging_UnitTests_Mocks_CodeCov_Linter:
-        Pool: $(LINUXPOOL)
-        OSVmImage: $(LINUXVMIMAGE)
+        Pool: azsdk-pool-mms-ubuntu-2204-general
+        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcovr lcov clang-format-9'
@@ -124,8 +124,8 @@ jobs:
         BuildType: Debug
 
       LinuxGCC11_Release_MapFiles_UnitTests:
-        Pool: $(LINUXPOOL)
-        OSVmImage: $(LINUXVMIMAGE)
+        Pool: azsdk-pool-mms-ubuntu-2204-general
+        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF'
@@ -141,7 +141,6 @@ jobs:
     os: linux
 
   variables:
-    - template: /eng/pipelines/templates/variables/image.yml
     - name: CMOCKA_XML_FILE
       value: "%g-test-results.xml"
     - name: CMOCKA_MESSAGE_OUTPUT

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -116,7 +116,7 @@ jobs:
         OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
-        AptDependencies: 'gcovr lcov clang-format-9'
+        AptDependencies: 'gcovr lcov'
         build.args: '-DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON'
         AZ_SDK_CODE_COV: 1
         AZ_SDK_C_NO_SAMPLES: 'true'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -40,7 +40,7 @@ jobs:
   strategy:
     matrix:
       LinuxARM_Release_Logging:
-        Pool: azsdk-pool-mms-ubuntu-2204-general
+        Pool: azsdk-pool
         OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
@@ -51,7 +51,7 @@ jobs:
         BuildType: Release
 
       LinuxARM:
-        Pool: azsdk-pool-mms-ubuntu-2204-general
+        Pool: azsdk-pool
         OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
@@ -62,7 +62,7 @@ jobs:
         BuildType: Debug
 
       Linux_Release_MapFiles_Logging_UnitTests_Mocks_Samples:
-        Pool: azsdk-pool-mms-ubuntu-2204-general
+        Pool: azsdk-pool
         OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: 'cmocka paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
@@ -72,7 +72,7 @@ jobs:
         BuildType: Release
 
       Linux_Logging_UnitTests_Mocks_Samples:
-        Pool: azsdk-pool-mms-ubuntu-2204-general
+        Pool: azsdk-pool
         OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
@@ -81,7 +81,7 @@ jobs:
         BuildType: Debug
 
       LinuxARM_Release_Preconditions:
-        Pool: azsdk-pool-mms-ubuntu-2204-general
+        Pool: azsdk-pool
         OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
@@ -92,7 +92,7 @@ jobs:
         BuildType: Release
 
       LinuxARM_Preconditions_Logging:
-        Pool: azsdk-pool-mms-ubuntu-2204-general
+        Pool: azsdk-pool
         OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
@@ -103,7 +103,7 @@ jobs:
         BuildType: Debug
 
       Linux_Release_Preconditions_Logging_UnitTests_Mocks_Samples:
-        Pool: azsdk-pool-mms-ubuntu-2204-general
+        Pool: azsdk-pool
         OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
@@ -112,7 +112,7 @@ jobs:
         BuildType: Release
 
       Linux_Preconditions_Logging_UnitTests_Mocks_CodeCov_Linter:
-        Pool: azsdk-pool-mms-ubuntu-2204-general
+        Pool: azsdk-pool
         OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
@@ -124,7 +124,7 @@ jobs:
         BuildType: Debug
 
       LinuxGCC11_Release_MapFiles_UnitTests:
-        Pool: azsdk-pool-mms-ubuntu-2204-general
+        Pool: azsdk-pool
         OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
@@ -157,7 +157,7 @@ jobs:
   strategy:
     matrix:
       Windows_VS2022_X86_Release_MapFiles_UnitTests:
-        Pool: azsdk-pool-mms-win-2022-general
+        Pool: azsdk-pool
         OSVmImage: azsdk-pool-mms-win-2022-1espt
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
@@ -181,7 +181,7 @@ jobs:
         BuildType: Debug
 
       Windows2022_Preconditions_UnitTests_Samples:
-        Pool: azsdk-pool-mms-win-2022-general
+        Pool: azsdk-pool
         OSVmImage: azsdk-pool-mms-win-2022-1espt
         vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
@@ -192,7 +192,7 @@ jobs:
         BuildType: Debug
 
       Windows_Release_Samples_MapFiles:
-        Pool: azsdk-pool-mms-win-2022-general
+        Pool: azsdk-pool
         OSVmImage: azsdk-pool-mms-win-2022-1espt
         vcpkg.deps: 'paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -40,8 +40,8 @@ jobs:
   strategy:
     matrix:
       LinuxARM_Release_Logging:
-        Pool: azsdk-pool-mms-ubuntu-2004-general
-        OSVmImage: azsdk-pool-mms-ubuntu-2004-1espt
+        Pool: $(LINUXPOOL)
+        OSVmImage: $(LINUXVMIMAGE)
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -51,8 +51,8 @@ jobs:
         BuildType: Release
 
       LinuxARM:
-        Pool: azsdk-pool-mms-ubuntu-2004-general
-        OSVmImage: azsdk-pool-mms-ubuntu-2004-1espt
+        Pool: $(LINUXPOOL)
+        OSVmImage: $(LINUXVMIMAGE)
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -62,8 +62,8 @@ jobs:
         BuildType: Debug
 
       Linux_Release_MapFiles_Logging_UnitTests_Mocks_Samples:
-        Pool: azsdk-pool-mms-ubuntu-2004-general
-        OSVmImage: azsdk-pool-mms-ubuntu-2004-1espt
+        Pool: $(LINUXPOOL)
+        OSVmImage: $(LINUXVMIMAGE)
         vcpkg.deps: 'cmocka paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON -DTRANSPORT_PAHO=ON -DADDRESS_SANITIZER=ON'
@@ -72,8 +72,8 @@ jobs:
         BuildType: Release
 
       Linux_Logging_UnitTests_Mocks_Samples:
-        Pool: azsdk-pool-mms-ubuntu-2004-general
-        OSVmImage: azsdk-pool-mms-ubuntu-2004-1espt
+        Pool: $(LINUXPOOL)
+        OSVmImage: $(LINUXVMIMAGE)
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DADDRESS_SANITIZER=ON -DUNIT_TESTING_MOCKS=ON'
@@ -81,8 +81,8 @@ jobs:
         BuildType: Debug
 
       LinuxARM_Release_Preconditions:
-        Pool: azsdk-pool-mms-ubuntu-2004-general
-        OSVmImage: azsdk-pool-mms-ubuntu-2004-1espt
+        Pool: $(LINUXPOOL)
+        OSVmImage: $(LINUXVMIMAGE)
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -92,8 +92,8 @@ jobs:
         BuildType: Release
 
       LinuxARM_Preconditions_Logging:
-        Pool: azsdk-pool-mms-ubuntu-2004-general
-        OSVmImage: azsdk-pool-mms-ubuntu-2004-1espt
+        Pool: $(LINUXPOOL)
+        OSVmImage: $(LINUXVMIMAGE)
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -103,8 +103,8 @@ jobs:
         BuildType: Debug
 
       Linux_Release_Preconditions_Logging_UnitTests_Mocks_Samples:
-        Pool: azsdk-pool-mms-ubuntu-2004-general
-        OSVmImage: azsdk-pool-mms-ubuntu-2004-1espt
+        Pool: $(LINUXPOOL)
+        OSVmImage: $(LINUXVMIMAGE)
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON'
@@ -112,8 +112,8 @@ jobs:
         BuildType: Release
 
       Linux_Preconditions_Logging_UnitTests_Mocks_CodeCov_Linter:
-        Pool: azsdk-pool-mms-ubuntu-2004-general
-        OSVmImage: azsdk-pool-mms-ubuntu-2004-1espt
+        Pool: $(LINUXPOOL)
+        OSVmImage: $(LINUXVMIMAGE)
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcovr lcov clang-format-9'
@@ -124,8 +124,8 @@ jobs:
         BuildType: Debug
 
       LinuxGCC11_Release_MapFiles_UnitTests:
-        Pool: azsdk-pool-mms-ubuntu-2204-general
-        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
+        Pool: $(LINUXPOOL)
+        OSVmImage: $(LINUXVMIMAGE)
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -41,7 +41,7 @@ jobs:
     matrix:
       LinuxARM_Release_Logging:
         Pool: azsdk-pool
-        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
+        OSVmImage: ubuntu-22.04
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -52,7 +52,7 @@ jobs:
 
       LinuxARM:
         Pool: azsdk-pool
-        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
+        OSVmImage: ubuntu-22.04
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -63,7 +63,7 @@ jobs:
 
       Linux_Release_MapFiles_Logging_UnitTests_Mocks_Samples:
         Pool: azsdk-pool
-        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
+        OSVmImage: ubuntu-22.04
         vcpkg.deps: 'cmocka paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON -DTRANSPORT_PAHO=ON -DADDRESS_SANITIZER=ON'
@@ -73,7 +73,7 @@ jobs:
 
       Linux_Logging_UnitTests_Mocks_Samples:
         Pool: azsdk-pool
-        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
+        OSVmImage: ubuntu-22.04
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DADDRESS_SANITIZER=ON -DUNIT_TESTING_MOCKS=ON'
@@ -82,7 +82,7 @@ jobs:
 
       LinuxARM_Release_Preconditions:
         Pool: azsdk-pool
-        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
+        OSVmImage: ubuntu-22.04
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -93,7 +93,7 @@ jobs:
 
       LinuxARM_Preconditions_Logging:
         Pool: azsdk-pool
-        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
+        OSVmImage: ubuntu-22.04
         vcpkg.deps: ''
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcc-arm-none-eabi'
@@ -104,7 +104,7 @@ jobs:
 
       Linux_Release_Preconditions_Logging_UnitTests_Mocks_Samples:
         Pool: azsdk-pool
-        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
+        OSVmImage: ubuntu-22.04
         vcpkg.deps: 'curl[ssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=POSIX -DUNIT_TESTING=ON -DUNIT_TESTING_MOCKS=ON'
@@ -113,7 +113,7 @@ jobs:
 
       Linux_Preconditions_Logging_UnitTests_Mocks_CodeCov_Linter:
         Pool: azsdk-pool
-        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
+        OSVmImage: ubuntu-22.04
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         AptDependencies: 'gcovr lcov'
@@ -125,7 +125,7 @@ jobs:
 
       LinuxGCC11_Release_MapFiles_UnitTests:
         Pool: azsdk-pool
-        OSVmImage: azsdk-pool-mms-ubuntu-2204-1espt
+        OSVmImage: ubuntu-22.04
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-linux'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -157,8 +157,8 @@ jobs:
   strategy:
     matrix:
       Windows_VS2022_X86_Release_MapFiles_UnitTests:
-        Pool: azsdk-pool
-        OSVmImage: windows-2022
+        Pool: azsdk-pool-mms-win-2022-general
+        OSVmImage: azsdk-pool-mms-win-2022-1espt
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF -DADDRESS_SANITIZER=OFF'
@@ -181,8 +181,8 @@ jobs:
         BuildType: Debug
 
       Windows2022_Preconditions_UnitTests_Samples:
-        Pool: azsdk-pool
-        OSVmImage: windows-2022
+        Pool: azsdk-pool-mms-win-2022-general
+        OSVmImage: azsdk-pool-mms-win-2022-1espt
         vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON -DLOGGING=OFF -DADDRESS_SANITIZER=OFF'
@@ -192,8 +192,8 @@ jobs:
         BuildType: Debug
 
       Windows_Release_Samples_MapFiles:
-        Pool: azsdk-pool
-        OSVmImage: windows-2022
+        Pool: azsdk-pool-mms-win-2022-general
+        OSVmImage: azsdk-pool-mms-win-2022-1espt
         vcpkg.deps: 'paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DLOGGING=OFF -DTRANSPORT_PAHO=ON'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -158,7 +158,7 @@ jobs:
     matrix:
       Windows_VS2022_X86_Release_MapFiles_UnitTests:
         Pool: azsdk-pool
-        OSVmImage: azsdk-pool-mms-win-2022-1espt
+        OSVmImage: windows-2022
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF -DADDRESS_SANITIZER=OFF'
@@ -182,7 +182,7 @@ jobs:
 
       Windows2022_Preconditions_UnitTests_Samples:
         Pool: azsdk-pool
-        OSVmImage: azsdk-pool-mms-win-2022-1espt
+        OSVmImage: windows-2022
         vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON -DLOGGING=OFF -DADDRESS_SANITIZER=OFF'
@@ -193,7 +193,7 @@ jobs:
 
       Windows_Release_Samples_MapFiles:
         Pool: azsdk-pool
-        OSVmImage: azsdk-pool-mms-win-2022-1espt
+        OSVmImage: windows-2022
         vcpkg.deps: 'paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DLOGGING=OFF -DTRANSPORT_PAHO=ON'

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -157,8 +157,8 @@ jobs:
   strategy:
     matrix:
       Windows_VS2022_X86_Release_MapFiles_UnitTests:
-        Pool: azsdk-pool-mms-win-2022-general
-        OSVmImage: azsdk-pool-mms-win-2022-1espt
+        Pool: azsdk-pool
+        OSVmImage: windows-2022
         vcpkg.deps: 'cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x86-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DUNIT_TESTING=ON -DLOGGING=OFF -DADDRESS_SANITIZER=OFF'
@@ -181,8 +181,8 @@ jobs:
         BuildType: Debug
 
       Windows2022_Preconditions_UnitTests_Samples:
-        Pool: azsdk-pool-mms-win-2022-general
-        OSVmImage: azsdk-pool-mms-win-2022-1espt
+        Pool: azsdk-pool
+        OSVmImage: windows-2022
         vcpkg.deps: 'curl[winssl] paho-mqtt cmocka'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DTRANSPORT_CURL=ON -DTRANSPORT_PAHO=ON -DAZ_PLATFORM_IMPL=WIN32 -DUNIT_TESTING=ON -DLOGGING=OFF -DADDRESS_SANITIZER=OFF'
@@ -192,8 +192,8 @@ jobs:
         BuildType: Debug
 
       Windows_Release_Samples_MapFiles:
-        Pool: azsdk-pool-mms-win-2022-general
-        OSVmImage: azsdk-pool-mms-win-2022-1espt
+        Pool: azsdk-pool
+        OSVmImage: windows-2022
         vcpkg.deps: 'paho-mqtt'
         VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
         build.args: '-DPRECONDITIONS=OFF -DLOGGING=OFF -DTRANSPORT_PAHO=ON'

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         # Test on the win 2019
         Win2019_x64_with_iot_samples:
-          Pool: $(WINDOWSPOOL)
+          Pool: azsdk-pool
           OSVmImage: windows-2022
           VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
           CMAKE_GENERATOR: 'Visual Studio 16 2019'
@@ -56,7 +56,7 @@ jobs:
           os: 'win'
         # Test on the win 2022
         Win2022_x64_with_iot_samples:
-          Pool: $(WINDOWSPOOL)
+          Pool: azsdk-pool
           OSVmImage: windows-2022
           VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
           CMAKE_GENERATOR: 'Visual Studio 17 2022'

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -15,8 +15,8 @@ jobs:
           test_type: 'iot'
           os: 'linux'
         Linux_ubuntu_2204_x64_with_iot_samples:
-          Pool: $(LINUXNEXTPOOL)
-          OSVmImage: $(LINUXNEXTVMIMAGE)
+          Pool: $(LINUXPOOL)
+          OSVmImage: $(LINUXVMIMAGE)
           VCPKG_DEFAULT_TRIPLET: 'x64-linux'
           build.args: ' -DTRANSPORT_PAHO=ON'
           test_type: 'iot'

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -47,7 +47,7 @@ jobs:
         # Test on the win 2019
         Win2019_x64_with_iot_samples:
           Pool: $(WINDOWSPOOL)
-          OSVmImage: $(WINDOWSVMIMAGE)
+          OSVmImage: windows-2022
           VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
           CMAKE_GENERATOR: 'Visual Studio 16 2019'
           CMAKE_GENERATOR_PLATFORM: x64
@@ -57,7 +57,7 @@ jobs:
         # Test on the win 2022
         Win2022_x64_with_iot_samples:
           Pool: $(WINDOWSPOOL)
-          OSVmImage: $(WINDOWSVMIMAGE)
+          OSVmImage: windows-2022
           VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
           CMAKE_GENERATOR: 'Visual Studio 17 2022'
           CMAKE_GENERATOR_PLATFORM: x64

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -46,8 +46,8 @@ jobs:
       matrix:
         # Test on the win 2019
         Win2019_x64_with_iot_samples:
-          Pool: $(WINDOWSPREVIOUSPOOL)
-          OSVmImage: $(WINDOWSPREVIOUSVMIMAGE)
+          Pool: $(WINDOWSPOOL)
+          OSVmImage: $(WINDOWSVMIMAGE)
           VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
           CMAKE_GENERATOR: 'Visual Studio 16 2019'
           CMAKE_GENERATOR_PLATFORM: x64

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -83,7 +83,7 @@ jobs:
     pool:
       name: $(Pool)
       vmImage: $(OSVmImage)
-      os: ${{ parameters.OSName }}
+      os: windows
 
     steps:
       - template: /eng/pipelines/templates/steps/ci.livetest.yml

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -46,8 +46,8 @@ jobs:
       matrix:
         # Test on the win 2019
         Win2019_x64_with_iot_samples:
-          Pool: azsdk-pool-mms-win-2019-general
-          OSVmImage: azsdk-pool-mms-win-2019-1espt
+          Pool: $(WINDOWSPREVIOUSPOOL)
+          OSVmImage: $(WINDOWSPREVIOUSVMIMAGE)
           VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
           CMAKE_GENERATOR: 'Visual Studio 16 2019'
           CMAKE_GENERATOR_PLATFORM: x64
@@ -56,8 +56,8 @@ jobs:
           os: 'win'
         # Test on the win 2022
         Win2022_x64_with_iot_samples:
-          Pool: azsdk-pool-mms-win-2022-general
-          OSVmImage: azsdk-pool-mms-win-2022-1espt
+          Pool: $(WINDOWSPOOL)
+          OSVmImage: $(WINDOWSVMIMAGE)
           VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
           CMAKE_GENERATOR: 'Visual Studio 17 2022'
           CMAKE_GENERATOR_PLATFORM: x64

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -46,8 +46,8 @@ jobs:
       matrix:
         # Test on the win 2019
         Win2019_x64_with_iot_samples:
-          Pool: azsdk-pool
-          OSVmImage: windows-2022
+          Pool: azsdk-pool-mms-win-2019-general
+          OSVmImage: azsdk-pool-mms-win-2019-1espt
           VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
           CMAKE_GENERATOR: 'Visual Studio 16 2019'
           CMAKE_GENERATOR_PLATFORM: x64
@@ -56,8 +56,8 @@ jobs:
           os: 'win'
         # Test on the win 2022
         Win2022_x64_with_iot_samples:
-          Pool: azsdk-pool
-          OSVmImage: windows-2022
+          Pool: azsdk-pool-mms-win-2022-general
+          OSVmImage: azsdk-pool-mms-win-2022-1espt
           VCPKG_DEFAULT_TRIPLET: 'x64-windows-static'
           CMAKE_GENERATOR: 'Visual Studio 17 2022'
           CMAKE_GENERATOR_PLATFORM: x64

--- a/eng/pipelines/templates/stages/archetype-c-release.yml
+++ b/eng/pipelines/templates/stages/archetype-c-release.yml
@@ -12,7 +12,7 @@ stages:
         environment: package-publish
 
         pool:
-          name: azsdk-pool-mms-win-2022-general
+          name: azsdk-pool
           image: azsdk-pool-mms-win-2022-1espt
           os: windows
 

--- a/eng/pipelines/templates/stages/archetype-c-release.yml
+++ b/eng/pipelines/templates/stages/archetype-c-release.yml
@@ -12,8 +12,8 @@ stages:
         environment: package-publish
 
         pool:
-          name: azsdk-pool-mms-win-2022-general
-          image: azsdk-pool-mms-win-2022-1espt
+          name: azsdk-pool
+          image: windows-2022
           os: windows
 
         templateContext:

--- a/eng/pipelines/templates/stages/archetype-c-release.yml
+++ b/eng/pipelines/templates/stages/archetype-c-release.yml
@@ -13,7 +13,7 @@ stages:
 
         pool:
           name: azsdk-pool
-          image: azsdk-pool-mms-win-2022-1espt
+          image: windows-2022
           os: windows
 
         templateContext:

--- a/eng/pipelines/templates/stages/archetype-c-release.yml
+++ b/eng/pipelines/templates/stages/archetype-c-release.yml
@@ -12,8 +12,8 @@ stages:
         environment: package-publish
 
         pool:
-          name: azsdk-pool
-          image: windows-2022
+          name: azsdk-pool-mms-win-2022-general
+          image: azsdk-pool-mms-win-2022-1espt
           os: windows
 
         templateContext:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -19,8 +19,8 @@ extends:
           isMainPipeline: true
           enableForGitHub: true
       sourceAnalysisPool:
-        name: azsdk-pool
-        image: windows-2022
+        name: azsdk-pool-mms-win-2022-general
+        image: azsdk-pool-mms-win-2022-1espt
         os: windows
       # Turn off the build warnings caused by disabling some sdl checks
       createAdoIssuesForJustificationsForDisablement: false

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -20,7 +20,7 @@ extends:
           enableForGitHub: true
       sourceAnalysisPool:
         name: azsdk-pool
-        image: azsdk-pool-mms-win-2022-1espt
+        image: windows-2022
         os: windows
       # Turn off the build warnings caused by disabling some sdl checks
       createAdoIssuesForJustificationsForDisablement: false

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -19,7 +19,7 @@ extends:
           isMainPipeline: true
           enableForGitHub: true
       sourceAnalysisPool:
-        name: azsdk-pool-mms-win-2022-general
+        name: azsdk-pool
         image: azsdk-pool-mms-win-2022-1espt
         os: windows
       # Turn off the build warnings caused by disabling some sdl checks

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -19,8 +19,8 @@ extends:
           isMainPipeline: true
           enableForGitHub: true
       sourceAnalysisPool:
-        name: azsdk-pool-mms-win-2022-general
-        image: azsdk-pool-mms-win-2022-1espt
+        name: azsdk-pool
+        image: windows-2022
         os: windows
       # Turn off the build warnings caused by disabling some sdl checks
       createAdoIssuesForJustificationsForDisablement: false

--- a/eng/pipelines/templates/steps/ci.test.yml
+++ b/eng/pipelines/templates/steps/ci.test.yml
@@ -136,27 +136,6 @@ steps:
   displayName: Validate Characters are ASCII
   condition: eq(variables['AZ_SDK_CODE_COV'], 1)
 
-# Validate all the files are formatted correctly according to the .clang-format file.
-- bash: |
-    # Run clang-format-9 recursively on each source and header file within the repo.
-    clang-format-9 --version
-    find . \( -iname '*.h' -o -iname '*.c' \) -exec clang-format-9 -i {} \;
-
-    git status --untracked-files=no --porcelain
-
-    if [[ `git status --untracked-files=no --porcelain` ]]; then
-      echo Some files were not formatted correctly according to the .clang-format file.
-      echo Please run clang-format-9 to fix the issue by using this bash command at the root of the repo:
-      echo "find . \( -iname '*.h' -o -iname '*.c' \) -exec clang-format-9 -i {} \;"
-      exit 1
-    fi
-
-    echo Success, all files are formatted correctly according to the .clang-format file.
-    exit 0
-
-  displayName: Validate Clang Format
-  condition: eq(variables['AZ_SDK_CODE_COV'], 1)
-
 - pwsh: |
     $artifactName = "$(Agent.JobName)"
     $parts = $artifactName -split ' '

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -2,9 +2,9 @@
 
 variables:
   - name: LINUXPOOL
-    value: azsdk-pool-mms-ubuntu-2204-general
+    value: azsdk-pool
   - name: WINDOWSPOOL
-    value: azsdk-pool-mms-win-2022-general
+    value: azsdk-pool
   - name: WINDOWSPREVIOUSPOOL
     value: azsdk-pool-mms-win-2019-general
   - name: MACPOOL

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -2,8 +2,6 @@
 
 variables:
   - name: LINUXPOOL
-    value: azsdk-pool-mms-ubuntu-2004-general
-  - name: LINUXNEXTPOOL
     value: azsdk-pool-mms-ubuntu-2204-general
   - name: WINDOWSPOOL
     value: azsdk-pool-mms-win-2022-general
@@ -13,8 +11,6 @@ variables:
     value: Azure Pipelines
 
   - name: LINUXVMIMAGE
-    value: azsdk-pool-mms-ubuntu-2004-1espt
-  - name: LINUXNEXTVMIMAGE
     value: azsdk-pool-mms-ubuntu-2204-1espt
   - name: WINDOWSVMIMAGE
     value: azsdk-pool-mms-win-2022-1espt

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -11,7 +11,7 @@ variables:
     value: Azure Pipelines
 
   - name: LINUXVMIMAGE
-    value: azsdk-pool-mms-ubuntu-2204-1espt
+    value: ubuntu-22.04
   - name: WINDOWSVMIMAGE
     value: azsdk-pool-mms-win-2022-1espt
   - name: WINDOWSPREVIOUSVMIMAGE

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -4,7 +4,7 @@ variables:
   - name: LINUXPOOL
     value: azsdk-pool
   - name: WINDOWSPOOL
-    value: azsdk-pool
+    value: azsdk-pool-mms-win-2022-general
   - name: WINDOWSPREVIOUSPOOL
     value: azsdk-pool-mms-win-2019-general
   - name: MACPOOL
@@ -13,7 +13,7 @@ variables:
   - name: LINUXVMIMAGE
     value: ubuntu-22.04
   - name: WINDOWSVMIMAGE
-    value: windows-2022
+    value: azsdk-pool-mms-win-2022-1espt
   - name: WINDOWSPREVIOUSVMIMAGE
     value: azsdk-pool-mms-win-2019-1espt
   - name: MACVMIMAGE

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -13,7 +13,7 @@ variables:
   - name: LINUXVMIMAGE
     value: ubuntu-22.04
   - name: WINDOWSVMIMAGE
-    value: azsdk-pool-mms-win-2022-1espt
+    value: windows-2022
   - name: WINDOWSPREVIOUSVMIMAGE
     value: azsdk-pool-mms-win-2019-1espt
   - name: MACVMIMAGE

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -4,7 +4,7 @@ variables:
   - name: LINUXPOOL
     value: azsdk-pool
   - name: WINDOWSPOOL
-    value: azsdk-pool-mms-win-2022-general
+    value: azsdk-pool
   - name: WINDOWSPREVIOUSPOOL
     value: azsdk-pool-mms-win-2019-general
   - name: MACPOOL
@@ -13,7 +13,7 @@ variables:
   - name: LINUXVMIMAGE
     value: ubuntu-22.04
   - name: WINDOWSVMIMAGE
-    value: azsdk-pool-mms-win-2022-1espt
+    value: windows-2022
   - name: WINDOWSPREVIOUSVMIMAGE
     value: azsdk-pool-mms-win-2019-1espt
   - name: MACVMIMAGE


### PR DESCRIPTION
Changes of note: 
* Compiler/matrix information described here: https://github.com/Azure/azure-sdk-for-c/issues/3098
* Removed `clang-format-9`... it's not available on Ubuntu 22

Fixes https://github.com/Azure/azure-sdk-for-c/issues/3093