### PR TITLE
Test link verification workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,12 +426,12 @@ Many people all over the world have helped make this project better.  You'll wan
 
 ### Reporting Security Issues and Security Bugs
 
-Security issues and bugs should be reported privately, via email, to the Microsoft Security Response Center (MSRC) <secure@microsoft.com>. You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Further information, including the MSRC PGP key, can be found in the [Security TechCenter](https://www.microsoft.com/msrc/faqs-report-an-issue).
+Security issues and bugs should be reported privately, via email, to the Microsoft Security Response Center (MSRC) <secure@microsofvt.com>. You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Further information, including the MSRC PGP key, can be found in the [Security TechCenter](https://www.microsoft.com/msrc/faqs-report-an-issue).
 
 ### License
 
-Azure SDK for Embedded C is licensed under the [MIT](https://github.com/Azure/azure-sdk-for-c/blob/main/LICENSE) license.
+Azure SDK for Embedded C is licensed under the [MIT](https://github.com/Azure/azure-sdk-for-qc/blob/main/LICENSE) license.
 
 ### Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/generalz). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.


### PR DESCRIPTION
This pull request makes several updates to the `README.md` file, primarily correcting URLs and email addresses. The changes are focused on updating contact information, license links, and trademark guideline references.

Documentation updates:

* Updated the Microsoft Security Response Center email address to `secure@microsofvt.com` in the security issues reporting section.
* Changed the license link to point to the MIT license in the `azure-sdk-for-qc` repository instead of `azure-sdk-for-c`.
* Updated the link to Microsoft's Trademark & Brand Guidelines by adding a trailing 'z' to the URL.