### PR TITLE
Document input-validation contract in az_json_writer_chunked_init (#2237)

### DIFF
--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -44,6 +44,12 @@ AZ_NODISCARD az_result az_json_writer_chunked_init(
 {
   _az_PRECONDITION_NOT_NULL(out_json_writer);
   _az_PRECONDITION_NOT_NULL(allocator_callback);
+  // first_destination_buffer is intentionally not validated for size here: it may be empty
+  // (including AZ_SPAN_EMPTY) because the chunked writer obtains additional storage on demand
+  // through allocator_callback. The writer and callback being non-null is the only contract.
+  // user_context is an opaque, caller-owned pass-through: the SDK never dereferences or
+  // validates it; it is only handed back to allocator_callback. Validating it would be
+  // meaningless. See https://github.com/Azure/azure-sdk-for-c/issues/2237.
 
   *out_json_writer = (az_json_writer){
     .total_bytes_written = 0,


### PR DESCRIPTION
## Why

A security scan (Improper Input Validation, CWE-20) flagged `az_json_writer_chunked_init` for not validating all of its arguments. Per the discussion in #2237, this is a **by-design false positive**:

- `user_context` is an **opaque, caller-owned pass-through** — the SDK never dereferences or inspects it; it is only handed back to the user's `allocator_callback` (like `void* context` in any callback API). Validating it is meaningless.
- `first_destination_buffer` **may legitimately be empty** (including `AZ_SPAN_EMPTY`) because the chunked writer obtains additional storage on demand via `allocator_callback`. The existing unit tests rely on this.

The existing `_az_PRECONDITION_NOT_NULL` checks on `out_json_writer` and `allocator_callback` are the complete input contract.

## What changed

Added clarifying comments to `az_json_writer_chunked_init` documenting the opaque `user_context` and the empty-buffer behavior, so future readers and scanners understand why no further validation is added. **No functional change.**

Closes #2237.