### PR TITLE
Fix JSON writer integer overflow (#2240) and harden escaping (#2238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 - Fixed error handling when parsing HTTP response status line.
+- [[#2238](https://github.com/Azure/azure-sdk-for-c/issues/2238)] Hardened the JSON writer against an out-of-bounds write (CWE-787) by adding tests that keep the escaped-length calculator and the byte-by-byte copier in sync.
+- [[#2240](https://github.com/Azure/azure-sdk-for-c/issues/2240)] Guarded `az_json_writer` byte counters against signed integer overflow (CWE-190); appends that would push the total past `INT32_MAX` now return `AZ_ERROR_NOT_ENOUGH_SPACE`.
 
 ### Other Changes
 

--- a/sdk/src/azure/core/az_json_writer.c
+++ b/sdk/src/azure/core/az_json_writer.c
@@ -389,17 +389,30 @@ static AZ_NODISCARD az_span _az_json_writer_escape_and_copy(az_span destination,
   return remaining_destination;
 }
 
-AZ_INLINE void _az_update_json_writer_state(
+AZ_NODISCARD AZ_INLINE az_result _az_update_json_writer_state(
     az_json_writer* ref_json_writer,
     int32_t bytes_written_in_last,
     int32_t total_bytes_written,
     bool need_comma,
     az_json_token_kind token_kind)
 {
+  // Guard against signed integer overflow (CWE-190) when accumulating the byte counters. The byte
+  // deltas are always non-negative, and neither running total may exceed INT32_MAX. Without this
+  // check, accumulating close to INT32_MAX bytes of JSON would overflow and produce a wrong
+  // (negative) length. Use the MAX - x idiom to detect the overflow before it happens.
+  if (bytes_written_in_last < 0 || total_bytes_written < 0
+      || ref_json_writer->_internal.bytes_written > INT32_MAX - bytes_written_in_last
+      || ref_json_writer->total_bytes_written > INT32_MAX - total_bytes_written)
+  {
+    return AZ_ERROR_NOT_ENOUGH_SPACE;
+  }
+
   ref_json_writer->_internal.bytes_written += bytes_written_in_last;
   ref_json_writer->total_bytes_written += total_bytes_written;
   ref_json_writer->_internal.need_comma = need_comma;
   ref_json_writer->_internal.token_kind = token_kind;
+
+  return AZ_OK;
 }
 
 static AZ_NODISCARD az_result az_json_writer_span_copy_chunked(
@@ -478,9 +491,8 @@ az_json_writer_append_string_small(az_json_writer* ref_json_writer, az_span valu
 
   az_span_copy_u8(remaining_json, '"');
 
-  _az_update_json_writer_state(
+  return _az_update_json_writer_state(
       ref_json_writer, required_size, required_size, true, AZ_JSON_TOKEN_STRING);
-  return AZ_OK;
 }
 
 static AZ_NODISCARD az_result
@@ -555,8 +567,7 @@ az_json_writer_append_string_chunked(az_json_writer* ref_json_writer, az_span va
   required_size += consumed;
 
   // We already tracked and updated bytes_written while writing, so no need to update it here.
-  _az_update_json_writer_state(ref_json_writer, 0, required_size, true, AZ_JSON_TOKEN_STRING);
-  return AZ_OK;
+  return _az_update_json_writer_state(ref_json_writer, 0, required_size, true, AZ_JSON_TOKEN_STRING);
 }
 
 AZ_NODISCARD az_result az_json_writer_append_string(az_json_writer* ref_json_writer, az_span value)
@@ -620,9 +631,8 @@ az_json_writer_append_property_name_small(az_json_writer* ref_json_writer, az_sp
   remaining_json = az_span_copy_u8(remaining_json, '"');
   az_span_copy_u8(remaining_json, ':');
 
-  _az_update_json_writer_state(
+  return _az_update_json_writer_state(
       ref_json_writer, required_size, required_size, false, AZ_JSON_TOKEN_PROPERTY_NAME);
-  return AZ_OK;
 }
 
 static AZ_NODISCARD az_result
@@ -698,9 +708,8 @@ az_json_writer_append_property_name_chunked(az_json_writer* ref_json_writer, az_
   required_size += consumed;
 
   // We already tracked and updated bytes_written while writing, so no need to update it here.
-  _az_update_json_writer_state(
+  return _az_update_json_writer_state(
       ref_json_writer, 0, required_size, false, AZ_JSON_TOKEN_PROPERTY_NAME);
-  return AZ_OK;
 }
 
 AZ_NODISCARD az_result
@@ -814,8 +823,7 @@ az_json_writer_append_json_text(az_json_writer* ref_json_writer, az_span json_te
   // Therefore, need_comma must be true after appending the json_text.
 
   // We already tracked and updated bytes_written while writing, so no need to update it here.
-  _az_update_json_writer_state(ref_json_writer, 0, required_size, true, last_token_kind);
-  return AZ_OK;
+  return _az_update_json_writer_state(ref_json_writer, 0, required_size, true, last_token_kind);
 }
 
 static AZ_NODISCARD az_result _az_json_writer_append_literal(
@@ -848,8 +856,8 @@ static AZ_NODISCARD az_result _az_json_writer_append_literal(
 
   az_span_copy(remaining_json, literal);
 
-  _az_update_json_writer_state(ref_json_writer, required_size, required_size, true, literal_kind);
-  return AZ_OK;
+  return _az_update_json_writer_state(
+      ref_json_writer, required_size, required_size, true, literal_kind);
 }
 
 AZ_NODISCARD az_result az_json_writer_append_bool(az_json_writer* ref_json_writer, bool value)
@@ -896,8 +904,7 @@ AZ_NODISCARD az_result az_json_writer_append_int32(az_json_writer* ref_json_writ
   // actual bytes written.
   int32_t written
       = required_size + _az_span_diff(leftover, remaining_json) - _az_MAX_SIZE_FOR_INT32;
-  _az_update_json_writer_state(ref_json_writer, written, written, true, AZ_JSON_TOKEN_NUMBER);
-  return AZ_OK;
+  return _az_update_json_writer_state(ref_json_writer, written, written, true, AZ_JSON_TOKEN_NUMBER);
 }
 
 AZ_NODISCARD az_result az_json_writer_append_double(
@@ -938,8 +945,7 @@ AZ_NODISCARD az_result az_json_writer_append_double(
   // actual bytes written.
   int32_t written
       = required_size + _az_span_diff(leftover, remaining_json) - _az_MAX_SIZE_FOR_WRITING_DOUBLE;
-  _az_update_json_writer_state(ref_json_writer, written, written, true, AZ_JSON_TOKEN_NUMBER);
-  return AZ_OK;
+  return _az_update_json_writer_state(ref_json_writer, written, written, true, AZ_JSON_TOKEN_NUMBER);
 }
 
 static AZ_NODISCARD az_result _az_json_writer_append_container_start(
@@ -976,8 +982,8 @@ static AZ_NODISCARD az_result _az_json_writer_append_container_start(
 
   az_span_copy_u8(remaining_json, byte);
 
-  _az_update_json_writer_state(
-      ref_json_writer, required_size, required_size, false, container_kind);
+  _az_RETURN_IF_FAILED(_az_update_json_writer_state(
+      ref_json_writer, required_size, required_size, false, container_kind));
   if (container_kind == AZ_JSON_TOKEN_BEGIN_OBJECT)
   {
     _az_json_stack_push(&ref_json_writer->_internal.bit_stack, _az_JSON_STACK_OBJECT);
@@ -1017,7 +1023,8 @@ static AZ_NODISCARD az_result az_json_writer_append_container_end(
 
   az_span_copy_u8(remaining_json, byte);
 
-  _az_update_json_writer_state(ref_json_writer, required_size, required_size, true, container_kind);
+  _az_RETURN_IF_FAILED(_az_update_json_writer_state(
+      ref_json_writer, required_size, required_size, true, container_kind));
   _az_json_stack_pop(&ref_json_writer->_internal.bit_stack);
 
   return AZ_OK;

--- a/sdk/tests/core/test_az_json.c
+++ b/sdk/tests/core/test_az_json.c
@@ -3227,6 +3227,148 @@ static void test_az_json_string_unescape_same_buffer(void** state)
   }
 }
 
+// Issue #2238 (CWE-787): lock the escaped-length calculator and the byte-by-byte copier in sync.
+// For every possible byte value 0x00-0xFF, append it as a single-character JSON string and assert
+// that the bytes the writer emits exactly match the expected escaping. The calculator sizes the
+// destination reservation while the copier writes the bytes; if the two ever disagreed on how many
+// bytes a character expands to, either the emitted content or its length would not match below.
+static void test_json_writer_escape_length_matches_written(void** state)
+{
+  (void)state;
+
+  for (int32_t byte_value = 0; byte_value <= 0xFF; byte_value++)
+  {
+    uint8_t source_buffer[1] = { (uint8_t)byte_value };
+    az_span source = AZ_SPAN_FROM_BUFFER(source_buffer);
+
+    uint8_t expected_buffer[8] = { 0 };
+    int32_t expected_size = 0;
+    expected_buffer[expected_size++] = '"';
+
+    switch (byte_value)
+    {
+      case '"':
+      case '\\':
+        expected_buffer[expected_size++] = '\\';
+        expected_buffer[expected_size++] = (uint8_t)byte_value;
+        break;
+      case '\b':
+        expected_buffer[expected_size++] = '\\';
+        expected_buffer[expected_size++] = 'b';
+        break;
+      case '\f':
+        expected_buffer[expected_size++] = '\\';
+        expected_buffer[expected_size++] = 'f';
+        break;
+      case '\n':
+        expected_buffer[expected_size++] = '\\';
+        expected_buffer[expected_size++] = 'n';
+        break;
+      case '\r':
+        expected_buffer[expected_size++] = '\\';
+        expected_buffer[expected_size++] = 'r';
+        break;
+      case '\t':
+        expected_buffer[expected_size++] = '\\';
+        expected_buffer[expected_size++] = 't';
+        break;
+      default:
+        if (byte_value < 0x20)
+        {
+          static char const hex[] = "0123456789ABCDEF";
+          expected_buffer[expected_size++] = '\\';
+          expected_buffer[expected_size++] = 'u';
+          expected_buffer[expected_size++] = '0';
+          expected_buffer[expected_size++] = '0';
+          expected_buffer[expected_size++] = (uint8_t)hex[(byte_value >> 4) & 0xF];
+          expected_buffer[expected_size++] = (uint8_t)hex[byte_value & 0xF];
+        }
+        else
+        {
+          expected_buffer[expected_size++] = (uint8_t)byte_value;
+        }
+        break;
+    }
+    expected_buffer[expected_size++] = '"';
+
+    uint8_t array[16] = { 0 };
+    az_json_writer writer = { 0 };
+    TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+    TEST_EXPECT_SUCCESS(az_json_writer_append_string(&writer, source));
+
+    az_span written = az_json_writer_get_bytes_used_in_destination(&writer);
+
+    // The number of bytes written must equal the escaped length predicted by the calculator.
+    assert_int_equal(az_span_size(written), expected_size);
+    assert_int_equal(writer.total_bytes_written, expected_size);
+    assert_true(
+        az_span_is_content_equal(written, az_span_create(expected_buffer, expected_size)));
+  }
+}
+
+// Issue #2238 (CWE-787): a string made entirely of control characters expands by 6x (\u00XX).
+// Verify the writer succeeds when the destination is sized exactly to the escaped length and fails
+// (rather than writing out of bounds) when it is one byte short.
+static void test_json_writer_escape_boundary(void** state)
+{
+  (void)state;
+
+  enum
+  {
+    control_char_count = 8
+  };
+  uint8_t control_chars[control_char_count];
+  for (int32_t i = 0; i < control_char_count; i++)
+  {
+    control_chars[i] = 0x01; // Escapes to the 6-byte sequence "\u0001".
+  }
+  az_span source = AZ_SPAN_FROM_BUFFER(control_chars);
+
+  // 2 surrounding quotes + 6 bytes per control character.
+  int32_t const escaped_size = 2 + (control_char_count * 6);
+
+  // Exact fit succeeds.
+  {
+    uint8_t array[2 + (control_char_count * 6)] = { 0 };
+    az_json_writer writer = { 0 };
+    TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+    TEST_EXPECT_SUCCESS(az_json_writer_append_string(&writer, source));
+    assert_int_equal(
+        az_span_size(az_json_writer_get_bytes_used_in_destination(&writer)), escaped_size);
+  }
+
+  // One byte short fails with AZ_ERROR_NOT_ENOUGH_SPACE instead of an out-of-bounds write.
+  {
+    uint8_t array[(2 + (control_char_count * 6)) - 1] = { 0 };
+    az_json_writer writer = { 0 };
+    TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+    assert_int_equal(az_json_writer_append_string(&writer, source), AZ_ERROR_NOT_ENOUGH_SPACE);
+  }
+}
+
+// Issue #2240 (CWE-190): guard against int32 overflow when accumulating total_bytes_written.
+// Rather than buffering ~2 GB of JSON, stub the running counter close to INT32_MAX and confirm the
+// next append that would push it past INT32_MAX returns an error instead of overflowing to a wrong
+// (negative) length.
+static void test_json_writer_total_bytes_overflow(void** state)
+{
+  (void)state;
+
+  uint8_t array[64] = { 0 };
+  az_json_writer writer = { 0 };
+  TEST_EXPECT_SUCCESS(az_json_writer_init(&writer, AZ_SPAN_FROM_BUFFER(array), NULL));
+
+  TEST_EXPECT_SUCCESS(az_json_writer_append_begin_array(&writer));
+
+  // Pretend the writer has already emitted nearly INT32_MAX bytes overall.
+  writer.total_bytes_written = INT32_MAX - 1;
+
+  // Appending "ab" requires 4 bytes ("ab" plus the two surrounding quotes), which would push
+  // total_bytes_written past INT32_MAX. The overflow guard must reject this.
+  assert_int_equal(
+      az_json_writer_append_string(&writer, AZ_SPAN_FROM_STR("ab")), AZ_ERROR_NOT_ENOUGH_SPACE);
+}
+
 int test_az_json()
 {
   const struct CMUnitTest tests[]
@@ -3252,6 +3394,9 @@ int test_az_json()
           cmocka_unit_test(test_az_json_token_copy),
           cmocka_unit_test(test_az_json_reader_chunked),
           cmocka_unit_test(test_az_json_string_unescape),
-          cmocka_unit_test(test_az_json_string_unescape_same_buffer) };
+          cmocka_unit_test(test_az_json_string_unescape_same_buffer),
+          cmocka_unit_test(test_json_writer_escape_length_matches_written),
+          cmocka_unit_test(test_json_writer_escape_boundary),
+          cmocka_unit_test(test_json_writer_total_bytes_overflow) };
   return cmocka_run_group_tests_name("az_core_json", tests, NULL, NULL);
 }


### PR DESCRIPTION
## Summary

Fixes two static-analysis security findings in the Core JSON writer (`sdk/src/azure/core/az_json_writer.c`):

- **#2240 — Integer overflow (CWE-190) in `_az_update_json_writer_state`.** The helper accumulated `bytes_written`/`total_bytes_written` (`int32_t`) with no overflow guard and returned `void`. It now returns `az_result` and verifies, using the `MAX - x` idiom, that neither running total can exceed `INT32_MAX` (and that the deltas are non-negative), returning `AZ_ERROR_NOT_ENOUGH_SPACE` on violation. All ~10 call sites propagate the result.
- **#2238 — Out-of-bounds write (CWE-787) in `_az_json_writer_escape_and_copy`.** The path is guarded in practice by the caller's always-on size check; the genuine residual risk is a logic mismatch between the escaped-length calculator and the byte-by-byte copier. Added tests that lock the two in sync.

## Tests

- `test_json_writer_escape_length_matches_written` — for every byte `0x00`–`0xFF`, asserts the bytes the writer emits exactly match the expected JSON escaping (locks calculator and copier in sync).
- `test_json_writer_escape_boundary` — escape-heavy (`\u00XX`) string against a destination sized exactly at, and one byte below, the escaped length; verifies success at exact fit and `AZ_ERROR_NOT_ENOUGH_SPACE` (no OOB write) one byte short.
- `test_json_writer_total_bytes_overflow` — stubs `total_bytes_written` near `INT32_MAX` and confirms the next append returns `AZ_ERROR_NOT_ENOUGH_SPACE` instead of overflowing.

All 26 `az_core_json` tests pass locally (Debug, MSVC).

## Notes

- Public struct layout is unchanged (ABI stable).
- No public API behavior change beyond returning an error in the previously-unreachable overflow case.

Fixes #2238
Fixes #2240
