### PR TITLE
fix(iot/adu): forward-compatible manifest step parsing

### DIFF
--- a/sdk/src/azure/iot/az_iot_adu_client.c
+++ b/sdk/src/azure/iot/az_iot_adu_client.c
@@ -645,28 +645,39 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_update_manifest(
               _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
               RETURN_IF_JSON_TOKEN_NOT_TYPE((ref_json_reader), AZ_JSON_TOKEN_BEGIN_OBJECT);
               _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
-              RETURN_IF_JSON_TOKEN_NOT_TYPE((ref_json_reader), AZ_JSON_TOKEN_PROPERTY_NAME);
 
-              if (az_json_token_is_text_equal(
-                      &ref_json_reader->token,
-                      AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_INSTALLED_CRITERIA)))
+              while (ref_json_reader->token.kind != AZ_JSON_TOKEN_END_OBJECT)
               {
+                RETURN_IF_JSON_TOKEN_NOT_TYPE((ref_json_reader), AZ_JSON_TOKEN_PROPERTY_NAME);
+
+                if (az_json_token_is_text_equal(
+                        &ref_json_reader->token,
+                        AZ_SPAN_FROM_STR(
+                            AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_INSTALLED_CRITERIA)))
+                {
+                  _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
+                  RETURN_IF_JSON_TOKEN_NOT_TYPE((ref_json_reader), AZ_JSON_TOKEN_STRING);
+                  update_manifest->instructions.steps[step_index]
+                      .handler_properties.installed_criteria
+                      = ref_json_reader->token.slice;
+                }
+                else
+                {
+                  // Skip unknown handlerProperties members so future manifest
+                  // versions remain parseable (forward compatibility).
+                  _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
+                  _az_RETURN_IF_FAILED(az_json_reader_skip_children(ref_json_reader));
+                }
+
                 _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
-                RETURN_IF_JSON_TOKEN_NOT_TYPE((ref_json_reader), AZ_JSON_TOKEN_STRING);
-                update_manifest->instructions.steps[step_index]
-                    .handler_properties.installed_criteria
-                    = ref_json_reader->token.slice;
-                _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
-                RETURN_IF_JSON_TOKEN_NOT_TYPE((ref_json_reader), AZ_JSON_TOKEN_END_OBJECT);
-              }
-              else
-              {
-                return AZ_ERROR_JSON_INVALID_STATE;
               }
             }
             else
             {
-              return AZ_ERROR_JSON_INVALID_STATE;
+              // Skip unknown step members so future manifest versions remain
+              // parseable (forward compatibility).
+              _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
+              _az_RETURN_IF_FAILED(az_json_reader_skip_children(ref_json_reader));
             }
 
             _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));

--- a/sdk/tests/iot/adu/test_az_iot_adu.c
+++ b/sdk/tests/iot/adu/test_az_iot_adu.c
@@ -321,6 +321,19 @@ static uint8_t adu_request_manifest_unused_fields[]
       "\"properties\":{\"microsoft.sourceFileAlgorithm\":\"sha256\",\"microsoft.sourceFileHash\":"
       "\"YmFY...\"}}],\"downloadHandler\":{\"id\":\"microsoft/"
       "delta:1\"}}},\"createdDateTime\":\"2022-07-07T03:02:48.8449038Z\"}";
+// Manifest carrying properties the parser does not recognize, both inside a
+// steps[] object ("type", "detachedManifestFileId") and inside handlerProperties
+// ("swVersion"). A forward-compatible parser must skip them and still succeed.
+static uint8_t adu_request_manifest_unknown_nested_fields[]
+    = "{\"manifestVersion\":\"5\",\"updateId\":{\"provider\":\"Contoso\",\"name\":\"Foobar\","
+      "\"version\":\"1.1\"},\"compatibility\":[{\"deviceManufacturer\":\"Contoso\",\"deviceModel\":"
+      "\"Foobar\"}],\"instructions\":{\"steps\":[{\"handler\":\"microsoft/"
+      "swupdate:1\",\"type\":\"inline\",\"files\":[\"f2f4a804ca17afbae\"],\"handlerProperties\":{"
+      "\"installedCriteria\":\"1.0\",\"swVersion\":\"1.1\"},\"detachedManifestFileId\":"
+      "\"f9fec76f10aede60e\"}]},\"files\":{\"f2f4a804ca17afbae\":{\"fileName\":"
+      "\"iot-middleware-sample-adu-v1.1\",\"sizeInBytes\":844976,\"hashes\":{\"sha256\":"
+      "\"xsoCnYAMkZZ7m9RL9Vyg9jKfFehCNxyuPFaJVM/"
+      "WBi0=\"}}},\"createdDateTime\":\"2022-07-07T03:02:48.8449038Z\"}";
 static uint8_t adu_request_manifest_reverse_order[]
     = "{\"createdDateTime\":\"2022-07-07T03:02:48.8449038Z\",\"files\":{\"f2f4a804ca17afbae\":{"
       "\"fileName\":\"iot-middleware-sample-adu-v1.1\",\"sizeInBytes\":844976,\"hashes\":{"
