### PR TITLE
Hand off @ronniegeraghty CODEOWNERS to new owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,13 +6,13 @@
 ###########
 
 # Catch all for non-code project files
-/**                            @rickwinter @ronniegeraghty
+/**                            @rickwinter
 
 # GitHub integration files
-/.github/                      @rickwinter @ronniegeraghty
+/.github/                      @rickwinter
 
 # SDK team
-/sdk/                          @rickwinter @ronniegeraghty
+/sdk/                          @rickwinter
 
 # Samples
 /samples/                      @antkmsft @rickwinter @LarryOsterman
@@ -41,7 +41,7 @@
 /eng/                          @danieljurek @weshaggard @benbp
 /eng/common/                   @Azure/azure-sdk-eng
 /.github/workflows/            @Azure/azure-sdk-eng
-/.github/CODEOWNERS            @rickwinter @ronniegeraghty @Azure/azure-sdk-eng
+/.github/CODEOWNERS            @rickwinter @Azure/azure-sdk-eng
 
 # Add owners for notifications for specific pipelines
 /eng/common/pipelines/codeowners-linter.yml       @rickwinter @danieljurek


### PR DESCRIPTION
## Summary

Removing `@ronniegeraghty` from `.github/CODEOWNERS` as Ronnie transitions from the Azure SDK / Tools portfolio into a different role.

## What changed

See the diff. For lines where removing Ronnie would leave fewer than one human owner, a replacement was added per discussion with Ronnie. All other lines simply drop his alias.

## Reviewers

Tagging the existing co-owners on the affected lines for review.

## Related

- Workitem: Azure/projects/424 - "Review CODEOWNERS entries in SDK repos, transfer to right new owner"
- Full handoff plan: internal doc `projects/sdk-team-brain-dump/codeowners-handoff/README.md` in `ronniegeraghty/ronnies-agent-team`

---
*Opened as part of the Azure SDK handoff. Marking as draft until Ronnie reviews; flip to ready-for-review once approved internally.*
