### PR TITLE
Use authenticated npmrc

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -273,6 +273,8 @@ jobs:
       value: false
 
   steps:
+    - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    
     - template: /eng/common/pipelines/templates/steps/check-spelling.yml
 
     - template: /eng/common/pipelines/templates/steps/verify-links.yml


### PR DESCRIPTION
This pull request updates the documentation generation pipeline to support authenticated npm access during artifact creation. The most important changes are:

**Pipeline authentication setup:**

* Added a step to create an authenticated `.npmrc` file using the `create-authenticated-npmrc.yml` template, ensuring that npm commands in later steps have the necessary credentials.

**Environment configuration for artifact generation:**

* Configured the `New-DocsMsArtifact.ps1` script step to use the generated authenticated `.npmrc` by setting the `npm_config_userconfig` environment variable, enabling secure npm operations during artifact generation.

[c - client](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6468224&view=results)