### PR TITLE
Add last_token_kind precondition and document json_text validation in _az_validate_json (#2239)

### DIFF
--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -720,7 +720,14 @@ static AZ_NODISCARD az_result _az_validate_json(
     az_json_token_kind* last_token_kind)
 {
   _az_PRECONDITION_NOT_NULL(first_token_kind);
+  // Checked for consistency and maintainability alongside first_token_kind. The only caller
+  // (az_json_writer_append_json_text) always passes a valid pointer.
+  _az_PRECONDITION_NOT_NULL(last_token_kind);
 
+  // json_text is intentionally not precondition-validated here: az_json_reader_init below
+  // performs the appropriate validation, and the only caller (az_json_writer_append_json_text)
+  // already enforces _az_PRECONDITION_VALID_SPAN on it. Duplicating that validation would be
+  // unnecessary. See https://github.com/Azure/azure-sdk-for-c/issues/2239.
   az_json_reader reader = { 0 };
   _az_RETURN_IF_FAILED(az_json_reader_init(&reader, json_text, NULL));
 


### PR DESCRIPTION
## Why

A security scan (CWE-476 / CWE-20) flagged the internal helper `_az_validate_json`. Per the discussion in #2239, this is a **by-design false positive**: the function is private with a single caller (`az_json_writer_append_json_text`) that always supplies valid inputs.

## What changed

Following the maintainer's guidance in the issue:

- Added `_az_PRECONDITION_NOT_NULL(last_token_kind)` for consistency and maintainability with the existing `first_token_kind` precondition.
- Documented that `json_text` is validated by `az_json_reader_init` (and is already guarded by the caller's `_az_PRECONDITION_VALID_SPAN`), so duplicating that precondition here is unnecessary.

**No functional change.**

Closes #2239.