### PR TITLE
Improve error handling when parsing HTTP response status line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed error handling when parsing HTTP response status line.
+
 ### Other Changes
 
 - Changed POSIX implementation of `az_platform_clock_msec()` to use `clock_gettime()` instead of `clock()`.

--- a/sdk/src/azure/core/az_http_response.c
+++ b/sdk/src/azure/core/az_http_response.c
@@ -75,6 +75,7 @@ _az_get_http_status_line(az_span* ref_span, az_http_response_status_line* out_st
   _az_RETURN_IF_FAILED(_az_is_expected_span(ref_span, space));
 
   // status-code = 3DIGIT
+  _az_RETURN_IF_NOT_ENOUGH_SIZE(*ref_span, 3);
   {
     uint64_t code = 0;
     _az_RETURN_IF_FAILED(az_span_atou64(az_span_create(az_span_ptr(*ref_span), 3), &code));

--- a/sdk/tests/core/test_az_http.c
+++ b/sdk/tests/core/test_az_http.c
@@ -601,6 +601,91 @@ static void test_http_response(void** state)
     }
   }
 
+  // Bad response. Not enough space for the HTTP code - has 0 bytes (needs 3)
+  {
+    az_span response_span = AZ_SPAN_FROM_STR( //
+        "HTTP/1.1 ");
+
+    az_http_response response = { 0 };
+    az_result const result = az_http_response_init(&response, response_span);
+    assert_true(result == AZ_OK);
+
+    // read a status line
+    {
+      az_http_response_status_line status_line = { 0 };
+      az_result get_result = az_http_response_get_status_line(&response, &status_line);
+      assert_true(get_result == AZ_ERROR_NOT_ENOUGH_SPACE);
+    }
+  }
+
+  // Bad response. Not enough space for the HTTP code - has 1 byte (needs 3)
+  {
+    az_span response_span = AZ_SPAN_FROM_STR( //
+        "HTTP/1.1 7");
+
+    az_http_response response = { 0 };
+    az_result const result = az_http_response_init(&response, response_span);
+    assert_true(result == AZ_OK);
+
+    // read a status line
+    {
+      az_http_response_status_line status_line = { 0 };
+      az_result get_result = az_http_response_get_status_line(&response, &status_line);
+      assert_true(get_result == AZ_ERROR_NOT_ENOUGH_SPACE);
+    }
+  }
+
+  // Bad response. Not enough space for the HTTP code - has 2 bytes (needs 3)
+  {
+    az_span response_span = AZ_SPAN_FROM_STR( //
+        "HTTP/1.1 42");
+
+    az_http_response response = { 0 };
+    az_result const result = az_http_response_init(&response, response_span);
+    assert_true(result == AZ_OK);
+
+    // read a status line
+    {
+      az_http_response_status_line status_line = { 0 };
+      az_result get_result = az_http_response_get_status_line(&response, &status_line);
+      assert_true(get_result == AZ_ERROR_NOT_ENOUGH_SPACE);
+    }
+  }
+
+  // Bad response. Has enough space for the HTTP code, but the code is not a number
+  {
+    az_span response_span = AZ_SPAN_FROM_STR( //
+        "HTTP/1.1 ABC");
+
+    az_http_response response = { 0 };
+    az_result const result = az_http_response_init(&response, response_span);
+    assert_true(result == AZ_OK);
+
+    // read a status line
+    {
+      az_http_response_status_line status_line = { 0 };
+      az_result get_result = az_http_response_get_status_line(&response, &status_line);
+      assert_true(get_result == AZ_ERROR_UNEXPECTED_CHAR);
+    }
+  }
+
+  // Bad response. Has enough space for the HTTP code, but not the Status Line
+  {
+    az_span response_span = AZ_SPAN_FROM_STR( //
+        "HTTP/1.1 999");
+
+    az_http_response response = { 0 };
+    az_result const result = az_http_response_init(&response, response_span);
+    assert_true(result == AZ_OK);
+
+    // read a status line
+    {
+      az_http_response_status_line status_line = { 0 };
+      az_result get_result = az_http_response_get_status_line(&response, &status_line);
+      assert_true(get_result == AZ_ERROR_UNEXPECTED_END);
+    }
+  }
+
   // Bad response. handle unexpected end when getting headers
   {
     az_span response_span = AZ_SPAN_FROM_STR( //


### PR DESCRIPTION
CI is blocked on an unrelated issue. I have verified that locally the new unit tests do pass, so this change can be reviewed.