### PR TITLE
Fix memory-safety bugs in core parsing and POSIX clock

### DIFF
--- a/sdk/src/azure/core/az_http_request.c
+++ b/sdk/src/azure/core/az_http_request.c
@@ -30,6 +30,10 @@ AZ_NODISCARD az_result az_http_request_init(
   _az_PRECONDITION_VALID_SPAN(method, 1, false);
   _az_PRECONDITION_VALID_SPAN(url, 1, false);
   _az_PRECONDITION_VALID_SPAN(headers_buffer, 0, false);
+  // url_length is the number of meaningful bytes within the url span; it must not exceed the span
+  // size, otherwise the scan below (and later az_span_slice calls on the url) would read past the
+  // end of the buffer.
+  _az_PRECONDITION_RANGE(0, url_length, az_span_size(url));
 
   int32_t query_start = 0;
   uint8_t const* const ptr = az_span_ptr(url);

--- a/sdk/src/azure/core/az_http_response.c
+++ b/sdk/src/azure/core/az_http_response.c
@@ -108,7 +108,7 @@ _az_get_http_status_line(az_span* ref_span, az_http_response_status_line* out_st
   }
 
   // save reason-phrase in status line now that we got the offset. Remove 1 last chars(\r)
-  out_status_line->reason_phrase = az_span_slice(*ref_span, 0, offset - 1);
+  out_status_line->reason_phrase = az_span_slice(*ref_span, 0, offset > 0 ? offset - 1 : 0);
   // move position of reader after reason-phrase (parsed done)
   *ref_span = az_span_slice_to_end(*ref_span, offset + 1);
   // CR LF
@@ -249,8 +249,15 @@ AZ_NODISCARD az_result az_http_response_get_next_header(
   {
     int32_t offset = 0;
     int32_t offset_value_end = offset;
+    int32_t const reader_size = az_span_size(*reader);
     while (true)
     {
+      // Guard against reading past the end of the buffer when the header value is not
+      // terminated by a carriage return (malformed or truncated response).
+      if (offset >= reader_size)
+      {
+        return AZ_ERROR_HTTP_CORRUPT_RESPONSE_HEADER;
+      }
       uint8_t c = az_span_ptr(*reader)[offset];
       offset += 1;
       if (c == '\r')

--- a/sdk/src/azure/core/az_http_response.c
+++ b/sdk/src/azure/core/az_http_response.c
@@ -250,18 +250,18 @@ AZ_NODISCARD az_result az_http_response_get_next_header(
     int32_t offset = 0;
     int32_t offset_value_end = offset;
     int32_t const reader_size = az_span_size(*reader);
-    while (true)
+    // Scan the header value, bounding the scan by the size of the reader so a malformed or
+    // truncated response (one whose last header value lacks a terminating carriage return)
+    // cannot read past the end of the buffer. A non-positive reader size leaves the loop body
+    // unexecuted and is reported as a corrupt header below.
+    bool found_carriage_return = false;
+    for (; offset < reader_size; offset += 1)
     {
-      // Guard against reading past the end of the buffer when the header value is not
-      // terminated by a carriage return (malformed or truncated response).
-      if (offset >= reader_size)
-      {
-        return AZ_ERROR_HTTP_CORRUPT_RESPONSE_HEADER;
-      }
       uint8_t c = az_span_ptr(*reader)[offset];
-      offset += 1;
       if (c == '\r')
       {
+        offset += 1; // consume the carriage return
+        found_carriage_return = true;
         break; // break as soon as end of value char is found
       }
       if (_az_is_http_whitespace(c))
@@ -272,7 +272,11 @@ AZ_NODISCARD az_result az_http_response_get_next_header(
       {
         return AZ_ERROR_HTTP_CORRUPT_RESPONSE_HEADER;
       }
-      offset_value_end = offset; // increasing index only for valid chars,
+      offset_value_end = offset + 1; // increasing index only for valid chars,
+    }
+    if (!found_carriage_return)
+    {
+      return AZ_ERROR_HTTP_CORRUPT_RESPONSE_HEADER;
     }
     *out_value = az_span_slice(*reader, 0, offset_value_end);
     // moving reader. It is currently after \r was found

--- a/sdk/src/azure/core/az_json_token.c
+++ b/sdk/src/azure/core/az_json_token.c
@@ -363,7 +363,7 @@ AZ_NODISCARD az_span az_json_string_unescape(az_span json_string, az_span destin
       return az_span_slice(destination, 0, position);
     }
 
-    if (position > destination_size)
+    if (position >= destination_size)
     {
       // We assume that the destination buffer is large enough, but stop processing, in-case it
       // isn't.

--- a/sdk/src/azure/platform/az_posix.c
+++ b/sdk/src/azure/platform/az_posix.c
@@ -21,8 +21,8 @@ AZ_NODISCARD az_result az_platform_clock_msec(int64_t* out_clock_msec)
     return AZ_ERROR_CLOCK;
   }
 
-  *out_clock_msec = (int64_t)((ts.tv_sec * _az_TIME_MILLISECONDS_PER_SECOND)
-                              + (ts.tv_nsec / _az_TIME_NANOSECONDS_PER_MILLISECOND));
+  *out_clock_msec = ((int64_t)ts.tv_sec * _az_TIME_MILLISECONDS_PER_SECOND)
+      + ((int64_t)ts.tv_nsec / _az_TIME_NANOSECONDS_PER_MILLISECOND);
 
   return AZ_OK;
 }

--- a/sdk/tests/core/test_az_http.c
+++ b/sdk/tests/core/test_az_http.c
@@ -730,6 +730,52 @@ static void test_http_response(void** state)
       assert_true(get_result == AZ_ERROR_HTTP_CORRUPT_RESPONSE_HEADER);
     }
   }
+
+  // Bad response. Header value reaches the end of the buffer without a terminating
+  // carriage return. The value scan must stay within bounds and report a corrupt header.
+  {
+    az_span response_span = AZ_SPAN_FROM_STR( //
+        "HTTP/2.0 205 \r\n"
+        "header: value"); // no terminating \r\n
+
+    az_http_response response = { 0 };
+    az_result const result = az_http_response_init(&response, response_span);
+    assert_true(result == AZ_OK);
+
+    // read a status line
+    {
+      az_http_response_status_line status_line = { 0 };
+      az_result get_result = az_http_response_get_status_line(&response, &status_line);
+      assert_true(get_result == AZ_OK);
+      az_span header_name = { 0 };
+      az_span header_value = { 0 };
+      get_result = az_http_response_get_next_header(&response, &header_name, &header_value);
+      assert_true(get_result == AZ_ERROR_HTTP_CORRUPT_RESPONSE_HEADER);
+    }
+  }
+
+  // Bad response. Header value has trailing optional whitespace running to the end of the
+  // buffer without a terminating carriage return. The scan must stay within bounds.
+  {
+    az_span response_span = AZ_SPAN_FROM_STR( //
+        "HTTP/2.0 205 \r\n"
+        "header: value \t"); // valid value then trailing OWS, no terminating \r\n
+
+    az_http_response response = { 0 };
+    az_result const result = az_http_response_init(&response, response_span);
+    assert_true(result == AZ_OK);
+
+    // read a status line
+    {
+      az_http_response_status_line status_line = { 0 };
+      az_result get_result = az_http_response_get_status_line(&response, &status_line);
+      assert_true(get_result == AZ_OK);
+      az_span header_name = { 0 };
+      az_span header_value = { 0 };
+      get_result = az_http_response_get_next_header(&response, &header_name, &header_value);
+      assert_true(get_result == AZ_ERROR_HTTP_CORRUPT_RESPONSE_HEADER);
+    }
+  }
 }
 
 static void test_http_response_get_status_code(void** state)


### PR DESCRIPTION
## Summary

Code review of the library ahead of repo lock surfaced **five latent memory-safety / correctness defects**. None duplicate existing GitHub issues. Each fix is minimal, confined to the malformed-input / boundary paths, and validated against the core and IoT unit-test suites (all passing).

## Fixes

| File | Function | Defect | Class |
|------|----------|--------|-------|
| `az_json_token.c` | `az_json_string_unescape` | Bounds guard `position > destination_size` allowed a 1-byte write at `index == destination_size` (and returned an over-long span). Changed to `>=`. | OOB write (CWE-787) |
| `az_http_response.c` | `az_http_response_get_next_header` | Header-value scan read `reader[offset]` in `while (true)` with no bound (the sibling field-name/OWS loops bound-check). A response whose last header value lacks a terminating CR read past the buffer. Added `offset >= reader_size` guard. | OOB read (CWE-125) |
| `az_http_response.c` | `_az_get_http_status_line` | When LF immediately follows the status code, `offset == 0` made the reason-phrase slice request end index `-1` (negative-size span). Guarded with `offset > 0 ? offset - 1 : 0`. | Invalid span |
| `az_posix.c` | `az_platform_clock_msec` | `ts.tv_sec * 1000` evaluated in `time_t` width (constants are `int` enums) then cast to `int64_t` too late. On 32-bit `time_t` targets, monotonic uptime > ~24.8 days overflows, corrupting retry backoff, SAS expiry and context timeouts. Cast to `int64_t` before the arithmetic. | Integer overflow (CWE-190) |
| `az_http_request.c` | `az_http_request_init` | `url_length` was never validated against the `url` span size, so the query scan (and later `az_span_slice` calls) could read OOB on caller misuse. Added `_az_PRECONDITION_RANGE(0, url_length, az_span_size(url))`, matching sibling init functions. | OOB read / hardening |

## Validation

- Builds clean (MSVC, incl. Code Analysis): `az_core`, `az_iot_hub`, `az_iot_provisioning`, `az_iot_adu`.
- `ctest` — **5/5 suites pass** (core, adu, common, hub, provisioning), 0 failures.

> Note: `az_posix.c` is not compiled on Windows; the change is a trivial, inspected cast. The other four files are exercised by the passing suites.