### PR TITLE
Add CFSClean enforcement

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -13,6 +13,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      networkIsolationPolicy: Permissive, CFSClean
     sdl:
       ${{ if and(eq(variables['Build.DefinitionName'], 'c - client'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}:
         autobaseline:


### PR DESCRIPTION
This pull request introduces a configuration update to the `eng/pipelines/templates/stages/archetype-sdk-client.yml` file, specifically adding a new network isolation policy to the pipeline parameters.

Pipeline configuration:

* Added `networkIsolationPolicy: Permissive, CFSClean` to the `settings` parameters to adjust network isolation behavior in the pipeline.