### PR TITLE
Fix indexes from one span being used to slice another span

### DIFF
--- a/sdk/src/azure/iot/az_iot_hub_client_twin.c
+++ b/sdk/src/azure/iot/az_iot_hub_client_twin.c
@@ -138,9 +138,9 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
       az_span remainder;
       az_span status_str = _az_span_token(
           az_span_slice(
-              received_topic,
+              twin_feature_span,
               twin_feature_index + az_span_size(az_iot_hub_twin_response_sub_topic),
-              az_span_size(received_topic)),
+              az_span_size(twin_feature_span)),
           AZ_SPAN_FROM_STR("/"),
           &remainder,
           &index);
@@ -201,10 +201,10 @@ AZ_NODISCARD az_result az_iot_hub_client_twin_parse_received_topic(
       // Is a /PATCH case (desired props)
       az_iot_message_properties props;
       az_span prop_span = az_span_slice(
-          received_topic,
+          twin_feature_span,
           twin_feature_index + az_span_size(az_iot_hub_twin_patch_sub_topic)
               + (int32_t)sizeof(az_iot_hub_client_twin_question),
-          az_span_size(received_topic));
+          az_span_size(twin_feature_span));
       _az_RETURN_IF_FAILED(
           az_iot_message_properties_init(&props, prop_span, az_span_size(prop_span)));
       _az_RETURN_IF_FAILED(az_iot_message_properties_find(

--- a/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client_twin.c
@@ -43,6 +43,14 @@ static const az_span test_twin_received_topic_400_success
 static const az_span test_twin_received_topic_504_success
     = AZ_SPAN_LITERAL_FROM_STR("$iothub/twin/res/504/?$rid=id_one");
 
+// Topics where the "$iothub/twin/" prefix does NOT start at offset 0 (twin_index > 0). These lock
+// in the fix for the off-by-twin_index slicing bug: indexes computed within twin_feature_span must
+// be applied to twin_feature_span, not to the full received_topic. See PR #3365 / issue this fixes.
+static const az_span test_twin_received_topic_get_response_with_prefix_success
+    = AZ_SPAN_LITERAL_FROM_STR("devices/my_device/$iothub/twin/res/200/?$rid=id_one");
+static const az_span test_twin_received_topic_desired_with_prefix_success = AZ_SPAN_LITERAL_FROM_STR(
+    "devices/my_device/$iothub/twin/PATCH/properties/desired/?$version=id_one");
+
 static const char test_correct_twin_get_request_topic[] = "$iothub/twin/GET/?$rid=id_one";
 static const char test_correct_twin_patch_pub_topic[]
     = "$iothub/twin/PATCH/properties/reported/?$rid=id_one";
@@ -325,6 +333,52 @@ static void test_az_iot_hub_client_twin_parse_received_topic_get_response_found_
   assert_int_equal(response.response_type, AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_GET);
 }
 
+static void test_az_iot_hub_client_twin_parse_received_topic_get_response_with_prefix_found_succeed(
+    void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
+  az_iot_hub_client_twin_response response;
+
+  // The "$iothub/twin/" prefix is not at offset 0 here (twin_index > 0). Parsing must yield the
+  // same result as the unprefixed topic; before the fix the response fields were sliced from the
+  // wrong base span and the parse produced incorrect values / errors.
+  assert_int_equal(
+      az_iot_hub_client_twin_parse_received_topic(
+          &client, test_twin_received_topic_get_response_with_prefix_success, &response),
+      AZ_OK);
+  assert_true(az_span_is_content_equal(response.request_id, test_device_request_id));
+  assert_true(az_span_is_content_equal(response.version, AZ_SPAN_EMPTY));
+  assert_int_equal(response.status, AZ_IOT_STATUS_OK);
+  assert_int_equal(response.response_type, AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_GET);
+}
+
+static void test_az_iot_hub_client_twin_parse_received_topic_desired_with_prefix_found_succeed(
+    void** state)
+{
+  (void)state;
+
+  az_iot_hub_client client;
+  assert_int_equal(
+      az_iot_hub_client_init(&client, test_device_hostname, test_device_id, NULL), AZ_OK);
+  az_iot_hub_client_twin_response response;
+
+  // The "$iothub/twin/" prefix is not at offset 0 here (twin_index > 0). Parsing must yield the
+  // same result as the unprefixed desired-properties topic; before the fix the version property
+  // span was sliced from the wrong base span.
+  assert_int_equal(
+      az_iot_hub_client_twin_parse_received_topic(
+          &client, test_twin_received_topic_desired_with_prefix_success, &response),
+      AZ_OK);
+  assert_true(az_span_is_content_equal((response.version), test_device_request_id));
+  assert_true(az_span_is_content_equal(response.request_id, AZ_SPAN_EMPTY));
+  assert_int_equal(response.status, AZ_IOT_STATUS_OK);
+  assert_int_equal(response.response_type, AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_TYPE_DESIRED_PROPERTIES);
+}
+
 static void test_az_iot_hub_client_twin_parse_received_topic_reported_props_version_found_succeed(
     void** state)
 {
@@ -573,6 +627,10 @@ int test_az_iot_hub_client_twin()
     cmocka_unit_test(test_az_iot_hub_client_twin_patch_get_publish_topic_small_buffer_fails),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_desired_found_succeed),
     cmocka_unit_test(test_az_iot_hub_client_twin_parse_received_topic_get_response_found_succeed),
+    cmocka_unit_test(
+        test_az_iot_hub_client_twin_parse_received_topic_get_response_with_prefix_found_succeed),
+    cmocka_unit_test(
+        test_az_iot_hub_client_twin_parse_received_topic_desired_with_prefix_found_succeed),
     cmocka_unit_test(
         test_az_iot_hub_client_twin_parse_received_topic_reported_props_version_found_succeed),
     cmocka_unit_test(


### PR DESCRIPTION
Fix index from `twin_feature_span` being used to slice into `received_topic`.

It accidentally worked fine as long as `twin_feature_index` was 0.