### PR TITLE
Add CODEOWNERS entry for .github/skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,6 +42,7 @@
 /eng/common/                   @Azure/azure-sdk-eng
 /.github/workflows/            @Azure/azure-sdk-eng
 /.github/CODEOWNERS            @rickwinter @xirzec @Azure/azure-sdk-eng
+/.github/skills/               @azure/azsdk-cli
 
 # Add owners for notifications for specific pipelines
 /eng/common/pipelines/codeowners-linter.yml       @rickwinter @xirzec @danieljurek


### PR DESCRIPTION
Assigns ownership of the skill definitions under `.github/skills/` to the `@azure/azsdk-cli` team, so changes to those files automatically request review from that team.

The entry is grouped with the other `.github/` paths in the Eng Sys section of `.github/CODEOWNERS`.