@@ -1331,6 +1344,14 @@ static void test_az_iot_adu_client_parse_update_manifest_unused_fields_succeed(v
       adu_request_manifest_unused_fields, sizeof(adu_request_manifest_unused_fields));
 }
 
+static void test_az_iot_adu_client_parse_update_manifest_unknown_nested_fields_succeed(void** state)
+{
+  (void)state;
+  parse_update_manifest_succeed(
+      adu_request_manifest_unknown_nested_fields,
+      sizeof(adu_request_manifest_unknown_nested_fields));
+}
+
 static void test_az_iot_adu_client_parse_update_manifest_payload_reverse_order_succeed(void** state)
 {
   (void)state;
@@ -1435,6 +1456,7 @@ int test_az_iot_adu()
         test_az_iot_adu_client_parse_service_properties_payload_no_deployment_null_file_url_value),
     cmocka_unit_test(test_az_iot_adu_client_parse_update_manifest_succeed),
     cmocka_unit_test(test_az_iot_adu_client_parse_update_manifest_unused_fields_succeed),
+    cmocka_unit_test(test_az_iot_adu_client_parse_update_manifest_unknown_nested_fields_succeed),
     cmocka_unit_test(test_az_iot_adu_client_parse_update_manifest_payload_reverse_order_succeed),
     cmocka_unit_test(test_az_iot_adu_client_parse_update_manifest_payload_too_many_file_ids_fail),
     cmocka_unit_test(test_az_iot_adu_client_parse_update_manifest_payload_too_many_total_files_fail)


### PR DESCRIPTION
## Summary

Make `az_iot_adu_client_parse_update_manifest()` forward-compatible with future ADU update-manifest versions by skipping **unrecognized** members inside `instructions.steps[]` objects and inside `handlerProperties`, instead of returning `AZ_ERROR_JSON_INVALID_STATE`.

## Motivation

Today the nested step parsers reject any property name they don't recognize:

- a member of a `steps[]` object other than `handler` / `files` / `handlerProperties` → `AZ_ERROR_JSON_INVALID_STATE`
- a member of `handlerProperties` other than `installedCriteria` → `AZ_ERROR_JSON_INVALID_STATE`

This makes the agent brittle: if the ADU service introduces a new step or `handlerProperties` field in a future manifest revision, parsing fails and the device can no longer process the deployment.

The **top-level** manifest parser already handles this gracefully (`property_parsed = false` → `az_json_reader_next_token` + `az_json_reader_skip_children`). This change brings the nested parsers in line with that established, tolerant pattern.

## Changes

- `sdk/src/azure/iot/az_iot_adu_client.c`
  - `steps[]` object: unknown members are now skipped (`next_token` + `skip_children`) instead of rejected.
  - `handlerProperties`: converted from a single-property check into a loop that consumes `installedCriteria` and skips any other member.
- `sdk/tests/iot/adu/test_az_iot_adu.c`
  - New `test_az_iot_adu_client_parse_update_manifest_unknown_nested_fields_succeed` exercising unknown members in `steps[]` (`type`, `detachedManifestFileId`) and `handlerProperties` (`swVersion`).

## Behavior preserved

Known fields still validate their JSON token type via `RETURN_IF_JSON_TOKEN_NOT_TYPE`, so malformed values for recognized fields are still rejected. Only **unknown property names** are now tolerated. Existing manifests parse exactly as before.
