### PR TITLE
Remove link verification from GenerateReleaseArtifacts job

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -277,11 +277,6 @@ jobs:
     
     - template: /eng/common/pipelines/templates/steps/check-spelling.yml
 
-    - template: /eng/common/pipelines/templates/steps/verify-links.yml
-      parameters:
-        Directory: ''
-        CheckLinkGuidance: $true
-
     # Generate release-info
     - pwsh: >-
         New-Item


### PR DESCRIPTION
This pull request makes a small change to the pipeline configuration by removing the link verification step from the `archetype-sdk-client.yml` job template. This simplifies the pipeline by no longer running the `verify-links.yml` template.