### PR TITLE
Add az_span_dtoa_with_fractional for fixed-precision double formatting (#2157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- [[#2157](https://github.com/Azure/azure-sdk-for-c/issues/2157)] Added `az_span_dtoa_fixed()`, which converts a `double` to text while preserving trailing zeros so the output always has exactly the requested number of fractional digits (e.g. `1.0` with 2 fractional digits produces `"1.00"`). `az_span_dtoa()` continues to strip non-significant trailing zeros.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- [[#2157](https://github.com/Azure/azure-sdk-for-c/issues/2157)] Added `az_span_dtoa_fixed()`, which converts a `double` to text while preserving trailing zeros so the output always has exactly the requested number of fractional digits (e.g. `1.0` with 2 fractional digits produces `"1.00"`). `az_span_dtoa()` continues to strip non-significant trailing zeros.
+- [[#2157](https://github.com/Azure/azure-sdk-for-c/issues/2157)] Added `az_span_dtoa_with_fractional()`, which converts a `double` to text while preserving trailing zeros so the output always has exactly the requested number of fractional digits (e.g. `1.0` with 2 fractional digits produces `"1.00"`). `az_span_dtoa()` continues to strip non-significant trailing zeros.
 
 ### Breaking Changes
 

--- a/sdk/inc/azure/core/az_span.h
+++ b/sdk/inc/azure/core/az_span.h
@@ -483,6 +483,43 @@ AZ_NODISCARD az_result az_span_u64toa(az_span destination, uint64_t source, az_s
 AZ_NODISCARD az_result
 az_span_dtoa(az_span destination, double source, int32_t fractional_digits, az_span* out_span);
 
+/**
+ * @brief Converts a `double` into its digit characters (base 10 decimal notation) and copies them
+ * to the \p destination #az_span starting at its 0-th index, always writing exactly \p
+ * fractional_digits digits after the decimal point (padding with trailing zeros).
+ *
+ * @param destination The #az_span where the bytes should be copied to.
+ * @param[in] source The `double` whose number is copied to the \p destination #az_span as ASCII
+ * digits and characters.
+ * @param[in] fractional_digits The exact number of digits to write into the \p destination #az_span
+ * after the decimal point, padding with trailing zeros and truncating the rest.
+ * @param[out] out_span A pointer to an #az_span that receives the remainder of the \p destination
+ * #az_span after the `double` has been copied.
+ *
+ * @return An #az_result value indicating the result of the operation.
+ * @retval #AZ_OK Success.
+ * @retval #AZ_ERROR_NOT_ENOUGH_SPACE The \p destination is not big enough to contain the copied
+ * bytes.
+ * @retval #AZ_ERROR_NOT_SUPPORTED The \p source is not a finite decimal number or contains an
+ * integer component that is too large and would overflow beyond `2^53 - 1`.
+ *
+ * @remark Only finite `double` values are supported. Values such as `NaN` and `INFINITY` are not
+ * allowed.
+ *
+ * @remark Unlike #az_span_dtoa, trailing zeros after the decimal point are preserved. For example,
+ * `az_span_dtoa_fixed(destination, 1.0, 2, &out_span)` writes `"1.00"`, and
+ * `az_span_dtoa_fixed(destination, 1.001, 2, &out_span)` writes `"1.00"`. When \p fractional_digits
+ * is 0, no decimal point is written.
+ *
+ * @remark The \p fractional_digits must be between 0 and 15 (inclusive). Any value passed in that
+ * is larger will be clamped down to 15.
+ */
+AZ_NODISCARD az_result az_span_dtoa_fixed(
+    az_span destination,
+    double source,
+    int32_t fractional_digits,
+    az_span* out_span);
+
 /******************************  NON-CONTIGUOUS SPAN  */
 
 /**

--- a/sdk/inc/azure/core/az_span.h
+++ b/sdk/inc/azure/core/az_span.h
@@ -81,7 +81,10 @@ AZ_NODISCARD az_span az_span_create(uint8_t* ptr, int32_t size);
  * @remark There is no guarantee that the pointer backing this span will be `NULL` and the caller
  * shouldn't rely on it. However, the size will be 0.
  */
-#define AZ_SPAN_LITERAL_EMPTY { ._internal = { .ptr = NULL, .size = 0 } }
+#define AZ_SPAN_LITERAL_EMPTY              \
+  {                                        \
+    ._internal = {.ptr = NULL, .size = 0 } \
+  }
 
 /**
  * @brief An empty #az_span.
@@ -106,7 +109,7 @@ AZ_NODISCARD az_span az_span_create(uint8_t* ptr, int32_t size);
  *
  * @remarks An empty ("") literal string results in an #az_span with size set to 0.
  */
-#define AZ_SPAN_LITERAL_FROM_STR(STRING_LITERAL) \
+#define AZ_SPAN_LITERAL_FROM_STR(STRING_LITERAL)      \
   {                                                   \
     ._internal = {                                    \
       .ptr = (uint8_t*)(STRING_LITERAL),              \

--- a/sdk/inc/azure/core/az_span.h
+++ b/sdk/inc/azure/core/az_span.h
@@ -81,10 +81,7 @@ AZ_NODISCARD az_span az_span_create(uint8_t* ptr, int32_t size);
  * @remark There is no guarantee that the pointer backing this span will be `NULL` and the caller
  * shouldn't rely on it. However, the size will be 0.
  */
-#define AZ_SPAN_LITERAL_EMPTY              \
-  {                                        \
-    ._internal = {.ptr = NULL, .size = 0 } \
-  }
+#define AZ_SPAN_LITERAL_EMPTY { ._internal = { .ptr = NULL, .size = 0 } }
 
 /**
  * @brief An empty #az_span.
@@ -109,7 +106,7 @@ AZ_NODISCARD az_span az_span_create(uint8_t* ptr, int32_t size);
  *
  * @remarks An empty ("") literal string results in an #az_span with size set to 0.
  */
-#define AZ_SPAN_LITERAL_FROM_STR(STRING_LITERAL)      \
+#define AZ_SPAN_LITERAL_FROM_STR(STRING_LITERAL) \
   {                                                   \
     ._internal = {                                    \
       .ptr = (uint8_t*)(STRING_LITERAL),              \
@@ -507,14 +504,14 @@ az_span_dtoa(az_span destination, double source, int32_t fractional_digits, az_s
  * allowed.
  *
  * @remark Unlike #az_span_dtoa, trailing zeros after the decimal point are preserved. For example,
- * `az_span_dtoa_fixed(destination, 1.0, 2, &out_span)` writes `"1.00"`, and
- * `az_span_dtoa_fixed(destination, 1.001, 2, &out_span)` writes `"1.00"`. When \p fractional_digits
- * is 0, no decimal point is written.
+ * `az_span_dtoa_with_fractional(destination, 1.0, 2, &out_span)` writes `"1.00"`, and
+ * `az_span_dtoa_with_fractional(destination, 1.001, 2, &out_span)` writes `"1.00"`. When \p
+ * fractional_digits is 0, no decimal point is written.
  *
  * @remark The \p fractional_digits must be between 0 and 15 (inclusive). Any value passed in that
  * is larger will be clamped down to 15.
  */
-AZ_NODISCARD az_result az_span_dtoa_fixed(
+AZ_NODISCARD az_result az_span_dtoa_with_fractional(
     az_span destination,
     double source,
     int32_t fractional_digits,

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -686,7 +686,8 @@ AZ_NODISCARD az_result az_span_i32toa(az_span destination, int32_t source, az_sp
 }
 
 // Shared implementation behind az_span_dtoa (compact, keep_trailing_zeros == false) and
-// az_span_dtoa_fixed (fixed precision, keep_trailing_zeros == true). When keep_trailing_zeros is
+// az_span_dtoa_with_fractional (fixed precision, keep_trailing_zeros == true). When
+// keep_trailing_zeros is
 // true and fractional_digits > 0, exactly fractional_digits digits are written after the decimal
 // point, padding with trailing zeros as needed.
 static AZ_NODISCARD az_result _az_span_dtoa(
@@ -773,7 +774,7 @@ static AZ_NODISCARD az_result _az_span_dtoa(
     }
 
     // For the fixed-precision contract, print the decimal point followed by exactly
-    // fractional_digits zeros (e.g. az_span_dtoa_fixed(dst, 1.0, 2, ...) -> "1.00").
+    // fractional_digits zeros (e.g. az_span_dtoa_with_fractional(dst, 1.0, 2, ...) -> "1.00").
     _az_RETURN_IF_NOT_ENOUGH_SIZE(*out_span, 1 + fractional_digits);
     *out_span = az_span_copy_u8(*out_span, '.');
     for (int32_t z = 0; z < fractional_digits; z++)
@@ -818,7 +819,7 @@ az_span_dtoa(az_span destination, double source, int32_t fractional_digits, az_s
   return _az_span_dtoa(destination, source, fractional_digits, false, out_span);
 }
 
-AZ_NODISCARD az_result az_span_dtoa_fixed(
+AZ_NODISCARD az_result az_span_dtoa_with_fractional(
     az_span destination,
     double source,
     int32_t fractional_digits,

--- a/sdk/src/azure/core/az_span.c
+++ b/sdk/src/azure/core/az_span.c
@@ -685,15 +685,17 @@ AZ_NODISCARD az_result az_span_i32toa(az_span destination, int32_t source, az_sp
   return _az_span_builder_append_u32toa(*out_span, (uint32_t)source, out_span);
 }
 
-AZ_NODISCARD az_result
-az_span_dtoa(az_span destination, double source, int32_t fractional_digits, az_span* out_span)
+// Shared implementation behind az_span_dtoa (compact, keep_trailing_zeros == false) and
+// az_span_dtoa_fixed (fixed precision, keep_trailing_zeros == true). When keep_trailing_zeros is
+// true and fractional_digits > 0, exactly fractional_digits digits are written after the decimal
+// point, padding with trailing zeros as needed.
+static AZ_NODISCARD az_result _az_span_dtoa(
+    az_span destination,
+    double source,
+    int32_t fractional_digits,
+    bool keep_trailing_zeros,
+    az_span* out_span)
 {
-  _az_PRECONDITION_VALID_SPAN(destination, 0, false);
-  // Inputs that are either positive or negative infinity, or not a number, are not supported.
-  _az_PRECONDITION(_az_isfinite(source));
-  _az_PRECONDITION_RANGE(0, fractional_digits, _az_MAX_SUPPORTED_FRACTIONAL_DIGITS);
-  _az_PRECONDITION_NOT_NULL(out_span);
-
   *out_span = destination;
 
   // The input is either positive or negative infinity, or not a number.
@@ -761,18 +763,35 @@ az_span_dtoa(az_span destination, double source, int32_t fractional_digits, az_s
   uint64_t fractional_part = (uint64_t)shifted_fractional_integer_part;
 
   // If there is no fractional part (at least within the number of fractional digits the user
-  // specified), or if they were all non-significant zeros, don't print the decimal point or any
-  // trailing zeros.
+  // specified), or if they were all non-significant zeros...
   if (fractional_part == 0)
   {
+    // For the compact contract, don't print the decimal point or any trailing zeros.
+    if (!keep_trailing_zeros)
+    {
+      return AZ_OK;
+    }
+
+    // For the fixed-precision contract, print the decimal point followed by exactly
+    // fractional_digits zeros (e.g. az_span_dtoa_fixed(dst, 1.0, 2, ...) -> "1.00").
+    _az_RETURN_IF_NOT_ENOUGH_SIZE(*out_span, 1 + fractional_digits);
+    *out_span = az_span_copy_u8(*out_span, '.');
+    for (int32_t z = 0; z < fractional_digits; z++)
+    {
+      *out_span = az_span_copy_u8(*out_span, '0');
+    }
     return AZ_OK;
   }
 
   // Remove trailing zeros of the fraction part that don't need to be printed since they aren't
-  // significant.
-  while (fractional_part % _az_NUMBER_OF_DECIMAL_VALUES == 0)
+  // significant. For the fixed-precision contract they are kept so the output always has exactly
+  // fractional_digits digits after the decimal point.
+  if (!keep_trailing_zeros)
   {
-    fractional_part /= _az_NUMBER_OF_DECIMAL_VALUES;
+    while (fractional_part % _az_NUMBER_OF_DECIMAL_VALUES == 0)
+    {
+      fractional_part /= _az_NUMBER_OF_DECIMAL_VALUES;
+    }
   }
 
   _az_RETURN_IF_NOT_ENOUGH_SIZE(*out_span, 1 + leading_zeros);
@@ -785,6 +804,33 @@ az_span_dtoa(az_span destination, double source, int32_t fractional_digits, az_s
 
   // Append the fractional part.
   return _az_span_builder_append_uint64(out_span, fractional_part);
+}
+
+AZ_NODISCARD az_result
+az_span_dtoa(az_span destination, double source, int32_t fractional_digits, az_span* out_span)
+{
+  _az_PRECONDITION_VALID_SPAN(destination, 0, false);
+  // Inputs that are either positive or negative infinity, or not a number, are not supported.
+  _az_PRECONDITION(_az_isfinite(source));
+  _az_PRECONDITION_RANGE(0, fractional_digits, _az_MAX_SUPPORTED_FRACTIONAL_DIGITS);
+  _az_PRECONDITION_NOT_NULL(out_span);
+
+  return _az_span_dtoa(destination, source, fractional_digits, false, out_span);
+}
+
+AZ_NODISCARD az_result az_span_dtoa_fixed(
+    az_span destination,
+    double source,
+    int32_t fractional_digits,
+    az_span* out_span)
+{
+  _az_PRECONDITION_VALID_SPAN(destination, 0, false);
+  // Inputs that are either positive or negative infinity, or not a number, are not supported.
+  _az_PRECONDITION(_az_isfinite(source));
+  _az_PRECONDITION_RANGE(0, fractional_digits, _az_MAX_SUPPORTED_FRACTIONAL_DIGITS);
+  _az_PRECONDITION_NOT_NULL(out_span);
+
+  return _az_span_dtoa(destination, source, fractional_digits, true, out_span);
 }
 
 // TODO: pass az_span by value

--- a/sdk/tests/core/test_az_span.c
+++ b/sdk/tests/core/test_az_span.c
@@ -1343,23 +1343,23 @@ static void az_span_dtoa_succeeds(void** state)
   AZ_SPAN_DTOA_SUCCEEDS_HELPER(1e-300, 2, AZ_SPAN_FROM_STR("0"));
 }
 
-#define AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(v, fractional_digits, expected)                  \
-  do                                                                                        \
-  {                                                                                         \
-    az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);                                       \
-    az_span out_span = AZ_SPAN_EMPTY;                                                       \
-    assert_true(                                                                            \
-        az_result_succeeded(az_span_dtoa_fixed(buffer, v, fractional_digits, &out_span)));  \
-    az_span output = az_span_slice(buffer, 0, _az_span_diff(out_span, buffer));             \
-    assert_int_equal(az_span_size(output), az_span_size(expected));                         \
-    assert_memory_equal(                                                                    \
-        az_span_ptr(output), az_span_ptr(expected), (size_t)az_span_size(expected));        \
-    double round_trip = 0;                                                                  \
-    assert_true(az_result_succeeded(az_span_atod(output, &round_trip)));                    \
-    assert_true(fabs(v - round_trip) < 0.01);                                               \
+#define AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(v, fractional_digits, expected) \
+  do                                                                                 \
+  {                                                                                  \
+    az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);                                \
+    az_span out_span = AZ_SPAN_EMPTY;                                                \
+    assert_true(az_result_succeeded(                                                 \
+        az_span_dtoa_with_fractional(buffer, v, fractional_digits, &out_span)));     \
+    az_span output = az_span_slice(buffer, 0, _az_span_diff(out_span, buffer));      \
+    assert_int_equal(az_span_size(output), az_span_size(expected));                  \
+    assert_memory_equal(                                                             \
+        az_span_ptr(output), az_span_ptr(expected), (size_t)az_span_size(expected)); \
+    double round_trip = 0;                                                           \
+    assert_true(az_result_succeeded(az_span_atod(output, &round_trip)));             \
+    assert_true(fabs(v - round_trip) < 0.01);                                        \
   } while (0)
 
-static void az_span_dtoa_fixed_succeeds(void** state)
+static void az_span_dtoa_with_fractional_succeeds(void** state)
 {
   (void)state;
 
@@ -1369,46 +1369,46 @@ static void az_span_dtoa_fixed_succeeds(void** state)
 
   // Cases reported in https://github.com/Azure/azure-sdk-for-c/issues/2157: trailing zeros after
   // the decimal point must be preserved so the output always has exactly fractional_digits digits.
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.00, 2, AZ_SPAN_FROM_STR("1.00"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.01, 2, AZ_SPAN_FROM_STR("1.01"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.001, 2, AZ_SPAN_FROM_STR("1.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(1.00, 2, AZ_SPAN_FROM_STR("1.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(1.01, 2, AZ_SPAN_FROM_STR("1.01"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(1.001, 2, AZ_SPAN_FROM_STR("1.00"));
 
   // Zero and integer values are padded out to fractional_digits.
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(0, 2, AZ_SPAN_FROM_STR("0.00"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(0.0, 2, AZ_SPAN_FROM_STR("0.00"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1, 2, AZ_SPAN_FROM_STR("1.00"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.0, 2, AZ_SPAN_FROM_STR("1.00"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(-1.0, 2, AZ_SPAN_FROM_STR("-1.00"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(12345, 2, AZ_SPAN_FROM_STR("12345.00"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(-12345, 2, AZ_SPAN_FROM_STR("-12345.00"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.e3, 2, AZ_SPAN_FROM_STR("1000.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(0, 2, AZ_SPAN_FROM_STR("0.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(0.0, 2, AZ_SPAN_FROM_STR("0.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(1, 2, AZ_SPAN_FROM_STR("1.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(1.0, 2, AZ_SPAN_FROM_STR("1.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(-1.0, 2, AZ_SPAN_FROM_STR("-1.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(12345, 2, AZ_SPAN_FROM_STR("12345.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(-12345, 2, AZ_SPAN_FROM_STR("-12345.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(1.e3, 2, AZ_SPAN_FROM_STR("1000.00"));
 
   // Trailing zeros within the fractional part are preserved (these differ from az_span_dtoa).
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.5, 2, AZ_SPAN_FROM_STR("1.50"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(0.5, 2, AZ_SPAN_FROM_STR("0.50"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.25, 2, AZ_SPAN_FROM_STR("1.25"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(100.25, 2, AZ_SPAN_FROM_STR("100.25"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(1.5, 2, AZ_SPAN_FROM_STR("1.50"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(0.5, 2, AZ_SPAN_FROM_STR("0.50"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(1.25, 2, AZ_SPAN_FROM_STR("1.25"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(100.25, 2, AZ_SPAN_FROM_STR("100.25"));
 
   // Leading zeros after the decimal point are preserved as well.
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.05, 2, AZ_SPAN_FROM_STR("1.05"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(0.05, 2, AZ_SPAN_FROM_STR("0.05"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(0.005, 2, AZ_SPAN_FROM_STR("0.00"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(987654.0000321, 2, AZ_SPAN_FROM_STR("987654.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(1.05, 2, AZ_SPAN_FROM_STR("1.05"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(0.05, 2, AZ_SPAN_FROM_STR("0.05"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(0.005, 2, AZ_SPAN_FROM_STR("0.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(987654.0000321, 2, AZ_SPAN_FROM_STR("987654.00"));
 
   // Negative and sub-fractional values.
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(-.34567, 2, AZ_SPAN_FROM_STR("-0.34"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(0.001, 2, AZ_SPAN_FROM_STR("0.00"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(-1.2e-4, 2, AZ_SPAN_FROM_STR("-0.00"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1e-300, 2, AZ_SPAN_FROM_STR("0.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(-.34567, 2, AZ_SPAN_FROM_STR("-0.34"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(0.001, 2, AZ_SPAN_FROM_STR("0.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(-1.2e-4, 2, AZ_SPAN_FROM_STR("-0.00"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(1e-300, 2, AZ_SPAN_FROM_STR("0.00"));
 
   // Other fractional widths.
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(2.5, 1, AZ_SPAN_FROM_STR("2.5"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.0, 3, AZ_SPAN_FROM_STR("1.000"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.5, 4, AZ_SPAN_FROM_STR("1.5000"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(2.5, 1, AZ_SPAN_FROM_STR("2.5"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(1.0, 3, AZ_SPAN_FROM_STR("1.000"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(1.5, 4, AZ_SPAN_FROM_STR("1.5000"));
 
   // With fractional_digits == 0 no decimal point is written, matching az_span_dtoa.
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(0, 0, AZ_SPAN_FROM_STR("0"));
-  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.0, 0, AZ_SPAN_FROM_STR("1"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(0, 0, AZ_SPAN_FROM_STR("0"));
+  AZ_SPAN_DTOA_WITH_FRACTIONAL_SUCCEEDS_HELPER(1.0, 0, AZ_SPAN_FROM_STR("1"));
 }
 
 static void az_span_dtoa_overflow_fails(void** state)
@@ -1864,7 +1864,7 @@ int test_az_span()
     cmocka_unit_test(az_span_u32toa_max_uint_succeeds),
     cmocka_unit_test(az_span_u32toa_overflow_fails),
     cmocka_unit_test(az_span_dtoa_succeeds),
-    cmocka_unit_test(az_span_dtoa_fixed_succeeds),
+    cmocka_unit_test(az_span_dtoa_with_fractional_succeeds),
     cmocka_unit_test(az_span_dtoa_overflow_fails),
     cmocka_unit_test(az_span_dtoa_too_large),
     cmocka_unit_test(az_span_copy_empty),

--- a/sdk/tests/core/test_az_span.c
+++ b/sdk/tests/core/test_az_span.c
@@ -1343,6 +1343,74 @@ static void az_span_dtoa_succeeds(void** state)
   AZ_SPAN_DTOA_SUCCEEDS_HELPER(1e-300, 2, AZ_SPAN_FROM_STR("0"));
 }
 
+#define AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(v, fractional_digits, expected)                  \
+  do                                                                                        \
+  {                                                                                         \
+    az_span buffer = AZ_SPAN_FROM_BUFFER(raw_buffer);                                       \
+    az_span out_span = AZ_SPAN_EMPTY;                                                       \
+    assert_true(                                                                            \
+        az_result_succeeded(az_span_dtoa_fixed(buffer, v, fractional_digits, &out_span)));  \
+    az_span output = az_span_slice(buffer, 0, _az_span_diff(out_span, buffer));             \
+    assert_int_equal(az_span_size(output), az_span_size(expected));                         \
+    assert_memory_equal(                                                                    \
+        az_span_ptr(output), az_span_ptr(expected), (size_t)az_span_size(expected));        \
+    double round_trip = 0;                                                                  \
+    assert_true(az_result_succeeded(az_span_atod(output, &round_trip)));                    \
+    assert_true(fabs(v - round_trip) < 0.01);                                               \
+  } while (0)
+
+static void az_span_dtoa_fixed_succeeds(void** state)
+{
+  (void)state;
+
+  // We don't need more than 33 bytes to hold the supported doubles:
+  // [-][0-9]{16}.[0-9]{15}, i.e. 1+16+1+15
+  uint8_t raw_buffer[33] = { 0 };
+
+  // Cases reported in https://github.com/Azure/azure-sdk-for-c/issues/2157: trailing zeros after
+  // the decimal point must be preserved so the output always has exactly fractional_digits digits.
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.00, 2, AZ_SPAN_FROM_STR("1.00"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.01, 2, AZ_SPAN_FROM_STR("1.01"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.001, 2, AZ_SPAN_FROM_STR("1.00"));
+
+  // Zero and integer values are padded out to fractional_digits.
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(0, 2, AZ_SPAN_FROM_STR("0.00"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(0.0, 2, AZ_SPAN_FROM_STR("0.00"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1, 2, AZ_SPAN_FROM_STR("1.00"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.0, 2, AZ_SPAN_FROM_STR("1.00"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(-1.0, 2, AZ_SPAN_FROM_STR("-1.00"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(12345, 2, AZ_SPAN_FROM_STR("12345.00"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(-12345, 2, AZ_SPAN_FROM_STR("-12345.00"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.e3, 2, AZ_SPAN_FROM_STR("1000.00"));
+
+  // Trailing zeros within the fractional part are preserved (these differ from az_span_dtoa).
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.5, 2, AZ_SPAN_FROM_STR("1.50"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(0.5, 2, AZ_SPAN_FROM_STR("0.50"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.25, 2, AZ_SPAN_FROM_STR("1.25"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(100.25, 2, AZ_SPAN_FROM_STR("100.25"));
+
+  // Leading zeros after the decimal point are preserved as well.
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.05, 2, AZ_SPAN_FROM_STR("1.05"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(0.05, 2, AZ_SPAN_FROM_STR("0.05"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(0.005, 2, AZ_SPAN_FROM_STR("0.00"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(987654.0000321, 2, AZ_SPAN_FROM_STR("987654.00"));
+
+  // Negative and sub-fractional values.
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(-.34567, 2, AZ_SPAN_FROM_STR("-0.34"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(0.001, 2, AZ_SPAN_FROM_STR("0.00"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(-1.2e-4, 2, AZ_SPAN_FROM_STR("-0.00"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1e-300, 2, AZ_SPAN_FROM_STR("0.00"));
+
+  // Other fractional widths.
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(2.5, 1, AZ_SPAN_FROM_STR("2.5"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.0, 3, AZ_SPAN_FROM_STR("1.000"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.5, 4, AZ_SPAN_FROM_STR("1.5000"));
+
+  // With fractional_digits == 0 no decimal point is written, matching az_span_dtoa.
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(0, 0, AZ_SPAN_FROM_STR("0"));
+  AZ_SPAN_DTOA_FIXED_SUCCEEDS_HELPER(1.0, 0, AZ_SPAN_FROM_STR("1"));
+}
+
 static void az_span_dtoa_overflow_fails(void** state)
 {
   (void)state;
@@ -1796,6 +1864,7 @@ int test_az_span()
     cmocka_unit_test(az_span_u32toa_max_uint_succeeds),
     cmocka_unit_test(az_span_u32toa_overflow_fails),
     cmocka_unit_test(az_span_dtoa_succeeds),
+    cmocka_unit_test(az_span_dtoa_fixed_succeeds),
     cmocka_unit_test(az_span_dtoa_overflow_fails),
     cmocka_unit_test(az_span_dtoa_too_large),
     cmocka_unit_test(az_span_copy_empty),


### PR DESCRIPTION
Fixes #2157.

## Problem

`az_span_dtoa` intentionally strips non-significant trailing fractional zeros, so `1.0` with `fractional_digits = 2` renders as `"1"` instead of `"1.00"`. This is correct/compact for interoperable JSON numbers, but callers that need fixed-precision text output (e.g. a fixed number of decimal places) cannot get it.

## Approach (opt-in, non-breaking)

Changing the default behavior of `az_span_dtoa` would alter every existing payload, break ~15 existing `test_az_span.c` golden expectations (`1.0 -> "1"`, `0 -> "0"`, `1.5 -> "1.5"`, ...), and change the JSON writer's number output contract. As noted in the issue thread (and by `@ahsonkhan`), the default should not change.

Instead, this PR adds an **opt-in** public function that keeps trailing zeros:

```c
AZ_NODISCARD az_result az_span_dtoa_with_fractional(
    az_span destination,
    double source,
    int32_t fractional_digits,
    az_span* out_span);
```

`az_span_dtoa_with_fractional` always writes exactly `fractional_digits` digits after the decimal point (padding with trailing zeros), e.g. `1.0 -> "1.00"`, `1.001 -> "1.00"`, `1.01 -> "1.01"`. When `fractional_digits == 0`, no decimal point is written. `az_span_dtoa` is unchanged.

`fractional_digits` is a required parameter (not derived from `source`) because a `double` is an IEEE-754 binary value and carries no decimal precision — `1.0`, `1.00`, and `1.000` are byte-identical, so the desired number of fractional digits must come from the caller.

The shared conversion logic is factored into a static helper `_az_span_dtoa(..., bool keep_trailing_zeros, ...)`; both public functions are thin wrappers, so behavior and preconditions for `az_span_dtoa` are byte-for-byte identical.

## Tests

Adds `az_span_dtoa_with_fractional_succeeds`, covering the reported cases (`1.00`, `1.01`, `1.001` at 2 digits), integer/zero padding, preserved trailing zeros (`1.5 -> "1.50"`), leading zeros (`1.05 -> "1.05"`), negatives, sub-fractional values, other widths, and the `fractional_digits == 0` (no decimal point) case. All core tests pass.

## Note

This adds a new public API symbol, so it will need to go through API review (APIView). It is deliberately **not** a change to the existing `az_span_dtoa` default. A CHANGELOG entry is included under `1.6.0-beta.1`.
